### PR TITLE
feat: make budget description optional

### DIFF
--- a/backend-nest/src/modules/budget/budget.validator.ts
+++ b/backend-nest/src/modules/budget/budget.validator.ts
@@ -90,7 +90,7 @@ export class BudgetValidator {
     const missingFields = [];
     if (!createBudgetDto.month) missingFields.push('month');
     if (!createBudgetDto.year) missingFields.push('year');
-    if (!createBudgetDto.description) missingFields.push('description');
+    // Description is optional - no validation needed
     if (!createBudgetDto.templateId) missingFields.push('templateId');
 
     if (missingFields.length > 0) {
@@ -131,10 +131,11 @@ export class BudgetValidator {
    * @param createBudgetDto - Budget creation data
    */
   private validateBusinessRules(createBudgetDto: BudgetCreate): void {
-    // Description length validation
+    // Description length validation (only if description is provided)
     if (
+      createBudgetDto.description &&
       createBudgetDto.description.length >
-      BUDGET_CONSTANTS.DESCRIPTION_MAX_LENGTH
+        BUDGET_CONSTANTS.DESCRIPTION_MAX_LENGTH
     ) {
       throw new BusinessException(ERROR_DEFINITIONS.VALIDATION_FAILED, {
         reason: `Description cannot exceed ${BUDGET_CONSTANTS.DESCRIPTION_MAX_LENGTH} characters`,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/budget-creation-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/budget-creation-dialog.spec.ts
@@ -628,7 +628,8 @@ describe('CreateBudgetDialogComponent', () => {
 
   describe('Form Validation Integration', () => {
     it('should prevent budget creation when form is invalid', async () => {
-      // Make form invalid by clearing required fields
+      // Make form invalid by clearing required fields (monthYear and templateId)
+      // Note: description is optional, so empty string is valid
       component.budgetForm.patchValue({
         monthYear: undefined,
         description: '',
@@ -644,6 +645,14 @@ describe('CreateBudgetDialogComponent', () => {
 
       expect(createBudgetSpy).not.toHaveBeenCalled();
       expect(component.isCreating()).toBe(false);
+    });
+
+    it('should allow empty description (optional field)', () => {
+      component.budgetForm.patchValue({ description: '' });
+      component.budgetForm.get('description')?.markAsTouched();
+
+      expect(component.budgetForm.get('description')?.valid).toBe(true);
+      expect(component.budgetForm.get('description')?.errors).toBeNull();
     });
 
     it('should validate description length correctly', () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/budget-creation-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/budget-creation-dialog.ts
@@ -37,7 +37,6 @@ const BUDGET_CREATION_CONSTANTS = {
 
   // Error messages
   ERROR_MESSAGES: {
-    INVALID_DESCRIPTION: 'La description est requise',
     DESCRIPTION_TOO_LONG: 'La description ne peut pas dépasser 100 caractères',
   } as const,
 
@@ -124,7 +123,7 @@ const MONTH_YEAR_FORMATS = {
 
           <!-- Description Field -->
           <mat-form-field appearance="outline" class="w-full">
-            <mat-label>Description</mat-label>
+            <mat-label>Description (optionnelle)</mat-label>
             <input
               matInput
               formControlName="description"
@@ -136,17 +135,9 @@ const MONTH_YEAR_FORMATS = {
                 constants.DESCRIPTION_MAX_LENGTH
               }}</mat-hint
             >
-            @if (
-              budgetForm.get('description')?.invalid &&
-              budgetForm.get('description')?.touched
-            ) {
+            @if (budgetForm.get('description')?.errors?.['maxlength']) {
               <mat-error>
-                @if (budgetForm.get('description')?.errors?.['required']) {
-                  {{ constants.ERROR_MESSAGES.INVALID_DESCRIPTION }}
-                }
-                @if (budgetForm.get('description')?.errors?.['maxlength']) {
-                  {{ constants.ERROR_MESSAGES.DESCRIPTION_TOO_LONG }}
-                }
+                {{ constants.ERROR_MESSAGES.DESCRIPTION_TOO_LONG }}
               </mat-error>
             }
           </mat-form-field>
@@ -255,10 +246,7 @@ export class CreateBudgetDialogComponent {
     monthYear: [this.#getInitialDate(), Validators.required],
     description: [
       '',
-      [
-        Validators.required,
-        Validators.maxLength(BUDGET_CREATION_CONSTANTS.DESCRIPTION_MAX_LENGTH),
-      ],
+      [Validators.maxLength(BUDGET_CREATION_CONSTANTS.DESCRIPTION_MAX_LENGTH)],
     ],
     templateId: ['', Validators.required],
   });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/budget-creation-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/budget-creation-dialog.ts
@@ -128,7 +128,7 @@ const MONTH_YEAR_FORMATS = {
               matInput
               formControlName="description"
               [maxlength]="constants.DESCRIPTION_MAX_LENGTH"
-              placeholder="Saisissez une description pour ce budget"
+              placeholder="Ex: Budget vacances d'été"
             />
             <mat-hint align="end"
               >{{ descriptionLength() }}/{{

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -62,7 +62,7 @@ export const budgetSchema = z.object({
   id: z.uuid(),
   month: z.number().int().min(MONTH_MIN).max(MONTH_MAX),
   year: z.number().int().min(MIN_YEAR).max(MAX_YEAR),
-  description: z.string().min(1).max(500),
+  description: z.string().max(500),
   userId: z.uuid().optional(),
   templateId: z.uuid(),
   // ending_balance : STOCKÉ en base selon SPECS.md section 3
@@ -85,7 +85,7 @@ export type Budget = z.infer<typeof budgetSchema>;
 export const budgetCreateSchema = z.object({
   month: z.number().int().min(MONTH_MIN).max(MONTH_MAX),
   year: z.number().int().min(MIN_YEAR).max(MAX_YEAR),
-  description: z.string().min(1).max(500).trim(),
+  description: z.string().max(500).trim().optional().default(''),
   templateId: z.uuid(),
 });
 export type BudgetCreate = z.infer<typeof budgetCreateSchema>;


### PR DESCRIPTION
## Summary

Allow users to create budgets without providing a description. The field now accepts empty strings and defaults to empty when not provided.

## Changes

- Frontend: Remove required validator, add "(optionnelle)" label with French grammar
- Backend: Update validator to allow empty descriptions
- Shared: Make description optional in budgetCreateSchema with default empty string
- Tests: Add test for optional description field

## Testing

All 705 frontend tests and 21 backend tests pass. Lint and type checks pass.