### PR TITLE
fix(auth): restore navigation to welcome from login/signup

### DIFF
--- a/frontend/projects/webapp/src/app/feature/auth/login/login.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/login/login.ts
@@ -43,7 +43,15 @@ import { LoadingButton } from '@ui/loading-button';
       <div
         class="w-full max-w-md bg-surface rounded-2xl p-8 flex flex-col shadow-lg"
       >
-        <div class="text-center mb-8">
+        <a
+          [routerLink]="['/', ROUTES.WELCOME]"
+          class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+        >
+          <mat-icon class="text-lg">arrow_back</mat-icon>
+          <span>Retour à l'accueil</span>
+        </a>
+
+        <div class="text-center mb-8 mt-4">
           <h1 class="text-headline-large text-on-surface mb-2">Connexion</h1>
           <p class="text-body-large text-on-surface-variant">
             Accédez à votre espace personnel

--- a/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
@@ -69,7 +69,15 @@ function passwordsMatchValidator(
       <div
         class="w-full max-w-md bg-surface rounded-2xl p-8 flex flex-col shadow-lg"
       >
-        <div class="text-center mb-8">
+        <a
+          [routerLink]="['/', ROUTES.WELCOME]"
+          class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+        >
+          <mat-icon class="text-lg">arrow_back</mat-icon>
+          <span>Retour à l'accueil</span>
+        </a>
+
+        <div class="text-center mb-8 mt-4">
           <h1 class="text-headline-large text-on-surface mb-2">
             Créer un compte
           </h1>


### PR DESCRIPTION
## Summary
- Add back button to login and signup pages
- Allows users to return to welcome page and access demo mode
- Fixes navigation flow broken after Google OAuth integration

## Test plan
- Navigate: Welcome → Login → Back button → Welcome ✓
- Navigate: Welcome → Signup → Back button → Welcome ✓
- Demo mode accessible from welcome after returning from login/signup ✓