### PR TITLE
fix: remove restrictive throttle limit on bulk operations endpoint

### DIFF
--- a/backend-nest/src/modules/budget-template/budget-template.controller.ts
+++ b/backend-nest/src/modules/budget-template/budget-template.controller.ts
@@ -9,7 +9,6 @@ import {
   UseGuards,
   ParseUUIDPipe,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
 import {
   ApiTags,
   ApiOperation,
@@ -337,7 +336,6 @@ export class BudgetTemplateController {
     description: 'Budget template not found',
     type: ErrorResponseDto,
   })
-  @Throttle({ default: { limit: 10, ttl: 60000 } }) // 10 requests per minute for bulk operations
   async bulkOperationsTemplateLines(
     @Param('id', ParseUUIDPipe) templateId: string,
     @Body() bulkOperationsDto: TemplateLinesBulkOperationsDto,


### PR DESCRIPTION
**Problem:**
Users were hitting HTTP 429 (Too Many Requests) errors when performing normal workflows like planning a complete year, which requires multiple bulk operations on template lines.

**Root Cause:**
The bulk operations endpoint had an overly restrictive rate limit:
- Current: 10 requests per minute
- Default: 1000 requests per minute

When planning a year (creating templates, adding/modifying lines, propagating to budgets), users easily exceeded 10 requests/minute during normal usage.

**Solution:**
Remove the custom @Throttle decorator from the bulk operations endpoint to use the default global limit of 1000 requests/minute.

**Why this is safe:**
- The endpoint is already protected by JWT authentication
- The global rate limit (1000 req/min) is sufficient protection
- Authenticated users are not an abuse risk
- This aligns with normal user workflows (multiple operations during planning)

**Impact:**
- ✅ Users can now plan complete years without hitting rate limits
- ✅ Normal bulk operations work smoothly
- ✅ Global rate limiting still protects against abuse
- ✅ Demo endpoint protection (10 req/hour) remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)