### PR TITLE
feat(fonts): implement dual font strategy with Plus Jakarta Sans and JetBrains Mono

### DIFF
--- a/.claude/tasks/01-dual-font-strategy/explore.md
+++ b/.claude/tasks/01-dual-font-strategy/explore.md
@@ -1,0 +1,200 @@
+# Task: Dual Font Strategy - Plus Jakarta Sans + JetBrains Mono
+
+## Résumé
+
+**Faisabilité: OUI, facilement réalisable** avec deux approches possibles:
+
+1. **Approche recommandée** : Garder une seule police (Plus Jakarta Sans) et utiliser `font-variant-numeric: tabular-nums` pour les montants alignés
+2. **Approche demandée** : Utiliser deux polices distinctes (Plus Jakarta Sans pour le texte, JetBrains Mono pour les montants)
+
+---
+
+## Codebase Context
+
+### Configuration Actuelle des Fonts
+
+| Fichier | Rôle |
+|---------|------|
+| `projects/webapp/src/index.html:9-17` | Chargement Google Fonts (Poppins) |
+| `projects/webapp/src/_variables.scss:1-2` | Variables SCSS pour Material |
+| `projects/webapp/src/styles.scss:21-24` | Configuration Material v20 typography |
+| `projects/webapp/src/app/styles/vendors/_tailwind.css:210-213` | Variables CSS Tailwind (`--font-mono`) |
+
+### État Actuel
+
+```scss
+// _variables.scss
+$heading-font-family: Poppins, sans-serif;
+$regular-font-family: Poppins, sans-serif;
+```
+
+```css
+/* _tailwind.css:209-213 */
+--font-sans: var(--mat-sys-body-large-font), sans-serif;
+--font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+--font-display: var(--mat-sys-display-large-font), sans-serif;
+```
+
+**Note importante**: JetBrains Mono est défini mais **PAS chargé** - il n'y a pas d'import Google Fonts ou @font-face.
+
+### Composants Affichant des Montants
+
+| Composant | Fichier | Format |
+|-----------|---------|--------|
+| CurrencyInput | `ui/currency-input/currency-input.ts` | Input CHF |
+| FinancialSummary | `ui/financial-summary/financial-summary.ts:44` | `CurrencyPipe 'CHF':'symbol':'1.2-2':'de-CH'` |
+| FinancialEntry | `feature/current-month/components/financial-entry.ts:100` | `DecimalPipe '1.2-2':'de-CH'` |
+| BudgetFinancialOverview | `feature/budget/budget-details/budget-financial-overview.ts:39-98` | `DecimalPipe '1.0-0':'de-CH'` |
+| BudgetTable | `feature/budget/budget-details/budget-table/budget-table.ts:169-172` | `CurrencyPipe '1.0-0'` |
+
+---
+
+## Documentation Insights
+
+### Tailwind CSS v4 - Fonts
+
+Configuration dans `@theme` (pas de tailwind.config.js en v4) :
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap');
+@import "tailwindcss";
+
+@theme {
+  --font-sans: "Plus Jakarta Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+}
+```
+
+### Angular Material v20 - Typography
+
+```scss
+@use '@angular/material' as mat;
+
+html {
+  @include mat.theme((
+    typography: (
+      plain-family: "Plus Jakarta Sans",
+      brand-family: "Plus Jakarta Sans",
+    ),
+  ));
+}
+```
+
+### Font-Variant-Numeric (Alternative)
+
+```css
+/* Chiffres tabulaires sans changer de police */
+.amount {
+  font-variant-numeric: tabular-nums;
+}
+```
+
+**Support navigateur**: 97%+ (Chrome 52+, Firefox 34+, Safari 9.1+)
+
+---
+
+## Research Findings
+
+### Plus Jakarta Sans
+
+- **Type**: Géométrique moderne, inspiré Futura/Neuzit Grotesk
+- **Poids**: 200-800 (variable font disponible)
+- **Source**: Google Fonts gratuit
+- **Caractéristiques**: Hauteur x élevée, counters ouverts, excellente lisibilité
+
+### Pairing Plus Jakarta Sans + JetBrains Mono
+
+Ce pairing fonctionne car:
+- Plus Jakarta Sans (géométrique, ouvert) complète JetBrains Mono (technique, haute lisibilité)
+- Les deux sont gratuits et bien maintenus
+- JetBrains Mono a des ligatures code-spécifiques et supporte tabular-nums
+
+### Recommandation Experte
+
+**Ne pas changer de police pour les nombres** - utiliser `font-variant-numeric: tabular-nums` :
+- Moins de requêtes HTTP
+- Cohérence visuelle
+- Meilleures performances
+- Pas de décalage baseline
+
+---
+
+## Key Files à Modifier
+
+| Fichier | Action |
+|---------|--------|
+| `projects/webapp/src/index.html:12-17` | Remplacer Poppins par Plus Jakarta Sans |
+| `projects/webapp/src/_variables.scss:1-2` | Changer `$heading-font-family` et `$regular-font-family` |
+| `projects/webapp/src/app/styles/vendors/_tailwind.css:209-213` | Mettre à jour `--font-sans` |
+
+### Optionnel (si JetBrains Mono pour montants)
+
+| Fichier | Action |
+|---------|--------|
+| `projects/webapp/src/index.html` | Ajouter import Google Fonts JetBrains Mono |
+| `projects/webapp/src/app/styles/vendors/_tailwind.css` | Créer classe utilitaire `.font-amount` |
+| Composants montants | Ajouter classe `font-mono` ou `font-amount` |
+
+---
+
+## Patterns to Follow
+
+### Pattern Existant: Material Typography Tokens
+
+Les fonts passent par les variables CSS Material (`--mat-sys-body-large-font`) puis Tailwind.
+
+### Pattern Existant: Tailwind Typography Utilities
+
+Classes existantes: `text-display-*`, `text-headline-*`, `text-title-*`, `text-body-*`, `text-label-*`
+
+### Pattern Existant: Font Mono
+
+La classe `font-mono` existe déjà et utilise JetBrains Mono (voir `about-dialog.ts:38`).
+
+---
+
+## Deux Stratégies Possibles
+
+### Option A: Font Unique + Tabular Nums (Recommandée)
+
+```css
+/* Plus Jakarta Sans partout, chiffres tabulaires pour alignement */
+.amount, .currency, .financial-data {
+  font-variant-numeric: tabular-nums;
+}
+```
+
+**Avantages**: Simple, performant, cohérent
+**Inconvénients**: Pas d'esthétique "monospace" pour les chiffres
+
+### Option B: Dual Font Strategy (Demandée)
+
+```css
+/* Plus Jakarta Sans pour texte, JetBrains Mono pour montants */
+--font-body: "Plus Jakarta Sans", sans-serif;
+--font-amount: "JetBrains Mono", monospace;
+```
+
+**Avantages**: Distinction visuelle forte, esthétique technique
+**Inconvénients**: +1 font à charger (~100KB), maintenance des classes
+
+---
+
+## Dependencies
+
+- Google Fonts CDN (déjà utilisé pour Poppins)
+- Aucune nouvelle dépendance npm requise
+
+---
+
+## Blockers / Concerns
+
+1. **JetBrains Mono non chargé actuellement** - nécessite ajout d'import
+2. **Roboto chargé mais non utilisé** (`index.html:16`) - à nettoyer
+3. **Migration ~30 composants** si classe explicite pour montants (Option B)
+
+---
+
+## Next Step
+
+Lancer `/epct:plan 01-dual-font-strategy` pour créer le plan d'implémentation détaillé.

--- a/.claude/tasks/01-dual-font-strategy/implementation.md
+++ b/.claude/tasks/01-dual-font-strategy/implementation.md
@@ -1,0 +1,80 @@
+# Implementation: Dual Font Strategy
+
+## Completed
+
+### Base Font Configuration
+- Replaced Poppins with Plus Jakarta Sans as the primary UI font
+- Added JetBrains Mono as the monospace font for financial amounts
+- Updated Google Fonts URL in `index.html` (both main link and noscript fallback)
+- Updated `_variables.scss` to use Plus Jakarta Sans for both heading and regular font families
+- Updated `styles.scss` fallback font stack
+
+### Component Updates with `font-mono`
+Applied `font-mono` class to all financial amount displays in the following components:
+
+**Summary/Overview Components:**
+- `financial-summary.ts` - Main financial amount display
+- `budget-financial-overview.ts` - Income, expenses, savings, and remaining amounts
+- `budget-progress-bar.ts` - Expenses and remaining amounts
+- `realized-balance-progress-bar.ts` - Realized expenses and balance
+
+**Budget Table Components:**
+- `budget-table.ts` - Mobile transaction amounts, desktop remaining, planned, spent, and balance columns
+- `budget-table-mobile-card.ts` - Main amount display and menu balance
+
+**List/Entry Components:**
+- `financial-entry.ts` - Amount display in list items
+- `financial-accordion.ts` - Total amount in accordion header
+- `month-card-item.ts` - Total amount on month cards
+- `month-tile.ts` - Available amount in calendar tiles
+
+**Dialog Components:**
+- `search-transactions-dialog.ts` - Amount column in search results
+- `template-details-dialog.ts` - Total income, expenses, line amounts, and net balance
+- `template-list-item.ts` - Income, expenses, and net balance amounts
+- `allocated-transactions-dialog.ts` - Summary amounts and table amounts
+- `allocated-transactions-bottom-sheet.ts` - Summary amounts and transaction amounts
+- `edit-transactions-dialog.ts` - Running total column
+
+**Template Components:**
+- `transactions-table.ts` - All financial columns (spent, earned, saved, total)
+
+## Deviations from Plan
+
+None - all changes followed the plan exactly.
+
+## Test Results
+
+- Typecheck: ✓
+- Lint: ✓ (backend warnings are pre-existing, unrelated to font changes)
+- Format: ✓
+
+## Follow-up Tasks
+
+None identified - implementation is complete.
+
+## Files Modified
+
+### Configuration Files
+- `frontend/projects/webapp/src/index.html`
+- `frontend/projects/webapp/src/_variables.scss`
+- `frontend/projects/webapp/src/styles.scss`
+
+### Component Files (20 total)
+- `frontend/projects/webapp/src/app/ui/financial-summary/financial-summary.ts`
+- `frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-financial-overview.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-mobile-card.ts`
+- `frontend/projects/webapp/src/app/feature/budget/ui/month-card-item.ts`
+- `frontend/projects/webapp/src/app/feature/current-month/components/financial-accordion.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-list/search-transactions-dialog/search-transactions-dialog.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/template-details-dialog.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/ui/template-list-item.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-dialog.ts`
+- `frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts`
+- `frontend/projects/webapp/src/app/feature/budget-templates/details/components/transactions-table.ts`
+- `frontend/projects/webapp/src/app/feature/budget-templates/details/components/edit-transactions-dialog.ts`
+- `frontend/projects/webapp/src/app/ui/realized-balance-progress-bar/realized-balance-progress-bar.ts`
+- `frontend/projects/webapp/src/app/ui/calendar/month-tile.ts`
+- `frontend/projects/webapp/src/app/feature/current-month/components/budget-progress-bar.ts`

--- a/.claude/tasks/01-dual-font-strategy/plan.md
+++ b/.claude/tasks/01-dual-font-strategy/plan.md
@@ -1,0 +1,200 @@
+# Implementation Plan: Dual Font Strategy (Option B)
+
+## Overview
+
+Remplacer Poppins par Plus Jakarta Sans pour tout le texte UI, et utiliser JetBrains Mono pour les montants financiers.
+
+**Stratégie:**
+1. Charger les deux fonts via Google Fonts
+2. Configurer Plus Jakarta Sans comme font principale (Material + Tailwind)
+3. Ajouter la classe `font-mono` aux éléments affichant des montants
+4. Nettoyer les fonts inutilisées (Roboto)
+
+## Dependencies
+
+Ordre d'exécution obligatoire:
+1. `index.html` (fonts chargées) → doit être fait en premier
+2. `_variables.scss` (variables SCSS) → utilisé par styles.scss
+3. `styles.scss` (Material theme) → dépend de _variables
+4. `_tailwind.css` (utilities CSS) → peut être fait en parallèle avec 2-3
+5. Composants (utilisent les classes) → doit être fait en dernier
+
+---
+
+## File Changes
+
+### `projects/webapp/src/index.html`
+
+**Action principale:** Remplacer Poppins par Plus Jakarta Sans + ajouter JetBrains Mono
+
+- Ligne 12-14: Remplacer l'URL Google Fonts
+  - Ancien: `family=Poppins:wght@300;400;500;600;700&family=Roboto:wght@300;400;500`
+  - Nouveau: `family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500`
+- Ligne 27: Même modification dans le bloc `<noscript>`
+- Note: Supprimer Roboto (non utilisé), garder seulement les poids nécessaires
+- Note: JetBrains Mono 400+500 suffisent pour les montants
+
+---
+
+### `projects/webapp/src/_variables.scss`
+
+**Action principale:** Changer la font family principale
+
+- Ligne 1: `$heading-font-family: 'Plus Jakarta Sans', sans-serif;`
+- Ligne 2: `$regular-font-family: 'Plus Jakarta Sans', sans-serif;`
+
+---
+
+### `projects/webapp/src/styles.scss`
+
+**Action principale:** Mettre à jour le fallback dans body
+
+- Ligne 44: Remplacer `Poppins` par `'Plus Jakarta Sans'` dans le fallback font-family
+
+---
+
+### `projects/webapp/src/app/styles/vendors/_tailwind.css`
+
+**Action principale:** Aucun changement requis
+
+- Les lignes 209-213 restent inchangées car elles référencent `--mat-sys-body-large-font` qui sera automatiquement Plus Jakarta Sans via la cascade Material
+- `--font-mono` est déjà configuré avec JetBrains Mono
+
+---
+
+## Composants à Modifier (Ajout de `font-mono`)
+
+Les composants ci-dessous affichent des montants et doivent recevoir la classe `font-mono` sur les éléments contenant des valeurs numériques formatées.
+
+### `projects/webapp/src/app/ui/financial-summary/financial-summary.ts`
+
+- Localiser l'élément affichant le montant (ligne ~44 avec CurrencyPipe)
+- Ajouter `font-mono` à la classe de l'élément contenant `{{ ... | currency }}`
+
+### `projects/webapp/src/app/feature/current-month/components/financial-entry.ts`
+
+- Localiser l'élément affichant le montant (ligne ~100 avec DecimalPipe)
+- Ajouter `font-mono` à la classe de l'élément `<span>` contenant le montant
+
+### `projects/webapp/src/app/feature/budget/budget-details/budget-financial-overview.ts`
+
+- 4 montants à traiter (lignes ~41, 56, 71, 98)
+- Ajouter `font-mono` aux éléments contenant `{{ totals().income | number }}`, etc.
+
+### `projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts`
+
+- Localiser les cellules de montants (lignes ~169-172)
+- Ajouter `font-mono` aux éléments `<td>` ou `<span>` contenant les montants
+
+### `projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-mobile-card.ts`
+
+- Localiser les éléments affichant des montants
+- Ajouter `font-mono` aux spans de montants
+
+### `projects/webapp/src/app/feature/budget/ui/month-card-item.ts`
+
+- Localiser les montants affichés dans la card
+- Ajouter `font-mono` aux éléments de montants
+
+### `projects/webapp/src/app/feature/current-month/components/financial-accordion.ts`
+
+- Localiser les montants dans l'accordion
+- Ajouter `font-mono` aux éléments de totaux
+
+### `projects/webapp/src/app/feature/budget/budget-list/search-transactions-dialog/search-transactions-dialog.ts`
+
+- Localiser les montants dans les résultats de recherche
+- Ajouter `font-mono` aux cellules de montants
+
+### `projects/webapp/src/app/feature/budget/budget-list/create-budget/template-details-dialog.ts`
+
+- Localiser les montants affichés dans le dialog
+- Ajouter `font-mono` si des montants sont visibles
+
+### `projects/webapp/src/app/feature/budget/budget-list/create-budget/ui/template-list-item.ts`
+
+- Localiser les montants dans chaque item
+- Ajouter `font-mono` aux spans de montants
+
+### `projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-dialog.ts`
+
+- Localiser les montants des transactions allouées
+- Ajouter `font-mono` aux cellules de montants
+
+### `projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts`
+
+- Même traitement que le dialog
+- Ajouter `font-mono` aux montants
+
+### `projects/webapp/src/app/feature/budget-templates/details/components/transactions-table.ts`
+
+- Localiser les colonnes de montants dans le tableau
+- Ajouter `font-mono` aux cellules de montants
+
+### `projects/webapp/src/app/feature/budget-templates/details/components/edit-transactions-dialog.ts`
+
+- Localiser les champs de montants
+- Ajouter `font-mono` si des montants sont affichés (pas les inputs)
+
+### `projects/webapp/src/app/ui/realized-balance-progress-bar/realized-balance-progress-bar.ts`
+
+- Localiser les montants affichés dans la progress bar
+- Ajouter `font-mono` aux labels de montants
+
+### `projects/webapp/src/app/ui/calendar/month-tile.ts`
+
+- Localiser les montants dans la tuile calendrier
+- Ajouter `font-mono` aux montants affichés
+
+### `projects/webapp/src/app/feature/current-month/components/budget-progress-bar.ts`
+
+- Localiser les montants dans la barre de progression
+- Ajouter `font-mono` aux labels numériques
+
+---
+
+## Testing Strategy
+
+### Tests visuels manuels
+1. Vérifier que Plus Jakarta Sans charge correctement (DevTools > Network > Fonts)
+2. Vérifier que JetBrains Mono charge correctement
+3. Vérifier l'apparence sur les pages principales:
+   - Dashboard / Current Month
+   - Budget Details
+   - Budget List
+4. Vérifier en mode sombre (dark theme)
+5. Vérifier sur mobile (responsive)
+
+### Pas de tests unitaires requis
+- Les changements sont purement CSS/styling
+- Aucun changement de logique métier
+
+---
+
+## Documentation
+
+Aucune documentation à mettre à jour - changement purement visuel.
+
+---
+
+## Rollout Considerations
+
+### Risques
+- **FOUT (Flash of Unstyled Text)**: Déjà mitigé par le pattern `media="print" onload="this.media='all'"` existant
+- **Performance**: +1 font à charger (~50KB pour JetBrains Mono 400+500), impact mineur
+
+### Rollback
+- Simple: revenir aux imports Poppins dans index.html et _variables.scss
+- Les classes `font-mono` peuvent rester (inoffensives avec Poppins)
+
+---
+
+## Summary
+
+| Phase | Fichiers | Effort estimé |
+|-------|----------|---------------|
+| 1. Fonts | index.html, _variables.scss, styles.scss | 10 min |
+| 2. Composants | ~17 fichiers (ajout classe) | 30 min |
+| 3. Tests | Vérification visuelle | 15 min |
+
+**Total estimé: ~1 heure**

--- a/frontend/projects/webapp/src/_variables.scss
+++ b/frontend/projects/webapp/src/_variables.scss
@@ -1,2 +1,2 @@
-$heading-font-family: Poppins, sans-serif;
-$regular-font-family: Poppins, sans-serif;
+$heading-font-family: "Plus Jakarta Sans", sans-serif;
+$regular-font-family: "Plus Jakarta Sans", sans-serif;

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/components/edit-transactions-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/components/edit-transactions-dialog.ts
@@ -230,7 +230,7 @@ interface EditTransactionsDialogResult {
                 <span
                   [class.text-financial-income]="runningTotals()[i] >= 0"
                   [class.text-financial-negative]="runningTotals()[i] < 0"
-                  class="font-medium ph-no-capture"
+                  class="font-medium ph-no-capture font-mono"
                 >
                   {{
                     runningTotals()[i]

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/components/transactions-table.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/components/transactions-table.ts
@@ -62,7 +62,11 @@ export interface FinancialEntry {
             >
               Dépensé
             </th>
-            <td mat-cell *matCellDef="let row" class="text-right px-4 py-2">
+            <td
+              mat-cell
+              *matCellDef="let row"
+              class="text-right px-4 py-2 font-mono"
+            >
               @if (row.spent !== 0) {
                 <span class="ph-no-capture">{{
                   row.spent | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
@@ -80,7 +84,11 @@ export interface FinancialEntry {
             >
               Gagné
             </th>
-            <td mat-cell *matCellDef="let row" class="text-right px-4 py-2">
+            <td
+              mat-cell
+              *matCellDef="let row"
+              class="text-right px-4 py-2 font-mono"
+            >
               @if (row.earned !== 0) {
                 <span class="ph-no-capture">{{
                   row.earned | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
@@ -98,7 +106,11 @@ export interface FinancialEntry {
             >
               Économisé
             </th>
-            <td mat-cell *matCellDef="let row" class="text-right px-4 py-2">
+            <td
+              mat-cell
+              *matCellDef="let row"
+              class="text-right px-4 py-2 font-mono"
+            >
               @if (row.saved !== 0) {
                 <span class="ph-no-capture">{{
                   row.saved | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
@@ -116,7 +128,11 @@ export interface FinancialEntry {
             >
               Total
             </th>
-            <td mat-cell *matCellDef="let row" class="text-right px-4 py-2">
+            <td
+              mat-cell
+              *matCellDef="let row"
+              class="text-right px-4 py-2 font-mono"
+            >
               <span class="ph-no-capture">{{
                 row.total | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
               }}</span>

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts
@@ -46,7 +46,7 @@ import type {
         <div class="text-center p-2 bg-surface-container rounded-lg">
           <div class="text-label-small text-on-surface-variant">Dépensé</div>
           <div
-            class="text-title-medium font-bold"
+            class="text-title-medium font-bold font-mono"
             [class.text-financial-income]="data.budgetLine.kind === 'income'"
             [class.text-financial-expense]="data.budgetLine.kind === 'expense'"
             [class.text-financial-savings]="data.budgetLine.kind === 'saving'"
@@ -59,7 +59,7 @@ import type {
         <!-- Prévu -->
         <div class="text-center p-2 bg-surface-container rounded-lg">
           <div class="text-label-small text-on-surface-variant">Prévu</div>
-          <div class="text-title-small font-semibold">
+          <div class="text-title-small font-semibold font-mono">
             {{ data.budgetLine.amount | currency: 'CHF' : 'symbol' : '1.0-0' }}
           </div>
         </div>
@@ -67,7 +67,7 @@ import type {
         <div class="text-center p-2 bg-surface-container rounded-lg">
           <div class="text-label-small text-on-surface-variant">Reste</div>
           <div
-            class="text-title-small font-semibold"
+            class="text-title-small font-semibold font-mono"
             [class.text-error]="data.consumption.remaining < 0"
             [class.text-financial-income]="data.consumption.remaining >= 0"
           >
@@ -108,7 +108,7 @@ import type {
                 </div>
                 <div class="flex items-center gap-2">
                   <span
-                    class="text-body-medium font-semibold whitespace-nowrap"
+                    class="text-body-medium font-semibold whitespace-nowrap font-mono"
                   >
                     {{ tx.amount | currency: 'CHF' : 'symbol' : '1.2-2' }}
                   </span>

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-dialog.ts
@@ -47,7 +47,7 @@ export interface AllocatedTransactionsDialogResult {
         <div class="grid grid-cols-3 gap-4 p-4 bg-surface-container rounded-lg">
           <div class="text-center">
             <div class="text-label-small text-on-surface-variant">Prévu</div>
-            <div class="text-title-medium font-semibold">
+            <div class="text-title-medium font-semibold font-mono">
               {{
                 data.budgetLine.amount | currency: 'CHF' : 'symbol' : '1.2-2'
               }}
@@ -55,7 +55,7 @@ export interface AllocatedTransactionsDialogResult {
           </div>
           <div class="text-center">
             <div class="text-label-small text-on-surface-variant">Consommé</div>
-            <div class="text-title-medium font-semibold">
+            <div class="text-title-medium font-semibold font-mono">
               {{
                 data.consumption.consumed | currency: 'CHF' : 'symbol' : '1.2-2'
               }}
@@ -66,7 +66,7 @@ export interface AllocatedTransactionsDialogResult {
               Disponible
             </div>
             <div
-              class="text-title-medium font-semibold"
+              class="text-title-medium font-semibold font-mono"
               [class.text-error]="data.consumption.remaining < 0"
               [class.text-financial-income]="data.consumption.remaining >= 0"
             >
@@ -120,7 +120,7 @@ export interface AllocatedTransactionsDialogResult {
               <td
                 mat-cell
                 *matCellDef="let tx"
-                class="text-right text-body-medium font-medium"
+                class="text-right text-body-medium font-medium font-mono"
               >
                 {{ tx.amount | currency: 'CHF' : 'symbol' : '1.2-2' }}
               </td>

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-financial-overview.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-financial-overview.ts
@@ -36,7 +36,7 @@ import { RealizedBalanceTooltip } from '@ui/realized-balance-tooltip/realized-ba
                 <span class="text-label-large"> Revenus CHF </span>
               </div>
               <div
-                class="text-title-large font-bold text-financial-income ph-no-capture"
+                class="text-title-large font-bold text-financial-income ph-no-capture font-mono"
               >
                 {{ totals().income | number: '1.0-0' : 'de-CH' }}
               </div>
@@ -51,7 +51,7 @@ import { RealizedBalanceTooltip } from '@ui/realized-balance-tooltip/realized-ba
                 <span class="text-label-large"> Dépenses CHF </span>
               </div>
               <div
-                class="text-title-large font-bold text-financial-expense ph-no-capture"
+                class="text-title-large font-bold text-financial-expense ph-no-capture font-mono"
               >
                 {{ totals().expenses | number: '1.0-0' : 'de-CH' }}
               </div>
@@ -66,7 +66,7 @@ import { RealizedBalanceTooltip } from '@ui/realized-balance-tooltip/realized-ba
                 <span class="text-label-large"> Épargne CHF </span>
               </div>
               <div
-                class="text-title-large font-bold text-financial-savings ph-no-capture"
+                class="text-title-large font-bold text-financial-savings ph-no-capture font-mono"
               >
                 {{ totals().savings | number: '1.0-0' : 'de-CH' }}
               </div>
@@ -91,7 +91,7 @@ import { RealizedBalanceTooltip } from '@ui/realized-balance-tooltip/realized-ba
                 </span>
               </div>
               <div
-                class="text-title-large font-bold ph-no-capture"
+                class="text-title-large font-bold ph-no-capture font-mono"
                 [class.text-financial-savings]="totals().remaining >= 0"
                 [class.text-error]="totals().remaining < 0"
               >

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-mobile-card.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table-mobile-card.ts
@@ -122,10 +122,10 @@ import { type BudgetLineTableItem } from './budget-table-models';
               </div>
               <div class="px-4 pb-2 text-label-medium">
                 Solde:
-                {{
+                <span class="font-mono">{{
                   item().metadata.cumulativeBalance
                     | currency: 'CHF' : 'symbol' : '1.0-0'
-                }}
+                }}</span>
               </div>
               <mat-divider />
               <button
@@ -172,7 +172,7 @@ import { type BudgetLineTableItem } from './budget-table-models';
         <!-- Amount display -->
         <div class="text-center py-2 mb-3">
           <div
-            class="text-headline-medium font-bold"
+            class="text-headline-medium font-bold font-mono"
             [class.text-financial-income]="item().data.kind === 'income'"
             [class.text-financial-expense]="item().data.kind === 'expense'"
             [class.text-financial-savings]="item().data.kind === 'saving'"

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-table/budget-table.ts
@@ -162,7 +162,7 @@ import { BudgetTableViewToggle } from './budget-table-view-toggle';
                           }
                         </div>
                         <div
-                          class="text-title-medium font-bold"
+                          class="text-title-medium font-bold font-mono"
                           [class.text-financial-income]="item.data.amount > 0"
                           [class.text-error]="item.data.amount < 0"
                         >
@@ -330,12 +330,13 @@ import { BudgetTableViewToggle } from './budget-table-view-toggle';
                     <div class="flex flex-col items-end gap-1">
                       <div class="flex flex-col items-center">
                         <span
-                          class="text-body-medium font-semibold"
+                          class="text-body-medium font-semibold font-mono"
                           [class.text-error]="isExceeded"
                         >
                           {{ remaining | currency: 'CHF' : 'symbol' : '1.0-0' }}
                           @if (isExceeded) {
-                            <span class="text-label-small font-normal ml-1"
+                            <span
+                              class="text-label-small font-normal font-sans ml-1"
                               >dépassé</span
                             >
                           }
@@ -392,7 +393,7 @@ import { BudgetTableViewToggle } from './budget-table-view-toggle';
                     </form>
                   } @else {
                     <span
-                      class="text-body-medium font-bold"
+                      class="text-body-medium font-bold font-mono"
                       [class.italic]="line.metadata.isRollover"
                       [class.text-financial-income]="
                         line.data.kind === 'income'
@@ -423,7 +424,7 @@ import { BudgetTableViewToggle } from './budget-table-view-toggle';
                   ) {
                     <button
                       matButton
-                      class="text-body-small h-8! px-3!"
+                      class="text-body-small h-8! px-3! font-mono"
                       [matBadge]="line.consumption.transactionCount"
                       matBadgeColor="primary"
                       (click)="onViewTransactionsFromLine(line)"
@@ -465,7 +466,7 @@ import { BudgetTableViewToggle } from './budget-table-view-toggle';
                       }
                     </mat-icon>
                     <span
-                      class="text-body-medium font-medium"
+                      class="text-body-medium font-medium font-mono"
                       [class.text-financial-income]="
                         line.metadata.cumulativeBalance >= 0
                       "

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/template-details-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/template-details-dialog.ts
@@ -46,7 +46,9 @@ export interface TemplateDetailsDialogData {
         <div class="flex justify-between mb-4">
           <div class="flex flex-col">
             <div>Revenus total:</div>
-            <div class="ph-no-capture text-financial-income text-label-large">
+            <div
+              class="ph-no-capture text-financial-income text-label-large font-mono"
+            >
               {{
                 totalIncome() | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
               }}
@@ -54,7 +56,9 @@ export interface TemplateDetailsDialogData {
           </div>
           <div class="flex flex-col">
             <div>Dépenses total:</div>
-            <div class="ph-no-capture text-financial-negative text-label-large">
+            <div
+              class="ph-no-capture text-financial-negative text-label-large font-mono"
+            >
               {{
                 totalExpenses() | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'
               }}
@@ -84,7 +88,7 @@ export interface TemplateDetailsDialogData {
                   }
                 </div>
                 <div
-                  class="ph-no-capture text-body-medium font-medium flex-shrink-0"
+                  class="ph-no-capture text-body-medium font-medium flex-shrink-0 font-mono"
                   [class.text-financial-savings]="line.kind === 'saving'"
                   [class.text-financial-negative]="line.kind === 'expense'"
                   [class.text-financial-income]="line.kind === 'income'"
@@ -106,7 +110,7 @@ export interface TemplateDetailsDialogData {
         <mat-divider class="mb-2!"></mat-divider>
         <div class="flex justify-between text-body-medium font-medium">
           <span>Solde net:</span>
-          <span class="ph-no-capture">
+          <span class="ph-no-capture font-mono">
             {{ netBalance() | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH' }}
           </span>
         </div>

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/ui/template-list-item.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/ui/template-list-item.ts
@@ -113,7 +113,7 @@ import { type TemplateViewModel } from './template-view-model';
               >
               <span
                 matListItemMeta
-                class="ph-no-capture text-body-medium! font-medium!"
+                class="ph-no-capture text-body-medium! font-medium! font-mono"
               >
                 {{
                   templateViewModel().income
@@ -134,7 +134,7 @@ import { type TemplateViewModel } from './template-view-model';
               >
               <span
                 matListItemMeta
-                class="ph-no-capture text-body-medium! font-medium!"
+                class="ph-no-capture text-body-medium! font-medium! font-mono"
               >
                 {{
                   templateViewModel().expenses
@@ -153,7 +153,7 @@ import { type TemplateViewModel } from './template-view-model';
               <span matListItemTitle class="text-body-medium">Disponible</span>
               <span
                 matListItemMeta
-                class="ph-no-capture text-body-medium! font-medium!"
+                class="ph-no-capture text-body-medium! font-medium! font-mono"
               >
                 {{
                   templateViewModel().netBalance

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/search-transactions-dialog/search-transactions-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/search-transactions-dialog/search-transactions-dialog.ts
@@ -141,7 +141,7 @@ import { Logger } from '@core/logging/logger';
               <td
                 mat-cell
                 *matCellDef="let row"
-                class="text-right text-body-medium font-bold"
+                class="text-right text-body-medium font-bold font-mono"
                 [class.text-financial-income]="row.kind === 'income'"
                 [class.text-financial-expense]="row.kind === 'expense'"
                 [class.text-financial-savings]="row.kind === 'saving'"

--- a/frontend/projects/webapp/src/app/feature/budget/ui/month-card-item.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/ui/month-card-item.ts
@@ -37,7 +37,7 @@ import { CurrencyPipe } from '@angular/common';
       <mat-card-content>
         <div class="flex justify-center gap-2 items-center">
           <p
-            class="ph-no-capture text-headline-small financial-amount overflow-hidden text-ellipsis"
+            class="ph-no-capture text-headline-small financial-amount overflow-hidden text-ellipsis font-mono"
             [attr.data-type]="totalAmount() >= 0 ? 'positive' : 'negative'"
             data-testid="month-card-amount"
           >

--- a/frontend/projects/webapp/src/app/feature/current-month/components/budget-progress-bar.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/budget-progress-bar.ts
@@ -56,7 +56,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
               </span>
               <span class="text-headline-small md:text-headline-large">
                 <div
-                  class="flex flex-col ph-no-capture"
+                  class="flex flex-col ph-no-capture font-mono"
                   data-testid="expenses-amount"
                 >
                   {{ expenses() | number: '1.2-2' : 'de-CH' }}
@@ -66,7 +66,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
             <div class="flex flex-col text-right text-outline">
               <span class="text-body-small md:text-body">Disponible CHF</span>
               <span
-                class="text-headline-small md:text-headline-large ph-no-capture"
+                class="text-headline-small md:text-headline-large ph-no-capture font-mono"
                 data-testid="remaining-amount"
               >
                 {{ remaining() | number: '1.2-2' : 'de-CH' }}

--- a/frontend/projects/webapp/src/app/feature/current-month/components/financial-accordion.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/financial-accordion.ts
@@ -74,7 +74,7 @@ export interface FinancialAccordionConfig {
         <div data-testid="right-side" class="flex items-center gap-3">
           @if (config().totalAmount !== undefined) {
             <span
-              class="ph-no-capture text-title-medium font-medium"
+              class="ph-no-capture text-title-medium font-medium font-mono"
               [class.text-pulpe-financial-income]="config().totalAmount! > 0"
               [class.text-pulpe-financial-expense]="config().totalAmount! < 0"
               [class.text-on-surface]="config().totalAmount! === 0"

--- a/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/financial-entry.ts
@@ -95,7 +95,7 @@ export type FinancialEntryViewModel = FinancialEntryModel & {
         }
       </div>
       <div matListItemMeta class="flex! h-full! items-center!">
-        <span class="ph-no-capture" [class.italic]="isRollover()">
+        <span class="ph-no-capture font-mono" [class.italic]="isRollover()">
           {{ data().kind === 'income' ? '+' : '-'
           }}{{ data().amount | number: '1.2-2' : 'de-CH' }}
         </span>

--- a/frontend/projects/webapp/src/app/ui/calendar/month-tile.ts
+++ b/frontend/projects/webapp/src/app/ui/calendar/month-tile.ts
@@ -45,7 +45,7 @@ import { type CalendarMonth } from './calendar-types';
               Disponible CHF
             </p>
             <p
-              class="text-headline-small md:text-headline-medium ph-no-capture"
+              class="text-headline-small md:text-headline-medium ph-no-capture font-mono"
               [class.text-[var(--pulpe-financial-savings)]]="
                 valueType() === 'positive'
               "

--- a/frontend/projects/webapp/src/app/ui/financial-summary/financial-summary.ts
+++ b/frontend/projects/webapp/src/app/ui/financial-summary/financial-summary.ts
@@ -38,7 +38,7 @@ export interface FinancialSummaryData {
               <ng-content select="[slot=title-info]" />
             </h3>
             <p
-              class="text-headline-small financial-amount ph-no-capture overflow-hidden text-ellipsis"
+              class="text-headline-small financial-amount ph-no-capture overflow-hidden text-ellipsis font-mono"
             >
               {{
                 data().amount | currency: 'CHF' : 'symbol' : '1.2-2' : 'de-CH'

--- a/frontend/projects/webapp/src/app/ui/realized-balance-progress-bar/realized-balance-progress-bar.ts
+++ b/frontend/projects/webapp/src/app/ui/realized-balance-progress-bar/realized-balance-progress-bar.ts
@@ -30,7 +30,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
               Dépenses réalisées CHF
             </span>
             <span
-              class="text-headline-small md:text-headline-large ph-no-capture"
+              class="text-headline-small md:text-headline-large ph-no-capture font-mono"
             >
               {{ realizedExpenses() | number: '1.2-2' : 'de-CH' }}
             </span>
@@ -44,7 +44,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
               <ng-content select="[slot=title-info]" />
             </span>
             <span
-              class="text-headline-small md:text-headline-large ph-no-capture"
+              class="text-headline-small md:text-headline-large ph-no-capture font-mono"
               [class.text-financial-income]="realizedBalance() >= 0"
               [class.text-financial-negative]="realizedBalance() < 0"
             >

--- a/frontend/projects/webapp/src/index.html
+++ b/frontend/projects/webapp/src/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Roboto:wght@300;400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
       media="print"
       onload="this.media = 'all'"
@@ -24,7 +24,7 @@
     <!-- Fallback pour navigateurs sans JS -->
     <noscript>
       <link
-        href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Roboto:wght@300;400;500&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
         rel="stylesheet"
       />
       <link

--- a/frontend/projects/webapp/src/styles.scss
+++ b/frontend/projects/webapp/src/styles.scss
@@ -41,7 +41,7 @@ body {
 body {
   margin: 0;
   font-family:
-    var(--mat-sys-typescale-body-medium-font-family-name), Poppins,
+    var(--mat-sys-typescale-body-medium-font-family-name), "Plus Jakarta Sans",
     "Helvetica Neue", sans-serif;
   background: var(--mat-sys-surface);
   color: var(--mat-sys-on-surface);


### PR DESCRIPTION
## Summary
Replace Poppins with Plus Jakarta Sans for all UI text. Introduce JetBrains Mono as the monospace font for financial amounts to improve visual distinction between UI text and numerical data.

Applied `font-mono` class to 17 components displaying currency values across summaries, tables, dialogs, and list items. All quality checks pass with no breaking changes.

## Changes
- Updated Google Fonts imports to load Plus Jakarta Sans (400-700 weights) and JetBrains Mono (400-500 weights)
- Modified font family variables and fallback stacks
- Added `font-mono` class to all financial amount displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)