### PR TITLE
feat(budget): add transaction allocation to budget lines

### DIFF
--- a/.claude/tasks/12-allocated-transactions-budget-impact/explore.md
+++ b/.claude/tasks/12-allocated-transactions-budget-impact/explore.md
@@ -1,0 +1,237 @@
+# Task: Transactions allouées - Impact sur le budget total
+
+## Règle Métier à Implémenter
+
+**Principe fondamental :** Une transaction allouée à une enveloppe (budget line) ne doit PAS être déduite du budget total, sauf en cas de dépassement.
+
+### Exemples concrets :
+| Enveloppe | Transactions allouées | Impact sur budget total |
+|-----------|----------------------|------------------------|
+| 500 CHF   | 100 CHF              | **0 CHF** (couvert par l'enveloppe) |
+| 500 CHF   | 500 CHF              | **0 CHF** (exactement couvert) |
+| 500 CHF   | 600 CHF              | **100 CHF** (dépassement uniquement) |
+| 500 CHF   | 200 + 100 + 300 CHF  | **100 CHF** (total 600 - 500 = 100 de dépassement) |
+
+### Formule actuelle (problème) :
+```
+expenses_M = Σ(budget_lines) + Σ(transactions)
+```
+→ **Toutes** les transactions sont comptées, même celles allouées à une enveloppe = double comptage.
+
+### Formule corrigée :
+```
+expenses_M = Σ(budget_lines) + Σ(free_transactions) + Σ(envelope_overruns)
+
+où:
+- free_transactions = transactions SANS budget_line_id
+- envelope_overruns = MAX(0, allocated_transactions_total - budget_line_amount) pour chaque enveloppe
+```
+
+---
+
+## Codebase Context
+
+### Fichier principal à modifier
+
+**`shared/src/calculators/budget-formulas.ts`** (lignes 74-87)
+
+```typescript
+static calculateTotalExpenses(
+  budgetLines: FinancialItem[],
+  transactions: FinancialItem[] = [],
+): number {
+  const budgetExpenses = budgetLines
+    .filter((line) => line.kind === 'expense' || line.kind === 'saving')
+    .reduce((sum, line) => sum + line.amount, 0);
+
+  const transactionExpenses = transactions
+    .filter((t) => t.kind === 'expense' || t.kind === 'saving')
+    .reduce((sum, t) => sum + t.amount, 0);
+
+  return budgetExpenses + transactionExpenses;  // ❌ Problème ici
+}
+```
+
+**Problème actuel :** La méthode ne connaît pas le lien `budgetLineId` des transactions, donc elle les compte toutes.
+
+### Tests existants
+
+**`shared/src/calculators/budget-formulas.spec.ts`**
+- 435 lignes de tests
+- Tests SPECS compliance (Janvier→Avril)
+- Aucun test pour les transactions allouées
+
+**`frontend/projects/webapp/src/app/core/budget/budget-calculator.spec.ts`**
+- 527 lignes de tests
+- Helper `createTransaction` avec `budgetLineId: null` (ligne 23)
+- Aucun test pour les transactions allouées
+
+---
+
+## Interface FinancialItem à étendre
+
+**Actuel :**
+```typescript
+interface FinancialItem {
+  kind: TransactionKind;
+  amount: number;
+}
+```
+
+**Nécessaire :**
+```typescript
+interface FinancialItem {
+  kind: TransactionKind;
+  amount: number;
+  id?: string;          // Pour identifier les budget lines
+  budgetLineId?: string | null;  // Pour identifier les transactions allouées
+}
+```
+
+---
+
+## Flux de données
+
+```
+Transaction créée/modifiée
+        ↓
+TransactionService.create/update() (backend-nest)
+        ↓
+budgetService.recalculateBalances(budgetId)
+        ↓
+BudgetCalculator.recalculateAndPersist(budgetId)
+        ↓
+repository.fetchBudgetData() ← Doit inclure budget_line_id
+        ↓
+BudgetFormulas.calculateTotalExpenses() ← Modifier ici
+        ↓
+Persister ending_balance dans monthly_budget
+```
+
+---
+
+## Key Files
+
+| Fichier | Lignes clés | Rôle |
+|---------|-------------|------|
+| `shared/src/calculators/budget-formulas.ts` | 74-87, 138-160 | **Single source of truth** - À modifier |
+| `shared/src/calculators/budget-formulas.spec.ts` | 77-116 | Tests calculateTotalExpenses - À enrichir |
+| `backend-nest/src/modules/budget/budget.calculator.ts` | 30-63 | Appelle BudgetFormulas |
+| `frontend/projects/webapp/src/app/core/budget/budget-calculator.ts` | 25-31 | Wrapper frontend |
+| `frontend/projects/webapp/src/app/core/budget/budget-calculator.spec.ts` | 142-234 | Tests frontend |
+
+---
+
+## Patterns to Follow
+
+### Test-Driven Development
+1. **Écrire d'abord le test** dans `budget-formulas.spec.ts`
+2. Le test doit échouer (comportement actuel)
+3. Modifier `calculateTotalExpenses` pour le faire passer
+4. Vérifier que les autres tests passent toujours
+
+### Signature compatible
+- La nouvelle interface doit être backward-compatible
+- `budgetLineId` et `id` optionnels pour ne pas casser les appels existants
+
+---
+
+## Tests à écrire
+
+### Test 1: Transaction allouée dans limite de l'enveloppe
+```typescript
+it('should NOT count allocated transaction when within envelope limit', () => {
+  const budgetLines = [
+    { id: 'bl-1', kind: 'expense', amount: 500 },  // Enveloppe 500 CHF
+  ];
+  const transactions = [
+    { kind: 'expense', amount: 100, budgetLineId: 'bl-1' },  // Allouée
+  ];
+
+  // Attendu: 500 (enveloppe) + 0 (transaction couverte) = 500
+  expect(BudgetFormulas.calculateTotalExpenses(budgetLines, transactions)).toBe(500);
+});
+```
+
+### Test 2: Transaction allouée avec dépassement
+```typescript
+it('should count ONLY excess when allocated transactions exceed envelope', () => {
+  const budgetLines = [
+    { id: 'bl-1', kind: 'expense', amount: 500 },  // Enveloppe 500 CHF
+  ];
+  const transactions = [
+    { kind: 'expense', amount: 600, budgetLineId: 'bl-1' },  // Dépassement de 100
+  ];
+
+  // Attendu: 500 (enveloppe) + 100 (dépassement) = 600
+  expect(BudgetFormulas.calculateTotalExpenses(budgetLines, transactions)).toBe(600);
+});
+```
+
+### Test 3: Transaction libre (non allouée)
+```typescript
+it('should count free transactions (not allocated) fully', () => {
+  const budgetLines = [
+    { id: 'bl-1', kind: 'expense', amount: 500 },
+  ];
+  const transactions = [
+    { kind: 'expense', amount: 100, budgetLineId: null },  // Libre
+  ];
+
+  // Attendu: 500 (enveloppe) + 100 (transaction libre) = 600
+  expect(BudgetFormulas.calculateTotalExpenses(budgetLines, transactions)).toBe(600);
+});
+```
+
+### Test 4: Mix de transactions allouées et libres
+```typescript
+it('should handle mix of allocated and free transactions correctly', () => {
+  const budgetLines = [
+    { id: 'bl-1', kind: 'expense', amount: 500 },  // Enveloppe
+  ];
+  const transactions = [
+    { kind: 'expense', amount: 300, budgetLineId: 'bl-1' },  // Allouée (couvert)
+    { kind: 'expense', amount: 400, budgetLineId: 'bl-1' },  // Allouée (200 en dépassement)
+    { kind: 'expense', amount: 150, budgetLineId: null },    // Libre
+  ];
+
+  // allocated_total = 700, envelope = 500 → dépassement = 200
+  // Attendu: 500 (enveloppe) + 200 (dépassement) + 150 (libre) = 850
+  expect(BudgetFormulas.calculateTotalExpenses(budgetLines, transactions)).toBe(850);
+});
+```
+
+### Test 5: Backward compatibility
+```typescript
+it('should maintain backward compatibility with items without budgetLineId', () => {
+  // Ancien comportement: items sans budgetLineId ni id
+  const budgetLines = [
+    { kind: 'expense', amount: 500 },  // Pas d'id
+  ];
+  const transactions = [
+    { kind: 'expense', amount: 100 },  // Pas de budgetLineId
+  ];
+
+  // Attendu: comportement original 500 + 100 = 600
+  expect(BudgetFormulas.calculateTotalExpenses(budgetLines, transactions)).toBe(600);
+});
+```
+
+---
+
+## Dependencies
+
+### Prérequis
+- Migration DB `budget_line_id` déjà appliquée ✓
+- Schémas Zod avec `budgetLineId` déjà en place ✓
+- Data provider calcule déjà `consumedAmount` ✓
+
+### Impact sur autres modules
+1. **Backend**: `fetchBudgetData()` doit retourner `budget_line_id` des transactions et `id` des budget lines
+2. **Frontend**: Mise à jour automatique car utilise `BudgetFormulas` via le shared package
+
+---
+
+## Prochaine étape
+
+Exécuter `/workflow:epct:plan .claude/tasks/12-allocated-transactions-budget-impact` pour créer le plan d'implémentation.

--- a/.claude/tasks/12-allocated-transactions-budget-impact/implementation.md
+++ b/.claude/tasks/12-allocated-transactions-budget-impact/implementation.md
@@ -1,0 +1,114 @@
+# Implementation: Transactions Allouées - Impact sur le Budget Total
+
+## Completed
+
+### 1. Extended FinancialItem Interface (`shared/src/calculators/budget-formulas.ts:31-36`)
+- Added `id?: string` for identifying budget lines
+- Added `budgetLineId?: string | null` for identifying allocated transactions
+- Both fields are optional for backward compatibility
+
+### 2. Refactored calculateTotalExpenses (`shared/src/calculators/budget-formulas.ts:82-111`)
+Implemented the corrected formula:
+```
+expenses_M = Σ(budget_lines) + Σ(free_transactions) + Σ(envelope_overruns)
+```
+
+- Separates transactions into free (no `budgetLineId`) and allocated (with `budgetLineId`)
+- Free transactions are counted fully
+- Allocated transactions only count their overrun beyond the envelope amount
+
+### 3. Added calculateEnvelopeOverruns (`shared/src/calculators/budget-formulas.ts:123-158`)
+- Groups allocated transactions by `budgetLineId`
+- Calculates `MAX(0, allocated_total - envelope_amount)` for each envelope
+- Falls back to treating transaction as free if envelope doesn't exist
+
+### 4. Updated Backend Repository (`backend-nest/src/modules/budget/budget.repository.ts`)
+- Extended `BudgetDataOptions` with `budgetLineFields` and `transactionFields` options
+- Updated `buildFetchQueries` to use separate fields for each table
+- Maintains backward compatibility with existing `selectFields` option
+
+### 5. Updated Backend Calculator (`backend-nest/src/modules/budget/budget.calculator.ts:30-65`)
+- Now fetches `id, kind, amount` for budget lines
+- Now fetches `kind, amount, budget_line_id` for transactions
+- Maps database fields (snake_case) to formula fields (camelCase)
+
+### 6. Added Unit Tests
+
+#### Shared Package (`shared/src/calculators/budget-formulas.spec.ts`)
+9 new tests covering:
+- Transaction within envelope limit (no impact)
+- Transaction exceeding envelope (only overrun counted)
+- Free transactions (fully counted)
+- Mix of allocated and free transactions
+- Backward compatibility
+- Multiple envelopes with mixed overruns
+- Transaction allocated to non-existent envelope
+- Savings allocated to envelope
+- Exactly matched allocation
+
+#### Frontend (`frontend/projects/webapp/src/app/core/budget/budget-calculator.spec.ts`)
+4 new tests covering:
+- Allocated transaction within envelope
+- Allocated transaction with overrun
+- Free transactions
+- Mix of allocated and free transactions
+
+## Deviations from Plan
+
+None - implementation followed the plan exactly.
+
+## Test Results
+
+- Typecheck: ✓
+- Lint: ✓ (pre-existing warning in transaction.service.ts not related to changes)
+- Shared tests: 35 passed (9 new)
+- Frontend tests: 649 passed (4 new)
+
+## Follow-up Tasks
+
+None identified - the implementation is complete and all tests pass.
+
+---
+
+# Update 2: Frontend Display Fix
+
+## Problem
+
+Allocated transactions appeared twice in the UI:
+1. Inside their envelope (correctly)
+2. As standalone rows in the main table (incorrectly)
+
+## Fix
+
+Modified `BudgetTableDataProvider.#createDisplayItems()` to filter out allocated transactions:
+
+```typescript
+// Before: Added ALL transactions
+transactions.forEach((transaction) => { ... });
+
+// After: Only add free transactions
+const freeTransactions = transactions.filter((t) => !t.budgetLineId);
+freeTransactions.forEach((transaction) => { ... });
+```
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-data-provider.ts` | Filter allocated transactions in `#createDisplayItems()` |
+| `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-data-provider.spec.ts` | Added 3 tests for allocated transactions filtering |
+
+## Test Results
+
+- All 652 frontend tests pass
+- Quality checks pass
+
+## Key Files Modified
+
+| File | Changes |
+|------|---------|
+| `shared/src/calculators/budget-formulas.ts` | Extended interface, refactored calculateTotalExpenses, added calculateEnvelopeOverruns |
+| `shared/src/calculators/budget-formulas.spec.ts` | Added 9 tests for allocated transactions |
+| `backend-nest/src/modules/budget/budget.repository.ts` | Extended options, separate fields per table |
+| `backend-nest/src/modules/budget/budget.calculator.ts` | Updated field selection and mapping |
+| `frontend/projects/webapp/src/app/core/budget/budget-calculator.spec.ts` | Added 4 tests for allocated transactions |

--- a/.claude/tasks/12-allocated-transactions-budget-impact/plan.md
+++ b/.claude/tasks/12-allocated-transactions-budget-impact/plan.md
@@ -1,0 +1,149 @@
+# Implementation Plan: Transactions Allouées - Impact sur le Budget Total
+
+## Overview
+
+Modifier `BudgetFormulas.calculateTotalExpenses()` pour ne compter les transactions allouées à une enveloppe (budget line) que si elles dépassent le montant de l'enveloppe. Actuellement, toutes les transactions sont comptées intégralement, causant un double comptage.
+
+### Formule corrigée
+
+```
+expenses_M = Σ(budget_lines) + Σ(free_transactions) + Σ(envelope_overruns)
+
+où:
+- free_transactions = transactions SANS budgetLineId
+- envelope_overruns = MAX(0, allocated_transactions_total - budget_line_amount) pour chaque enveloppe
+```
+
+## Dependencies
+
+1. Migration DB `budget_line_id` sur transactions - **DÉJÀ FAIT** ✓
+2. Schémas Zod avec `budgetLineId` - **DÉJÀ FAIT** ✓
+3. Build du shared package avant tests
+
+## File Changes
+
+### 1. `shared/src/calculators/budget-formulas.ts`
+
+**Étendre l'interface FinancialItem** (lignes 31-34):
+- Ajouter `id?: string` pour identifier les budget lines
+- Ajouter `budgetLineId?: string | null` pour identifier les transactions allouées
+- Ces champs sont optionnels pour maintenir la rétrocompatibilité
+
+**Refactoriser calculateTotalExpenses** (lignes 74-87):
+- Extraire le calcul des budget lines expenses (inchangé)
+- Séparer les transactions en deux catégories :
+  - `freeTransactions` : transactions sans `budgetLineId`
+  - `allocatedTransactions` : transactions avec `budgetLineId`
+- Pour les transactions libres : compter intégralement
+- Pour les transactions allouées :
+  - Grouper par `budgetLineId`
+  - Pour chaque groupe, calculer le dépassement : `MAX(0, total_allocated - budget_line_amount)`
+  - Nécessite de trouver le budget line correspondant dans la liste
+
+**Logique de dépassement**:
+- Créer une Map `budgetLineId → amount` depuis les budget lines
+- Créer une Map `budgetLineId → total_transactions` depuis les transactions allouées
+- Calculer le dépassement pour chaque enveloppe
+
+### 2. `shared/src/calculators/budget-formulas.spec.ts`
+
+**Ajouter un nouveau bloc describe** `'calculateTotalExpenses with allocated transactions'` après la ligne 116:
+
+**Test 1 - Transaction allouée dans limite de l'enveloppe**:
+- Budget line: 500 CHF (id: 'bl-1')
+- Transaction allouée: 100 CHF (budgetLineId: 'bl-1')
+- Attendu: 500 (enveloppe seule, transaction couverte)
+
+**Test 2 - Transaction allouée avec dépassement**:
+- Budget line: 500 CHF (id: 'bl-1')
+- Transaction allouée: 600 CHF (budgetLineId: 'bl-1')
+- Attendu: 600 (500 + 100 dépassement)
+
+**Test 3 - Transaction libre (non allouée)**:
+- Budget line: 500 CHF (id: 'bl-1')
+- Transaction libre: 100 CHF (budgetLineId: null)
+- Attendu: 600 (500 + 100)
+
+**Test 4 - Mix de transactions allouées et libres**:
+- Budget line: 500 CHF
+- Transactions allouées: 300 + 400 = 700 CHF → dépassement 200
+- Transaction libre: 150 CHF
+- Attendu: 850 (500 + 200 + 150)
+
+**Test 5 - Backward compatibility**:
+- Items sans `id` ni `budgetLineId`
+- Comportement original: somme simple
+- Attendu: 600 (500 + 100)
+
+**Test 6 - Plusieurs enveloppes avec dépassements mixtes**:
+- Budget line 1: 500 CHF, transactions: 400 (pas de dépassement)
+- Budget line 2: 300 CHF, transactions: 500 (dépassement 200)
+- Attendu: 1000 (500 + 300 + 200)
+
+**Mettre à jour createFinancialItem helper** (ligne 15):
+- Ajouter paramètres optionnels `id` et `budgetLineId`
+
+### 3. `backend-nest/src/modules/budget/budget.repository.ts`
+
+**Modifier fetchBudgetData selectFields** (ligne 126):
+- Changer le default de `'kind, amount'` à `'id, kind, amount'` pour budget lines
+- Pour les transactions, le default doit inclure `'kind, amount, budget_line_id'`
+
+**Note**: La méthode `calculateEndingBalance` dans `budget.calculator.ts` (ligne 37) passe `selectFields: 'kind, amount'`. Ce select doit être mis à jour.
+
+### 4. `backend-nest/src/modules/budget/budget.calculator.ts`
+
+**Modifier calculateEndingBalance** (lignes 30-50):
+- Mettre à jour l'appel à `fetchBudgetData` pour récupérer les champs nécessaires
+- Changer le `selectFields` en un format qui inclut `id` pour budget lines et `budget_line_id` pour transactions
+
+**Option A (préférée)**: Modifier `BudgetDataOptions` pour avoir des select séparés:
+- `budgetLineFields: 'id, kind, amount'`
+- `transactionFields: 'kind, amount, budget_line_id'`
+
+**Option B**: Utiliser `selectFields: '*'` (plus simple mais moins optimal)
+
+### 5. `frontend/projects/webapp/src/app/core/budget/budget-calculator.spec.ts`
+
+**Ajouter tests pour les transactions allouées** après ligne 395:
+- Mêmes scénarios que dans le shared, en utilisant les types `BudgetLine` et `Transaction`
+- Modifier `createTransaction` helper pour supporter `budgetLineId` non-null
+- Modifier `createBudgetLine` helper - l'`id` existe déjà
+
+**Tests à ajouter**:
+- Transaction allouée couverte par enveloppe
+- Transaction allouée avec dépassement
+- Mix de transactions allouées et libres
+
+## Testing Strategy
+
+### Unit Tests
+- `shared/src/calculators/budget-formulas.spec.ts` - Tests des nouvelles règles
+- `frontend/projects/webapp/src/app/core/budget/budget-calculator.spec.ts` - Tests frontend
+
+### Exécution
+```bash
+cd shared && pnpm test
+cd frontend && pnpm test -- budget-calculator.spec.ts
+```
+
+### Validation manuelle
+1. Créer une enveloppe de 500 CHF
+2. Ajouter une transaction de 100 CHF allouée → budget total inchangé
+3. Ajouter une transaction de 500 CHF allouée → budget total +100 (dépassement)
+4. Ajouter une transaction de 50 CHF libre → budget total +50
+
+## Rollout Considerations
+
+### Backward Compatibility
+- L'interface `FinancialItem` reste compatible (nouveaux champs optionnels)
+- Les calculs sans `id`/`budgetLineId` fonctionnent comme avant
+- Aucune migration de données nécessaire
+
+### Impact
+- Le recalcul des balances existantes sera corrigé automatiquement
+- Les budgets avec transactions allouées verront leur `ending_balance` potentiellement augmenter
+
+### Risques
+- Performance: le groupement des transactions par `budgetLineId` est O(n)
+- Si une transaction référence un `budgetLineId` inexistant, elle sera traitée comme libre (fallback sécurisé)

--- a/backend-nest/src/common/constants/error-definitions.ts
+++ b/backend-nest/src/common/constants/error-definitions.ts
@@ -245,6 +245,14 @@ export const ERROR_DEFINITIONS = {
         : 'Budget line does not belong to the specified budget',
     httpStatus: HttpStatus.BAD_REQUEST,
   },
+  TRANSACTION_BUDGET_LINE_KIND_MISMATCH: {
+    code: 'ERR_TRANSACTION_BUDGET_LINE_KIND_MISMATCH',
+    message: (details?: Record<string, unknown>) =>
+      details?.transactionKind && details?.budgetLineKind
+        ? `Transaction kind '${details.transactionKind}' must match budget line kind '${details.budgetLineKind}'`
+        : 'Transaction kind must match budget line kind',
+    httpStatus: HttpStatus.BAD_REQUEST,
+  },
   TRANSACTION_VALIDATION_FAILED: {
     code: 'ERR_TRANSACTION_VALIDATION_FAILED',
     message: (details?: Record<string, unknown>) =>

--- a/backend-nest/src/modules/budget-line/budget-line.controller.ts
+++ b/backend-nest/src/modules/budget-line/budget-line.controller.ts
@@ -23,6 +23,7 @@ import {
   type BudgetLineResponse,
   type BudgetLineListResponse,
   type BudgetLineDeleteResponse,
+  type AllocatedTransactionsResponse,
 } from '@pulpe/shared';
 import { AuthGuard } from '@common/guards/auth.guard';
 import {
@@ -171,5 +172,39 @@ export class BudgetLineController {
     @SupabaseClient() supabase: AuthenticatedSupabaseClient,
   ): Promise<BudgetLineDeleteResponse> {
     return this.budgetLineService.remove(id, user, supabase);
+  }
+
+  @Get(':id/transactions')
+  @ApiOperation({
+    summary: 'Récupère les transactions allouées à une ligne budgétaire',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Identifiant unique de la ligne budgétaire',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Transactions allouées récupérées avec succès',
+  })
+  @ApiNotFoundResponse({
+    description: 'Budget line not found',
+    type: ErrorResponseDto,
+  })
+  async getAllocatedTransactions(
+    @Param('id') id: string,
+    @User() user: AuthenticatedUser,
+    @SupabaseClient() supabase: AuthenticatedSupabaseClient,
+  ): Promise<AllocatedTransactionsResponse> {
+    const transactions = await this.budgetLineService.getAllocatedTransactions(
+      id,
+      supabase,
+    );
+    // Import transaction mappers to convert DB rows to API format
+    const { toApiList } = await import('../transaction/transaction.mappers');
+    return {
+      success: true,
+      data: toApiList(transactions),
+    };
   }
 }

--- a/backend-nest/src/modules/budget/budget.calculator.ts
+++ b/backend-nest/src/modules/budget/budget.calculator.ts
@@ -34,16 +34,31 @@ export class BudgetCalculator {
     const { budgetLines, transactions } = await this.repository.fetchBudgetData(
       budgetId,
       supabase,
-      { selectFields: 'kind, amount' },
+      {
+        budgetLineFields: 'id, kind, amount',
+        transactionFields: 'kind, amount, budget_line_id',
+      },
     );
 
+    const mappedBudgetLines = budgetLines.map((line) => ({
+      id: line.id,
+      kind: line.kind,
+      amount: line.amount,
+    }));
+
+    const mappedTransactions = transactions.map((t) => ({
+      kind: t.kind,
+      amount: t.amount,
+      budgetLineId: t.budget_line_id,
+    }));
+
     const totalIncome = BudgetFormulas.calculateTotalIncome(
-      budgetLines,
-      transactions,
+      mappedBudgetLines,
+      mappedTransactions,
     );
     const totalExpenses = BudgetFormulas.calculateTotalExpenses(
-      budgetLines,
-      transactions,
+      mappedBudgetLines,
+      mappedTransactions,
     );
 
     return totalIncome - totalExpenses;

--- a/backend-nest/src/modules/demo/demo-data-generator.service.ts
+++ b/backend-nest/src/modules/demo/demo-data-generator.service.ts
@@ -655,6 +655,7 @@ export class DemoDataGeneratorService {
   ): Omit<TransactionRow, 'id' | 'created_at' | 'updated_at'> {
     return {
       budget_id: budget.id,
+      budget_line_id: null,
       name,
       amount,
       kind: 'expense',

--- a/backend-nest/src/modules/transaction/transaction.mappers.ts
+++ b/backend-nest/src/modules/transaction/transaction.mappers.ts
@@ -19,6 +19,7 @@ export function toApi(transactionDb: TransactionRow): Transaction {
     createdAt: transactionDb.created_at,
     updatedAt: transactionDb.updated_at,
     budgetId: transactionDb.budget_id,
+    budgetLineId: transactionDb.budget_line_id,
     amount: transactionDb.amount,
     name: transactionDb.name,
     kind: transactionDb.kind, // Pas de conversion - les enums sont maintenant unifiés
@@ -64,6 +65,7 @@ export function toInsert(
 
   return {
     budget_id: finalBudgetId,
+    budget_line_id: createDto.budgetLineId ?? null,
     amount: createDto.amount,
     name: createDto.name,
     kind: createDto.kind, // Pas de conversion - les enums sont maintenant unifiés
@@ -94,6 +96,9 @@ export function toUpdate(
   }
   if (updateDto.category !== undefined) {
     updateData.category = updateDto.category;
+  }
+  if (updateDto.budgetLineId !== undefined) {
+    updateData.budget_line_id = updateDto.budgetLineId;
   }
 
   return updateData;

--- a/backend-nest/src/modules/transaction/transaction.module.ts
+++ b/backend-nest/src/modules/transaction/transaction.module.ts
@@ -1,11 +1,13 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TransactionController } from './transaction.controller';
 import { TransactionService } from './transaction.service';
 import { BudgetModule } from '@modules/budget/budget.module';
+import { BudgetLineModule } from '@modules/budget-line/budget-line.module';
 
 @Module({
-  imports: [BudgetModule],
+  imports: [BudgetModule, forwardRef(() => BudgetLineModule)],
   controllers: [TransactionController],
   providers: [TransactionService],
+  exports: [TransactionService],
 })
 export class TransactionModule {}

--- a/backend-nest/src/modules/transaction/transaction.service.spec.ts
+++ b/backend-nest/src/modules/transaction/transaction.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { TransactionService } from './transaction.service';
 import { BudgetService } from '../budget/budget.service';
+import { BudgetLineService } from '../budget-line/budget-line.service';
 import { PinoLogger } from 'nestjs-pino';
 import type { TransactionCreate, TransactionUpdate } from '@pulpe/shared';
 import {
@@ -19,6 +20,7 @@ describe('TransactionService', () => {
   let service: TransactionService;
   let mockLogger: Partial<PinoLogger>;
   let mockBudgetService: Partial<BudgetService>;
+  let mockBudgetLineService: Partial<BudgetLineService>;
   let mockSupabaseClient: MockSupabaseClient;
 
   beforeEach(() => {
@@ -33,9 +35,30 @@ describe('TransactionService', () => {
     mockBudgetService = {
       recalculateBalances: mock(() => Promise.resolve()),
     };
+    mockBudgetLineService = {
+      findOne: mock(() =>
+        Promise.resolve({
+          success: true as const,
+          data: {
+            id: 'budget-line-123',
+            budgetId: MOCK_BUDGET_ID,
+            templateLineId: null,
+            savingsGoalId: null,
+            name: 'Test Budget Line',
+            amount: 100,
+            kind: 'expense' as const,
+            recurrence: 'fixed' as const,
+            isManuallyAdjusted: false,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        }),
+      ),
+    };
     service = new TransactionService(
       mockLogger as PinoLogger,
       mockBudgetService as BudgetService,
+      mockBudgetLineService as BudgetLineService,
     );
   });
 

--- a/backend-nest/src/types/database.types.ts
+++ b/backend-nest/src/types/database.types.ts
@@ -256,6 +256,7 @@ export type Database = {
         Row: {
           amount: number;
           budget_id: string;
+          budget_line_id: string | null;
           category: string | null;
           created_at: string;
           id: string;
@@ -267,6 +268,7 @@ export type Database = {
         Insert: {
           amount: number;
           budget_id: string;
+          budget_line_id?: string | null;
           category?: string | null;
           created_at?: string;
           id?: string;
@@ -278,6 +280,7 @@ export type Database = {
         Update: {
           amount?: number;
           budget_id?: string;
+          budget_line_id?: string | null;
           category?: string | null;
           created_at?: string;
           id?: string;
@@ -292,6 +295,13 @@ export type Database = {
             columns: ['budget_id'];
             isOneToOne: false;
             referencedRelation: 'monthly_budget';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'transaction_budget_line_id_fkey';
+            columns: ['budget_line_id'];
+            isOneToOne: false;
+            referencedRelation: 'budget_line';
             referencedColumns: ['id'];
           },
         ];

--- a/backend-nest/supabase/migrations/20251223100000_add_budget_line_id_to_transaction.sql
+++ b/backend-nest/supabase/migrations/20251223100000_add_budget_line_id_to_transaction.sql
@@ -1,0 +1,24 @@
+-- Add budget_line_id column to transaction table
+-- This enables optional allocation of transactions to budget lines (prévisions)
+-- Nullable to maintain backward compatibility with existing transactions
+
+-- Step 1: Add the column
+ALTER TABLE public.transaction
+ADD COLUMN budget_line_id UUID NULL;
+
+-- Step 2: Add descriptive comment
+COMMENT ON COLUMN public.transaction.budget_line_id IS
+'Optional reference to a budget line. Allows tracking which planned budget line this transaction is allocated to. NULL means the transaction is not allocated to any specific budget line.';
+
+-- Step 3: Create partial index for performance (only index non-null values)
+CREATE INDEX idx_transaction_budget_line_id
+ON public.transaction(budget_line_id)
+WHERE budget_line_id IS NOT NULL;
+
+-- Step 4: Add foreign key constraint with ON DELETE SET NULL
+-- If a budget line is deleted, transactions become "unallocated" rather than deleted
+ALTER TABLE public.transaction
+ADD CONSTRAINT transaction_budget_line_id_fkey
+FOREIGN KEY (budget_line_id)
+REFERENCES public.budget_line(id)
+ON DELETE SET NULL;

--- a/frontend/e2e/helpers/api-mocks.ts
+++ b/frontend/e2e/helpers/api-mocks.ts
@@ -1,6 +1,8 @@
 import type {
   BudgetDetailsResponse,
   BudgetLineResponse,
+  TransactionCreateResponse,
+  TransactionUpdateResponse,
   Budget,
   BudgetLine,
   Transaction,
@@ -81,4 +83,42 @@ export function createMultipleBudgetLinesMock(
       kind: line.kind || 'expense',
     })
   );
+}
+
+export function createTransactionMock(
+  id: string,
+  budgetId: string,
+  overrides?: Partial<Transaction>
+): Transaction {
+  return {
+    id,
+    budgetId,
+    budgetLineId: null,
+    name: 'Test Transaction',
+    amount: 50,
+    kind: 'expense',
+    transactionDate: '2025-01-15T00:00:00Z',
+    category: null,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+export function createTransactionCreateResponseMock(
+  transaction: Transaction
+): TransactionCreateResponse {
+  return {
+    success: true,
+    data: transaction,
+  };
+}
+
+export function createTransactionUpdateResponseMock(
+  transaction: Transaction
+): TransactionUpdateResponse {
+  return {
+    success: true,
+    data: transaction,
+  };
 }

--- a/frontend/e2e/tests/features/budget-allocated-transactions.spec.ts
+++ b/frontend/e2e/tests/features/budget-allocated-transactions.spec.ts
@@ -1,0 +1,672 @@
+import { test, expect } from '../../fixtures/test-fixtures';
+import {
+  createBudgetDetailsMock,
+  createBudgetLineMock,
+  createTransactionMock,
+  createTransactionCreateResponseMock,
+  createTransactionUpdateResponseMock,
+} from '../../helpers/api-mocks';
+
+test.describe('Budget Allocated Transactions', () => {
+  test('should open allocated transactions dialog from budget table', async ({
+    authenticatedPage,
+    budgetDetailsPage,
+  }) => {
+    const budgetId = 'test-budget-123';
+    const budgetLineId = 'line-1';
+
+    // Mock budget with budget line (December 2025)
+    const mockResponse = createBudgetDetailsMock(budgetId, {
+      budget: {
+        month: 12,
+        year: 2025,
+      },
+      budgetLines: [
+        createBudgetLineMock(budgetLineId, budgetId, {
+          name: 'Groceries',
+          amount: 500,
+          kind: 'expense',
+        }),
+      ],
+      transactions: [],
+    });
+
+    await authenticatedPage.route('**/api/v1/budgets/*/details', (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockResponse),
+      });
+    });
+
+    await budgetDetailsPage.goto(budgetId);
+    await budgetDetailsPage.expectPageLoaded();
+
+    // Wait for budget line row to be visible in the table
+    const budgetLineRow = authenticatedPage
+      .locator('tr')
+      .filter({ hasText: 'Groceries' });
+    await expect(budgetLineRow).toBeVisible({ timeout: 10000 });
+
+    // Click on "View transactions" button (desktop mode)
+    const viewTransactionsButton = authenticatedPage.locator(
+      `[data-testid="view-transactions-${budgetLineId}"]`
+    );
+    await expect(viewTransactionsButton).toBeVisible({ timeout: 5000 });
+    await viewTransactionsButton.click();
+
+    // Wait for dialog to open
+    await authenticatedPage.waitForTimeout(500);
+
+    // Verify dialog is opened with correct title
+    await expect(
+      authenticatedPage.locator('.mat-mdc-dialog-container')
+    ).toBeVisible({ timeout: 5000 });
+
+    await expect(
+      authenticatedPage
+        .locator('.mat-mdc-dialog-container h2')
+        .filter({ hasText: 'Groceries' })
+    ).toBeVisible();
+
+    // Verify empty state message
+    await expect(
+      authenticatedPage.locator('.mat-mdc-dialog-container')
+    ).toContainText('Aucune transaction');
+  });
+
+  test('should display allocated transactions count badge', async ({
+    authenticatedPage,
+    budgetDetailsPage,
+  }) => {
+    const budgetId = 'test-budget-123';
+    const budgetLineId = 'line-1';
+
+    // Mock budget with budget line and 2 allocated transactions (December 2025)
+    const mockResponse = createBudgetDetailsMock(budgetId, {
+      budget: {
+        month: 12,
+        year: 2025,
+      },
+      budgetLines: [
+        createBudgetLineMock(budgetLineId, budgetId, {
+          name: 'Groceries',
+          amount: 500,
+          kind: 'expense',
+        }),
+      ],
+      transactions: [
+        createTransactionMock('tx-1', budgetId, {
+          name: 'Migros',
+          amount: 120,
+          kind: 'expense',
+          budgetLineId,
+          transactionDate: '2025-12-05T00:00:00Z',
+        }),
+        createTransactionMock('tx-2', budgetId, {
+          name: 'Coop',
+          amount: 80,
+          kind: 'expense',
+          budgetLineId,
+          transactionDate: '2025-12-08T00:00:00Z',
+        }),
+      ],
+    });
+
+    await authenticatedPage.route('**/api/v1/budgets/*/details', (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockResponse),
+      });
+    });
+
+    await budgetDetailsPage.goto(budgetId);
+    await budgetDetailsPage.expectPageLoaded();
+
+    // Wait for table to render
+    await authenticatedPage.waitForSelector('table[mat-table]', { timeout: 10000 });
+
+    // Verify badge shows count of 2
+    const budgetLineRow = authenticatedPage
+      .locator('tr')
+      .filter({ hasText: 'Groceries' });
+    await expect(budgetLineRow.locator('.rounded-full')).toContainText('2', {
+      timeout: 5000,
+    });
+  });
+
+  test('should add a transaction to budget line', async ({
+    authenticatedPage,
+    budgetDetailsPage,
+  }) => {
+    const budgetId = 'test-budget-123';
+    const budgetLineId = 'line-1';
+    let transactionCreated = false;
+
+    // Initial mock - no transactions (December 2025 to match current date)
+    const initialMockResponse = createBudgetDetailsMock(budgetId, {
+      budget: {
+        month: 12,
+        year: 2025,
+      },
+      budgetLines: [
+        createBudgetLineMock(budgetLineId, budgetId, {
+          name: 'Groceries',
+          amount: 500,
+          kind: 'expense',
+        }),
+      ],
+      transactions: [],
+    });
+
+    // Mock after transaction creation (December 2025)
+    const newTransaction = createTransactionMock('tx-new', budgetId, {
+      name: 'Migros',
+      amount: 120,
+      kind: 'expense',
+      budgetLineId,
+      transactionDate: '2025-12-15T00:00:00Z',
+    });
+
+    const updatedMockResponse = createBudgetDetailsMock(budgetId, {
+      budget: {
+        month: 12,
+        year: 2025,
+      },
+      budgetLines: [
+        createBudgetLineMock(budgetLineId, budgetId, {
+          name: 'Groceries',
+          amount: 500,
+          kind: 'expense',
+        }),
+      ],
+      transactions: [newTransaction],
+    });
+
+    // Mock budget details endpoint
+    await authenticatedPage.route('**/api/v1/budgets/*/details', (route) => {
+      const response = transactionCreated
+        ? updatedMockResponse
+        : initialMockResponse;
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      });
+    });
+
+    // Mock transaction creation endpoint
+    await authenticatedPage.route('**/api/v1/transactions', (route) => {
+      if (route.request().method() === 'POST') {
+        transactionCreated = true;
+        const response = createTransactionCreateResponseMock(newTransaction);
+        void route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify(response),
+        });
+      }
+    });
+
+    await budgetDetailsPage.goto(budgetId);
+    await budgetDetailsPage.expectPageLoaded();
+
+    // Open allocated transactions dialog
+    const viewTransactionsButton = authenticatedPage.locator(
+      `[data-testid="view-transactions-${budgetLineId}"]`
+    );
+    await viewTransactionsButton.click();
+
+    // Click "Add transaction" button
+    const addButton = authenticatedPage.locator(
+      '[data-testid="add-transaction"]'
+    );
+    await addButton.click();
+
+    // Wait for form to be visible
+    await authenticatedPage.waitForSelector('[data-testid="transaction-name-input"]');
+
+    // Fill transaction form
+    await authenticatedPage
+      .locator('[data-testid="transaction-name-input"]')
+      .fill('Migros');
+    await authenticatedPage
+      .locator('[data-testid="transaction-amount-input"]')
+      .fill('120');
+
+    // Fill date using datepicker toggle
+    const dateToggle = authenticatedPage.locator('mat-datepicker-toggle button');
+    await dateToggle.click();
+    await authenticatedPage.waitForTimeout(300);
+
+    // Select first available day in calendar
+    const firstDay = authenticatedPage
+      .locator('.mat-calendar-body-cell')
+      .filter({ hasNotText: '' })
+      .first();
+    await firstDay.click();
+    await authenticatedPage.waitForTimeout(300);
+
+    // Submit form
+    const submitButton = authenticatedPage.locator('[data-testid="submit-button"]');
+    await expect(submitButton).toBeEnabled({ timeout: 3000 });
+    await submitButton.click();
+
+    // Verify success snackbar
+    await expect(
+      authenticatedPage.locator('.mat-mdc-snack-bar-label').last()
+    ).toHaveText('Transaction ajoutée.');
+
+    // Wait for dialogs to settle
+    await authenticatedPage.waitForTimeout(2000);
+
+    // Verify allocated transactions dialog reopened by checking for the dialog title
+    const dialogTitle = authenticatedPage
+      .locator('h2')
+      .filter({ hasText: 'Groceries' });
+
+    // If dialog is open, verify transaction is shown
+    if (await dialogTitle.isVisible({ timeout: 1000 })) {
+      const transactionItem = authenticatedPage
+        .locator('mat-list-item')
+        .filter({ hasText: 'Migros' });
+      await expect(transactionItem).toBeVisible();
+
+      // Close the dialog
+      await authenticatedPage.locator('button:has-text("Fermer")').first().click();
+      await authenticatedPage.waitForTimeout(300);
+    }
+
+    // Verify the badge shows 1 transaction in the budget table
+    const budgetLineRow = authenticatedPage
+      .locator('tr')
+      .filter({ hasText: 'Groceries' });
+    await expect(budgetLineRow.locator('.rounded-full')).toContainText('1');
+  });
+
+  test('should edit an allocated transaction', async ({
+    authenticatedPage,
+    budgetDetailsPage,
+  }) => {
+    const budgetId = 'test-budget-123';
+    const budgetLineId = 'line-1';
+    const transactionId = 'tx-1';
+    let transactionUpdated = false;
+
+    const originalTransaction = createTransactionMock(transactionId, budgetId, {
+      name: 'Migros',
+      amount: 120,
+      kind: 'expense',
+      budgetLineId,
+      transactionDate: '2025-12-10T00:00:00Z',
+    });
+
+    const updatedTransaction = createTransactionMock(transactionId, budgetId, {
+      name: 'Migros Updated',
+      amount: 150,
+      kind: 'expense',
+      budgetLineId,
+      transactionDate: '2025-12-10T00:00:00Z',
+    });
+
+    // Mock budget details endpoint (December 2025)
+    await authenticatedPage.route('**/api/v1/budgets/*/details', (route) => {
+      const transaction = transactionUpdated
+        ? updatedTransaction
+        : originalTransaction;
+      const mockResponse = createBudgetDetailsMock(budgetId, {
+        budget: {
+          month: 12,
+          year: 2025,
+        },
+        budgetLines: [
+          createBudgetLineMock(budgetLineId, budgetId, {
+            name: 'Groceries',
+            amount: 500,
+            kind: 'expense',
+          }),
+        ],
+        transactions: [transaction],
+      });
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockResponse),
+      });
+    });
+
+    // Mock transaction update endpoint
+    await authenticatedPage.route(
+      `**/api/v1/transactions/${transactionId}`,
+      (route) => {
+        if (route.request().method() === 'PATCH') {
+          transactionUpdated = true;
+          const response =
+            createTransactionUpdateResponseMock(updatedTransaction);
+          void route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(response),
+          });
+        }
+      }
+    );
+
+    await budgetDetailsPage.goto(budgetId);
+    await budgetDetailsPage.expectPageLoaded();
+
+    // Wait for table to render
+    await authenticatedPage.waitForSelector('table[mat-table]', { timeout: 10000 });
+
+    // Open allocated transactions dialog
+    const viewTransactionsButton = authenticatedPage.locator(
+      `[data-testid="view-transactions-${budgetLineId}"]`
+    );
+    await viewTransactionsButton.click();
+
+    // Wait for dialog to open and transaction to be visible
+    await expect(
+      authenticatedPage.locator('.mat-mdc-dialog-container')
+    ).toBeVisible({ timeout: 5000 });
+    await expect(
+      authenticatedPage.locator('.mat-mdc-dialog-container mat-list-item')
+    ).toContainText('Migros');
+
+    // Open transaction action menu (more_vert button)
+    const menuButton = authenticatedPage.locator('[data-testid^="transaction-menu-"]').first();
+    await expect(menuButton).toBeVisible({ timeout: 3000 });
+    await menuButton.click();
+
+    // Wait for menu to open
+    await authenticatedPage.waitForTimeout(300);
+
+    // Click edit button in menu
+    const editButton = authenticatedPage.locator('[data-testid="edit-transaction"]');
+    await expect(editButton).toBeVisible({ timeout: 3000 });
+    await editButton.click();
+
+    // Update form fields
+    const nameInput = authenticatedPage.locator(
+      '[data-testid="transaction-name-input"]'
+    );
+    await nameInput.clear();
+    await nameInput.fill('Migros Updated');
+
+    const amountInput = authenticatedPage.locator(
+      '[data-testid="transaction-amount-input"]'
+    );
+    await amountInput.clear();
+    await amountInput.fill('150');
+
+    // Submit form
+    const submitButton = authenticatedPage.locator(
+      '[data-testid="submit-button"]'
+    );
+    await submitButton.click();
+
+    // Verify success snackbar
+    await expect(
+      authenticatedPage.locator('.mat-mdc-snack-bar-label').last()
+    ).toHaveText('Transaction modifiée.');
+
+    // Verify dialog reopened with updated transaction
+    await expect(authenticatedPage.locator('mat-list-item')).toContainText(
+      'Migros Updated'
+    );
+    await expect(authenticatedPage.locator('mat-list-item')).toContainText(
+      '150'
+    );
+  });
+
+  test('should delete an allocated transaction', async ({
+    authenticatedPage,
+    budgetDetailsPage,
+  }) => {
+    const budgetId = 'test-budget-123';
+    const budgetLineId = 'line-1';
+    const transactionId = 'tx-1';
+    let transactionDeleted = false;
+
+    const transaction = createTransactionMock(transactionId, budgetId, {
+      name: 'Migros',
+      amount: 120,
+      kind: 'expense',
+      budgetLineId,
+      transactionDate: '2025-12-10T00:00:00Z',
+    });
+
+    // Mock budget details endpoint (December 2025)
+    await authenticatedPage.route('**/api/v1/budgets/*/details', (route) => {
+      const transactions = transactionDeleted ? [] : [transaction];
+      const mockResponse = createBudgetDetailsMock(budgetId, {
+        budget: {
+          month: 12,
+          year: 2025,
+        },
+        budgetLines: [
+          createBudgetLineMock(budgetLineId, budgetId, {
+            name: 'Groceries',
+            amount: 500,
+            kind: 'expense',
+          }),
+        ],
+        transactions,
+      });
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockResponse),
+      });
+    });
+
+    // Mock transaction delete endpoint
+    await authenticatedPage.route(
+      `**/api/v1/transactions/${transactionId}`,
+      (route) => {
+        if (route.request().method() === 'DELETE') {
+          transactionDeleted = true;
+          void route.fulfill({
+            status: 204,
+          });
+        }
+      }
+    );
+
+    await budgetDetailsPage.goto(budgetId);
+    await budgetDetailsPage.expectPageLoaded();
+
+    // Wait for table to render
+    await authenticatedPage.waitForSelector('table[mat-table]', { timeout: 10000 });
+
+    // Open allocated transactions dialog
+    const viewTransactionsButton = authenticatedPage.locator(
+      `[data-testid="view-transactions-${budgetLineId}"]`
+    );
+    await viewTransactionsButton.click();
+
+    // Wait for dialog to open and transaction to be visible
+    await expect(
+      authenticatedPage.locator('.mat-mdc-dialog-container')
+    ).toBeVisible({ timeout: 5000 });
+    await expect(
+      authenticatedPage.locator('.mat-mdc-dialog-container mat-list-item')
+    ).toContainText('Migros');
+
+    // Open transaction action menu (more_vert button)
+    const menuButton = authenticatedPage.locator('[data-testid^="transaction-menu-"]').first();
+    await expect(menuButton).toBeVisible({ timeout: 3000 });
+    await menuButton.click();
+
+    // Wait for menu to open
+    await authenticatedPage.waitForTimeout(300);
+
+    // Click delete button in menu
+    const deleteButton = authenticatedPage.locator('[data-testid="delete-transaction"]');
+    await expect(deleteButton).toBeVisible({ timeout: 3000 });
+    await deleteButton.click();
+
+    // Wait for confirmation dialog to open
+    await authenticatedPage.waitForTimeout(500);
+
+    // Confirm deletion in confirmation dialog
+    const confirmButton = authenticatedPage
+      .locator('.mat-mdc-dialog-container button')
+      .filter({ hasText: 'Supprimer' })
+      .last(); // Use last() in case multiple dialogs are stacked
+    await expect(confirmButton).toBeVisible({ timeout: 3000 });
+    await confirmButton.click();
+
+    // Verify success snackbar
+    await expect(
+      authenticatedPage.locator('.mat-mdc-snack-bar-label').last()
+    ).toHaveText('Transaction supprimée.');
+
+    // Wait for deletion to complete
+    await authenticatedPage.waitForTimeout(1000);
+
+    // The dialog should be closed after deletion
+    // Verify the badge is no longer visible (no transactions allocated)
+    const budgetLineRow = authenticatedPage
+      .locator('tr')
+      .filter({ hasText: 'Groceries' });
+    await expect(budgetLineRow).toBeVisible();
+
+    // Badge should not be present anymore
+    await expect(budgetLineRow.locator('.rounded-full')).not.toBeVisible();
+  });
+
+  test('should display consumed and remaining amounts correctly', async ({
+    authenticatedPage,
+    budgetDetailsPage,
+  }) => {
+    const budgetId = 'test-budget-123';
+    const budgetLineId = 'line-1';
+
+    const mockResponse = createBudgetDetailsMock(budgetId, {
+      budget: {
+        month: 12,
+        year: 2025,
+      },
+      budgetLines: [
+        createBudgetLineMock(budgetLineId, budgetId, {
+          name: 'Groceries',
+          amount: 500,
+          kind: 'expense',
+        }),
+      ],
+      transactions: [
+        createTransactionMock('tx-1', budgetId, {
+          name: 'Migros',
+          amount: 120,
+          kind: 'expense',
+          budgetLineId,
+          transactionDate: '2025-12-05T00:00:00Z',
+        }),
+        createTransactionMock('tx-2', budgetId, {
+          name: 'Coop',
+          amount: 200,
+          kind: 'expense',
+          budgetLineId,
+          transactionDate: '2025-12-10T00:00:00Z',
+        }),
+      ],
+    });
+
+    await authenticatedPage.route('**/api/v1/budgets/*/details', (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockResponse),
+      });
+    });
+
+    await budgetDetailsPage.goto(budgetId);
+    await budgetDetailsPage.expectPageLoaded();
+
+    // Open allocated transactions dialog
+    const viewTransactionsButton = authenticatedPage.locator(
+      `[data-testid="view-transactions-${budgetLineId}"]`
+    );
+    await viewTransactionsButton.click();
+
+    // Verify amounts are displayed correctly with the new grid layout
+    const dialog = authenticatedPage.locator('.mat-mdc-dialog-container');
+
+    // Check for "Prévu", "Consommé", "Restant" labels
+    await expect(dialog).toContainText('Prévu');
+    await expect(dialog).toContainText('Consommé');
+    await expect(dialog).toContainText('Restant');
+
+    // Check amounts (Swiss format: CHF 500.00)
+    await expect(dialog).toContainText('CHF 500.00'); // Planned
+    await expect(dialog).toContainText('CHF 320.00'); // Consumed
+    await expect(dialog).toContainText('CHF 180.00'); // Remaining (500 - 320)
+  });
+
+  test('should show over-budget indicator when consumed exceeds planned', async ({
+    authenticatedPage,
+    budgetDetailsPage,
+  }) => {
+    const budgetId = 'test-budget-123';
+    const budgetLineId = 'line-1';
+
+    const mockResponse = createBudgetDetailsMock(budgetId, {
+      budget: {
+        month: 12,
+        year: 2025,
+      },
+      budgetLines: [
+        createBudgetLineMock(budgetLineId, budgetId, {
+          name: 'Groceries',
+          amount: 500,
+          kind: 'expense',
+        }),
+      ],
+      transactions: [
+        createTransactionMock('tx-1', budgetId, {
+          name: 'Migros',
+          amount: 600, // Exceeds planned amount
+          kind: 'expense',
+          budgetLineId,
+          transactionDate: '2025-12-15T00:00:00Z',
+        }),
+      ],
+    });
+
+    await authenticatedPage.route('**/api/v1/budgets/*/details', (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockResponse),
+      });
+    });
+
+    await budgetDetailsPage.goto(budgetId);
+    await budgetDetailsPage.expectPageLoaded();
+
+    // Open allocated transactions dialog
+    const viewTransactionsButton = authenticatedPage.locator(
+      `[data-testid="view-transactions-${budgetLineId}"]`
+    );
+    await viewTransactionsButton.click();
+
+    // Verify negative remaining amount is shown
+    const dialog = authenticatedPage.locator('.mat-mdc-dialog-container');
+
+    // Check labels and amounts
+    await expect(dialog).toContainText('Prévu');
+    await expect(dialog).toContainText('Consommé');
+    await expect(dialog).toContainText('Restant');
+
+    await expect(dialog).toContainText('CHF 500.00'); // Planned
+    await expect(dialog).toContainText('CHF 600.00'); // Consumed (over budget)
+    await expect(dialog).toContainText('CHF-100.00'); // Negative remaining (500 - 600)
+
+    // Verify negative amount has error styling
+    const remainingValue = dialog
+      .locator('span')
+      .filter({ hasText: 'CHF-100.00' });
+    await expect(remainingValue).toHaveClass(/text-financial-negative/);
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/allocated-transaction-form-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/allocated-transaction-form-dialog.ts
@@ -1,0 +1,446 @@
+import { CurrencyPipe, DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+  type AbstractControl,
+  type ValidationErrors,
+} from '@angular/forms';
+import {
+  MAT_BOTTOM_SHEET_DATA,
+  MatBottomSheetRef,
+} from '@angular/material/bottom-sheet';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import {
+  type BudgetLine,
+  type Transaction,
+  type TransactionCreate,
+  type TransactionUpdate,
+} from '@pulpe/shared';
+import { TransactionLabelPipe } from '@ui/transaction-display';
+import { endOfMonth, startOfMonth } from 'date-fns';
+import { startWith } from 'rxjs';
+
+export interface AllocatedTransactionFormDialogData {
+  budgetLine: BudgetLine;
+  budgetId: string;
+  month: number;
+  year: number;
+  /** Existing transaction for edit mode, undefined for create mode */
+  transaction?: Transaction;
+  /** Current consumed amount (excluding transaction being edited) */
+  consumedAmount: number;
+}
+
+export type AllocatedTransactionFormDialogResult =
+  | { action: 'create'; data: TransactionCreate }
+  | { action: 'update'; id: string; data: TransactionUpdate }
+  | undefined;
+
+@Component({
+  selector: 'pulpe-allocated-transaction-form-dialog',
+  imports: [
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatDatepickerModule,
+    ReactiveFormsModule,
+    CurrencyPipe,
+    DatePipe,
+    TransactionLabelPipe,
+  ],
+  template: `
+    <div class="flex flex-col h-full">
+      <!-- Drag handle for bottom sheet -->
+      @if (isBottomSheet()) {
+        <div class="flex justify-center pt-3 pb-2">
+          <div class="w-9 h-1 bg-outline-variant rounded-sm"></div>
+        </div>
+      }
+
+      <!-- Header -->
+      <div class="flex items-center justify-between gap-2 px-4 py-3">
+        <h2 class="text-title-large text-on-surface m-0">
+          {{
+            isEditMode() ? 'Modifier la transaction' : 'Nouvelle transaction'
+          }}
+        </h2>
+        <button
+          matIconButton
+          (click)="onCancel()"
+          aria-label="Fermer"
+          class="shrink-0"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+
+      <!-- Content - scrollable -->
+      <div class="flex-1 overflow-y-auto px-4">
+        <div class="flex flex-col gap-4">
+          <!-- Budget Line Context -->
+          <div
+            class="rounded-lg p-4 bg-surface-container border border-outline-variant"
+          >
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-2 min-w-0">
+                <mat-icon class="text-on-surface-variant">sell</mat-icon>
+                <span class="text-title-medium truncate">{{
+                  data.budgetLine.name
+                }}</span>
+              </div>
+              <span class="text-label-medium text-on-surface-variant">
+                {{ data.budgetLine.kind | transactionLabel }}
+              </span>
+            </div>
+
+            <!-- Progress Bar -->
+            <div
+              class="mb-2 h-2 rounded-full overflow-hidden bg-outline-variant"
+            >
+              <div
+                class="h-full rounded-full transition-all duration-300"
+                [class]="isOverBudget() ? 'bg-error' : 'bg-primary'"
+                [style.width.%]="progressPercentage()"
+              ></div>
+            </div>
+
+            <!-- Budget Stats -->
+            <div class="flex justify-between text-body-small">
+              <span class="text-on-surface-variant">
+                {{
+                  consumedAmount()
+                    | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
+                }}
+                consommés
+              </span>
+              <span
+                [class]="
+                  isOverBudget()
+                    ? 'text-error font-medium'
+                    : 'text-on-surface-variant'
+                "
+              >
+                {{
+                  remainingAmount()
+                    | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
+                }}
+                restants
+              </span>
+            </div>
+          </div>
+
+          <!-- Form -->
+          <form [formGroup]="form" class="flex flex-col gap-4">
+            <!-- Name Field -->
+            <mat-form-field appearance="outline" subscriptSizing="dynamic">
+              <mat-label>Description</mat-label>
+              <input
+                matInput
+                formControlName="name"
+                placeholder="Ex: Courses Migros, Loyer, Salaire"
+                maxlength="100"
+                data-testid="transaction-name-input"
+              />
+              <mat-hint align="end">
+                {{ form.get('name')?.value?.length || 0 }}/100
+              </mat-hint>
+              @if (
+                form.get('name')?.hasError('required') &&
+                form.get('name')?.touched
+              ) {
+                <mat-error>La description est requise</mat-error>
+              }
+              @if (
+                form.get('name')?.hasError('minlength') &&
+                form.get('name')?.touched
+              ) {
+                <mat-error>Minimum 2 caractères</mat-error>
+              }
+            </mat-form-field>
+
+            <!-- Amount Field -->
+            <mat-form-field appearance="outline" subscriptSizing="dynamic">
+              <mat-label>Montant</mat-label>
+              <mat-icon matIconPrefix class="text-on-surface-variant">
+                payments
+              </mat-icon>
+              <input
+                matInput
+                type="number"
+                formControlName="amount"
+                placeholder="0.00"
+                step="0.01"
+                min="0.01"
+                max="999999.99"
+                data-testid="transaction-amount-input"
+              />
+              <span matTextSuffix>CHF</span>
+              @if (
+                form.get('amount')?.hasError('required') &&
+                form.get('amount')?.touched
+              ) {
+                <mat-error>Le montant est requis</mat-error>
+              }
+              @if (
+                form.get('amount')?.hasError('min') &&
+                form.get('amount')?.touched
+              ) {
+                <mat-error>Minimum 0.01 CHF</mat-error>
+              }
+              @if (
+                form.get('amount')?.hasError('max') &&
+                form.get('amount')?.touched
+              ) {
+                <mat-error>Maximum 999'999.99 CHF</mat-error>
+              }
+            </mat-form-field>
+
+            <!-- Date Field -->
+            <mat-form-field appearance="outline" subscriptSizing="dynamic">
+              <mat-label>Date</mat-label>
+              <input
+                matInput
+                [matDatepicker]="picker"
+                [min]="minDate"
+                [max]="maxDate"
+                formControlName="transactionDate"
+                placeholder="jj.mm.aaaa"
+                readonly
+                data-testid="transaction-date-input"
+              />
+              <mat-datepicker-toggle
+                matIconSuffix
+                [for]="picker"
+                aria-label="Ouvrir le calendrier"
+              />
+              <mat-datepicker #picker />
+              <mat-hint>
+                Du {{ minDate | date: 'dd.MM.yyyy' }} au
+                {{ maxDate | date: 'dd.MM.yyyy' }}
+              </mat-hint>
+              @if (
+                form.get('transactionDate')?.hasError('required') &&
+                form.get('transactionDate')?.touched
+              ) {
+                <mat-error>La date est requise</mat-error>
+              }
+              @if (
+                form.get('transactionDate')?.hasError('dateOutOfRange') &&
+                form.get('transactionDate')?.touched
+              ) {
+                <mat-error>La date doit être dans le mois du budget</mat-error>
+              }
+            </mat-form-field>
+
+            <!-- Category/Notes Field -->
+            <mat-form-field appearance="outline" subscriptSizing="dynamic">
+              <mat-label>Notes (optionnel)</mat-label>
+              <input
+                matInput
+                formControlName="category"
+                placeholder="Ex: Alimentation, Transport"
+                maxlength="50"
+                data-testid="transaction-category-input"
+              />
+              <mat-hint align="end">
+                {{ form.get('category')?.value?.length || 0 }}/50
+              </mat-hint>
+            </mat-form-field>
+          </form>
+        </div>
+      </div>
+
+      <!-- Action buttons - fixed footer -->
+      <div
+        class="flex gap-3 p-4 border-t border-outline-variant bg-surface justify-end"
+      >
+        <button matButton (click)="onCancel()" data-testid="cancel-button">
+          Annuler
+        </button>
+        <button
+          matButton="filled"
+          [disabled]="form.invalid || isSubmitting()"
+          (click)="onSubmit()"
+          data-testid="submit-button"
+        >
+          @if (isSubmitting()) {
+            <mat-icon class="animate-spin">refresh</mat-icon>
+          } @else {
+            <mat-icon>{{ isEditMode() ? 'save' : 'add' }}</mat-icon>
+          }
+          {{ isEditMode() ? 'Enregistrer' : 'Ajouter' }}
+        </button>
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AllocatedTransactionFormDialog {
+  readonly #fb = inject(FormBuilder);
+
+  // Dual injection: component can be opened via Dialog or BottomSheet
+  readonly #dialogRef = inject(
+    MatDialogRef<
+      AllocatedTransactionFormDialog,
+      AllocatedTransactionFormDialogResult
+    >,
+    { optional: true },
+  );
+  readonly #bottomSheetRef = inject(
+    MatBottomSheetRef<
+      AllocatedTransactionFormDialog,
+      AllocatedTransactionFormDialogResult
+    >,
+    { optional: true },
+  );
+
+  // Data can come from Dialog or BottomSheet
+  readonly data =
+    inject<AllocatedTransactionFormDialogData>(MAT_DIALOG_DATA, {
+      optional: true,
+    }) ?? inject<AllocatedTransactionFormDialogData>(MAT_BOTTOM_SHEET_DATA);
+
+  readonly isSubmitting = signal(false);
+
+  // Check if opened as bottom sheet (for conditional UI like drag handle)
+  readonly isBottomSheet = computed(() => !!this.#bottomSheetRef);
+
+  readonly isEditMode = computed(() => !!this.data.transaction);
+
+  // Date constraints based on budget month/year
+  readonly minDate = startOfMonth(
+    new Date(this.data.year, this.data.month - 1),
+  );
+  readonly maxDate = endOfMonth(new Date(this.data.year, this.data.month - 1));
+
+  // Date range validator
+  readonly #dateRangeValidator = (
+    control: AbstractControl,
+  ): ValidationErrors | null => {
+    if (!control.value) return null;
+    const date = new Date(control.value);
+    if (date < this.minDate || date > this.maxDate) {
+      return { dateOutOfRange: true };
+    }
+    return null;
+  };
+
+  readonly form = this.#fb.group({
+    name: [
+      this.data.transaction?.name ?? '',
+      [Validators.required, Validators.minLength(2), Validators.maxLength(100)],
+    ],
+    amount: [
+      this.data.transaction?.amount ?? (null as number | null),
+      [Validators.required, Validators.min(0.01), Validators.max(999999.99)],
+    ],
+    transactionDate: [
+      this.data.transaction
+        ? new Date(this.data.transaction.transactionDate)
+        : (new Date() as Date | null),
+      [Validators.required, this.#dateRangeValidator],
+    ],
+    category: [
+      this.data.transaction?.category ?? '',
+      [Validators.maxLength(50)],
+    ],
+  });
+
+  // Reactive signal for amount field - enables real-time progress bar updates
+  readonly #amountValue = toSignal(
+    this.form.controls.amount.valueChanges.pipe(
+      startWith(this.form.controls.amount.value),
+    ),
+  );
+
+  // Budget consumption calculations - uses reactive signal for real-time updates
+  // Note: data.consumedAmount already excludes the transaction being edited (see interface doc)
+  readonly consumedAmount = computed(() => {
+    const formAmount = this.#amountValue() ?? 0;
+    return this.data.consumedAmount + formAmount;
+  });
+
+  readonly remainingAmount = computed(
+    () => this.data.budgetLine.amount - this.consumedAmount(),
+  );
+
+  readonly progressPercentage = computed(() => {
+    const consumed = this.consumedAmount();
+    const planned = this.data.budgetLine.amount;
+    if (planned <= 0) return 0;
+    return Math.min(100, (consumed / planned) * 100);
+  });
+
+  readonly isOverBudget = computed(() => this.remainingAmount() < 0);
+
+  onCancel(): void {
+    this.#close(undefined);
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid || this.isSubmitting()) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting.set(true);
+
+    const { name, amount, transactionDate, category } = this.form.getRawValue();
+
+    if (this.isEditMode() && this.data.transaction) {
+      // Update mode
+      const updateData: TransactionUpdate = {
+        name: name!.trim(),
+        amount: amount!,
+        transactionDate: (transactionDate as Date).toISOString(),
+        category: category?.trim() || null,
+      };
+
+      this.#close({
+        action: 'update',
+        id: this.data.transaction.id,
+        data: updateData,
+      });
+    } else {
+      // Create mode
+      const createData: TransactionCreate = {
+        name: name!.trim(),
+        amount: amount!,
+        kind: this.data.budgetLine.kind,
+        transactionDate: (transactionDate as Date).toISOString(),
+        category: category?.trim() || null,
+        budgetId: this.data.budgetId,
+        budgetLineId: this.data.budgetLine.id,
+      };
+
+      this.#close({
+        action: 'create',
+        data: createData,
+      });
+    }
+  }
+
+  // Unified close method for Dialog or BottomSheet
+  #close(result: AllocatedTransactionFormDialogResult): void {
+    if (this.#dialogRef) {
+      this.#dialogRef.close(result);
+    } else if (this.#bottomSheetRef) {
+      this.#bottomSheetRef.dismiss(result);
+    }
+  }
+}

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/allocated-transactions-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/allocated-transactions-dialog.ts
@@ -1,0 +1,339 @@
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { DatePipe, CurrencyPipe } from '@angular/common';
+import {
+  Component,
+  inject,
+  ChangeDetectionStrategy,
+  computed,
+  signal,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import {
+  MatBottomSheetRef,
+  MAT_BOTTOM_SHEET_DATA,
+} from '@angular/material/bottom-sheet';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
+import { type BudgetLine, type Transaction } from '@pulpe/shared';
+import { TransactionIconPipe } from '@ui/transaction-display';
+import { map } from 'rxjs/operators';
+
+export interface AllocatedTransactionsDialogData {
+  budgetLine: BudgetLine;
+  allocatedTransactions: Transaction[];
+}
+
+export interface AllocatedTransactionsDialogResult {
+  action: 'add' | 'edit' | 'delete';
+  transaction?: Transaction;
+}
+
+@Component({
+  selector: 'pulpe-allocated-transactions-dialog',
+  imports: [
+    MatButtonModule,
+    MatIconModule,
+    MatListModule,
+    MatDividerModule,
+    MatMenuModule,
+    DatePipe,
+    CurrencyPipe,
+    TransactionIconPipe,
+  ],
+  template: `
+    <div class="flex flex-col h-full">
+      <!-- Drag handle for bottom sheet -->
+      @if (isBottomSheet()) {
+        <div class="flex justify-center pt-3 pb-2">
+          <div class="w-9 h-1 bg-outline-variant rounded-sm"></div>
+        </div>
+      }
+
+      <!-- Header -->
+      <div class="flex items-center justify-between gap-2 px-4 py-3">
+        <div class="flex items-center gap-3 min-w-0">
+          <span
+            class="inline-flex items-center justify-center size-10 rounded-full shrink-0"
+            [class]="kindBadgeClass()"
+          >
+            <mat-icon>{{ data.budgetLine.kind | transactionIcon }}</mat-icon>
+          </span>
+          <h2 class="text-title-large text-on-surface m-0 truncate">
+            {{ data.budgetLine.name }}
+          </h2>
+        </div>
+        <button
+          matIconButton
+          (click)="onClose()"
+          aria-label="Fermer"
+          class="shrink-0"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+
+      <!-- Summary: Card-like structure -->
+      <div class="px-4 pb-3">
+        <div
+          class="grid grid-cols-3 gap-2 p-3 bg-surface-container rounded-xl text-center"
+        >
+          <div class="flex flex-col gap-0.5">
+            <span class="text-label-small text-on-surface-variant">Prévu</span>
+            <span
+              class="text-body-medium font-medium"
+              [class]="kindTextClass()"
+            >
+              {{
+                plannedAmount() | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
+              }}
+            </span>
+          </div>
+          <div class="flex flex-col gap-0.5">
+            <span class="text-label-small text-on-surface-variant"
+              >Consommé</span
+            >
+            <span
+              class="text-body-medium font-medium"
+              [class]="kindTextClass()"
+            >
+              {{
+                consumedAmount()
+                  | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
+              }}
+            </span>
+          </div>
+          <div class="flex flex-col gap-0.5">
+            <span class="text-label-small text-on-surface-variant"
+              >Restant</span
+            >
+            <span
+              class="text-body-medium font-medium"
+              [class]="remainingClass()"
+            >
+              {{
+                remainingAmount()
+                  | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
+              }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <mat-divider />
+
+      <!-- Transactions list - scrollable content -->
+      <div class="flex-1 overflow-y-auto px-4">
+        @if (hasTransactions()) {
+          <mat-list class="-mx-4">
+            @for (
+              transaction of sortedTransactions();
+              track transaction.id;
+              let isLast = $last
+            ) {
+              <mat-list-item class="!h-auto !py-3">
+                <div class="flex items-center justify-between w-full gap-2">
+                  <div class="flex items-center gap-3 min-w-0 flex-1">
+                    <mat-icon
+                      class="!text-xl opacity-60 shrink-0"
+                      [class]="kindTextClass()"
+                    >
+                      {{ transaction.kind | transactionIcon }}
+                    </mat-icon>
+                    <div class="flex flex-col min-w-0 flex-1">
+                      <span class="text-body-medium truncate">
+                        {{ transaction.name }}
+                      </span>
+                      <span class="text-body-small text-on-surface-variant">
+                        {{ transaction.transactionDate | date: 'dd.MM.yyyy' }}
+                        @if (transaction.category) {
+                          · {{ transaction.category }}
+                        }
+                      </span>
+                    </div>
+                  </div>
+                  <div class="flex items-center gap-1 shrink-0">
+                    <span
+                      class="text-body-medium font-medium whitespace-nowrap"
+                      [class]="kindTextClass()"
+                    >
+                      {{
+                        transaction.amount
+                          | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
+                      }}
+                    </span>
+                    <!-- Mobile: Menu dropdown -->
+                    <button
+                      matIconButton
+                      [matMenuTriggerFor]="actionMenu"
+                      [attr.data-testid]="'transaction-menu-' + transaction.id"
+                      aria-label="Actions"
+                    >
+                      <mat-icon>more_vert</mat-icon>
+                    </button>
+                    <mat-menu #actionMenu="matMenu">
+                      <button
+                        mat-menu-item
+                        (click)="onEditTransaction(transaction)"
+                        data-testid="edit-transaction"
+                      >
+                        <mat-icon>edit</mat-icon>
+                        <span>Modifier</span>
+                      </button>
+                      <button
+                        mat-menu-item
+                        (click)="onDeleteTransaction(transaction)"
+                        data-testid="delete-transaction"
+                      >
+                        <mat-icon color="warn">delete</mat-icon>
+                        <span class="text-error">Supprimer</span>
+                      </button>
+                    </mat-menu>
+                  </div>
+                </div>
+              </mat-list-item>
+              @if (!isLast) {
+                <mat-divider />
+              }
+            }
+          </mat-list>
+        } @else {
+          <div class="py-10 text-center text-on-surface-variant">
+            <mat-icon class="!text-5xl mb-3 opacity-40">receipt_long</mat-icon>
+            <p class="text-body-large m-0">Aucune transaction</p>
+            <p class="text-body-medium mt-1 opacity-70">
+              Ajoutez votre première transaction
+            </p>
+          </div>
+        }
+      </div>
+
+      <!-- Action buttons - fixed footer -->
+      <div
+        class="flex flex-col gap-3 p-4 border-t border-outline-variant bg-surface"
+      >
+        <button
+          matButton="filled"
+          (click)="onAddTransaction()"
+          data-testid="add-transaction"
+          class="w-full"
+        >
+          <mat-icon>add</mat-icon>
+          Ajouter une transaction
+        </button>
+        <button
+          matButton
+          (click)="onClose()"
+          data-testid="close-dialog"
+          class="w-full"
+        >
+          Fermer
+        </button>
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AllocatedTransactionsDialog {
+  // Dual injection: component can be opened via Dialog or BottomSheet
+  #dialogRef = inject(MatDialogRef<AllocatedTransactionsDialog>, {
+    optional: true,
+  });
+  #bottomSheetRef = inject(MatBottomSheetRef<AllocatedTransactionsDialog>, {
+    optional: true,
+  });
+
+  // Data can come from Dialog or BottomSheet
+  data =
+    inject<AllocatedTransactionsDialogData>(MAT_DIALOG_DATA, {
+      optional: true,
+    }) ?? inject<AllocatedTransactionsDialogData>(MAT_BOTTOM_SHEET_DATA);
+
+  // Mobile detection
+  #breakpointObserver = inject(BreakpointObserver);
+  isMobile = toSignal(
+    this.#breakpointObserver
+      .observe(Breakpoints.Handset)
+      .pipe(map((result) => result.matches)),
+    { initialValue: false },
+  );
+
+  // Check if opened as bottom sheet (for conditional UI like drag handle)
+  isBottomSheet = computed(() => !!this.#bottomSheetRef);
+
+  // Use signal to track transactions locally if needed for updates
+  #transactions = signal(this.data.allocatedTransactions);
+
+  plannedAmount = computed(() => this.data.budgetLine.amount);
+
+  consumedAmount = computed(() =>
+    this.#transactions().reduce((sum, t) => sum + t.amount, 0),
+  );
+
+  remainingAmount = computed(
+    () => this.plannedAmount() - this.consumedAmount(),
+  );
+
+  remainingClass = computed(() => {
+    const remaining = this.remainingAmount();
+    if (remaining < 0) return 'text-financial-negative font-medium';
+    if (remaining === 0) return 'text-on-surface-variant';
+    return 'text-financial-positive';
+  });
+
+  kindBadgeClass = computed(() => {
+    const kind = this.data.budgetLine.kind;
+    return {
+      income: 'bg-primary-container text-on-primary-container',
+      expense: 'bg-secondary-container text-on-secondary-container',
+      saving: 'bg-tertiary-container text-on-tertiary-container',
+    }[kind];
+  });
+
+  kindTextClass = computed(() => {
+    const kind = this.data.budgetLine.kind;
+    return {
+      income: 'text-financial-income',
+      expense: 'text-financial-expense',
+      saving: 'text-financial-savings',
+    }[kind];
+  });
+
+  hasTransactions = computed(() => this.#transactions().length > 0);
+
+  sortedTransactions = computed(() =>
+    [...this.#transactions()].sort(
+      (a, b) =>
+        new Date(b.transactionDate).getTime() -
+        new Date(a.transactionDate).getTime(),
+    ),
+  );
+
+  onAddTransaction(): void {
+    this.#close({ action: 'add' });
+  }
+
+  onEditTransaction(transaction: Transaction): void {
+    this.#close({ action: 'edit', transaction });
+  }
+
+  onDeleteTransaction(transaction: Transaction): void {
+    this.#close({ action: 'delete', transaction });
+  }
+
+  onClose(): void {
+    this.#close();
+  }
+
+  // Unified close method for Dialog or BottomSheet
+  #close(result?: AllocatedTransactionsDialogResult): void {
+    if (this.#dialogRef) {
+      this.#dialogRef.close(result);
+    } else if (this.#bottomSheetRef) {
+      this.#bottomSheetRef.dismiss(result);
+    }
+  }
+}

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-models.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-models.ts
@@ -12,6 +12,13 @@ export interface TableItem {
     isRollover?: boolean;
     isTemplateLinked?: boolean;
     isPropagationLocked?: boolean;
+    /** Number of transactions allocated to this budget line */
+    allocatedTransactionsCount?: number;
+    /** Total consumed amount from allocated transactions */
+    consumedAmount?: number;
+    /** Has transactions allocated to this budget line */
+    hasAllocatedTransactions?: boolean;
+    isLoading?: boolean;
   };
 }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -7,6 +7,9 @@ import {
   type BudgetLine,
   type BudgetLineCreate,
   type BudgetLineUpdate,
+  type Transaction,
+  type TransactionCreate,
+  type TransactionUpdate,
 } from '@pulpe/shared';
 
 import { firstValueFrom } from 'rxjs';
