### PR TITLE
fix: force full page reload on logout to clear in-memory state

### DIFF
--- a/frontend/projects/webapp/src/app/core/auth/auth-interceptor.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-interceptor.ts
@@ -6,7 +6,6 @@ import {
   type HttpErrorResponse,
 } from '@angular/common/http';
 import { type Observable, throwError, from, switchMap, catchError } from 'rxjs';
-import { Router } from '@angular/router';
 import { AuthApi } from './auth-api';
 import { ApplicationConfiguration } from '../config/application-configuration';
 import { ROUTES } from '../routing/routes-constants';
@@ -17,7 +16,6 @@ export const authInterceptor: HttpInterceptorFn = (
 ): Observable<HttpEvent<unknown>> => {
   const authApi = inject(AuthApi);
   const applicationConfig = inject(ApplicationConfiguration);
-  const router = inject(Router);
 
   // Vérifier si la requête va vers notre backend
   if (!shouldInterceptRequest(req.url, applicationConfig.backendApiUrl())) {
@@ -27,7 +25,7 @@ export const authInterceptor: HttpInterceptorFn = (
   // Obtenir le token actuel et l'ajouter à la requête
   return from(addAuthToken(req, authApi)).pipe(
     switchMap((authReq) => next(authReq)),
-    catchError((error) => handleAuthError(error, req, next, authApi, router)),
+    catchError((error) => handleAuthError(error, req, next, authApi)),
   );
 };
 
@@ -63,7 +61,6 @@ function handleAuthError(
   originalReq: HttpRequest<unknown>,
   next: (req: HttpRequest<unknown>) => Observable<HttpEvent<unknown>>,
   authApi: AuthApi,
-  router: Router,
 ): Observable<HttpEvent<unknown>> {
   // Only attempt refresh if it's a 401 and user is authenticated
   if (error.status === 401 && authApi.isAuthenticated()) {
@@ -71,9 +68,9 @@ function handleAuthError(
     return from(authApi.refreshSession()).pipe(
       switchMap((refreshSuccess) => {
         if (!refreshSuccess) {
-          // Refresh failed, sign out and navigate to login
+          // Refresh failed, sign out and force full page reload
           authApi.signOut();
-          router.navigate([ROUTES.LOGIN]);
+          window.location.href = '/' + ROUTES.LOGIN;
           return throwError(
             () => new Error('Session expirée, veuillez vous reconnecter'),
           );
@@ -85,9 +82,9 @@ function handleAuthError(
         );
       }),
       catchError((refreshError) => {
-        // Error during refresh attempt, sign out and navigate to login
+        // Error during refresh attempt, sign out and force full page reload
         authApi.signOut();
-        router.navigate([ROUTES.LOGIN]);
+        window.location.href = '/' + ROUTES.LOGIN;
         return throwError(() => refreshError);
       }),
     );

--- a/frontend/projects/webapp/src/app/layout/main-layout.spec.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed, type ComponentFixture } from '@angular/core/testing';
 import { Router, type NavigationEnd, ActivatedRoute } from '@angular/router';
@@ -247,8 +247,43 @@ describe('MainLayout', () => {
   });
 
   describe('Logout Functionality', () => {
+    let locationHrefSpy: ReturnType<typeof vi.fn>;
+    let originalDescriptor: PropertyDescriptor | undefined;
+
     beforeEach(() => {
       fixture.detectChanges();
+
+      // Mock window.location.href to prevent actual navigation during tests
+      locationHrefSpy = vi.fn();
+      originalDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: '',
+          assign: vi.fn(),
+          replace: vi.fn(),
+          reload: vi.fn(),
+          origin: 'http://localhost',
+          pathname: '/',
+          search: '',
+          hash: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      Object.defineProperty(window.location, 'href', {
+        set: locationHrefSpy as (v: string) => void,
+        get: () => '',
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      // Restore original window.location
+      if (originalDescriptor) {
+        Object.defineProperty(window, 'location', originalDescriptor);
+      }
     });
 
     it('should not allow multiple logout attempts', async () => {
@@ -263,12 +298,11 @@ describe('MainLayout', () => {
 
       // Should only be called once from the first logout
       expect(mockAuthApi.signOut).toHaveBeenCalledTimes(1);
-      expect(mockRouter.navigate).toHaveBeenCalledTimes(1);
+      expect(locationHrefSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should successfully logout and navigate to login', async () => {
+    it('should successfully logout and redirect via full page reload', async () => {
       mockAuthApi.signOut.mockResolvedValue(undefined);
-      mockRouter.navigate.mockResolvedValue(true);
 
       const logoutPromise = component.onLogout();
 
@@ -278,45 +312,21 @@ describe('MainLayout', () => {
       await logoutPromise;
 
       expect(mockAuthApi.signOut).toHaveBeenCalledOnce();
-      expect(mockRouter.navigate).toHaveBeenCalledWith([ROUTES.LOGIN]);
-      expect(component.isLoggingOut()).toBe(false);
+      // Verify full page reload to login (clears all in-memory state)
+      expect(locationHrefSpy).toHaveBeenCalledWith('/' + ROUTES.LOGIN);
     });
 
-    it('should handle auth service errors gracefully', async () => {
+    it('should handle auth service errors gracefully and still redirect', async () => {
       const authError = new Error('Auth service error');
       mockAuthApi.signOut.mockRejectedValue(authError);
-      mockRouter.navigate.mockResolvedValue(true);
 
       // Test the business behavior: error handling should not crash the app
       await component.onLogout();
 
       // Verify business requirements
       expect(mockAuthApi.signOut).toHaveBeenCalledOnce();
-      expect(mockRouter.navigate).toHaveBeenCalledWith([ROUTES.LOGIN]);
-      expect(component.isLoggingOut()).toBe(false);
-    });
-
-    it('should handle navigation errors during logout', async () => {
-      const navError = new Error('Navigation error');
-      mockAuthApi.signOut.mockResolvedValue(undefined);
-      mockRouter.navigate.mockRejectedValue(navError);
-
-      // Test the business behavior: navigation errors should not crash the app
-      await component.onLogout();
-
-      // Verify business requirements
-      expect(mockAuthApi.signOut).toHaveBeenCalledOnce();
-      expect(mockRouter.navigate).toHaveBeenCalledWith([ROUTES.LOGIN]);
-      expect(component.isLoggingOut()).toBe(false);
-    });
-
-    it('should ensure loading state is reset even if both auth and navigation fail', async () => {
-      mockAuthApi.signOut.mockRejectedValue(new Error('Auth error'));
-      mockRouter.navigate.mockRejectedValue(new Error('Navigation error'));
-
-      await component.onLogout();
-
-      expect(component.isLoggingOut()).toBe(false);
+      // Even on error, should redirect to clear state
+      expect(locationHrefSpy).toHaveBeenCalledWith('/' + ROUTES.LOGIN);
     });
   });
 

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -470,9 +470,7 @@ export default class MainLayout {
       }
     }
 
-    // Force full page reload to clear all in-memory state (stores, signals, resources)
-    // This prevents stale data from previous user from persisting after login
-    window.location.href = '/' + ROUTES.LOGIN;
+    this.#forceLogoutRedirect();
   }
 
   /**
@@ -490,7 +488,15 @@ export default class MainLayout {
       this.#logger.error('Failed to exit demo mode', { error });
     }
 
-    // Force full page reload to clear all in-memory state
+    this.#forceLogoutRedirect();
+  }
+
+  /**
+   * Force redirect to login page with full page reload.
+   * Clears all in-memory state (stores, signals, resources).
+   */
+  #forceLogoutRedirect(): void {
+    this.#logger.info('Forcing logout redirect to login page');
     window.location.href = '/' + ROUTES.LOGIN;
   }
 }

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -463,28 +463,16 @@ export default class MainLayout {
 
       // Sign out and wait for session to be cleared
       await this.#authApi.signOut();
-
-      await this.#router.navigate([ROUTES.LOGIN]);
     } catch (error) {
       // Only log detailed errors in development
       if (!this.#applicationConfig.isProduction()) {
         this.#logger.error('Erreur lors de la déconnexion:', error);
       }
-
-      // Always navigate to login on error to ensure user is signed out
-      try {
-        await this.#router.navigate([ROUTES.LOGIN]);
-      } catch (navError) {
-        if (!this.#applicationConfig.isProduction()) {
-          this.#logger.error(
-            'Erreur lors de la navigation vers login:',
-            navError,
-          );
-        }
-      }
-    } finally {
-      this.#isLoggingOut.set(false);
     }
+
+    // Force full page reload to clear all in-memory state (stores, signals, resources)
+    // This prevents stale data from previous user from persisting after login
+    window.location.href = '/' + ROUTES.LOGIN;
   }
 
   /**
@@ -500,10 +488,9 @@ export default class MainLayout {
       await this.#demoInitializer.exitDemoMode();
     } catch (error) {
       this.#logger.error('Failed to exit demo mode', { error });
-    } finally {
-      // Always navigate to login, even if exit fails
-      // This ensures user is signed out even on error
-      await this.#router.navigate([ROUTES.LOGIN]);
     }
+
+    // Force full page reload to clear all in-memory state
+    window.location.href = '/' + ROUTES.LOGIN;
   }
 }


### PR DESCRIPTION
## Summary

Fixes stale cached data persisting after logout/login with a different user. When users logged out and logged back in with another account, they saw the previous user's data until they manually refreshed.

**Root cause**: Angular's Router navigation (`router.navigate()`) only clears Angular state but leaves signal-based stores and resources with their cached values in memory. Full page reload via `window.location.href` ensures complete cleanup.

**Solution**: Replace Router navigation with full page reload on logout, demo mode exit, and 401 auth errors. This is confirmed by Perplexity as recommended "defense-in-depth" security practice.

## Test plan

- All 703 unit tests pass ✓
- Quality checks pass (type-check, lint, format) ✓
- Main logout flow tested with mocked window.location.href ✓