### PR TITLE
refactor(budget-templates): simplify form with inputs/outputs pattern

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget-templates/create/components/create-template-form.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/create/components/create-template-form.ts
@@ -267,8 +267,10 @@ export class CreateTemplateForm {
   isFormValid = computed(() => this.formStatus() === 'VALID');
   isDefaultChecked = computed(() => this.formValues()?.isDefault ?? false);
 
-  // Computed: limit reached based on input
-  isLimitReached = computed(() => this.templateCount() >= this.maxTemplates);
+  // Computed: limit reached based on input (hidden during creation to avoid flicker)
+  isLimitReached = computed(
+    () => !this.isCreating() && this.templateCount() >= this.maxTemplates,
+  );
 
   // Computed: warning message when overriding default
   overrideDefaultWarning = computed(() => {

--- a/frontend/projects/webapp/src/app/feature/budget-templates/create/components/create-template-form.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/create/components/create-template-form.ts
@@ -5,7 +5,6 @@ import {
   effect,
   inject,
   input,
-  linkedSignal,
   output,
   signal,
 } from '@angular/core';
@@ -25,12 +24,13 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { type BudgetTemplateCreate } from '@pulpe/shared';
-import { BudgetTemplatesState } from '../../services/budget-templates-state';
 import { DefaultWarningPanel } from '../ui/default-warning-panel';
 import {
   duplicateNameValidator,
   getTemplateNameErrorMessage,
 } from './template-validators';
+
+const MAX_TEMPLATES = 5;
 
 @Component({
   selector: 'pulpe-create-template-form',
@@ -47,185 +47,177 @@ import {
     DefaultWarningPanel,
   ],
   template: `
-    @if (state.budgetTemplates.isLoading()) {
-      <div class="flex justify-center items-center py-16">
-        <mat-spinner diameter="40"></mat-spinner>
-      </div>
-    } @else {
-      <div
-        class="relative space-y-4 md:space-y-6"
-        data-testid="template-form-container"
-      >
-        <!-- Loading overlay during form submission -->
-        @if (isCreating()) {
-          <div
-            class="absolute inset-0 bg-surface/50 flex items-center justify-center z-10 rounded-corner-medium"
-          >
-            <div class="flex flex-col items-center gap-3">
-              <mat-spinner diameter="32"></mat-spinner>
-              <span
-                class="text-body-medium text-on-surface-variant font-medium"
-              >
-                Création en cours...
-              </span>
-            </div>
-          </div>
-        }
-
-        @if (state.templateCount() > 0) {
-          <div class="text-body-medium text-on-surface-variant">
-            {{ state.templateCount() }}/{{ state.MAX_TEMPLATES }} modèles créés
-          </div>
-        }
-
-        <form
-          [formGroup]="templateForm"
-          (ngSubmit)="onSubmit()"
-          (keydown.escape)="onEscapeKey()"
-          data-testid="template-form"
+    <div
+      class="relative space-y-4 md:space-y-6"
+      data-testid="template-form-container"
+    >
+      <!-- Loading overlay during form submission -->
+      @if (isCreating()) {
+        <div
+          class="absolute inset-0 bg-surface/50 flex items-center justify-center z-10 rounded-corner-medium"
         >
-          <!-- Grid container with responsive columns and MD3 spacing -->
-          <div class="flex flex-col gap-4 md:gap-6 pt-4">
-            <!-- Name field - full width for optimal UX -->
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Nom du modèle</mat-label>
-              <input
-                matInput
-                formControlName="name"
-                required
-                [maxlength]="50"
-                data-testid="template-name-input"
+          <div class="flex flex-col items-center gap-3">
+            <mat-spinner diameter="32"></mat-spinner>
+            <span class="text-body-medium text-on-surface-variant font-medium">
+              Création en cours...
+            </span>
+          </div>
+        </div>
+      }
+
+      @if (templateCount() > 0) {
+        <div class="text-body-medium text-on-surface-variant">
+          {{ templateCount() }}/{{ maxTemplates }} modèles créés
+        </div>
+      }
+
+      <form
+        [formGroup]="templateForm"
+        (ngSubmit)="onSubmit()"
+        (keydown.escape)="onEscapeKey()"
+        data-testid="template-form"
+      >
+        <!-- Grid container with responsive columns and MD3 spacing -->
+        <div class="flex flex-col gap-4 md:gap-6 pt-4">
+          <!-- Name field - full width for optimal UX -->
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Nom du modèle</mat-label>
+            <input
+              matInput
+              formControlName="name"
+              required
+              [maxlength]="50"
+              data-testid="template-name-input"
+            />
+            <mat-hint align="end">
+              {{ templateForm.get('name')?.value?.length }}/{{ 50 }}
+            </mat-hint>
+            @if (this.templateForm.get('name')?.errors) {
+              <mat-error data-testid="name-error" id="name-error-message">
+                {{
+                  getTemplateNameErrorMessage(
+                    this.templateForm.get('name')?.errors ?? null
+                  )
+                }}
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Description (optionnelle)</mat-label>
+            <textarea
+              matInput
+              formControlName="description"
+              rows="3"
+              aria-label="Description du modèle (optionnel)"
+              data-testid="template-description-input"
+            ></textarea>
+            <mat-hint align="end">
+              {{ templateForm.get('description')?.value?.length }}/{{ 200 }}
+            </mat-hint>
+            @if (templateForm.get('description')?.errors) {
+              <mat-error>
+                @if (templateForm.get('description')?.errors?.['maxlength']) {
+                  La description ne doit pas dépasser 200 caractères.
+                }
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <div class="flex items-center gap-2">
+            <mat-checkbox
+              formControlName="isDefault"
+              data-testid="template-default-checkbox"
+              aria-label="Définir comme modèle par défaut"
+              class="min-h-[44px] flex items-center"
+            >
+              Modèle par défaut
+            </mat-checkbox>
+            <mat-icon
+              matTooltip="Le modèle par défaut est sélectionné par défaut pour créer de nouveaux budgets mensuels."
+              matTooltipPosition="above"
+              aria-label="Information sur le modèle par défaut"
+              class="!text-on-surface-variant cursor-help"
+              tabindex="0"
+            >
+              info
+            </mat-icon>
+          </div>
+
+          <!-- Default warning panel -->
+          @if (overrideDefaultWarning(); as warningMessage) {
+            <div class="col-span-1">
+              <pulpe-default-warning-panel
+                id="default-warning"
+                [message]="warningMessage"
               />
-              <mat-hint align="end">
-                {{ templateForm.get('name')?.value?.length }}/{{ 50 }}
-              </mat-hint>
-              @if (this.templateForm.get('name')?.errors) {
-                <mat-error data-testid="name-error" id="name-error-message">
-                  {{
-                    getTemplateNameErrorMessage(
-                      this.templateForm.get('name')?.errors ?? null
-                    )
-                  }}
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Description (optionnelle)</mat-label>
-              <textarea
-                matInput
-                formControlName="description"
-                rows="3"
-                aria-label="Description du modèle (optionnel)"
-                data-testid="template-description-input"
-              ></textarea>
-              <mat-hint align="end">
-                {{ templateForm.get('description')?.value?.length }}/{{ 200 }}
-              </mat-hint>
-              @if (templateForm.get('description')?.errors) {
-                <mat-error>
-                  @if (templateForm.get('description')?.errors?.['maxlength']) {
-                    La description ne doit pas dépasser 200 caractères.
-                  }
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <div class="flex items-center gap-2">
-              <mat-checkbox
-                formControlName="isDefault"
-                data-testid="template-default-checkbox"
-                aria-label="Définir comme modèle par défaut"
-                class="min-h-[44px] flex items-center"
-              >
-                Modèle par défaut
-              </mat-checkbox>
-              <mat-icon
-                matTooltip="Le modèle par défaut est sélectionné par défaut pour créer de nouveaux budgets mensuels."
-                matTooltipPosition="above"
-                aria-label="Information sur le modèle par défaut"
-                class="!text-on-surface-variant cursor-help"
-                tabindex="0"
-              >
-                info
-              </mat-icon>
             </div>
+          }
 
-            <!-- Default warning panel -->
-            @if (overrideDefaultTemplateWarningMessage(); as warningMessage) {
-              <div class="col-span-1">
-                <pulpe-default-warning-panel
-                  id="default-warning"
-                  [message]="warningMessage"
-                />
-              </div>
-            }
-
-            <!-- Enhanced error message section -->
-            @if (globalFormError(); as errorMessage) {
-              <div class="col-span-1">
-                <div
-                  class="p-4 bg-error-container text-on-error-container rounded-corner-medium flex items-start gap-3"
-                  role="alert"
-                  aria-live="assertive"
+          <!-- Enhanced error message section -->
+          @if (globalFormError(); as errorMessage) {
+            <div class="col-span-1">
+              <div
+                class="p-4 bg-error-container text-on-error-container rounded-corner-medium flex items-start gap-3"
+                role="alert"
+                aria-live="assertive"
+              >
+                <mat-icon class="text-on-error-container flex-shrink-0 mt-0.5"
+                  >error</mat-icon
                 >
-                  <mat-icon class="text-on-error-container flex-shrink-0 mt-0.5"
-                    >error</mat-icon
-                  >
-                  <span class="text-body-medium leading-relaxed">
-                    {{ errorMessage }}
-                  </span>
-                </div>
+                <span class="text-body-medium leading-relaxed">
+                  {{ errorMessage }}
+                </span>
               </div>
-            }
+            </div>
+          }
 
-            <!-- Template limit information -->
-            @if (state.isTemplateLimitReached()) {
-              <div class="col-span-1">
-                <div
-                  id="limit-reached-info"
-                  class="p-4 bg-error-container text-on-error-container rounded-corner-medium flex items-start gap-3"
-                  role="status"
-                  aria-live="polite"
+          <!-- Template limit information -->
+          @if (isLimitReached()) {
+            <div class="col-span-1">
+              <div
+                id="limit-reached-info"
+                class="p-4 bg-error-container text-on-error-container rounded-corner-medium flex items-start gap-3"
+                role="status"
+                aria-live="polite"
+              >
+                <mat-icon class="text-on-error-container flex-shrink-0 mt-0.5"
+                  >warning</mat-icon
                 >
-                  <mat-icon class="text-on-error-container flex-shrink-0 mt-0.5"
-                    >warning</mat-icon
-                  >
-                  <span class="text-body-medium leading-relaxed">
-                    Limite de {{ state.MAX_TEMPLATES }} modèles atteinte.
-                    Supprimez un modèle existant pour en créer un nouveau.
-                  </span>
-                </div>
+                <span class="text-body-medium leading-relaxed">
+                  Limite de {{ maxTemplates }} modèles atteinte. Supprimez un
+                  modèle existant pour en créer un nouveau.
+                </span>
               </div>
-            }
-          </div>
+            </div>
+          }
+        </div>
 
-          <!-- Divider to separate form from actions -->
-          <mat-divider class="!mt-4 !mb-4" />
+        <!-- Divider to separate form from actions -->
+        <mat-divider class="!mt-4 !mb-4" />
 
-          <!-- Action buttons aligned right with mobile-first responsive layout -->
-          <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-            <button
-              matButton
-              (click)="cancelForm.emit()"
-              [disabled]="isCreating()"
-              data-testid="cancel-button"
-              type="button"
-            >
-              Annuler
-            </button>
-            <button
-              matButton="filled"
-              type="submit"
-              [disabled]="!isFormValidForSubmission()"
-              data-testid="template-submit-button"
-            >
-              {{ submitButtonText() }}
-            </button>
-          </div>
-        </form>
-      </div>
-    }
+        <!-- Action buttons aligned right with mobile-first responsive layout -->
+        <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            matButton
+            (click)="cancelForm.emit()"
+            [disabled]="isCreating()"
+            data-testid="cancel-button"
+            type="button"
+          >
+            Annuler
+          </button>
+          <button
+            matButton="filled"
+            type="submit"
+            [disabled]="!isFormValidForSubmission()"
+            data-testid="template-submit-button"
+          >
+            {{ submitButtonText() }}
+          </button>
+        </div>
+      </form>
+    </div>
   `,
   styles: `
     :host {
@@ -235,36 +227,37 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CreateTemplateForm {
-  // Injected dependencies
   #fb = inject(FormBuilder);
-  protected state = inject(BudgetTemplatesState);
 
+  // All data comes via inputs - NO state injection
   isCreating = input(false);
+  templateCount = input(0);
+  existingTemplateNames = input<string[]>([]);
+  defaultTemplateName = input<string | null>(null);
 
+  // Outputs
   addTemplate = output<BudgetTemplateCreate>();
   cancelForm = output<void>();
-  formReset = output<void>();
 
+  // Constants
+  readonly maxTemplates = MAX_TEMPLATES;
+
+  // Local state
   globalFormError = signal<string | null>(null);
+
+  // Form definition - validators set initially, updated via effect when inputs change
   templateForm = this.#fb.group({
     name: [
       '',
       {
-        validators: [
-          Validators.required,
-          Validators.maxLength(50),
-          duplicateNameValidator(
-            this.state.budgetTemplates
-              .value()
-              ?.map((t) => t.name.toLowerCase()),
-          ),
-        ],
+        validators: [Validators.required, Validators.maxLength(50)],
       },
     ],
     description: ['', [Validators.maxLength(200)]],
     isDefault: [false],
   });
 
+  // Form signals
   formValues = toSignal(this.templateForm.valueChanges, {
     initialValue: this.templateForm.getRawValue(),
   });
@@ -272,39 +265,36 @@ export class CreateTemplateForm {
     initialValue: this.templateForm.status,
   });
   isFormValid = computed(() => this.formStatus() === 'VALID');
-
-  // Computed signals reading from consolidated formValues
   isDefaultChecked = computed(() => this.formValues()?.isDefault ?? false);
 
-  overrideDefaultTemplateWarningMessage = linkedSignal(() => {
-    const defaultTemplate = this.state.defaultBudgetTemplate();
+  // Computed: limit reached based on input
+  isLimitReached = computed(() => this.templateCount() >= this.maxTemplates);
+
+  // Computed: warning message when overriding default
+  overrideDefaultWarning = computed(() => {
+    const defaultName = this.defaultTemplateName();
     const isDefaultChecked = this.isDefaultChecked();
 
-    if (!!defaultTemplate && isDefaultChecked) {
-      return `Le modèle "${defaultTemplate.name}" ne sera plus le modèle par défaut.`;
+    if (defaultName && isDefaultChecked) {
+      return `Le modèle "${defaultName}" ne sera plus le modèle par défaut.`;
     }
-
     return null;
   });
 
-  // Smart submit button state management
+  // Submit button text
   submitButtonText = computed(() => {
-    const isCreating = this.isCreating();
-    const isTemplateLimitReached = this.state.isTemplateLimitReached();
-    if (isCreating) return 'Création...';
-    if (isTemplateLimitReached) return 'Limite atteinte';
+    if (this.isCreating()) return 'Création...';
+    if (this.isLimitReached()) return 'Limite atteinte';
     return 'Créer';
   });
 
+  // Form valid for submission
   isFormValidForSubmission = computed(() => {
-    const isFormValid = this.isFormValid();
-    const isPending = this.isCreating();
-    const isTemplateLimitReached = this.state.isTemplateLimitReached();
-    return isFormValid && !isPending && !isTemplateLimitReached;
+    return this.isFormValid() && !this.isCreating() && !this.isLimitReached();
   });
 
   constructor() {
-    // Effect to disable/enable form fields based on isCreating signal
+    // Effect: disable form when creating
     effect(() => {
       if (this.isCreating()) {
         this.templateForm.disable();
@@ -313,31 +303,34 @@ export class CreateTemplateForm {
       }
     });
 
+    // Effect: update validators when existingTemplateNames input changes
     effect(() => {
-      const templates = this.state.budgetTemplates.value();
+      const existingNames = this.existingTemplateNames();
       this.templateForm
         .get('name')
         ?.setValidators([
           Validators.required,
           Validators.maxLength(50),
-          duplicateNameValidator(templates?.map((t) => t.name.toLowerCase())),
+          duplicateNameValidator(existingNames),
         ]);
-      this.templateForm.get('name')?.updateValueAndValidity();
+      // Only update validity if form is not being created (to avoid flicker)
+      if (!this.isCreating()) {
+        this.templateForm.get('name')?.updateValueAndValidity();
+      }
     });
   }
 
   onSubmit() {
     this.templateForm.markAllAsTouched();
     if (!this.isFormValidForSubmission()) {
-      if (this.state.isTemplateLimitReached()) {
+      if (this.isLimitReached()) {
         this.globalFormError.set(
-          `Vous avez atteint la limite de ${this.state.MAX_TEMPLATES} modèles`,
+          `Vous avez atteint la limite de ${this.maxTemplates} modèles`,
         );
       }
       return;
     }
 
-    // Form is valid, create template from form values
     const formVal = this.formValues();
     const template: BudgetTemplateCreate = {
       name: formVal?.name?.trim() ?? '',
@@ -347,20 +340,8 @@ export class CreateTemplateForm {
     };
 
     this.addTemplate.emit(template);
-    // Reset form immediately after successful submission
-    this.resetForm();
   }
 
-  // Enhanced form reset with better UX
-  resetForm() {
-    this.templateForm.reset();
-    this.templateForm.markAsUntouched();
-    this.templateForm.markAsPristine();
-
-    this.formReset.emit();
-  }
-
-  // Enhanced keyboard navigation
   onEscapeKey() {
     if (!this.isCreating()) {
       this.cancelForm.emit();

--- a/frontend/projects/webapp/src/app/feature/budget-templates/create/create-template-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/create/create-template-page.ts
@@ -119,7 +119,7 @@ export default class CreateTemplatePage {
     this.isCreatingTemplate.set(true);
 
     try {
-      const createdTemplate = await this.#state.addTemplate(template);
+      const response = await this.#state.addTemplate(template);
 
       // Show success message
       this.#snackBar.open(MESSAGES.SUCCESS, 'Fermer', SNACKBAR_CONFIG.SUCCESS);
@@ -127,10 +127,19 @@ export default class CreateTemplatePage {
       // Navigate to the details page of the newly created template
       // Note: We keep isCreating=true during navigation to prevent UI flicker.
       // The component will be destroyed when navigation completes.
-      if (createdTemplate?.id) {
-        await this.#router.navigate([
-          ROUTES.TEMPLATE_DETAILS(createdTemplate.id),
-        ]);
+      if (response?.template.id) {
+        // Pass POST response as router state for SWR (instant display)
+        await this.#router.navigate(
+          [ROUTES.TEMPLATE_DETAILS(response.template.id)],
+          {
+            state: {
+              initialData: {
+                template: response.template,
+                transactions: response.lines,
+              },
+            },
+          },
+        );
       } else {
         await this.#router.navigate([ROUTES.BUDGET_TEMPLATES]);
       }

--- a/frontend/projects/webapp/src/app/feature/budget-templates/create/create-template-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/create/create-template-page.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
   signal,
 } from '@angular/core';
@@ -70,10 +71,12 @@ const SNACKBAR_CONFIG = {
 
       <div class="flex-1 overflow-auto">
         <pulpe-create-template-form
+          [isCreating]="isCreatingTemplate()"
+          [templateCount]="templateCount()"
+          [existingTemplateNames]="existingTemplateNames()"
+          [defaultTemplateName]="defaultTemplateName()"
           (addTemplate)="onAddTemplate($event)"
           (cancelForm)="navigateBack()"
-          (formReset)="onFormReset()"
-          [isCreating]="isCreatingTemplate()"
           data-testid="add-template-form"
         />
       </div>
@@ -94,35 +97,48 @@ export default class CreateTemplatePage {
   #state = inject(BudgetTemplatesState);
   #snackBar = inject(MatSnackBar);
   #logger = inject(Logger);
-  // Properties
+
+  // Local state
   isCreatingTemplate = signal(false);
 
+  // Computed values to pass to child form (smart/dumb pattern)
+  // These are computed ONCE from state and passed as stable inputs
+  templateCount = computed(() => this.#state.templateCount());
+  existingTemplateNames = computed(
+    () =>
+      this.#state.budgetTemplates
+        .value()
+        ?.filter((t) => !t.id.startsWith('temp-'))
+        .map((t) => t.name.toLowerCase()) ?? [],
+  );
+  defaultTemplateName = computed(
+    () => this.#state.defaultBudgetTemplate()?.name ?? null,
+  );
+
   async onAddTemplate(template: BudgetTemplateCreate) {
+    this.isCreatingTemplate.set(true);
+
     try {
-      this.isCreatingTemplate.set(true);
       const createdTemplate = await this.#state.addTemplate(template);
 
       // Show success message
       this.#snackBar.open(MESSAGES.SUCCESS, 'Fermer', SNACKBAR_CONFIG.SUCCESS);
 
-      // Form will reset itself and emit formReset event
-
       // Navigate to the details page of the newly created template
-      if (createdTemplate && createdTemplate.id) {
-        this.#router.navigate([ROUTES.TEMPLATE_DETAILS(createdTemplate.id)]);
+      // Note: We keep isCreating=true during navigation to prevent UI flicker.
+      // The component will be destroyed when navigation completes.
+      if (createdTemplate?.id) {
+        await this.#router.navigate([
+          ROUTES.TEMPLATE_DETAILS(createdTemplate.id),
+        ]);
       } else {
-        this.navigateBack();
+        await this.#router.navigate([ROUTES.BUDGET_TEMPLATES]);
       }
     } catch (error) {
-      this.handleError(error);
-    } finally {
+      // Only reset isCreating on error (user stays on page to retry)
       this.isCreatingTemplate.set(false);
+      this.handleError(error);
     }
-  }
-
-  onFormReset() {
-    // Handle form reset completion if needed
-    // Currently no additional action required
   }
 
   navigateBack() {

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-details-store.ts
@@ -82,15 +82,18 @@ export class TemplateDetailsStore {
     id: string,
     staleData?: BudgetTemplateDetailViewModel,
   ): void {
+    // IMPORTANT: Set stale data BEFORE templateId to avoid loading flash
+    // When templateId changes, resource triggers isLoading=true
+    // Having staleData already set makes isLoading computed return false
+    if (staleData) {
+      this.#staleData.set(staleData);
+    }
+
     this.#state.update((state) => ({
       ...state,
       templateId: id,
       error: null,
     }));
-
-    if (staleData) {
-      this.#staleData.set(staleData);
-    }
   }
 
   /**

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/template-detail.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/template-detail.ts
@@ -245,15 +245,12 @@ export default class TemplateDetail implements OnInit {
     if (!templateId) return;
 
     // Extract stale data from router state (if navigated from create page)
-    // This enables SWR: instant display + background revalidation
-    const navigation = this.#router.getCurrentNavigation();
-    const staleData = navigation?.extras.state?.['initialData'] as
+    // Note: Use history.state because getCurrentNavigation() returns null in ngOnInit
+    // (navigation is already complete when component initializes)
+    const staleData = history.state?.['initialData'] as
       | BudgetTemplateDetailViewModel
       | undefined;
 
-    // Initialize store with optional SWR cache
-    // - With staleData: instant render + background fetch
-    // - Without staleData: normal loading (e.g., direct URL access)
     this.templateDetailsStore.initializeTemplateId(templateId, staleData);
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-api.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-api.ts
@@ -2,6 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { type Observable, forkJoin, map } from 'rxjs';
 import {
+  type BudgetTemplate,
   type BudgetTemplateCreate,
   type BudgetTemplateCreateFromOnboarding,
   type BudgetTemplateCreateResponse,
@@ -34,8 +35,12 @@ export class BudgetTemplatesApi {
     return this.#http.get<BudgetTemplateResponse>(`${this.#apiUrl}/${id}`);
   }
 
-  create$(template: BudgetTemplateCreate): Observable<BudgetTemplateResponse> {
-    return this.#http.post<BudgetTemplateResponse>(this.#apiUrl, template);
+  create$(
+    template: BudgetTemplateCreate,
+  ): Observable<{ data: BudgetTemplate }> {
+    return this.#http
+      .post<BudgetTemplateCreateResponse>(this.#apiUrl, template)
+      .pipe(map((response) => ({ data: response.data.template })));
   }
 
   createFromOnboarding$(

--- a/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-api.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-api.ts
@@ -2,7 +2,6 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { type Observable, forkJoin, map } from 'rxjs';
 import {
-  type BudgetTemplate,
   type BudgetTemplateCreate,
   type BudgetTemplateCreateFromOnboarding,
   type BudgetTemplateCreateResponse,
@@ -37,10 +36,11 @@ export class BudgetTemplatesApi {
 
   create$(
     template: BudgetTemplateCreate,
-  ): Observable<{ data: BudgetTemplate }> {
-    return this.#http
-      .post<BudgetTemplateCreateResponse>(this.#apiUrl, template)
-      .pipe(map((response) => ({ data: response.data.template })));
+  ): Observable<BudgetTemplateCreateResponse> {
+    return this.#http.post<BudgetTemplateCreateResponse>(
+      this.#apiUrl,
+      template,
+    );
   }
 
   createFromOnboarding$(

--- a/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-state.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-state.ts
@@ -1,5 +1,9 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
-import { type BudgetTemplate, type BudgetTemplateCreate } from '@pulpe/shared';
+import {
+  type BudgetTemplate,
+  type BudgetTemplateCreate,
+  type BudgetTemplateCreateResponse,
+} from '@pulpe/shared';
 import { catchError, firstValueFrom, map } from 'rxjs';
 import { BudgetTemplatesApi } from './budget-templates-api';
 import { rxResource } from '@angular/core/rxjs-interop';
@@ -60,7 +64,7 @@ export class BudgetTemplatesState {
 
   async addTemplate(
     template: BudgetTemplateCreate,
-  ): Promise<BudgetTemplate | void> {
+  ): Promise<BudgetTemplateCreateResponse['data'] | void> {
     // Validate business rules
     if (this.isTemplateLimitReached()) {
       throw new Error('Template limit reached');
@@ -74,12 +78,13 @@ export class BudgetTemplatesState {
       this.#budgetTemplatesApi.create$(template),
     );
 
-    // Update state with the real template after successful creation
+    // Update list state with template only (lines don't belong in list)
     this.budgetTemplates.update((data) => {
-      if (!data || !response.data) return data;
-      return [...data, response.data];
+      if (!data || !response.data.template) return data;
+      return [...data, response.data.template];
     });
 
+    // Return full data (template + lines) for SWR navigation
     return response.data;
   }
   async deleteTemplate(id: string): Promise<void> {

--- a/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-store.spec.ts
@@ -176,7 +176,9 @@ describe('BudgetTemplatesState', () => {
 
       mockApi.create$ = vi
         .fn()
-        .mockReturnValue(of({ data: createdTemplate, success: true }));
+        .mockReturnValue(
+          of({ data: { template: createdTemplate, lines: [] }, success: true }),
+        );
 
       // Wait for initial load
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -205,7 +207,9 @@ describe('BudgetTemplatesState', () => {
 
       mockApi.create$ = vi
         .fn()
-        .mockReturnValue(of({ data: createdTemplate, success: true }));
+        .mockReturnValue(
+          of({ data: { template: createdTemplate, lines: [] }, success: true }),
+        );
 
       // Wait for initial load
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -305,7 +309,11 @@ describe('BudgetTemplatesState', () => {
         updatedAt: new Date().toISOString(),
       };
 
-      mockApi.create$ = vi.fn().mockReturnValue(of({ data: createdTemplate }));
+      mockApi.create$ = vi
+        .fn()
+        .mockReturnValue(
+          of({ data: { template: createdTemplate, lines: [] }, success: true }),
+        );
 
       // Wait for initial load
       await new Promise((resolve) => setTimeout(resolve, 100));

--- a/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-store.spec.ts
@@ -289,11 +289,11 @@ describe('BudgetTemplatesState', () => {
     });
   });
 
-  describe('Optimistic Updates', () => {
-    it('should apply optimistic update during creation', async () => {
+  describe('Template Creation', () => {
+    it('should add template to state only after successful API response', async () => {
       const newTemplate: BudgetTemplateCreate = {
-        name: 'Optimistic Template',
-        description: 'Testing optimistic update',
+        name: 'New Template',
+        description: 'Testing creation',
         isDefault: false,
         lines: [],
       };
@@ -305,44 +305,23 @@ describe('BudgetTemplatesState', () => {
         updatedAt: new Date().toISOString(),
       };
 
-      let createResolve: (value: unknown) => void;
-      const createPromise = new Promise((resolve) => {
-        createResolve = resolve;
-      });
-
-      mockApi.create$ = vi.fn().mockReturnValue({
-        subscribe: (callbacks: { next: (value: unknown) => void }) => {
-          createPromise.then((value) => callbacks.next(value));
-          return {
-            unsubscribe: () => {
-              /* noop */
-            },
-          };
-        },
-      });
+      mockApi.create$ = vi.fn().mockReturnValue(of({ data: createdTemplate }));
 
       // Wait for initial load
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      const addPromise = state.addTemplate(newTemplate);
+      const initialCount = state.templateCount();
 
-      // Check optimistic update - should have temporary template
-      const templates = state.budgetTemplates.value();
-      const tempTemplate = templates?.find((t) => t.id.startsWith('temp-'));
-      expect(tempTemplate).toBeTruthy();
-      expect(tempTemplate?.name).toBe('Optimistic Template');
+      await state.addTemplate(newTemplate);
 
-      // Resolve the creation
-      createResolve!({ data: createdTemplate, success: true });
-      await addPromise;
-
-      // Check final state - temporary should be replaced
-      const finalTemplates = state.budgetTemplates.value();
-      expect(finalTemplates?.find((t) => t.id.startsWith('temp-'))).toBeFalsy();
-      expect(finalTemplates?.find((t) => t.id === 'template-3')).toBeTruthy();
+      // Template should be added after successful creation
+      expect(state.templateCount()).toBe(initialCount + 1);
+      expect(
+        state.budgetTemplates.value()?.find((t) => t.id === 'template-3'),
+      ).toBeTruthy();
     });
 
-    it('should rollback optimistic update on failure', async () => {
+    it('should not modify state on creation failure', async () => {
       const newTemplate: BudgetTemplateCreate = {
         name: 'Failing Template',
         description: 'This will fail',
@@ -365,11 +344,8 @@ describe('BudgetTemplatesState', () => {
         // Expected error
       }
 
-      // Template count should be back to original
+      // Template count should remain unchanged
       expect(state.templateCount()).toBe(initialCount);
-      expect(
-        state.budgetTemplates.value()?.find((t) => t.id.startsWith('temp-')),
-      ).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace state injection with input/output signals in CreateTemplateForm for better composability and testability
- Remove optimistic updates from creation flow to eliminate UI flicker during navigation
- Compute template metadata in parent component using the smart/dumb pattern
- Fix API response type mapping for consistency

## Testing
All unit tests updated and passing. Quality checks passed (lint, format, typecheck).