### PR TITLE
feat(current-month): display transaction creation dates

### DIFF
--- a/.claude/tasks/13-add-transaction-creation-dates/explore.md
+++ b/.claude/tasks/13-add-transaction-creation-dates/explore.md
@@ -1,0 +1,102 @@
+# Task: Add Creation Dates to Transactions
+
+Display the creation date (in small text) below the transaction name on each financial entry in the current-month page.
+
+## Codebase Context
+
+### Target Component
+- `frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts:66-82` - Main template section showing transaction name with `matListItemTitle`
+
+### Data Model
+- `frontend/projects/webapp/src/app/feature/current-month/models/financial-entry.model.ts:11` - `createdAt: z.string().datetime()` field already exists in the model
+
+### ViewModel
+- `frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts:24-27` - `FinancialEntryViewModel` extends `FinancialEntryModel`, so `createdAt` is already available in the component
+
+## Typography Patterns
+
+### Design System Location
+- `frontend/projects/webapp/src/app/styles/vendors/_tailwind.css:124-130` - `text-body-small` utility (smaller secondary text)
+- `frontend/projects/webapp/src/app/styles/vendors/_tailwind.css:203` - `text-on-surface-variant` color for muted text
+
+### Secondary Text Pattern (established convention)
+```html
+<p class="text-body-small text-on-surface-variant mt-1">
+  Secondary text here
+</p>
+```
+
+**Examples in codebase:**
+- `frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/ui/template-list-item.ts:67` - Description under template name
+- `frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/ui/template-list-item.ts:98` - Loading state secondary text
+
+## Date Formatting Patterns
+
+### DatePipe Usage (preferred for templates)
+- `frontend/projects/webapp/src/app/feature/current-month/current-month.ts:188` - `{{ date | date: 'MMMM yyyy' }}`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts:164` - `{{ budget.createdAt | date: 'short' : '' : 'fr-CH' }}`
+
+### Recommended Format for Short Dates
+Use `'short'` format with French-Swiss locale: `{{ createdAt | date: 'short' : '' : 'fr-CH' }}`
+- Produces: `24/12/2025 14:30` (compact, localized format)
+
+### Alternative: Custom Format
+`{{ createdAt | date: 'd MMM yyyy' : '' : 'fr-CH' }}` → `24 déc. 2025`
+
+## Key Files to Modify
+
+| File | Change |
+|------|--------|
+| `financial-entry.ts:66-82` | Add date display below transaction name |
+
+## Implementation Pattern
+
+### Current Template Structure (lines 66-82)
+```html
+<div matListItemTitle [class.rollover-text]="isRollover()">
+  @if (isRollover() && rolloverSourceBudgetId()) {
+    <a ...>{{ data().name | rolloverFormat }}</a>
+  } @else {
+    <span class="ph-no-capture">{{ data().name }}</span>
+  }
+</div>
+```
+
+### Required Change
+Add a secondary line after the title div showing the creation date:
+```html
+<div matListItemTitle ...>...</div>
+<span class="text-body-small text-on-surface-variant">
+  {{ data().createdAt | date: 'short' : '' : 'fr-CH' }}
+</span>
+```
+
+## Dependencies
+
+### Already Imported
+- `DatePipe` is already imported in the component (line 1: `import { DecimalPipe } from '@angular/common';`)
+- **Note**: Need to add `DatePipe` to imports array (currently only `DecimalPipe` is imported)
+
+### Imports to Add
+```typescript
+import { DatePipe, DecimalPipe } from '@angular/common';
+```
+And add `DatePipe` to the component's `imports` array.
+
+## Visual Considerations
+
+### List Item Height
+- Current: `list-item-one-line-container-height: 71px` (line 159 in styles)
+- May need to increase to `list-item-two-line-container-height` if single line height is insufficient
+
+### Rollover Styling
+- For rollover items, apply `text-on-surface-variant` (already muted, no change needed)
+- The date should appear regardless of rollover status
+
+## Patterns to Follow
+
+1. Use `text-body-small` for small secondary text
+2. Use `text-on-surface-variant` for muted/secondary color
+3. Use Angular's `DatePipe` with `'short'` format and `'fr-CH'` locale
+4. Add `DatePipe` to component imports
+5. No `mt-1` spacing needed here since we're within a list item structure

--- a/.claude/tasks/13-add-transaction-creation-dates/implementation.md
+++ b/.claude/tasks/13-add-transaction-creation-dates/implementation.md
@@ -1,0 +1,34 @@
+# Implementation: Add Transaction Creation Dates
+
+## Completed
+
+### `financial-entry.ts`
+- Added `DatePipe` import from `@angular/common`
+- Added `DatePipe` to component imports array
+- Added creation date display span after transaction name with classes `text-body-small text-on-surface-variant`
+- Date format: Swiss format `dd.MM.yyyy` (e.g., `01.01.2023`)
+
+### `financial-entry.spec.ts`
+- Added `fr-CH` locale registration for date formatting
+- Added test case verifying creation date is displayed in Swiss format
+
+## Deviations from Plan
+
+None - implementation followed plan exactly.
+
+## Test Results
+
+- Typecheck: ✓
+- Lint: ✓
+- Tests: ✓ (17 tests in financial-entry.spec.ts, 646 total tests passed)
+
+## Files Changed
+
+| File | Lines Changed |
+|------|---------------|
+| `financial-entry.ts` | +4 lines (import, imports array, template span) |
+| `financial-entry.spec.ts` | +8 lines (locale import, registration, test case) |
+
+## Follow-up Tasks
+
+None - feature is complete.

--- a/.claude/tasks/13-add-transaction-creation-dates/plan.md
+++ b/.claude/tasks/13-add-transaction-creation-dates/plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan: Add Transaction Creation Dates
+
+## Overview
+
+Add the creation date (Swiss format: dd.MM.yyyy) below each transaction name in the `FinancialEntry` component. The date will use the established typography pattern (`text-body-small text-on-surface-variant`).
+
+## Dependencies
+
+- None - `createdAt` field already exists in `FinancialEntryModel`
+
+## File Changes
+
+### `frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts`
+
+**Imports (line 1)**
+- Add `DatePipe` to the import from `@angular/common` alongside `DecimalPipe`
+
+**Component imports array (line 32-43)**
+- Add `DatePipe` to the component's `imports` array
+
+**Template (after line 82, after closing `</div>` of `matListItemTitle`)**
+- Add a `<span>` element displaying the creation date
+- Use classes: `text-body-small text-on-surface-variant`
+- Use DatePipe with format `'dd.MM.yyyy'` and locale `'fr-CH'`
+- Pattern: `{{ data().createdAt | date: 'dd.MM.yyyy' : '' : 'fr-CH' }}`
+
+## Testing Strategy
+
+### Update existing test: `frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.spec.ts`
+- Ensure test fixture includes a valid `createdAt` ISO date string
+- Add test case: verify creation date is displayed in Swiss format (dd.MM.yyyy)
+- Verify date appears after transaction name
+
+### Manual verification
+- Check date displays correctly on income, expense, and saving transactions
+- Verify rollover items also show the date
+- Confirm typography matches design system (small, muted text)
+
+## Rollout Considerations
+
+- No breaking changes
+- No migration needed
+- Feature is purely additive (display only)

--- a/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { registerLocaleData } from '@angular/common';
 import localeDeCH from '@angular/common/locales/de-CH';
+import localeFrCH from '@angular/common/locales/fr-CH';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { CurrencyPipe } from '@angular/common';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
@@ -24,8 +25,9 @@ import {
 } from './financial-entry';
 import { RolloverFormatPipe } from '@app/ui/rollover-format';
 
-// Register locale for currency formatting
+// Register locales for currency and date formatting
 registerLocaleData(localeDeCH);
+registerLocaleData(localeFrCH);
 
 // Mock RolloverFormatPipe
 class MockRolloverFormatPipe {
@@ -92,6 +94,14 @@ describe('FinancialEntry', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display the creation date in Swiss format', () => {
+    const dateElement = fixture.nativeElement.querySelector(
+      '.text-body-small.text-on-surface-variant',
+    );
+    expect(dateElement).toBeTruthy();
+    expect(dateElement.textContent.trim()).toBe('01.01.2023');
   });
 
   describe('Desktop view (non-mobile)', () => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.spec.ts
@@ -98,7 +98,7 @@ describe('FinancialEntry', () => {
 
   it('should display the creation date in Swiss format', () => {
     const dateElement = fixture.nativeElement.querySelector(
-      '.text-body-small.text-on-surface-variant',
+      '[data-testid="creation-date-test-id-1"]',
     );
     expect(dateElement).toBeTruthy();
     expect(dateElement.textContent.trim()).toBe('01.01.2023');

--- a/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts
@@ -1,4 +1,4 @@
-import { DecimalPipe } from '@angular/common';
+import { DatePipe, DecimalPipe } from '@angular/common';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import {
   ChangeDetectionStrategy,
@@ -30,6 +30,7 @@ export type FinancialEntryViewModel = FinancialEntryModel & {
   selector: 'pulpe-financial-entry',
 
   imports: [
+    DatePipe,
     DecimalPipe,
     MatIconModule,
     MatListModule,
@@ -80,6 +81,9 @@ export type FinancialEntryViewModel = FinancialEntryModel & {
           }}</span>
         }
       </div>
+      <span class="text-body-small text-on-surface-variant">
+        {{ data().createdAt | date: 'dd.MM.yyyy' : '' : 'fr-CH' }}
+      </span>
       <div matListItemMeta class="!flex !h-full !items-center">
         <span class="ph-no-capture" [class.italic]="isRollover()">
           {{ data().kind === 'income' ? '+' : '-'

--- a/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts
@@ -81,7 +81,10 @@ export type FinancialEntryViewModel = FinancialEntryModel & {
           }}</span>
         }
       </div>
-      <span class="text-body-small text-on-surface-variant">
+      <span
+        class="text-body-small text-on-surface-variant"
+        [attr.data-testid]="'creation-date-' + data().id"
+      >
         {{ data().createdAt | date: 'dd.MM.yyyy' : '' : 'fr-CH' }}
       </span>
       <div matListItemMeta class="!flex !h-full !items-center">


### PR DESCRIPTION
## Summary

Add creation date display below each transaction name on the current-month page. Dates are formatted in Swiss format (dd.MM.yyyy) using the established typography system.

## Changes

- Add `DatePipe` to FinancialEntry component
- Display createdAt in Swiss format (dd.MM.yyyy) with muted styling
- Add test case verifying date display in correct format

## Test Coverage

All 17 tests in financial-entry.spec.ts pass, including new date display test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)