### PR TITLE
feat(#117): Reset detached budget line from template

### DIFF
--- a/.claude/tasks/12-reset-detached-budget-line/explore.md
+++ b/.claude/tasks/12-reset-detached-budget-line/explore.md
@@ -1,0 +1,183 @@
+# Task: Reset Detached Budget Line from Template
+
+**Issue**: [#117](https://github.com/neogenz/pulpe/issues/117)
+
+## Summary
+
+When a budget line linked to a template is edited, it becomes "detached" (marked as `is_manually_adjusted = true`). This feature allows users to reset the line to its original template values and re-establish the association.
+
+---
+
+## Codebase Context
+
+### Detachment Mechanism
+
+The system uses a two-field approach:
+
+1. **`template_line_id`** (FK, nullable) - Links budget line to its template origin
+2. **`is_manually_adjusted`** (boolean) - Controls propagation protection
+
+**Key insight**: Detachment is tracked via the `is_manually_adjusted` flag, NOT by removing the FK. The `template_line_id` remains intact, making reset possible.
+
+### Where Detachment Happens
+
+```typescript
+// frontend/projects/webapp/src/app/feature/budget/budget-details/edit-budget-line/edit-budget-line-dialog.ts:191-204
+handleSubmit() {
+  const update: BudgetLineUpdate = {
+    name: this.budgetLineForm.value.name ?? this.budgetLine.name,
+    amount: this.budgetLineForm.value.amount ?? this.budgetLine.amount,
+    kind: this.budgetLineForm.value.kind ?? this.budgetLine.kind,
+    recurrence: this.budgetLineForm.value.recurrence ?? this.budgetLine.recurrence,
+    templateLineId: this.budgetLine.templateLineId,  // Preserved!
+    isManuallyAdjusted: true,  // ← ALWAYS set to true on edit
+  };
+  this.dialogRef.close(update);
+}
+```
+
+### Template Propagation Protection
+
+SQL functions explicitly skip manually adjusted lines:
+
+```sql
+-- backend-nest/supabase/migrations/20250928090000_apply_template_line_operations.sql:40-54
+WHERE bl.is_manually_adjusted = false  -- Key protection
+```
+
+---
+
+## Key Files
+
+### Database Layer
+
+| File | Line | Purpose |
+|------|------|---------|
+| `backend-nest/src/types/database.types.ts` | 48 | `template_line_id: string \| null` FK definition |
+| `backend-nest/src/types/database.types.ts` | 43 | `is_manually_adjusted: boolean` flag |
+| `shared/schemas.ts` | 177 | `templateLineId` in Zod schema |
+| `shared/schemas.ts` | 184 | `isManuallyAdjusted` in Zod schema |
+
+### Frontend - UI Components
+
+| File | Line | Purpose |
+|------|------|---------|
+| `frontend/.../edit-budget-line/edit-budget-line-dialog.ts` | 202 | Where detachment happens |
+| `frontend/.../budget-table/budget-table.ts` | 138-148 | Lock icon for detached lines |
+| `frontend/.../store/budget-details-store.ts` | 155-190 | `updateBudgetLine()` method |
+
+### Frontend - API
+
+| File | Line | Purpose |
+|------|------|---------|
+| `frontend/.../budget-line-api/budget-line-api.ts` | 48-62 | `updateBudgetLine$()` PATCH endpoint |
+| `frontend/projects/webapp/src/app/core/template/template-api.ts` | 46-50 | `getTemplateLines$()` for fetching original values |
+
+### Backend
+
+| File | Line | Purpose |
+|------|------|---------|
+| `backend-nest/src/modules/budget-line/budget-line.service.ts` | 341-382 | `update()` method |
+| `backend-nest/src/modules/budget-line/budget-line.service.ts` | 283-308 | `prepareBudgetLineUpdateData()` |
+
+### Business Rules
+
+| File | Line | Purpose |
+|------|------|---------|
+| `memory-bank/SPECS.md` | 74-77 | RG-001: Template propagation rules |
+
+---
+
+## Patterns to Follow
+
+### 1. Optimistic Updates with `resource()`
+
+```typescript
+// budget-details-store.ts pattern
+updateBudgetLine(id, update) {
+  // 1. Optimistic update
+  this._budgetLines.update(lines =>
+    lines.map(l => l.id === id ? { ...l, ...update } : l)
+  );
+  // 2. Persist to server
+  // 3. Handle errors by reloading
+}
+```
+
+### 2. Lock Icon for Detached Items
+
+```html
+<!-- budget-table.ts:138-148 -->
+@if (budgetLine.isPropagationLocked) {
+  <mat-icon matTooltip="Montants verrouillés = non affectés par la propagation">
+    lock
+  </mat-icon>
+}
+```
+
+### 3. Dialog Confirmation Pattern
+
+Existing dialogs use `MatDialog.open()` with component injection and `afterClosed()` observable.
+
+---
+
+## Reset Implementation Strategy
+
+### Required Steps
+
+1. **Check eligibility**: `templateLineId !== null`
+2. **Fetch template line**: Call backend to get original `template_line` values
+3. **Update budget line**:
+   ```typescript
+   {
+     name: templateLine.name,
+     amount: templateLine.amount,
+     kind: templateLine.kind,
+     recurrence: templateLine.recurrence,
+     isManuallyAdjusted: false  // ← Re-enable propagation
+   }
+   ```
+4. **Refresh UI**: Optimistic update + server persist
+
+### Backend Endpoint Needed
+
+New endpoint to fetch single template line:
+```
+GET /api/template-lines/:id
+```
+
+Or add to existing budget line API:
+```
+POST /api/budget-lines/:id/reset-from-template
+```
+
+---
+
+## Dependencies
+
+- `template_line_id` must exist on the budget line (nullable FK)
+- Template line must still exist (ON DELETE SET NULL could make it null)
+- User should have budget edit permissions
+
+---
+
+## Open Questions for Planning Phase
+
+1. **UI Placement**: Reset button in table row actions, edit dialog, or both?
+2. **Confirmation**: Dialog confirmation vs instant with undo snackbar?
+3. **Edge Case**: What if `template_line_id` is null (template was deleted)?
+4. **Batch Reset**: Should "reset all detached lines" be a feature?
+5. **Analytics**: Track reset action in PostHog?
+
+---
+
+## Test Coverage
+
+Existing test to extend:
+- `frontend/e2e/tests/features/budget-line-editing.spec.ts:52-69` - Tests detachment behavior
+
+New tests needed:
+- Reset button only visible for detached lines with valid template link
+- Reset updates values to match template
+- Reset sets `isManuallyAdjusted = false`
+- Reset fails gracefully if template line was deleted

--- a/.claude/tasks/12-reset-detached-budget-line/implementation.md
+++ b/.claude/tasks/12-reset-detached-budget-line/implementation.md
@@ -1,0 +1,74 @@
+# Implementation: Reset Detached Budget Line from Template
+
+## Completed
+
+### Backend
+- Added `resetFromTemplate()` method in `budget-line.service.ts`:
+  - Fetches budget line and validates `template_line_id` exists
+  - Fetches template line data from `template_line` table
+  - Updates budget line with template values (name, amount, kind, recurrence)
+  - Sets `is_manually_adjusted = false` to re-enable propagation
+  - Recalculates budget balances after update
+
+- Added `POST /budget-lines/:id/reset-from-template` endpoint in `budget-line.controller.ts`:
+  - Full OpenAPI documentation
+  - Returns 400 if budget line has no template
+  - Returns 404 if template line was deleted
+
+### Frontend
+- Added `resetFromTemplate$()` method in `budget-line-api.ts`:
+  - Calls POST endpoint
+  - Returns custom error message for deleted templates (404)
+
+- Updated `budget-table-models.ts`:
+  - Added `canResetFromTemplate` metadata field
+  - Added `isLoading` metadata field
+
+- Updated `budget-table-data-provider.ts`:
+  - Computes `canResetFromTemplate = isPropagationLocked`
+
+- Updated `budget-table.ts`:
+  - Transformed lock icon to clickable button
+  - Added confirmation dialog on click
+  - Added `resetFromTemplate` output event
+  - Updated tooltip text: "Montants verrouillés. Cliquer pour réinitialiser depuis le modèle."
+
+- Added `resetBudgetLineFromTemplate()` method in `budget-details-store.ts`:
+  - Calls API and updates local state with server response
+  - Error handling with re-throw for UI feedback
+
+- Updated `budget-details-page.ts`:
+  - Added `handleResetFromTemplate()` method
+  - Shows success snackbar on reset
+  - Shows error snackbar with message on failure
+
+## Deviations from Plan
+
+- Skipped adding `template-api.ts` method - the backend endpoint handles all the logic in one call, which is cleaner than having the frontend fetch template line separately.
+
+## Test Results
+
+- Typecheck: ✓
+- Backend lint: ✓
+- Frontend lint: ✓
+- Frontend tests: ✓ (645 tests pass)
+- Backend tests: ✓ (13 tests pass)
+
+## Files Modified
+
+### Backend (2 files)
+- `backend-nest/src/modules/budget-line/budget-line.service.ts`
+- `backend-nest/src/modules/budget-line/budget-line.controller.ts`
+
+### Frontend (6 files)
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line-api/budget-line-api.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-models.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-data-provider.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts`
+
+## Follow-up Tasks
+
+- Consider adding unit tests specifically for the reset functionality
+- Consider adding E2E test for the complete reset flow

--- a/.claude/tasks/12-reset-detached-budget-line/plan.md
+++ b/.claude/tasks/12-reset-detached-budget-line/plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Reset Detached Budget Line from Template
+
+## Overview
+
+Transform the lock icon for manually adjusted budget lines into a clickable button that opens a confirmation dialog. When confirmed, reset the budget line values to match the original template line and set `isManuallyAdjusted = false`.
+
+**User flow:**
+1. User sees lock icon button on detached lines (lines with `isPropagationLocked = true`)
+2. Click opens confirmation dialog asking to reset to template values
+3. If template line was deleted (`templateLineId` exists but template line is gone), show error snackbar
+4. On confirmation, fetch template line and update budget line with template values
+
+## Dependencies
+
+- **Backend endpoint exists**: `GET /budget-templates/:templateId/lines/:lineId` (findTemplateLine)
+- **ConfirmationDialog** already exists at `@ui/dialogs/confirmation-dialog`
+- **MatSnackBar** pattern already used in `budget-details-page.ts`
+
+## File Changes
+
+### 1. `frontend/projects/webapp/src/app/core/template/template-api.ts`
+
+- **Add method** `getTemplateLine$(templateId: string, lineId: string): Observable<TemplateLine>`
+  - Call `GET ${apiUrl}/${templateId}/lines/${lineId}`
+  - Map response to extract `data` field
+  - Pattern: Follow existing `getById$()` method structure
+
+### 2. `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-models.ts`
+
+- **Add metadata field** `canResetFromTemplate: boolean` to the `TableItemMetadata` interface
+  - True when: `itemType === 'budget_line' && isPropagationLocked && templateLineId !== null`
+  - This determines if the reset button should be shown
+
+### 3. `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-data-provider.ts`
+
+- **Add field** `templateLineId` to metadata (needed to call API)
+- **Add computed** `canResetFromTemplate` to metadata
+  - True when: `isPropagationLocked && budgetLine?.templateLineId !== null`
+
+### 4. `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts`
+
+- **Add output** `resetFromTemplate = output<{ budgetLineId: string; templateLineId: string; templateId: string }>()`
+
+- **Replace lock icon** (lines 138-148) with an icon button:
+  - Change from `<mat-icon>` to `<button matIconButton>`
+  - Keep same icon and tooltip
+  - Add `(click)` handler that opens confirmation dialog
+  - Emit `resetFromTemplate` event with required IDs if confirmed
+
+- **Add method** `onResetFromTemplateClick(line: BudgetLineTableItem)`:
+  - Open ConfirmationDialog with:
+    - title: "Réinitialiser depuis le modèle"
+    - message: "Cette action va remplacer les valeurs actuelles par celles du modèle. Cette action est irréversible."
+    - confirmText: "Réinitialiser"
+    - confirmColor: "primary"
+  - On confirmation, emit `resetFromTemplate` output with IDs
+
+- **Note**: Template ID must be available - check if it's in BudgetLine type or needs to be fetched via template line
+
+### 5. `frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts`
+
+- **Add method** `async resetBudgetLineFromTemplate(budgetLineId: string, templateLineId: string): Promise<void>`:
+  - Inject `TemplateApi` (needs to be added to constructor)
+  - Fetch template line data: `templateApi.getTemplateLine$(templateId, templateLineId)`
+  - If fetch fails (404 = template deleted), throw specific error
+  - Prepare update: `{ name, amount, kind, recurrence, isManuallyAdjusted: false }`
+  - Call existing `updateBudgetLine()` with the update data
+  - Handle errors appropriately
+
+- **Challenge**: We need `templateId` to call `getTemplateLine$()` but budget line only has `templateLineId`
+  - **Solution 1**: Add new backend endpoint `GET /budget-lines/:id/reset-from-template` (cleaner but more work)
+  - **Solution 2**: Store templateId in budget line metadata from budget response
+  - **Solution 3**: Have backend return templateId with template_line_id in budget line response
+  - **Recommended**: Add a simpler endpoint in budget-line module that handles the reset logic server-side
+
+### 6. `backend-nest/src/modules/budget-line/budget-line.controller.ts`
+
+- **Add endpoint** `POST /budget-lines/:id/reset-from-template`:
+  - Fetch budget line by ID
+  - Validate it has `template_line_id` set
+  - Fetch template line by `template_line_id`
+  - If template line not found, return 404 with clear message
+  - Update budget line with template values + `is_manually_adjusted = false`
+  - Return updated budget line
+
+### 7. `backend-nest/src/modules/budget-line/budget-line.service.ts`
+
+- **Add method** `async resetFromTemplate(budgetLineId: string, user: AuthenticatedUser, supabase: SupabaseClient)`:
+  - Fetch budget line
+  - Validate `template_line_id` is not null (throw BadRequest if null)
+  - Fetch template line from `template_line` table
+  - If template line not found, throw NotFoundException with message: "Le modèle a été supprimé"
+  - Update budget line: `{ name, amount, kind, recurrence, is_manually_adjusted: false }`
+  - Return updated budget line
+
+### 8. `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line-api/budget-line-api.ts`
+
+- **Add method** `resetFromTemplate$(budgetLineId: string): Observable<BudgetLineResponse>`:
+  - Call `POST ${apiUrl}/${budgetLineId}/reset-from-template`
+  - Return response
+
+### 9. `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts`
+
+- **Add handler** `async handleResetFromTemplate(event: { budgetLineId: string }): Promise<void>`:
+  - Call store method `resetBudgetLineFromTemplate()`
+  - On success: show snackbar "Prévision réinitialisée depuis le modèle"
+  - On error (template deleted): show error snackbar "Impossible de réinitialiser : le modèle a été supprimé"
+
+- **Bind to template**: Add `(resetFromTemplate)="handleResetFromTemplate($event)"` on `<pulpe-budget-table>`
+
+## Testing Strategy
+
+### Unit Tests
+
+**`budget-table.spec.ts`:**
+- Reset button visible only when `canResetFromTemplate = true`
+- Reset button hidden for non-detached lines
+- Click opens confirmation dialog
+- Emits event on confirmation
+
+**`budget-details-store.spec.ts`:**
+- `resetBudgetLineFromTemplate()` calls API correctly
+- Optimistic update sets `isManuallyAdjusted = false`
+- Error handling for template not found
+
+**`budget-line.service.spec.ts` (backend):**
+- `resetFromTemplate()` fetches template line correctly
+- Updates budget line with template values
+- Throws 404 when template line deleted
+- Throws 400 when `template_line_id` is null
+
+### E2E Tests
+
+**`frontend/e2e/tests/features/budget-line-reset.spec.ts`** (new):
+- Reset button appears for detached lines with valid template
+- Reset button NOT shown for lines without template
+- Clicking reset opens confirmation dialog
+- Confirming reset updates values and removes lock icon
+- Canceling reset keeps original values
+- Error snackbar when template deleted
+
+## Rollout Considerations
+
+- **No migration needed**: Uses existing database schema
+- **No breaking changes**: Adds new functionality without modifying existing behavior
+- **Feature flag**: Not needed - purely additive feature
+- **Error handling**: Gracefully handles deleted templates with user-friendly message
+
+## Summary of Changes
+
+| File | Type | Change |
+|------|------|--------|
+| `template-api.ts` | Frontend API | Add `getTemplateLine$()` |
+| `budget-table-models.ts` | Frontend Model | Add `canResetFromTemplate` metadata |
+| `budget-table-data-provider.ts` | Frontend Service | Compute reset eligibility |
+| `budget-table.ts` | Frontend Component | Lock icon → button + dialog |
+| `budget-details-store.ts` | Frontend Store | Add `resetBudgetLineFromTemplate()` |
+| `budget-line-api.ts` | Frontend API | Add `resetFromTemplate$()` |
+| `budget-details-page.ts` | Frontend Page | Handle reset event |
+| `budget-line.controller.ts` | Backend Controller | Add reset endpoint |
+| `budget-line.service.ts` | Backend Service | Add reset logic |

--- a/backend-nest/src/modules/budget-line/budget-line.controller.ts
+++ b/backend-nest/src/modules/budget-line/budget-line.controller.ts
@@ -149,6 +149,38 @@ export class BudgetLineController {
     );
   }
 
+  @Post(':id/reset-from-template')
+  @ApiOperation({
+    summary: 'Réinitialise une ligne budgétaire depuis son modèle',
+    description:
+      'Restaure les valeurs de la ligne budgétaire (nom, montant, type, récurrence) depuis le modèle associé et désactive le verrouillage manuel',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Identifiant unique de la ligne budgétaire',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Ligne budgétaire réinitialisée avec succès',
+    type: BudgetLineResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: "La ligne budgétaire n'a pas de modèle associé",
+    type: ErrorResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: 'Ligne budgétaire ou modèle non trouvé',
+    type: ErrorResponseDto,
+  })
+  async resetFromTemplate(
+    @Param('id') id: string,
+    @User() user: AuthenticatedUser,
+    @SupabaseClient() supabase: AuthenticatedSupabaseClient,
+  ): Promise<BudgetLineResponse> {
+    return this.budgetLineService.resetFromTemplate(id, user, supabase);
+  }
+
   @Delete(':id')
   @ApiOperation({ summary: 'Supprime une ligne budgétaire existante' })
   @ApiParam({

--- a/backend-nest/src/modules/budget-line/budget-line.service.ts
+++ b/backend-nest/src/modules/budget-line/budget-line.service.ts
@@ -511,9 +511,9 @@ export class BudgetLineService {
   private prepareResetUpdateData(templateLine: {
     name: string;
     amount: number;
-    kind: string;
-    recurrence: string;
-  }) {
+    kind: Database['public']['Enums']['transaction_kind'];
+    recurrence: Database['public']['Enums']['transaction_recurrence'];
+  }): Database['public']['Tables']['budget_line']['Update'] {
     return {
       name: templateLine.name,
       amount: templateLine.amount,

--- a/backend-nest/src/modules/budget-line/budget-line.service.ts
+++ b/backend-nest/src/modules/budget-line/budget-line.service.ts
@@ -453,6 +453,96 @@ export class BudgetLineService {
     );
   }
 
+  async resetFromTemplate(
+    id: string,
+    user: AuthenticatedUser,
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<BudgetLineResponse> {
+    try {
+      const budgetLine = await this.fetchBudgetLineById(id, user, supabase);
+      this.validateTemplateLineIdExists(budgetLine.template_line_id);
+
+      const templateLine = await this.fetchTemplateLineById(
+        budgetLine.template_line_id!,
+        supabase,
+      );
+
+      const updateData = this.prepareResetUpdateData(templateLine);
+      const updatedBudgetLine = await this.updateBudgetLineInDb(
+        id,
+        updateData,
+        supabase,
+        user,
+      );
+
+      await this.budgetService.recalculateBalances(
+        updatedBudgetLine.budget_id,
+        supabase,
+      );
+
+      return {
+        success: true,
+        data: budgetLineMappers.toApi(updatedBudgetLine),
+      };
+    } catch (error) {
+      handleServiceError(
+        error,
+        ERROR_DEFINITIONS.BUDGET_LINE_UPDATE_FAILED,
+        { id },
+        {
+          operation: 'resetFromTemplate',
+          userId: user.id,
+          entityId: id,
+          entityType: 'budget_line',
+        },
+      );
+    }
+  }
+
+  private validateTemplateLineIdExists(templateLineId: string | null): void {
+    if (!templateLineId) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.BUDGET_LINE_VALIDATION_FAILED,
+        { reason: 'Budget line has no associated template' },
+      );
+    }
+  }
+
+  private prepareResetUpdateData(templateLine: {
+    name: string;
+    amount: number;
+    kind: string;
+    recurrence: string;
+  }) {
+    return {
+      name: templateLine.name,
+      amount: templateLine.amount,
+      kind: templateLine.kind,
+      recurrence: templateLine.recurrence,
+      is_manually_adjusted: false,
+      updated_at: new Date().toISOString(),
+    };
+  }
+
+  private async fetchTemplateLineById(
+    templateLineId: string,
+    supabase: AuthenticatedSupabaseClient,
+  ) {
+    const { data: templateLine, error } = await supabase
+      .from('template_line')
+      .select('name, amount, kind, recurrence')
+      .eq('id', templateLineId)
+      .single();
+
+    if (error || !templateLine) {
+      throw new BusinessException(ERROR_DEFINITIONS.TEMPLATE_LINE_NOT_FOUND, {
+        id: templateLineId,
+      });
+    }
+
+    return templateLine;
+  }
+
   async findByBudgetId(
     budgetId: string,
     supabase: AuthenticatedSupabaseClient,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -128,6 +128,7 @@ import {
           (update)="handleUpdateBudgetLine($event)"
           (delete)="handleDeleteItem($event)"
           (add)="openAddBudgetLineDialog()"
+          (resetFromTemplate)="handleResetFromTemplate($event)"
           data-tour="budget-table"
         />
 
@@ -323,6 +324,29 @@ export default class BudgetDetailsPage {
       this.#snackBar.open('Transaction supprimée.', 'Fermer', {
         duration: 5000,
         panelClass: ['bg-[color-primary]', 'text-[color-on-primary]'],
+      });
+    }
+  }
+
+  async handleResetFromTemplate(budgetLineId: string): Promise<void> {
+    try {
+      await this.store.resetBudgetLineFromTemplate(budgetLineId);
+
+      this.#snackBar.open(
+        'Prévision réinitialisée depuis le modèle.',
+        'Fermer',
+        {
+          duration: 5000,
+          panelClass: ['bg-[color-primary]', 'text-[color-on-primary]'],
+        },
+      );
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erreur inconnue';
+
+      this.#snackBar.open(errorMessage, 'Fermer', {
+        duration: 5000,
+        panelClass: ['bg-error-container', 'text-on-error-container'],
       });
     }
   }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line-api/budget-line-api.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line-api/budget-line-api.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { type Observable, catchError, throwError } from 'rxjs';
 import {
   type BudgetLineResponse,
@@ -83,7 +83,8 @@ export class BudgetLineApi {
             'Error resetting budget line from template:',
             error,
           );
-          const isNotFound = error.status === 404;
+          const isNotFound =
+            error instanceof HttpErrorResponse && error.status === 404;
           return throwError(
             () =>
               new Error(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line-api/budget-line-api.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line-api/budget-line-api.ts
@@ -73,4 +73,26 @@ export class BudgetLineApi {
         }),
       );
   }
+
+  resetFromTemplate$(id: string): Observable<BudgetLineResponse> {
+    return this.#http
+      .post<BudgetLineResponse>(`${this.#apiUrl}/${id}/reset-from-template`, {})
+      .pipe(
+        catchError((error) => {
+          this.#logger.error(
+            'Error resetting budget line from template:',
+            error,
+          );
+          const isNotFound = error.status === 404;
+          return throwError(
+            () =>
+              new Error(
+                isNotFound
+                  ? 'Le modèle a été supprimé'
+                  : 'Impossible de réinitialiser la prévision',
+              ),
+          );
+        }),
+      );
+  }
 }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-data-provider.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-data-provider.ts
