### PR TITLE
fix: hide Swagger documentation in production environment

### DIFF
--- a/backend-nest/src/app.module.ts
+++ b/backend-nest/src/app.module.ts
@@ -235,7 +235,8 @@ function createPinoLoggerConfig(configService: ConfigService) {
     BudgetTemplateModule,
     TransactionModule,
     UserModule,
-    DebugModule,
+    // Only include DebugModule in non-production environments
+    ...(process.env.NODE_ENV !== 'production' ? [DebugModule] : []),
     FiltersModule,
   ],
   providers: [


### PR DESCRIPTION
## Summary
- Prevents Swagger documentation from being exposed in production environments
- Hides debug endpoints when running in production mode
- Maintains full documentation access in development/test environments

## Problem
As reported in issue #89, the Swagger documentation and debug endpoints were accessible in production, potentially exposing sensitive API structure and test endpoints to unauthorized users.

## Solution
Implemented conditional loading of Swagger and DebugModule based on the `NODE_ENV` environment variable:
- Swagger UI (`/docs`) and OpenAPI spec (`/api/openapi`) are only available when `NODE_ENV \!== 'production'`
- DebugModule with test endpoints is excluded from production builds
- Server logs clearly indicate whether Swagger is enabled or disabled

## Changes
- **backend-nest/src/main.ts**: Conditional Swagger setup and OpenAPI endpoint
- **backend-nest/src/app.module.ts**: Conditional DebugModule registration

## Testing
✅ **Development mode (`NODE_ENV=development`)**
- Swagger UI accessible at `/docs`
- OpenAPI JSON accessible at `/api/openapi`
- Debug endpoints available
- Logs show "📚 Swagger documentation" enabled

✅ **Production mode (`NODE_ENV=production`)**
- `/docs` returns 404
- `/api/openapi` returns 404
- Debug endpoints return 404
- Logs show "🔒 Swagger documentation is disabled in production"
- Regular API endpoints continue to work normally

## Security Impact
- ✅ API structure no longer exposed in production
- ✅ Test/debug endpoints removed from production
- ✅ Reduces attack surface by hiding implementation details

Closes #89

🤖 Generated with [Claude Code](https://claude.ai/code)