### PR TITLE
fix(ui): improve error-alert component layout with block display

### DIFF
--- a/frontend/projects/webapp/src/app/ui/error-alert/error-alert.ts
+++ b/frontend/projects/webapp/src/app/ui/error-alert/error-alert.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
   selector: 'pulpe-error-alert',
   imports: [MatIconModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block' },
   template: `
     @if (message()) {
       <div


### PR DESCRIPTION
## Summary
Add `host: { class: 'block' }` to the ErrorAlert component to properly position it in flex/grid containers.

## Problem
The pulpe-error-alert component was not displaying correctly when used in layout contexts, appearing stuck at the bottom with poor spacing.

## Solution
Setting the host display to block ensures the component respects the flex/grid layout rules of its parent container.

## Testing
All 863 tests pass, linting and type-checking are clean.