### PR TITLE
Update budget throttle limit

### DIFF
--- a/backend-nest/src/app.module.ts
+++ b/backend-nest/src/app.module.ts
@@ -236,7 +236,7 @@ function createPinoLoggerConfig(configService: ConfigService) {
           {
             name: 'default',
             ttl: config.get<number>('THROTTLE_TTL', 60000), // Default: 1 minute
-            limit: config.get<number>('THROTTLE_LIMIT', isDev ? 1000 : 100), // 1000 in dev, 100 in prod
+            limit: config.get<number>('THROTTLE_LIMIT', 1000), // 1000 requests per minute (same in dev/prod for authenticated users)
           },
           {
             name: 'demo',


### PR DESCRIPTION
## Background
The throttle limit for authenticated users was inadvertently reduced, causing 'Too Many Requests' errors during budget creation.

## Changes
- Modified `backend-nest/src/app.module.ts` to set the `THROTTLE_LIMIT` for the 'default' throttle to 1000 requests. This aligns the production limit with the development limit, providing more headroom for authenticated users. The previous limit was 100 requests per minute.

## Testing
- [ ] Create multiple budgets in quick succession to ensure no throttling errors occur.
- [ ] Verify that the demo throttle limit remains restrictive.
