### PR TITLE
feat(budget-table): improve frequency column UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ paths: "**/*.ts"
 
 ## Vocabulary
 
-- `budget_lines` → "prévisions" | `fixed` → "Tous les mois" | `one_off` → "Une seule fois"
+- `budget_lines` → "prévisions" | `fixed` → "Récurrent" | `one_off` → "Prévu" | `transaction` → "Réel"
 - `income` → "Revenu" | `expense` → "Dépense" | `saving` → "Épargne"
 - Labels: "Disponible à dépenser", "Épargne prévue", "Fréquence"
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts
@@ -127,7 +127,7 @@ import {
                         matButton
                         class="ph-no-capture text-body-medium font-semibold"
                       >
-                        <mat-icon class="!text-base">open_in_new</mat-icon>
+                        <mat-icon class="text-base!">open_in_new</mat-icon>
                         {{ line.data.name | rolloverFormat }}
                       </a>
                     } @else {
@@ -137,7 +137,7 @@ import {
                         {{ line.data.name | rolloverFormat }}
                         @if (line.metadata.isPropagationLocked) {
                           <mat-icon
-                            class="!text-base text-outline"
+                            class="text-base! text-outline"
                             [matTooltip]="
                               'Montants verrouillés = non affectés par la propagation'
                             "
@@ -159,27 +159,24 @@ import {
             <th mat-header-cell *matHeaderCellDef>Fréquence</th>
             <td mat-cell *matCellDef="let line">
               @if ('recurrence' in line.data) {
-                <mat-chip
-                  [class.bg-primary-container!]="
-                    line.data.recurrence === 'fixed'
-                  "
-                  [class.text-on-primary-container!]="
-                    line.data.recurrence === 'fixed'
-                  "
-                  [class.bg-secondary-container!]="
-                    line.data.recurrence === 'one_off'
-                  "
-                  [class.text-on-secondary-container!]="
-                    line.data.recurrence === 'one_off'
-                  "
-                >
-                  {{ line.data.recurrence | recurrenceLabel }}
+                <!-- Budget Lines: fixed ou one_off -->
+                <mat-chip class="bg-surface-container text-on-surface">
+                  <span class="flex items-center">
+                    @if (line.data.recurrence === 'fixed') {
+                      <mat-icon class="text-base!">repeat</mat-icon>
+                    } @else {
+                      <mat-icon class="text-base!">schedule</mat-icon>
+                    }
+                    {{ line.data.recurrence | recurrenceLabel }}
+                  </span>
                 </mat-chip>
               } @else {
-                <mat-chip
-                  class="bg-secondary-container text-on-secondary-container"
-                >
-                  Une seule fois
+                <!-- Transactions -->
+                <mat-chip class="bg-surface-container text-on-surface">
+                  <span class="flex items-center">
+                    <mat-icon class="text-base!">paid</mat-icon>
+                    Réel
+                  </span>
                 </mat-chip>
               }
             </td>
@@ -268,7 +265,7 @@ import {
                       [attr.data-testid]="'cancel-' + line.data.id"
                       class="density-3"
                     >
-                      <mat-icon class="!text-base mr-1">close</mat-icon>
+                      <mat-icon class="text-base! mr-1">close</mat-icon>
                       Annuler
                     </button>
                     <button
@@ -279,7 +276,7 @@ import {
                       [disabled]="!editForm.valid"
                       class="density-3"
                     >
-                      <mat-icon class="!text-base mr-1">check</mat-icon>
+                      <mat-icon class="text-base! mr-1">check</mat-icon>
                       Enregistrer
                     </button>
                   </div>
@@ -294,7 +291,7 @@ import {
                       "
                       [attr.data-testid]="'actions-menu-' + line.data.id"
                       [disabled]="line.metadata.isLoading"
-                      class="!w-10 !h-10 text-on-surface-variant"
+                      class="w-10! h-10! text-on-surface-variant"
                       (click)="$event.stopPropagation()"
                     >
                       <mat-icon>more_vert</mat-icon>
@@ -334,7 +331,7 @@ import {
                         "
                         [attr.data-testid]="'edit-' + line.data.id"
                         [disabled]="line.metadata.isLoading"
-                        class="!w-10 !h-10"
+                        class="w-10! h-10!"
                       >
                         <mat-icon>edit</mat-icon>
                       </button>
@@ -345,7 +342,7 @@ import {
                       [attr.aria-label]="'Delete ' + line.data.name"
                       [attr.data-testid]="'delete-' + line.data.id"
                       [disabled]="line.metadata.isLoading"
-                      class="!w-10 !h-10 text-error"
+                      class="w-10! h-10! text-error"
                     >
                       <mat-icon>delete</mat-icon>
                     </button>

--- a/frontend/projects/webapp/src/app/ui/transaction-display/recurrence-label.pipe.spec.ts
+++ b/frontend/projects/webapp/src/app/ui/transaction-display/recurrence-label.pipe.spec.ts
@@ -14,11 +14,11 @@ describe('RecurrenceLabelPipe', () => {
   });
 
   it('should return correct label for fixed', () => {
-    expect(pipe.transform('fixed')).toBe('Tous les mois');
+    expect(pipe.transform('fixed')).toBe('Récurrent');
   });
 
   it('should return correct label for one_off', () => {
-    expect(pipe.transform('one_off')).toBe('Une seule fois');
+    expect(pipe.transform('one_off')).toBe('Prévu');
   });
 
   it('should handle all TransactionRecurrence values', () => {
@@ -32,9 +32,9 @@ describe('RecurrenceLabelPipe', () => {
     });
   });
 
-  it('should return French labels', () => {
-    // Verify that labels follow French business vocabulary
-    expect(pipe.transform('fixed')).toBe('Tous les mois'); // Not "Fixe" or "Récurrent"
-    expect(pipe.transform('one_off')).toBe('Une seule fois'); // Not "Unique" or "Ponctuel"
+  it('should return Swiss French labels', () => {
+    // Verify that labels follow Swiss French budget vocabulary
+    expect(pipe.transform('fixed')).toBe('Récurrent'); // Monthly recurring expense
+    expect(pipe.transform('one_off')).toBe('Prévu'); // Planned one-time expense
   });
 });

--- a/frontend/projects/webapp/src/app/ui/transaction-display/recurrence-label.pipe.ts
+++ b/frontend/projects/webapp/src/app/ui/transaction-display/recurrence-label.pipe.ts
@@ -7,8 +7,8 @@ import type { TransactionRecurrence } from '@pulpe/shared';
 export class RecurrenceLabelPipe implements PipeTransform {
   transform(recurrence: TransactionRecurrence): string {
     const labels: Record<TransactionRecurrence, string> = {
-      fixed: 'Tous les mois',
-      one_off: 'Une seule fois',
+      fixed: 'Récurrent',
+      one_off: 'Prévu',
     };
     return labels[recurrence];
   }


### PR DESCRIPTION
## Summary

• Replace confusing frequency labels with Swiss vocabulary:
  - `fixed` → "Récurrent" (was "Tous les mois")
  - `one_off` → "Prévu" (was "Une seule fois")
  - `transaction` → "Réel" (was same as one_off)
• Add Material icons for visual differentiation (repeat, schedule, paid)
• Unify chip colors to neutral surface-container (removes confusing 3-color scheme)
• Fix icon/text alignment with flex layout

## Type

feat