### PR TITLE
feat(frontend): replace Roboto with Poppins font across the application

### DIFF
--- a/frontend/projects/webapp/src/_variables.scss
+++ b/frontend/projects/webapp/src/_variables.scss
@@ -1,2 +1,2 @@
 $heading-font-family: Poppins, sans-serif;
-$regular-font-family: Roboto, sans-serif;
+$regular-font-family: Poppins, sans-serif;

--- a/frontend/projects/webapp/src/index.html
+++ b/frontend/projects/webapp/src/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Roboto:wght@300;400;500&display=swap"
       rel="stylesheet"
       media="print"
       onload="this.media='all'"
@@ -24,7 +24,7 @@
     <!-- Fallback pour navigateurs sans JS -->
     <noscript>
       <link
-        href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Roboto:wght@300;400;500&display=swap"
         rel="stylesheet"
       />
       <link

--- a/frontend/projects/webapp/src/styles.scss
+++ b/frontend/projects/webapp/src/styles.scss
@@ -31,7 +31,7 @@ body {
 body {
   margin: 0;
   font-family:
-    var(--mat-sys-typescale-body-medium-font-family-name), Roboto,
+    var(--mat-sys-typescale-body-medium-font-family-name), Poppins,
     "Helvetica Neue", sans-serif;
   background: var(--mat-sys-surface);
   color: var(--mat-sys-on-surface);


### PR DESCRIPTION
## Summary
- Replace Roboto with Poppins as the primary font family across the frontend application
- Add comprehensive Poppins font weights (300, 400, 500, 600, 700) via Google Fonts
- Update SCSS variables and global styles to use Poppins consistently
- Maintain full compatibility with Angular Material typography system

## Changes
- Updated `index.html` to load Poppins font from Google Fonts
- Modified `_variables.scss` to set Poppins as the regular font family
- Updated `styles.scss` body font-family fallback to use Poppins

## Test plan
- [ ] Verify Poppins font loads correctly in browser
- [ ] Check that all typography scales use Poppins
- [ ] Ensure Material Design components display properly with new font
- [ ] Test font rendering across different browsers

🤖 Generated with [Claude Code](https://claude.ai/code)