### PR TITLE
feat: add About dialog with debug info to user menu

### DIFF
--- a/frontend/projects/webapp/src/app/layout/about-dialog.ts
+++ b/frontend/projects/webapp/src/app/layout/about-dialog.ts
@@ -1,0 +1,149 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { ApplicationConfiguration } from '@core/config/application-configuration';
+import { buildInfo } from '@env/build-info';
+
+interface DebugInfoSection {
+  readonly label: string;
+  readonly items: readonly DebugInfoItem[];
+}
+
+interface DebugInfoItem {
+  readonly label: string;
+  readonly value: string;
+}
+
+@Component({
+  selector: 'pulpe-about-dialog',
+  imports: [MatDialogModule, MatButtonModule, MatIconModule],
+  template: `
+    <h2 mat-dialog-title class="text-headline-small">À propos</h2>
+
+    <mat-dialog-content>
+      <div class="flex flex-col gap-6">
+        @for (section of sections; track section.label) {
+          <div>
+            <h3 class="text-label-large text-on-surface-variant mb-2">
+              {{ section.label }}
+            </h3>
+            <div class="flex flex-col gap-1">
+              @for (item of section.items; track item.label) {
+                <div class="flex justify-between gap-4 py-1">
+                  <span class="text-body-medium text-on-surface-variant">
+                    {{ item.label }}
+                  </span>
+                  <span
+                    class="text-body-medium text-on-surface font-mono text-right"
+                  >
+                    {{ item.value }}
+                  </span>
+                </div>
+              }
+            </div>
+          </div>
+        }
+      </div>
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      <button
+        matButton="filled"
+        (click)="close()"
+        data-testid="about-close-button"
+      >
+        Fermer
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      mat-dialog-content {
+        min-width: 320px;
+        max-width: 480px;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AboutDialog {
+  readonly #dialogRef = inject(MatDialogRef<AboutDialog>);
+  readonly #applicationConfig = inject(ApplicationConfiguration);
+
+  readonly sections: readonly DebugInfoSection[] = this.#buildSections();
+
+  close(): void {
+    this.#dialogRef.close();
+  }
+
+  #buildSections(): DebugInfoSection[] {
+    const config = this.#applicationConfig;
+
+    return [
+      {
+        label: 'Build',
+        items: [
+          { label: 'Version', value: buildInfo.version },
+          { label: 'Commit', value: buildInfo.shortCommitHash },
+          { label: 'Date', value: this.#formatDate(buildInfo.buildDate) },
+        ],
+      },
+      {
+        label: 'Environnement',
+        items: [{ label: 'Mode', value: config.environment() }],
+      },
+      {
+        label: 'Configuration',
+        items: [
+          {
+            label: 'Supabase URL',
+            value: this.#truncateUrl(config.supabaseUrl()),
+          },
+          {
+            label: 'Backend URL',
+            value: this.#truncateUrl(config.backendApiUrl()),
+          },
+        ],
+      },
+      {
+        label: 'Analytics',
+        items: [
+          {
+            label: 'PostHog',
+            value: config.postHog().enabled ? 'Actif' : 'Inactif',
+          },
+          { label: 'Host', value: this.#truncateUrl(config.postHog().host) },
+        ],
+      },
+    ];
+  }
+
+  #formatDate(isoDate: string): string {
+    try {
+      return new Date(isoDate).toLocaleDateString('fr-FR', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return isoDate;
+    }
+  }
+
+  #truncateUrl(url: string): string {
+    if (!url) return 'Non configuré';
+    try {
+      const parsed = new URL(url);
+      return parsed.host;
+    } catch {
+      return url;
+    }
+  }
+}

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -11,6 +11,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
+import { MatDialog } from '@angular/material/dialog';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -33,6 +34,7 @@ import { DemoModeService } from '@core/demo/demo-mode.service';
 import { DemoInitializerService } from '@core/demo/demo-initializer.service';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { LoadingIndicator } from '@core/loading/loading-indicator';
+import { AboutDialog } from './about-dialog';
 
 interface NavigationItem {
   readonly route: string;
@@ -241,6 +243,15 @@ interface NavigationItem {
             <mat-menu #userMenu="matMenu" xPosition="before">
               <button
                 mat-menu-item
+                (click)="openAboutDialog()"
+                aria-label="Afficher les informations de l'application"
+                data-testid="about-button"
+              >
+                <mat-icon matMenuItemIcon aria-hidden="true">info</mat-icon>
+                <span>À propos</span>
+              </button>
+              <button
+                mat-menu-item
                 (click)="onLogout()"
                 [disabled]="isLoggingOut()"
                 [attr.aria-label]="
@@ -351,6 +362,7 @@ export default class MainLayout {
   readonly #demoInitializer = inject(DemoInitializerService);
   readonly breadcrumbState = inject(BreadcrumbState);
   readonly #logger = inject(Logger);
+  readonly #dialog = inject(MatDialog);
   protected readonly loadingIndicator = inject(LoadingIndicator);
   // Display "Mode Démo" for demo users, otherwise show email
   readonly userEmail = computed(() => {
@@ -434,6 +446,13 @@ export default class MainLayout {
     if (this.isHandset()) {
       drawer.close();
     }
+  }
+
+  protected openAboutDialog(): void {
+    this.#dialog.open(AboutDialog, {
+      width: 'auto',
+      maxWidth: '90vw',
+    });
   }
 
   async onLogout(): Promise<void> {


### PR DESCRIPTION
## Summary

Add "À propos" dialog accessible from the user profile menu displaying application debug information (version, commit hash, build date, environment, configuration endpoints, and analytics status).

## Changes

- Created `AboutDialog` component in `layout/` with formatted debug info display
- Added "À propos" menu entry in user profile dropdown menu
- Dialog respects responsive design with `maxWidth: 90vw`

## Test Plan

- Click user profile menu in top toolbar
- Select "À propos" option
- Verify dialog displays correct build/config information
- Verify dialog closes on "Fermer" button click

🤖 Generated with [Claude Code](https://claude.com/claude-code)