@@ -210,6 +210,10 @@ export class BudgetTableDataProvider {
       const isRollover = isRolloverLine(item.item);
       const isBudgetLine = item.itemType === 'budget_line';
       const budgetLine = isBudgetLine ? (item.item as BudgetLine) : null;
+      const isPropagationLocked =
+        isBudgetLine &&
+        !!budgetLine?.templateLineId &&
+        !!budgetLine?.isManuallyAdjusted;
       return {
         data: item.item,
         metadata: {
@@ -218,13 +222,11 @@ export class BudgetTableDataProvider {
           isEditing:
             isBudgetLine &&
             params.editingLineId === item.item.id &&
-            !isRollover, // Rollover lines cannot be edited
+            !isRollover,
           isRollover,
           isTemplateLinked: isBudgetLine ? !!budgetLine?.templateLineId : false,
-          isPropagationLocked:
-            isBudgetLine &&
-            !!budgetLine?.templateLineId &&
-            !!budgetLine?.isManuallyAdjusted,
+          isPropagationLocked,
+          canResetFromTemplate: isPropagationLocked,
         },
       };
     });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-models.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-models.ts
@@ -12,6 +12,8 @@ export interface TableItem {
     isRollover?: boolean;
     isTemplateLinked?: boolean;
     isPropagationLocked?: boolean;
+    canResetFromTemplate?: boolean;
+    isLoading?: boolean;
   };
 }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-models.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-models.ts
