### PR TITLE
feat(ios): Display remaining amount on budget envelope when transactions linked

### DIFF
--- a/ios/Pulpe/Features/CurrentMonth/Components/RecurringExpensesList.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/RecurringExpensesList.swift
@@ -158,6 +158,12 @@ struct BudgetLineRow: View {
         consumption.available < 0 ? .red : line.kind.color
     }
 
+    private var amountTextColor: Color {
+        if line.isChecked { return .secondary }
+        if hasConsumption { return remainingColor }
+        return line.kind.color
+    }
+
     private var linkedTransactions: [Transaction] {
         allTransactions
             .filter { $0.budgetLineId == line.id }
@@ -204,7 +210,7 @@ struct BudgetLineRow: View {
                 VStack(alignment: .trailing, spacing: 2) {
                     Text(hasConsumption ? consumption.available.asCHF : line.amount.asCHF)
                         .font(.system(.callout, design: .rounded, weight: .semibold))
-                        .foregroundStyle(line.isChecked ? .secondary : (hasConsumption ? remainingColor : line.kind.color))
+                        .foregroundStyle(amountTextColor)
 
                     if hasConsumption {
                         Text("reste")


### PR DESCRIPTION
## Summary

• Show `consumption.available` instead of budgeted amount when envelope has linked transactions
• Add "reste" label to clarify the amount shown is remaining, not planned
• Style negative remaining amounts in red to indicate overspending
• Update accessibility hint to include remaining amount for screen readers

## Context

Improves UX for budget tracking by displaying the actionable "remaining to spend" amount instead of the initial budget when transactions exist.

## Type

feat