@@ -240,6 +243,100 @@ export class BudgetDetailsStore {
       const errorMessage = 'Erreur lors de la suppression de la transaction';
       this.#setError(errorMessage);
       this.#logger.error('Error deleting transaction', error);
+    }
+  }
+
+  /**
+   * Create a transaction allocated to a budget line with optimistic updates
+   */
+  async createAllocatedTransaction(
+    transaction: TransactionCreate,
+  ): Promise<void> {
+    const tempId = `temp-${uuidv4()}`;
+
+    // Create temporary transaction for optimistic update
+    const tempTransaction: Transaction = {
+      id: tempId,
+      budgetId: transaction.budgetId,
+      budgetLineId: transaction.budgetLineId ?? null,
+      name: transaction.name,
+      amount: transaction.amount,
+      kind: transaction.kind,
+      transactionDate: transaction.transactionDate ?? new Date().toISOString(),
+      category: transaction.category ?? null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    // Optimistic update - add the new transaction immediately
+    this.#budgetDetailsResource.update((details) => {
+      if (!details) return details;
+
+      return {
+        ...details,
+        transactions: [...(details.transactions ?? []), tempTransaction],
+      };
+    });
+
+    try {
+      const response = await firstValueFrom(
+        this.#transactionApi.create$(transaction),
+      );
+
+      // Replace temporary transaction with server response
+      this.#budgetDetailsResource.update((details) => {
+        if (!details) return details;
+
+        return {
+          ...details,
+          transactions: details.transactions?.map((tx) =>
+            tx.id === tempId ? response.data : tx,
+          ) ?? [response.data],
+        };
+      });
+
+      this.#clearError();
+    } catch (error) {
+      this.reloadBudgetDetails();
+
+      const errorMessage = "Erreur lors de l'ajout de la transaction";
+      this.#setError(errorMessage);
+      this.#logger.error('Error creating allocated transaction', error);
+    }
+  }
+
+  /**
+   * Update a transaction with optimistic updates
+   */
+  async updateAllocatedTransaction(
+    id: string,
+    transaction: TransactionUpdate,
+  ): Promise<void> {
+    // Optimistic update
+    this.#budgetDetailsResource.update((details) => {
+      if (!details) return details;
+
+      return {
+        ...details,
+        transactions:
+          details.transactions?.map((tx) =>
+            tx.id === id
+              ? { ...tx, ...transaction, updatedAt: new Date().toISOString() }
+              : tx,
+          ) ?? [],
+      };
+    });
+
+    try {
+      await firstValueFrom(this.#transactionApi.update$(id, transaction));
+
+      this.#clearError();
+    } catch (error) {
+      this.reloadBudgetDetails();
+
+      const errorMessage = 'Erreur lors de la modification de la transaction';
+      this.#setError(errorMessage);
+      this.#logger.error('Error updating allocated transaction', error);
     }
   }
 

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.spec.ts
@@ -24,6 +24,7 @@ const createTransaction = (
 ): Transaction => ({
   id: 'transaction-123',
   budgetId: 'budget-456',
+  budgetLineId: null,
   name: 'Test Transaction',
   amount: 50,
   kind: 'expense',

--- a/frontend/projects/webapp/src/app/feature/current-month/services/current-month-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/current-month-store.spec.ts
@@ -62,6 +62,7 @@ const mockTransactions: Transaction[] = [
   {
     id: 'txn-1',
     budgetId: 'budget-1',
+    budgetLineId: null,
     amount: 50,
     category: null,
     name: 'Coffee',

--- a/frontend/projects/webapp/src/app/testing/mock-factories.ts
+++ b/frontend/projects/webapp/src/app/testing/mock-factories.ts
@@ -27,6 +27,7 @@ const defaultBudgetLine: BudgetLine = {
 const defaultTransaction: Transaction = {
   id: 'transaction-1',
   budgetId: 'budget-1',
+  budgetLineId: null,
   name: 'Test Transaction',
   amount: 100,
   kind: 'expense',

--- a/frontend/projects/webapp/src/styles.scss
+++ b/frontend/projects/webapp/src/styles.scss
@@ -75,3 +75,31 @@ body {
     var(--pulpe-gradient-100) 100%
   );
 }
+
+// Bottom sheet panel classes for allocated transactions (mobile)
+.allocated-transactions-sheet,
+.transaction-form-sheet {
+  .mat-bottom-sheet-container {
+    max-height: 85vh;
+    border-radius: 28px 28px 0 0;
+    padding: 0;
+    background: var(--mat-sys-surface-container-low);
+
+    // Remove default dialog margins
+    .mat-mdc-dialog-title {
+      padding: 16px 16px 8px;
+      margin: 0;
+    }
+
+    .mat-mdc-dialog-content {
+      padding: 0 16px;
+      max-height: calc(85vh - 180px);
+    }
+
+    .mat-mdc-dialog-actions {
+      padding: 16px;
+      margin: 0;
+      min-height: auto;
+    }
+  }
+}

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -72,6 +72,10 @@ export {
   budgetLineResponseSchema,
   budgetLineListResponseSchema,
   budgetLineDeleteResponseSchema,
+  budgetLineWithTransactionsSchema,
+  budgetLineWithTransactionsResponseSchema,
+  budgetLineWithTransactionsListResponseSchema,
+  allocatedTransactionsResponseSchema,
 
   // User schemas
   userProfileSchema,
@@ -172,6 +176,10 @@ export type {
   BudgetLineResponse,
   BudgetLineListResponse,
   BudgetLineDeleteResponse,
+  BudgetLineWithTransactions,
+  BudgetLineWithTransactionsResponse,
+  BudgetLineWithTransactionsListResponse,
+  AllocatedTransactionsResponse,
 
   // User types
   UserProfile,

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -221,6 +221,9 @@ export type BudgetLineUpdate = z.infer<typeof budgetLineUpdateSchema>;
 export const transactionSchema = z.object({
   id: z.uuid(),
   budgetId: z.uuid(),
+  // Optional allocation to a budget line (prévision)
+  // NULL = transaction not allocated to any specific budget line
+  budgetLineId: z.uuid().nullable(),
   name: z.string().min(1).max(100).trim(),
   amount: z.number().positive(),
   kind: transactionKindSchema,
@@ -234,6 +237,8 @@ export type Transaction = z.infer<typeof transactionSchema>;
 
 export const transactionCreateSchema = z.object({
   budgetId: z.uuid(),
+  // Optional allocation to a budget line - must match budget and kind
+  budgetLineId: z.uuid().nullable().optional(),
   name: z.string().min(1).max(100).trim(),
   amount: z.number().positive(),
   kind: transactionKindSchema,
@@ -248,6 +253,8 @@ export const transactionUpdateSchema = z.object({
   kind: transactionKindSchema.optional(),
   transactionDate: z.iso.datetime().optional(),
   category: z.string().max(100).trim().nullable().optional(),
+  // Can update allocation: set to UUID to allocate, null to unallocate
+  budgetLineId: z.uuid().nullable().optional(),
 });
 export type TransactionUpdate = z.infer<typeof transactionUpdateSchema>;
 
@@ -677,6 +684,41 @@ export type BudgetLineListResponse = z.infer<
 export const budgetLineDeleteResponseSchema = deleteResponseSchema;
 export type BudgetLineDeleteResponse = z.infer<
   typeof budgetLineDeleteResponseSchema
+>;
+
+// Budget Line with Transactions (enriched data)
+export const budgetLineWithTransactionsSchema = z.object({
+  budgetLine: budgetLineSchema,
+  consumedAmount: z.number(),
+  remainingAmount: z.number(),
+  allocatedTransactions: z.array(transactionSchema),
+});
+export type BudgetLineWithTransactions = z.infer<
+  typeof budgetLineWithTransactionsSchema
+>;
+
+export const budgetLineWithTransactionsResponseSchema = z.object({
+  success: z.literal(true),
+  data: budgetLineWithTransactionsSchema,
+});
+export type BudgetLineWithTransactionsResponse = z.infer<
+  typeof budgetLineWithTransactionsResponseSchema
+>;
+
+export const budgetLineWithTransactionsListResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.array(budgetLineWithTransactionsSchema),
+});
+export type BudgetLineWithTransactionsListResponse = z.infer<
+  typeof budgetLineWithTransactionsListResponseSchema
+>;
+
+export const allocatedTransactionsResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.array(transactionSchema),
+});
+export type AllocatedTransactionsResponse = z.infer<
+  typeof allocatedTransactionsResponseSchema
 >;
 
 // Auth schemas


### PR DESCRIPTION
## Summary

Implement budget line allocation feature allowing transactions to be assigned to specific budget envelopes with validation and UI components for managing allocated transactions.

## Changes

- **Backend:** Add budget line ID to transactions with validation to ensure kind matching
- **Frontend:** New dialogs for viewing and managing allocated transactions
- **Database:** Migration to add budget_line_id column to transaction table
- **Formulas:** Update budget calculations to account for allocated transactions

## Test Coverage

- Added E2E tests for budget allocated transactions feature
- Extended unit tests for budget calculator with allocated transaction scenarios