### PR TITLE
feat(#115): Optimize budget loading with reloading indicator

### DIFF
--- a/frontend/projects/webapp/src/app/core/loading/loading-indicator.ts
+++ b/frontend/projects/webapp/src/app/core/loading/loading-indicator.ts
@@ -4,11 +4,11 @@ import { Injectable, signal } from '@angular/core';
   providedIn: 'root',
 })
 export class LoadingIndicator {
-  #isLoading = signal<boolean>(false);
-
-  setLoading(loading: boolean) {
-    this.#isLoading.set(loading);
-  }
+  readonly #isLoading = signal(false);
 
   readonly isLoading = this.#isLoading.asReadonly();
+
+  setLoading(loading: boolean): void {
+    this.#isLoading.set(loading);
+  }
 }

--- a/frontend/projects/webapp/src/app/core/loading/loading-indicator.ts
+++ b/frontend/projects/webapp/src/app/core/loading/loading-indicator.ts
@@ -1,0 +1,14 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LoadingIndicator {
+  #isLoading = signal<boolean>(false);
+
+  setLoading(loading: boolean) {
+    this.#isLoading.set(loading);
+  }
+
+  readonly isLoading = this.#isLoading.asReadonly();
+}

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   signal,
 } from '@angular/core';
@@ -29,6 +30,7 @@ import {
   ProductTourService,
   TOUR_START_DELAY,
 } from '@core/product-tour/product-tour.service';
+import { LoadingIndicator } from '@core/loading/loading-indicator';
 
 const YEARS_TO_DISPLAY = 8; // Current year + 7 future years for planning
 
@@ -74,10 +76,7 @@ const YEARS_TO_DISPLAY = 8; // Current year + 7 future years for planning
       </header>
 
       @switch (true) {
-        @case (
-          state.budgets.status() === 'loading' ||
-          state.budgets.status() === 'reloading'
-        ) {
+        @case (state.budgets.status() === 'loading') {
           <pulpe-base-loading
             message="Chargement des données mensuelles..."
             size="large"
@@ -89,7 +88,8 @@ const YEARS_TO_DISPLAY = 8; // Current year + 7 future years for planning
         }
         @case (
           state.budgets.status() === 'resolved' ||
-          state.budgets.status() === 'local'
+          state.budgets.status() === 'local' ||
+          state.budgets.status() === 'reloading'
         ) {
           <mat-tab-group
             mat-stretch-tabs="false"
@@ -130,6 +130,7 @@ export default class BudgetListPage {
   readonly #breakpointObserver = inject(BreakpointObserver);
   readonly #snackBar = inject(MatSnackBar);
   readonly #logger = inject(Logger);
+  readonly #loadingIndicator = inject(LoadingIndicator);
 
   constructor() {
     // Refresh data on init
@@ -143,6 +144,11 @@ export default class BudgetListPage {
           TOUR_START_DELAY,
         );
       }
+    });
+
+    effect(() => {
+      const status = this.state.budgets.status();
+      this.#loadingIndicator.setLoading(status === 'reloading');
     });
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
@@ -136,6 +136,11 @@ export default class BudgetListPage {
     // Refresh data on init
     this.state.refreshData();
 
+    effect(() => {
+      const status = this.state.budgets.status();
+      this.#loadingIndicator.setLoading(status === 'reloading');
+    });
+
     // Auto-trigger tour on first visit
     afterNextRender(() => {
       if (!this.#productTourService.hasSeenPageTour('budget-list')) {
@@ -144,11 +149,6 @@ export default class BudgetListPage {
           TOUR_START_DELAY,
         );
       }
-    });
-
-    effect(() => {
-      const status = this.state.budgets.status();
-      this.#loadingIndicator.setLoading(status === 'reloading');
     });
   }
 

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -31,6 +31,8 @@ import { ApplicationConfiguration } from '@core/config/application-configuration
 import { Logger } from '@core/logging/logger';
 import { DemoModeService } from '@core/demo/demo-mode.service';
 import { DemoInitializerService } from '@core/demo/demo-initializer.service';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { LoadingIndicator } from '@core/loading/loading-indicator';
 
 interface NavigationItem {
   readonly route: string;
@@ -53,13 +55,14 @@ interface NavigationItem {
     RouterLinkActive,
     RouterOutlet,
     PulpeBreadcrumb,
+    MatProgressBarModule,
   ],
   template: `
-    <mat-sidenav-container class="h-[100dvh] !bg-surface-container">
+    <mat-sidenav-container class="h-dvh bg-surface-container!">
       <!-- Navigation Sidenav -->
       <mat-sidenav
         #drawer
-        class="!bg-surface-container"
+        class="bg-surface-container!"
         [class.!w-auto]="!isHandset()"
         [mode]="isHandset() ? 'over' : 'side'"
         [opened]="!isHandset()"
@@ -82,7 +85,7 @@ interface NavigationItem {
         <!-- Navigation List -->
         @if (isHandset()) {
           <!-- Mobile: Full navigation list -->
-          <mat-nav-list class="pt-4 !px-2" data-testid="mobile-navigation">
+          <mat-nav-list class="pt-4 px-2!" data-testid="mobile-navigation">
             @for (item of navigationItems; track item.route) {
               <a
                 mat-list-item
@@ -156,6 +159,15 @@ interface NavigationItem {
           [class.p-2]="!isHandset()"
           [class.rounded-xl]="!isHandset()"
         >
+          @if (loadingIndicator.isLoading()) {
+            <div class="absolute top-0 left-0 right-0">
+              <mat-progress-bar
+                mode="indeterminate"
+                aria-label="Mise à jour en cours"
+                data-testid="budget-list-refresh-progress"
+              />
+            </div>
+          }
           <!-- Demo Mode Banner -->
           @if (isDemoMode()) {
             <div
@@ -193,7 +205,7 @@ interface NavigationItem {
           <!-- Top App Bar - Fixed Header -->
           <mat-toolbar
             color="primary"
-            class="flex-shrink-0"
+            class="shrink-0"
             [class.rounded-t-xl]="!isHandset()"
           >
             @if (isHandset()) {
@@ -274,7 +286,7 @@ interface NavigationItem {
           <!-- Page Content - Scrollable Container -->
           <main
             cdkScrollable
-            class="flex-1 overflow-y-auto bg-surface text-on-surface !pt-2"
+            class="flex-1 overflow-y-auto bg-surface text-on-surface pt-2!"
             [class.p-6]="!isHandset()"
             [class.md:p-8]="!isHandset()"
             [class.p-4]="isHandset()"
@@ -339,7 +351,7 @@ export default class MainLayout {
   readonly #demoInitializer = inject(DemoInitializerService);
   readonly breadcrumbState = inject(BreadcrumbState);
   readonly #logger = inject(Logger);
-
+  protected readonly loadingIndicator = inject(LoadingIndicator);
   // Display "Mode Démo" for demo users, otherwise show email
   readonly userEmail = computed(() => {
     if (this.#demoModeService.isDemoMode()) {


### PR DESCRIPTION
Cache budget data on initial load and show a non-blocking progress indicator when reloading.

When navigating from budget detail back to list, avoid full page reload. The user can view cached data while the latest data loads in the background.

## Changes
- Add LoadingIndicator service to manage loading state
- Show progress bar during budget reloading instead of blocking loader
- Allow viewing cached data while reloading in the background