### PR TITLE
feat: add ending balance to MonthInfo and update budget list display

### DIFF
--- a/frontend/projects/webapp/src/app/core/budget/month-info.ts
+++ b/frontend/projects/webapp/src/app/core/budget/month-info.ts
@@ -4,4 +4,5 @@ export interface MonthInfo {
   budgetId: string;
   description: string;
   displayName: string;
+  endingBalance: number;
 }

--- a/frontend/projects/webapp/src/app/feature/budget/list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/list/budget-list-page.ts
@@ -95,7 +95,7 @@ import { ROUTES } from '@core/routing';
                       ) {
                         <pulpe-month-card-item
                           [displayName]="month.displayName"
-                          [totalAmount]="0"
+                          [totalAmount]="month.endingBalance"
                           [id]="month.budgetId"
                           (detailsClick)="navigateToDetails($event)"
                         />

--- a/frontend/projects/webapp/src/app/feature/budget/list/budget-state.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/list/budget-state.ts
@@ -31,6 +31,7 @@ export class BudgetState {
           budgetId: budget.id,
           description: budget.description,
           displayName: this.#formatMonthYear(budget.month, budget.year),
+          endingBalance: budget.endingBalance ?? 0,
         }))
         .sort((a: MonthInfo, b: MonthInfo) => {
           // Trier par année décroissante puis par mois décroissant


### PR DESCRIPTION
- Added `endingBalance` property to the `MonthInfo` interface to track the final balance for each month.
- Updated the budget list page to display the `endingBalance` instead of a static total amount, enhancing the accuracy of financial information presented to users.
- Ensured that the `endingBalance` is initialized to zero if not provided, improving data handling in the budget state management.

These changes enhance the budget management features by providing more relevant financial data to users.

close #79 