### PR TITLE
fix: preserve tour keys when userId is unavailable

### DIFF
--- a/frontend/projects/webapp/src/app/core/analytics/posthog.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/posthog.spec.ts
@@ -126,8 +126,8 @@ describe('PostHogService', () => {
 
     expect(posthog.opt_in_capturing).toHaveBeenCalledTimes(1);
     expect(posthog.set_config).toHaveBeenCalledWith({
-      capture_pageleave: true,
-      capture_pageview: true,
+      capture_pageview: 'history_change',
+      capture_pageleave: 'if_capture_pageview',
     });
     expect(posthog.capture).toHaveBeenCalledWith('$pageview');
   });

--- a/frontend/projects/webapp/src/app/core/storage/storage.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage.service.spec.ts
@@ -288,7 +288,7 @@ describe('StorageService', () => {
       );
     });
 
-    it('should remove all tour keys when no userId is provided', () => {
+    it('should preserve all tour keys when no userId is provided (fail safely)', () => {
       // GIVEN: Both regular and tour keys exist
       localStorage.setItem('pulpe-budget', 'budget-data');
       localStorage.setItem('pulpe-tour-intro-user1', 'true');
@@ -297,10 +297,10 @@ describe('StorageService', () => {
       // WHEN: Clearing all without userId
       service.clearAll();
 
-      // THEN: All pulpe keys including tour keys are removed
+      // THEN: Regular pulpe keys are removed, but ALL tour keys are preserved
       expect(localStorage.getItem('pulpe-budget')).toBeNull();
-      expect(localStorage.getItem('pulpe-tour-intro-user1')).toBeNull();
-      expect(localStorage.getItem('pulpe-tour-intro-user2')).toBeNull();
+      expect(localStorage.getItem('pulpe-tour-intro-user1')).toBe('true');
+      expect(localStorage.getItem('pulpe-tour-intro-user2')).toBe('true');
     });
 
     it('should preserve only current user tour keys when userId is provided', () => {

--- a/frontend/projects/webapp/src/app/core/storage/storage.service.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage.service.ts
@@ -233,7 +233,7 @@ export class StorageService {
    *
    * Tour keys (pulpe-tour-*) are handled specially:
    * - If currentUserId is provided: only preserve that user's tour keys
-   * - If currentUserId is NOT provided: remove ALL tour keys
+   * - If currentUserId is NOT provided: preserve ALL tour keys (fail safely)
    *
    * Called on user logout to prevent data leakage between users.
    */
@@ -244,7 +244,7 @@ export class StorageService {
 
         // Tour keys: preserve only current user's, remove others
         if (key.startsWith('pulpe-tour-')) {
-          if (!currentUserId) return true; // No user = remove all tour keys
+          if (!currentUserId?.trim()) return false; // No user = preserve all tour keys (fail safely)
           return !key.endsWith(`-${currentUserId}`); // Keep only this user's
         }
 


### PR DESCRIPTION
## Summary

• Fix localStorage tour keys disappearing on session expiry or auth errors
• Preserve all tour keys when userId is undefined (fail-safe behavior)
• Add trim() check to handle whitespace-only userId edge case
• Update PostHog test to match SPA tracking config

## Type

fix

## Tests

All 963 tests passing (42/42 storage, 8/8 analytics)