### PR TITLE
fix(product-tour): decouple tours from user ID

### DIFF
--- a/frontend/e2e/utils/auth-bypass.ts
+++ b/frontend/e2e/utils/auth-bypass.ts
@@ -45,10 +45,9 @@ export async function setupAuthBypass(page: Page, options: {
     }
 
     // Disable product tours in E2E tests by marking them as already seen
-    // Key format matches ProductTourService: pulpe-tour-{tourId}-{userId}
+    // Key format matches ProductTourService: pulpe-tour-{tourId} (device-scoped)
     for (const tourId of config.tourIds) {
-      const key = `pulpe-tour-${tourId}-${config.USER.ID}`;
-      localStorage.setItem(key, 'true');
+      localStorage.setItem(`pulpe-tour-${tourId}`, 'true');
     }
   }, { ...TEST_CONFIG, setLocalStorage, tourIds: TOUR_IDS });
 

--- a/frontend/projects/webapp/src/app/core/auth/auth-cleanup.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-cleanup.service.spec.ts
@@ -79,12 +79,12 @@ describe('AuthCleanupService', () => {
       role: 'authenticated',
     } as User);
 
-    service.performCleanup('user-456');
+    service.performCleanup();
 
     expect(mockDemoMode.deactivateDemoMode).toHaveBeenCalled();
     expect(mockHasBudgetCache.clear).toHaveBeenCalled();
     expect(mockPostHog.reset).toHaveBeenCalled();
-    expect(mockStorage.clearAll).toHaveBeenCalledWith('user-456');
+    expect(mockStorage.clearAll).toHaveBeenCalled();
   });
 
   it('should prevent double cleanup when called rapidly', () => {
@@ -96,8 +96,8 @@ describe('AuthCleanupService', () => {
       role: 'authenticated',
     } as User);
 
-    service.performCleanup('user-789');
-    service.performCleanup('user-789');
+    service.performCleanup();
+    service.performCleanup();
 
     expect(mockDemoMode.deactivateDemoMode).toHaveBeenCalledTimes(1);
     expect(mockHasBudgetCache.clear).toHaveBeenCalledTimes(1);
@@ -121,7 +121,7 @@ describe('AuthCleanupService', () => {
       role: 'authenticated',
     } as User);
 
-    service.performCleanup('user-123');
+    service.performCleanup();
 
     TestBed.resetTestingModule();
 

--- a/frontend/projects/webapp/src/app/core/auth/auth-cleanup.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-cleanup.service.ts
@@ -32,11 +32,11 @@ export class AuthCleanupService {
     });
   }
 
