### PR TITLE
fix(frontend): persist product tour state across sessions

### DIFF
--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ProductTourService, type TourPageId } from './product-tour.service';
@@ -47,6 +47,7 @@ describe('ProductTourService', () => {
 
   afterEach(() => {
     localStorage.clear();
+    vi.restoreAllMocks();
   });
 
   describe('hasSeenIntro', () => {
@@ -102,7 +103,6 @@ describe('ProductTourService', () => {
         localStorage.setItem(getTourKey(tourId), 'true');
       });
 
-      // Verify setup
       expect(service.hasSeenIntro()).toBe(true);
       expect(service.hasSeenPageTour('current-month')).toBe(true);
 

--- a/frontend/projects/webapp/src/app/core/storage/storage.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage.service.spec.ts
@@ -287,6 +287,27 @@ describe('StorageService', () => {
         expect.stringContaining('3'),
       );
     });
+
+    it('should preserve product tour keys (pulpe-tour-*)', () => {
+      // GIVEN: Both regular and tour keys exist
+      localStorage.setItem('pulpe-budget', 'budget-data');
+      localStorage.setItem('pulpe-user', 'user-data');
+      localStorage.setItem('pulpe-tour-intro-user@example.com', 'true');
+      localStorage.setItem('pulpe-tour-current-month-user@example.com', 'true');
+
+      // WHEN: Clearing all
+      service.clearAll();
+
+      // THEN: Regular keys are removed, tour keys are preserved
+      expect(localStorage.getItem('pulpe-budget')).toBeNull();
+      expect(localStorage.getItem('pulpe-user')).toBeNull();
+      expect(localStorage.getItem('pulpe-tour-intro-user@example.com')).toBe(
+        'true',
+      );
+      expect(
+        localStorage.getItem('pulpe-tour-current-month-user@example.com'),
+      ).toBe('true');
+    });
   });
 
   describe('Error handling - localStorage failures', () => {

--- a/frontend/projects/webapp/src/app/core/storage/storage.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage.service.spec.ts
@@ -288,25 +288,61 @@ describe('StorageService', () => {
       );
     });
 
-    it('should preserve product tour keys (pulpe-tour-*)', () => {
+    it('should remove all tour keys when no userId is provided', () => {
       // GIVEN: Both regular and tour keys exist
       localStorage.setItem('pulpe-budget', 'budget-data');
-      localStorage.setItem('pulpe-user', 'user-data');
-      localStorage.setItem('pulpe-tour-intro-user@example.com', 'true');
-      localStorage.setItem('pulpe-tour-current-month-user@example.com', 'true');
+      localStorage.setItem('pulpe-tour-intro-user1', 'true');
+      localStorage.setItem('pulpe-tour-intro-user2', 'true');
 
-      // WHEN: Clearing all
+      // WHEN: Clearing all without userId
       service.clearAll();
 
-      // THEN: Regular keys are removed, tour keys are preserved
+      // THEN: All pulpe keys including tour keys are removed
       expect(localStorage.getItem('pulpe-budget')).toBeNull();
-      expect(localStorage.getItem('pulpe-user')).toBeNull();
-      expect(localStorage.getItem('pulpe-tour-intro-user@example.com')).toBe(
+      expect(localStorage.getItem('pulpe-tour-intro-user1')).toBeNull();
+      expect(localStorage.getItem('pulpe-tour-intro-user2')).toBeNull();
+    });
+
+    it('should preserve only current user tour keys when userId is provided', () => {
+      // GIVEN: Tour keys for multiple users exist
+      const currentUserId = 'abc-123';
+      localStorage.setItem('pulpe-budget', 'budget-data');
+      localStorage.setItem(`pulpe-tour-intro-${currentUserId}`, 'true');
+      localStorage.setItem(`pulpe-tour-month-${currentUserId}`, 'true');
+      localStorage.setItem('pulpe-tour-intro-other-user-456', 'true');
+      localStorage.setItem('pulpe-tour-month-xyz-789', 'true');
+
+      // WHEN: Clearing all with current userId
+      service.clearAll(currentUserId);
+
+      // THEN: Regular keys are removed, only current user's tour keys are preserved
+      expect(localStorage.getItem('pulpe-budget')).toBeNull();
+      expect(localStorage.getItem(`pulpe-tour-intro-${currentUserId}`)).toBe(
         'true',
       );
+      expect(localStorage.getItem(`pulpe-tour-month-${currentUserId}`)).toBe(
+        'true',
+      );
+      // Other users' tour keys are removed
       expect(
-        localStorage.getItem('pulpe-tour-current-month-user@example.com'),
-      ).toBe('true');
+        localStorage.getItem('pulpe-tour-intro-other-user-456'),
+      ).toBeNull();
+      expect(localStorage.getItem('pulpe-tour-month-xyz-789')).toBeNull();
+    });
+
+    it('should handle shared device scenario - prevent tour data leak', () => {
+      // GIVEN: Alice logged out previously, Bob's tour keys remain
+      localStorage.setItem('pulpe-tour-intro-alice-123', 'true');
+      localStorage.setItem('pulpe-tour-intro-bob-456', 'true');
+      localStorage.setItem('pulpe-budget', 'bob-budget');
+
+      // WHEN: Bob logs out with his userId
+      service.clearAll('bob-456');
+
+      // THEN: Only Bob's tour keys remain, Alice's are cleaned up
+      expect(localStorage.getItem('pulpe-tour-intro-bob-456')).toBe('true');
+      expect(localStorage.getItem('pulpe-tour-intro-alice-123')).toBeNull();
+      expect(localStorage.getItem('pulpe-budget')).toBeNull();
     });
   });
 

--- a/frontend/projects/webapp/src/app/core/storage/storage.service.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage.service.ts
@@ -114,15 +114,27 @@ export class StorageService {
 
   /**
    * Clear ALL app data from localStorage except persistent keys.
-   * This removes all keys starting with 'pulpe-' or 'pulpe_',
-   * but preserves product tour completion state (pulpe-tour-*).
+   * This removes all keys starting with 'pulpe-' or 'pulpe_'.
+   *
+   * Tour keys (pulpe-tour-*) are handled specially:
+   * - If currentUserId is provided: only preserve that user's tour keys
+   * - If currentUserId is NOT provided: remove ALL tour keys
+   *
    * Called on user logout to prevent data leakage between users.
    */
-  clearAll(): void {
+  clearAll(currentUserId?: string): void {
     try {
-      const keysToRemove = Object.keys(localStorage).filter(
-        (key) => key.startsWith('pulpe') && !key.startsWith('pulpe-tour-'),
-      );
+      const keysToRemove = Object.keys(localStorage).filter((key) => {
+        if (!key.startsWith('pulpe')) return false;
+
+        // Tour keys: preserve only current user's, remove others
+        if (key.startsWith('pulpe-tour-')) {
+          if (!currentUserId) return true; // No user = remove all tour keys
+          return !key.endsWith(`-${currentUserId}`); // Keep only this user's
+        }
+
+        return true; // Remove all other pulpe keys
+      });
 
       keysToRemove.forEach((key) => localStorage.removeItem(key));
 

--- a/frontend/projects/webapp/src/app/core/storage/storage.service.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage.service.ts
@@ -113,14 +113,15 @@ export class StorageService {
   }
 
   /**
-   * Clear ALL app data from localStorage.
-   * This removes all keys starting with 'pulpe-' or 'pulpe_'.
+   * Clear ALL app data from localStorage except persistent keys.
+   * This removes all keys starting with 'pulpe-' or 'pulpe_',
+   * but preserves product tour completion state (pulpe-tour-*).
    * Called on user logout to prevent data leakage between users.
    */
   clearAll(): void {
     try {
-      const keysToRemove = Object.keys(localStorage).filter((key) =>
-        key.startsWith('pulpe'),
+      const keysToRemove = Object.keys(localStorage).filter(
+        (key) => key.startsWith('pulpe') && !key.startsWith('pulpe-tour-'),
       );
 
       keysToRemove.forEach((key) => localStorage.removeItem(key));


### PR DESCRIPTION
- Use user-specific localStorage keys (pulpe-tour-{id}-{email})
- Exclude tour keys from clearAll() on logout
- Remove static TOUR_* constants from STORAGE_KEYS (now dynamic)