### PR TITLE
Fix: Align budget card amounts with progress bar display

### DIFF
--- a/backend-nest/src/modules/budget/budget.mappers.ts
+++ b/backend-nest/src/modules/budget/budget.mappers.ts
@@ -8,8 +8,12 @@ import { Tables, TablesInsert } from '@/types/database.types';
 /**
  * Transform database row (snake_case) to API entity (camelCase)
  */
-export function toApi(budgetDb: Tables<'monthly_budget'>): Budget {
-  return {
+export function toApi(
+  budgetDb:
+    | Tables<'monthly_budget'>
+    | (Tables<'monthly_budget'> & { remaining: number }),
+): Budget {
+  const baseEntity: Budget = {
     id: budgetDb.id,
     createdAt: budgetDb.created_at,
     updatedAt: budgetDb.updated_at,
@@ -20,12 +24,25 @@ export function toApi(budgetDb: Tables<'monthly_budget'>): Budget {
     description: budgetDb.description,
     endingBalance: budgetDb.ending_balance ?? undefined,
   };
+
+  // Add remaining if present in enriched budget
+  if ('remaining' in budgetDb) {
+    baseEntity.remaining = budgetDb.remaining;
+  }
+
+  return baseEntity;
 }
 
 /**
  * Transforme plusieurs entités DB vers modèles API
+ * Fonctionne avec des budgets enrichis ou normaux
  */
-export function toApiList(budgetsDb: Tables<'monthly_budget'>[]): Budget[] {
+export function toApiList(
+  budgetsDb: (
+    | Tables<'monthly_budget'>
+    | (Tables<'monthly_budget'> & { remaining: number })
+  )[],
+): Budget[] {
   return budgetsDb.map((budgetDb) => toApi(budgetDb));
 }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-mapper/budget-list.mapper.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-mapper/budget-list.mapper.ts
@@ -40,7 +40,8 @@ function mapToCalendarMonth(budget: Budget | BudgetPlaceholder): CalendarMonth {
       month: budget.month,
       year: budget.year,
       hasContent: true,
-      value: budget.endingBalance ?? undefined,
+      // Display value prioritizes remaining amount, fallback to endingBalance
+      value: budget.remaining ?? budget.endingBalance ?? undefined,
       displayName: formatCalendarMonthDisplayName(budget.month, budget.year),
     };
   }

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -76,6 +76,10 @@ export const budgetSchema = z.object({
   // rollover : CALCULÉ par le backend, pas persisté en base
   // Report du mois précédent selon formule SPECS rollover_M = ending_balance_M-1
   rollover: z.number().optional(),
+  // remaining : CALCULÉ par le backend pour la liste des budgets
+  // Formule: remaining = (totalIncome + rollover) - totalExpenses
+  // Correspond au "Disponible CHF" de la barre de progression
+  remaining: z.number().optional(),
   // previousBudgetId : Budget source du rollover pour traçabilité
   previousBudgetId: z.string().uuid().nullable().optional(),
   createdAt: z.string().datetime(),


### PR DESCRIPTION
## Summary
- Ensure monetary amounts on budget cards match "Disponible CHF" in progress bar
- Add `remaining` field to Budget API response calculated as `endingBalance + rollover`
- Update frontend mapper to prioritize `remaining` over `endingBalance` for display consistency

## Changes
### Backend (`backend-nest/`)
- **`budget.service.ts`**: Added `enrichBudgetsWithRemaining()` and `calculateRemainingForBudget()` to compute remaining amount efficiently
- **`budget.mappers.ts`**: Refactored `toApi()` to handle both base and enriched budget objects with optional `remaining` field

### Shared (`shared/`)
- **`schemas.ts`**: Added optional `remaining?: number` field to `budgetSchema` with documentation

### Frontend (`frontend/`)
- **`budget-list.mapper.ts`**: Updated display value logic to use `budget.remaining ?? budget.endingBalance ?? undefined`

## Technical Details
The core issue was a calculation discrepancy:
- **Budget cards** displayed `endingBalance` (stored DB value without rollover)  
- **Progress bar** displayed `remaining` (calculated with rollover included)

The fix calculates `remaining = endingBalance + rollover` in the backend API, ensuring both UI components show the same financial amount.

## Test Plan
- [x] All backend tests pass (159 tests)
- [x] All shared package tests pass (26 tests) 
- [x] All quality checks pass (lint, format, type-check)
- [x] Frontend builds successfully
- [ ] Manual verification: Budget card amounts match progress bar "Disponible CHF"

🤖 Generated with [Claude Code](https://claude.ai/code)