-  performCleanup(userId?: string): void {
-    this.#handleSignOut(userId);
+  performCleanup(): void {
+    this.#handleSignOut();
   }
 
-  #handleSignOut(userId?: string): void {
+  #handleSignOut(): void {
     if (this.#cleanupInProgress) {
       this.#logger.debug(
         'Cleanup already in progress, skipping duplicate call',
@@ -53,7 +53,7 @@ export class AuthCleanupService {
       );
       this.#safeCleanup(() => this.#hasBudgetCache.clear(), 'budget cache');
       this.#safeCleanup(() => this.#postHogService.reset(), 'PostHog');
-      this.#safeCleanup(() => this.#storageService.clearAll(userId), 'storage');
+      this.#safeCleanup(() => this.#storageService.clearAll(), 'storage');
     } finally {
       if (this.#resetTimeoutId !== null) {
         clearTimeout(this.#resetTimeoutId);

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -252,9 +252,7 @@ describe('AuthSessionService', () => {
 
     expect(mockAuthState.setSession).toHaveBeenCalledWith(null);
     expect(mockAuthState.setLoading).toHaveBeenCalledWith(false);
-    expect(mockCleanup.performCleanup).toHaveBeenCalledWith(
-      mockSession.user.id,
-    );
+    expect(mockCleanup.performCleanup).toHaveBeenCalled();
     expect(mockLogger.debug).toHaveBeenCalledWith('Auth event:', {
       event: 'SIGNED_OUT',
       session: undefined,
@@ -522,7 +520,7 @@ describe('AuthSessionService', () => {
     expect(mockSupabaseClient.auth.signOut).toHaveBeenCalled();
     expect(mockAuthState.setSession).toHaveBeenCalledWith(null);
     expect(mockAuthState.setLoading).toHaveBeenCalledWith(false);
-    expect(mockCleanup.performCleanup).toHaveBeenCalledWith('user-123');
+    expect(mockCleanup.performCleanup).toHaveBeenCalled();
   });
 
   it('should sign out in E2E mode and call cleanup directly', async () => {
@@ -555,9 +553,7 @@ describe('AuthSessionService', () => {
     );
     expect(mockAuthState.setSession).toHaveBeenCalledWith(null);
     expect(mockAuthState.setLoading).toHaveBeenCalledWith(false);
-    expect(mockCleanup.performCleanup).toHaveBeenCalledWith(
-      mockSession.user.id,
-    );
+    expect(mockCleanup.performCleanup).toHaveBeenCalled();
     expect(mockSupabaseClient.auth.signOut).not.toHaveBeenCalled();
 
     delete (window as E2EWindow).__E2E_AUTH_BYPASS__;

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -90,12 +90,10 @@ export class AuthSessionService {
             case 'TOKEN_REFRESHED':
               this.#updateAuthState(session);
               break;
-            case 'SIGNED_OUT': {
-              const userId = this.#state.user()?.id;
+            case 'SIGNED_OUT':
               this.#updateAuthState(null);
-              this.#cleanup.performCleanup(userId);
+              this.#cleanup.performCleanup();
               break;
-            }
             case 'USER_UPDATED':
               this.#updateAuthState(session);
               break;
@@ -219,8 +217,6 @@ export class AuthSessionService {
   }
 
   async signOut(): Promise<void> {
-    const userId = this.#state.user()?.id;
-
     try {
       if (this.#isE2EBypass()) {
         this.#logger.debug('🎭 Mode test E2E: Simulation du logout');
@@ -240,7 +236,7 @@ export class AuthSessionService {
       });
     } finally {
       this.#updateAuthState(null);
-      this.#cleanup.performCleanup(userId);
+      this.#cleanup.performCleanup();
     }
   }
 

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
@@ -130,15 +130,15 @@ describe('ProductTourService', () => {
     });
   });
 
-  describe('isReady', () => {
+  describe('isAuthenticated', () => {
     it('should return true when user is authenticated', () => {
-      expect(service.isReady()).toBe(true);
+      expect(service.isAuthenticated()).toBe(true);
     });
 
     it('should return false when user is not authenticated', () => {
       mockCurrentUser = null;
 
-      expect(service.isReady()).toBe(false);
+      expect(service.isAuthenticated()).toBe(false);
     });
   });
 

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -16,6 +16,8 @@ export type TourPageId =
   | 'budget-details'
   | 'templates-list';
 
+export type TourId = 'intro' | TourPageId;
+
 /**
  * Delay before starting tour to ensure DOM is fully rendered
  * and Angular animations have completed
@@ -55,8 +57,8 @@ export class ProductTourService {
    * Generate a storage key for a tour.
    * Keys are device-scoped (no userId) to persist across account changes.
    */
-  #getTourKey(tourId: string): StorageKey {
-    return `pulpe-tour-${tourId}` as StorageKey;
+  #getTourKey(tourId: TourId): StorageKey {
+    return `pulpe-tour-${tourId}`;
   }
 
   /**

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -47,9 +47,12 @@ export class ProductTourService {
   #activeDriver: Driver | null = null;
 
   /**
-   * Check if the service is ready to operate (user is authenticated)
+   * Check if user is authenticated.
+   * Tours require authentication to start because they reference app content
+   * that only exists for logged-in users, even though tour completion state
+   * is stored device-scoped (persists across account changes on same device).
    */
-  isReady(): boolean {
+  isAuthenticated(): boolean {
     return !!this.#authState.user()?.id;
   }
 
@@ -119,10 +122,10 @@ export class ProductTourService {
   /**
    * Start a page-specific tour
    * Includes intro steps if user hasn't seen them yet
-   * Does nothing if service is not ready (user not authenticated)
+   * Does nothing if user is not authenticated or a tour is already active
    */
   startPageTour(pageId: TourPageId): void {
-    if (!this.isReady() || this.#activeDriver) {
+    if (!this.isAuthenticated() || this.#activeDriver) {
       return;
     }
 

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -23,8 +23,8 @@ export type TourPageId =
 export const TOUR_START_DELAY = 500;
 
 /**
- * Tour identifiers used to generate user-specific storage keys.
- * Keys are stored as `pulpe-tour-{tourId}-{userId}` to persist across logout/login.
+ * Tour identifiers used to generate storage keys.
+ * Keys are stored as `pulpe-tour-{tourId}` (device-scoped, not user-scoped).
  */
 const TOUR_IDS = {
   intro: 'intro',
@@ -52,79 +52,56 @@ export class ProductTourService {
   }
 
   /**
-   * Generate a user-specific storage key for a tour.
-   * Requires authenticated user - returns null if not ready.
+   * Generate a storage key for a tour.
+   * Keys are device-scoped (no userId) to persist across account changes.
    */
-  #getTourKey(tourId: string): StorageKey | null {
-    const userId = this.#authState.user()?.id;
-    if (!userId) {
-      return null;
-    }
-    return `pulpe-tour-${tourId}-${userId}` as StorageKey;
+  #getTourKey(tourId: string): StorageKey {
+    return `pulpe-tour-${tourId}` as StorageKey;
   }
 
   /**
    * Check if user has seen the intro (welcome + navigation)
-   * Returns true if not ready (graceful degradation - don't show tour)
    */
   hasSeenIntro(): boolean {
-    const key = this.#getTourKey(TOUR_IDS.intro);
-    if (!key) {
-      return true;
-    }
-    return this.#storageService.getString(key) === 'true';
+    return (
+      this.#storageService.getString(this.#getTourKey(TOUR_IDS.intro)) ===
+      'true'
+    );
   }
 
   /**
    * Check if user has seen a specific page tour
-   * Returns true if not ready (graceful degradation - don't show tour)
    */
   hasSeenPageTour(pageId: TourPageId): boolean {
-    const key = this.#getTourKey(TOUR_IDS[pageId]);
-    if (!key) {
-      return true;
-    }
-    return this.#storageService.getString(key) === 'true';
+    return (
+      this.#storageService.getString(this.#getTourKey(TOUR_IDS[pageId])) ===
+      'true'
+    );
   }
 
   /**
    * Mark intro as completed
    */
   #markIntroCompleted(): void {
-    const key = this.#getTourKey(TOUR_IDS.intro);
-    if (key) {
-      this.#storageService.setString(key, 'true');
-    }
+    this.#storageService.setString(this.#getTourKey(TOUR_IDS.intro), 'true');
   }
 
   /**
    * Mark a page tour as completed
    */
   #markPageTourCompleted(pageId: TourPageId): void {
-    const key = this.#getTourKey(TOUR_IDS[pageId]);
-    if (key) {
-      this.#storageService.setString(key, 'true');
-    }
+    this.#storageService.setString(this.#getTourKey(TOUR_IDS[pageId]), 'true');
   }
 
   /**
-   * Reset all tours for the current user
+   * Reset all tours (device-scoped)
    */
   resetAllTours(): void {
-    if (!this.isReady()) {
-      return;
-    }
-    const introKey = this.#getTourKey(TOUR_IDS.intro);
-    const currentMonthKey = this.#getTourKey(TOUR_IDS['current-month']);
-    const budgetListKey = this.#getTourKey(TOUR_IDS['budget-list']);
-    const budgetDetailsKey = this.#getTourKey(TOUR_IDS['budget-details']);
-    const templatesListKey = this.#getTourKey(TOUR_IDS['templates-list']);
-
-    if (introKey) this.#storageService.remove(introKey);
-    if (currentMonthKey) this.#storageService.remove(currentMonthKey);
-    if (budgetListKey) this.#storageService.remove(budgetListKey);
-    if (budgetDetailsKey) this.#storageService.remove(budgetDetailsKey);
-    if (templatesListKey) this.#storageService.remove(templatesListKey);
+    this.#storageService.remove(this.#getTourKey(TOUR_IDS.intro));
+    this.#storageService.remove(this.#getTourKey(TOUR_IDS['current-month']));
+    this.#storageService.remove(this.#getTourKey(TOUR_IDS['budget-list']));
+    this.#storageService.remove(this.#getTourKey(TOUR_IDS['budget-details']));
+    this.#storageService.remove(this.#getTourKey(TOUR_IDS['templates-list']));
   }
 
   /**

--- a/frontend/projects/webapp/src/app/core/storage/storage.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage.service.spec.ts
@@ -288,61 +288,19 @@ describe('StorageService', () => {
       );
     });
 
-    it('should preserve all tour keys when no userId is provided (fail safely)', () => {
+    it('should preserve all tour keys (device-scoped)', () => {
       // GIVEN: Both regular and tour keys exist
       localStorage.setItem('pulpe-budget', 'budget-data');
-      localStorage.setItem('pulpe-tour-intro-user1', 'true');
-      localStorage.setItem('pulpe-tour-intro-user2', 'true');
+      localStorage.setItem('pulpe-tour-intro', 'true');
+      localStorage.setItem('pulpe-tour-current-month', 'true');
 
-      // WHEN: Clearing all without userId
+      // WHEN: Clearing all
       service.clearAll();
 
       // THEN: Regular pulpe keys are removed, but ALL tour keys are preserved
       expect(localStorage.getItem('pulpe-budget')).toBeNull();
-      expect(localStorage.getItem('pulpe-tour-intro-user1')).toBe('true');
-      expect(localStorage.getItem('pulpe-tour-intro-user2')).toBe('true');
-    });
-
-    it('should preserve only current user tour keys when userId is provided', () => {
-      // GIVEN: Tour keys for multiple users exist
-      const currentUserId = 'abc-123';
-      localStorage.setItem('pulpe-budget', 'budget-data');
-      localStorage.setItem(`pulpe-tour-intro-${currentUserId}`, 'true');
-      localStorage.setItem(`pulpe-tour-month-${currentUserId}`, 'true');
-      localStorage.setItem('pulpe-tour-intro-other-user-456', 'true');
-      localStorage.setItem('pulpe-tour-month-xyz-789', 'true');
-
-      // WHEN: Clearing all with current userId
-      service.clearAll(currentUserId);
-
-      // THEN: Regular keys are removed, only current user's tour keys are preserved
-      expect(localStorage.getItem('pulpe-budget')).toBeNull();
-      expect(localStorage.getItem(`pulpe-tour-intro-${currentUserId}`)).toBe(
-        'true',
-      );
-      expect(localStorage.getItem(`pulpe-tour-month-${currentUserId}`)).toBe(
-        'true',
-      );
-      // Other users' tour keys are removed
-      expect(
-        localStorage.getItem('pulpe-tour-intro-other-user-456'),
-      ).toBeNull();
-      expect(localStorage.getItem('pulpe-tour-month-xyz-789')).toBeNull();
-    });
-
-    it('should handle shared device scenario - prevent tour data leak', () => {
-      // GIVEN: Alice logged out previously, Bob's tour keys remain
-      localStorage.setItem('pulpe-tour-intro-alice-123', 'true');
-      localStorage.setItem('pulpe-tour-intro-bob-456', 'true');
-      localStorage.setItem('pulpe-budget', 'bob-budget');
-
-      // WHEN: Bob logs out with his userId
-      service.clearAll('bob-456');
-
-      // THEN: Only Bob's tour keys remain, Alice's are cleaned up
-      expect(localStorage.getItem('pulpe-tour-intro-bob-456')).toBe('true');
-      expect(localStorage.getItem('pulpe-tour-intro-alice-123')).toBeNull();
-      expect(localStorage.getItem('pulpe-budget')).toBeNull();
+      expect(localStorage.getItem('pulpe-tour-intro')).toBe('true');
+      expect(localStorage.getItem('pulpe-tour-current-month')).toBe('true');
     });
   });
 

--- a/frontend/projects/webapp/src/app/core/storage/storage.service.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage.service.ts
@@ -231,22 +231,17 @@ export class StorageService {
    * Clear ALL app data from localStorage except persistent keys.
    * This removes all keys starting with 'pulpe-' or 'pulpe_'.
    *
-   * Tour keys (pulpe-tour-*) are handled specially:
-   * - If currentUserId is provided: only preserve that user's tour keys
-   * - If currentUserId is NOT provided: preserve ALL tour keys (fail safely)
+   * Tour keys (pulpe-tour-*) are always preserved as they are device-scoped.
    *
    * Called on user logout to prevent data leakage between users.
    */
-  clearAll(currentUserId?: string): void {
+  clearAll(): void {
     try {
       const keysToRemove = Object.keys(localStorage).filter((key) => {
         if (!key.startsWith('pulpe')) return false;
 
-        // Tour keys: preserve only current user's, remove others
-        if (key.startsWith('pulpe-tour-')) {
-          if (!currentUserId?.trim()) return false; // No user = preserve all tour keys (fail safely)
-          return !key.endsWith(`-${currentUserId}`); // Keep only this user's
-        }
+        // Tour keys are device-scoped, always preserve them
+        if (key.startsWith('pulpe-tour-')) return false;
 
         return true; // Remove all other pulpe keys
       });

--- a/frontend/projects/webapp/src/app/layout/logout-dialog.ts
+++ b/frontend/projects/webapp/src/app/layout/logout-dialog.ts
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'pulpe-logout-dialog',
+  imports: [MatDialogModule, MatProgressSpinnerModule],
+  template: `
+    <mat-dialog-content class="flex flex-col items-center justify-center py-8">
+      <mat-spinner diameter="48" />
+      <p class="mt-4 text-on-surface-variant text-body-large">Déconnexion...</p>
+    </mat-dialog-content>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      mat-dialog-content {
+        min-width: 200px;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LogoutDialog {}

--- a/frontend/projects/webapp/src/app/layout/logout-dialog.ts
+++ b/frontend/projects/webapp/src/app/layout/logout-dialog.ts
@@ -6,19 +6,18 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
   selector: 'pulpe-logout-dialog',
   imports: [MatDialogModule, MatProgressSpinnerModule],
   template: `
-    <mat-dialog-content class="flex flex-col items-center justify-center py-8">
+    <div class="flex flex-col items-center justify-center p-8 min-w-64">
       <mat-spinner diameter="48" />
-      <p class="mt-4 text-on-surface-variant text-body-large">Déconnexion...</p>
-    </mat-dialog-content>
+      <p class="mt-6 text-on-surface text-title-medium">Déconnexion en cours</p>
+      <p class="mt-1 text-on-surface-variant text-body-small">
+        Veuillez patienter...
+      </p>
+    </div>
   `,
   styles: [
     `
       :host {
         display: block;
-      }
-
-      mat-dialog-content {
-        min-width: 200px;
       }
     `,
   ],

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -46,9 +46,9 @@ import { Logger } from '@core/logging/logger';
 import { DemoModeService } from '@core/demo/demo-mode.service';
 import { DemoInitializerService } from '@core/demo/demo-initializer.service';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { LoadingIndicator } from '@core/loading/loading-indicator';
 import { AboutDialog } from './about-dialog';
+import { LogoutDialog } from './logout-dialog';
 
 interface NavigationItem {
   readonly route: string;
@@ -73,7 +73,6 @@ interface NavigationItem {
     RouterOutlet,
     PulpeBreadcrumb,
     MatProgressBarModule,
-    MatProgressSpinnerModule,
   ],
   template: `
     <mat-sidenav-container class="h-dvh bg-surface-container!">
@@ -181,20 +180,6 @@ interface NavigationItem {
           [class.p-2]="!isHandset()"
           [class.rounded-xl]="!isHandset()"
         >
-          <!-- Logout overlay - prevents flash of empty dashboard during logout -->
-          @if (isLoggingOut()) {
-            <div
-              class="absolute inset-0 z-50 flex flex-col items-center justify-center bg-surface"
-              role="alert"
-              aria-live="assertive"
-              aria-label="Déconnexion en cours"
-            >
-              <mat-spinner diameter="48" />
-              <p class="mt-4 text-on-surface-variant text-body-large">
-                Déconnexion...
-              </p>
-            </div>
-          }
           @if (loadingIndicator.isLoading() || isNavigating()) {
             <div class="absolute top-0 left-0 right-0">
               <mat-progress-bar
@@ -526,13 +511,12 @@ export default class MainLayout {
   async onLogout(): Promise<void> {
     if (this.#isLoggingOut()) return;
 
-    try {
-      this.#isLoggingOut.set(true);
+    this.#isLoggingOut.set(true);
+    this.#dialog.open(LogoutDialog, { disableClose: true });
 
-      // Sign out and wait for session to be cleared
+    try {
       await this.#authSession.signOut();
     } catch (error) {
-      // Only log detailed errors in development
       if (!this.#applicationConfig.isProduction()) {
         this.#logger.error('Erreur lors de la déconnexion:', error);
       }
@@ -550,10 +534,17 @@ export default class MainLayout {
    * Exit demo mode and redirect to login
    */
   protected async exitDemoMode(): Promise<void> {
+    if (this.#isLoggingOut()) return;
+
+    this.#isLoggingOut.set(true);
+    this.#dialog.open(LogoutDialog, { disableClose: true });
+
     try {
       await this.#demoInitializer.exitDemoMode();
     } catch (error) {
-      this.#logger.error('Failed to exit demo mode', { error });
+      if (!this.#applicationConfig.isProduction()) {
+        this.#logger.error('Failed to exit demo mode', { error });
+      }
     }
 
     this.#forceLogoutRedirect();

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -46,6 +46,7 @@ import { Logger } from '@core/logging/logger';
 import { DemoModeService } from '@core/demo/demo-mode.service';
 import { DemoInitializerService } from '@core/demo/demo-initializer.service';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { LoadingIndicator } from '@core/loading/loading-indicator';
 import { AboutDialog } from './about-dialog';
 
@@ -72,6 +73,7 @@ interface NavigationItem {
     RouterOutlet,
     PulpeBreadcrumb,
     MatProgressBarModule,
+    MatProgressSpinnerModule,
   ],
   template: `
     <mat-sidenav-container class="h-dvh bg-surface-container!">
@@ -179,6 +181,20 @@ interface NavigationItem {
           [class.p-2]="!isHandset()"
           [class.rounded-xl]="!isHandset()"
         >
+          <!-- Logout overlay - prevents flash of empty dashboard during logout -->
+          @if (isLoggingOut()) {
+            <div
+              class="absolute inset-0 z-50 flex flex-col items-center justify-center bg-surface"
+              role="alert"
+              aria-live="assertive"
+              aria-label="Déconnexion en cours"
+            >
+              <mat-spinner diameter="48" />
+              <p class="mt-4 text-on-surface-variant text-body-large">
+                Déconnexion...
+              </p>
+            </div>
+          }
           @if (loadingIndicator.isLoading() || isNavigating()) {
             <div class="absolute top-0 left-0 right-0">
               <mat-progress-bar

--- a/landing/next-env.d.ts
+++ b/landing/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Tours are now stored with device-scoped keys (`pulpe-tour-{tourId}`) instead of user-scoped keys (`pulpe-tour-{tourId}-{userId}`). This fixes the issue where tours restart when Google users' IDs rotate on each sign-in.

## Changes

- Simplified tour key generation to remove userId parameter
- Updated storage cleanup to always preserve tour keys (device-scoped)
- Cascaded changes to auth cleanup service and all call sites
- Updated all tests to reflect new behavior

## Validation

- ✅ Quality checks pass (10/10)
- ✅ Unit tests pass (958/958)
- ✅ Adversarial review passed

Closes #214