### PR TITLE
Fix console object replacement in tests

### DIFF
--- a/backend-nest/src/test/setup.ts
+++ b/backend-nest/src/test/setup.ts
@@ -3,15 +3,41 @@ import "reflect-metadata";
 // Global test setup for Bun
 console.log("🧪 Test environment initialized with Bun");
 
-// Mock console.error in tests to avoid noise
+// Store original console.error for restoration and selective logging
 const originalConsoleError = console.error;
-global.console = {
-  ...console,
-  error: (message: any, ...args: any[]) => {
-    if (process.env.NODE_ENV === "test") {
-      // Only log in test if explicitly needed
+
+// Patterns of error messages that should be silenced in tests to reduce noise
+const SILENCED_ERROR_PATTERNS = [
+  /ExperimentalWarning/i,
+  /DeprecationWarning/i,
+  /UnhandledPromiseRejectionWarning/i,
+];
+
+// Override console.error method directly to preserve console object integrity
+if (process.env.NODE_ENV === "test") {
+  console.error = (message: any, ...args: any[]) => {
+    // Allow full error logging when DEBUG_TESTS is set
+    if (process.env.DEBUG_TESTS === "true") {
+      originalConsoleError(message, ...args);
       return;
     }
-    originalConsoleError(message, ...args);
-  },
+
+    // Convert message to string for pattern matching
+    const messageString = String(message);
+    
+    // Check if this error should be silenced
+    const shouldSilence = SILENCED_ERROR_PATTERNS.some(pattern => 
+      pattern.test(messageString)
+    );
+
+    // Only log errors that aren't in our silence list
+    if (!shouldSilence) {
+      originalConsoleError(message, ...args);
+    }
+  };
+}
+
+// Cleanup function to restore original console.error if needed
+export const restoreConsole = () => {
+  console.error = originalConsoleError;
 };


### PR DESCRIPTION
Refactor `console.error` silencing in tests to preserve console object integrity and allow targeted error filtering.

The original approach completely replaced `global.console`, breaking other console methods and hiding all `console.error` messages, which hindered debugging. This PR addresses these issues by directly overriding `console.error` to only silence specific known warning patterns, while providing a `DEBUG_TESTS=true` option to see all errors.