@@ -13,7 +13,6 @@ export interface TableItem {
     isTemplateLinked?: boolean;
     isPropagationLocked?: boolean;
     canResetFromTemplate?: boolean;
-    isLoading?: boolean;
   };
 }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts
@@ -302,7 +302,6 @@ import {
                         'Actions pour ' + (line.data.name | rolloverFormat)
                       "
                       [attr.data-testid]="'actions-menu-' + line.data.id"
-                      [disabled]="line.metadata.isLoading"
                       class="w-10! h-10! text-on-surface-variant"
                       (click)="$event.stopPropagation()"
                     >
@@ -342,7 +341,6 @@ import {
                           'Edit ' + (line.data.name | rolloverFormat)
                         "
                         [attr.data-testid]="'edit-' + line.data.id"
-                        [disabled]="line.metadata.isLoading"
                         class="w-10! h-10!"
                       >
                         <mat-icon>edit</mat-icon>
@@ -353,7 +351,6 @@ import {
                       (click)="delete.emit(line.data.id)"
                       [attr.aria-label]="'Delete ' + line.data.name"
                       [attr.data-testid]="'delete-' + line.data.id"
-                      [disabled]="line.metadata.isLoading"
                       class="w-10! h-10! text-error"
                     >
                       <mat-icon>delete</mat-icon>
@@ -371,9 +368,7 @@ import {
           <tr
             mat-row
             *matRowDef="let row; columns: currentColumns()"
-            class="hover:bg-surface-container-low transition-opacity"
-            [class.opacity-50]="row.metadata.isLoading"
-            [class.pointer-events-none]="row.metadata.isLoading"
+            class="hover:bg-surface-container-low"
             [attr.data-testid]="
               'budget-line-' + (row.data.name | rolloverFormat)
             "

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -244,6 +244,40 @@ export class BudgetDetailsStore {
   }
 
   /**
+   * Reset a budget line from its template values
+   */
+  async resetBudgetLineFromTemplate(id: string): Promise<void> {
+    try {
+      const response = await firstValueFrom(
+        this.#budgetLineApi.resetFromTemplate$(id),
+      );
+
+      this.#budgetDetailsResource.update((details) => {
+        if (!details) return details;
+
+        return {
+          ...details,
+          budgetLines: details.budgetLines.map((line) =>
+            line.id === id ? response.data : line,
+          ),
+        };
+      });
+
+      this.#clearError();
+    } catch (error) {
+      this.reloadBudgetDetails();
+
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : 'Erreur lors de la réinitialisation de la prévision';
+      this.#setError(errorMessage);
+      this.#logger.error('Error resetting budget line from template', error);
+      throw error;
+    }
+  }
+
+  /**
    * Manually reload budget details from the server
    */
   reloadBudgetDetails(): void {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -273,7 +273,6 @@ export class BudgetDetailsStore {
           : 'Erreur lors de la réinitialisation de la prévision';
       this.#setError(errorMessage);
       this.#logger.error('Error resetting budget line from template', error);
-      throw error;
     }
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -273,6 +273,7 @@ export class BudgetDetailsStore {
           : 'Erreur lors de la réinitialisation de la prévision';
       this.#setError(errorMessage);
       this.#logger.error('Error resetting budget line from template', error);
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary
Implement ability to reset budget lines back to their template values. When a budget line is edited, it becomes "detached" (`isManuallyAdjusted = true`) and stops receiving template updates. Users can now click the lock icon to reset the line to its original template values and re-enable template propagation.

## Changes
- Backend: New `POST /budget-lines/:id/reset-from-template` endpoint
- Frontend: Lock icon transformed to clickable button with confirmation dialog
- Error handling: Graceful message when template has been deleted

## Test Results
✓ All 645 frontend tests pass
✓ All 13 backend tests pass
✓ Full quality checks pass (typecheck, lint, format)