### PR TITLE
refactor(budget): hide frequency selector, use context-based defaults

### DIFF
--- a/frontend/e2e/tests/budget-line-edit-mobile.spec.ts
+++ b/frontend/e2e/tests/budget-line-edit-mobile.spec.ts
@@ -58,7 +58,6 @@ test.describe('Budget Line Edit - Mobile', () => {
     await expect(dialog.locator('[data-testid="edit-line-name"]')).toBeVisible();
     await expect(dialog.locator('[data-testid="edit-line-amount"]')).toBeVisible();
     await expect(dialog.locator('[data-testid="edit-line-kind"]')).toBeVisible();
-    await expect(dialog.locator('[data-testid="edit-line-recurrence"]')).toBeVisible();
 
     // Check that cancel and save buttons are present
     await expect(dialog.locator('[data-testid="cancel-edit-line"]')).toBeVisible();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.ts
@@ -17,7 +17,6 @@ import {
   type TransactionRecurrence,
 } from '@pulpe/shared';
 import {
-  RecurrenceLabelPipe,
   TransactionIconPipe,
   TransactionLabelPipe,
 } from '@ui/transaction-display';
@@ -36,7 +35,6 @@ export interface BudgetLineDialogData {
     MatButtonModule,
     MatIconModule,
     ReactiveFormsModule,
-    RecurrenceLabelPipe,
     TransactionIconPipe,
     TransactionLabelPipe,
   ],
@@ -70,46 +68,29 @@ export interface BudgetLineDialogData {
             <span matTextSuffix>CHF</span>
           </mat-form-field>
 
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Type</mat-label>
-              <mat-select formControlName="kind" data-testid="new-line-kind">
-                <mat-option value="income">
-                  <mat-icon class="text-financial-income">{{
-                    'income' | transactionIcon
-                  }}</mat-icon>
-                  <span>{{ 'income' | transactionLabel }}</span>
-                </mat-option>
-                <mat-option value="expense">
-                  <mat-icon class="text-financial-negative">{{
-                    'expense' | transactionIcon
-                  }}</mat-icon>
-                  <span>{{ 'expense' | transactionLabel }}</span>
-                </mat-option>
-                <mat-option value="saving">
-                  <mat-icon class="text-primary">{{
-                    'saving' | transactionIcon
-                  }}</mat-icon>
-                  <span>{{ 'saving' | transactionLabel }}</span>
-                </mat-option>
-              </mat-select>
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Fréquence</mat-label>
-              <mat-select
-                formControlName="recurrence"
-                data-testid="new-line-recurrence"
-              >
-                <mat-option value="fixed">{{
-                  'fixed' | recurrenceLabel
-                }}</mat-option>
-                <mat-option value="one_off">{{
-                  'one_off' | recurrenceLabel
-                }}</mat-option>
-              </mat-select>
-            </mat-form-field>
-          </div>
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Type</mat-label>
+            <mat-select formControlName="kind" data-testid="new-line-kind">
+              <mat-option value="income">
+                <mat-icon class="text-financial-income">{{
+                  'income' | transactionIcon
+                }}</mat-icon>
+                <span>{{ 'income' | transactionLabel }}</span>
+              </mat-option>
+              <mat-option value="expense">
+                <mat-icon class="text-financial-negative">{{
+                  'expense' | transactionIcon
+                }}</mat-icon>
+                <span>{{ 'expense' | transactionLabel }}</span>
+              </mat-option>
+              <mat-option value="saving">
+                <mat-icon class="text-primary">{{
+                  'saving' | transactionIcon
+                }}</mat-icon>
+                <span>{{ 'saving' | transactionLabel }}</span>
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
         </form>
       </div>
     </mat-dialog-content>
@@ -144,7 +125,7 @@ export class AddBudgetLineDialog {
       [Validators.required, Validators.min(0.01)],
     ],
     kind: ['expense' as TransactionKind, Validators.required],
-    recurrence: ['fixed' as TransactionRecurrence, Validators.required],
+    recurrence: ['one_off' as TransactionRecurrence],
   });
 
   formValue = toSignal(this.form.valueChanges, {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/edit-budget-line/edit-budget-line-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/edit-budget-line/edit-budget-line-dialog.ts
@@ -17,7 +17,6 @@ import {
   type TransactionRecurrence,
 } from '@pulpe/shared';
 import {
-  RecurrenceLabelPipe,
   TransactionIconPipe,
   TransactionLabelPipe,
 } from '@ui/transaction-display';
@@ -36,7 +35,6 @@ export interface EditBudgetLineDialogData {
     MatButtonModule,
     MatIconModule,
     ReactiveFormsModule,
-    RecurrenceLabelPipe,
     TransactionIconPipe,
     TransactionLabelPipe,
   ],
@@ -93,58 +91,35 @@ export interface EditBudgetLineDialogData {
             }
           </mat-form-field>
 
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Type</mat-label>
-              <mat-select formControlName="kind" data-testid="edit-line-kind">
-                <mat-option value="income">
-                  <mat-icon class="text-financial-income">{{
-                    'income' | transactionIcon
-                  }}</mat-icon>
-                  <span>{{ 'income' | transactionLabel }}</span>
-                </mat-option>
-                <mat-option value="expense">
-                  <mat-icon class="text-financial-negative">{{
-                    'expense' | transactionIcon
-                  }}</mat-icon>
-                  <span>{{ 'expense' | transactionLabel }}</span>
-                </mat-option>
-                <mat-option value="saving">
-                  <mat-icon class="text-primary">{{
-                    'saving' | transactionIcon
-                  }}</mat-icon>
-                  <span>{{ 'saving' | transactionLabel }}</span>
-                </mat-option>
-              </mat-select>
-              @if (
-                form.get('kind')?.hasError('required') &&
-                form.get('kind')?.touched
-              ) {
-                <mat-error>Le type est requis</mat-error>
-              }
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Fréquence</mat-label>
-              <mat-select
-                formControlName="recurrence"
-                data-testid="edit-line-recurrence"
-              >
-                <mat-option value="fixed">{{
-                  'fixed' | recurrenceLabel
-                }}</mat-option>
-                <mat-option value="one_off">{{
-                  'one_off' | recurrenceLabel
-                }}</mat-option>
-              </mat-select>
-              @if (
-                form.get('recurrence')?.hasError('required') &&
-                form.get('recurrence')?.touched
-              ) {
-                <mat-error>La fréquence est requise</mat-error>
-              }
-            </mat-form-field>
-          </div>
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Type</mat-label>
+            <mat-select formControlName="kind" data-testid="edit-line-kind">
+              <mat-option value="income">
+                <mat-icon class="text-financial-income">{{
+                  'income' | transactionIcon
+                }}</mat-icon>
+                <span>{{ 'income' | transactionLabel }}</span>
+              </mat-option>
+              <mat-option value="expense">
+                <mat-icon class="text-financial-negative">{{
+                  'expense' | transactionIcon
+                }}</mat-icon>
+                <span>{{ 'expense' | transactionLabel }}</span>
+              </mat-option>
+              <mat-option value="saving">
+                <mat-icon class="text-primary">{{
+                  'saving' | transactionIcon
+                }}</mat-icon>
+                <span>{{ 'saving' | transactionLabel }}</span>
+              </mat-option>
+            </mat-select>
+            @if (
+              form.get('kind')?.hasError('required') &&
+              form.get('kind')?.touched
+            ) {
+              <mat-error>Le type est requis</mat-error>
+            }
+          </mat-form-field>
         </form>
       </div>
     </mat-dialog-content>


### PR DESCRIPTION
The frequency field is now automatically set based on context:
- Budget lines (create/edit): defaults to 'one_off' (Prévu)
- Template lines: defaults to 'fixed' (Récurrent)

This simplifies the UX by removing a redundant choice - if something
is truly recurring, it should be added to the template, not manually
to a monthly budget.