### PR TITLE
feat(budget): UI polish - negative budget ring, button alignment, remove help buttons

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget-templates/list/template-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/list/template-list-page.ts
@@ -70,15 +70,6 @@ import {
         </div>
         <div class="flex gap-2 items-center">
           <button
-            matIconButton
-            (click)="startPageTour()"
-            matTooltip="Découvrir cette page"
-            aria-label="Aide"
-            data-testid="help-button"
-          >
-            <mat-icon>help_outline</mat-icon>
-          </button>
-          <button
             matButton="filled"
             class="shrink-0"
             routerLink="create"
@@ -177,10 +168,6 @@ export default class TemplateListPage {
         );
       }
     });
-  }
-
-  startPageTour(): void {
-    this.#productTourService.startPageTour('templates-list');
   }
 
   async onDeleteTemplate(template: BudgetTemplate) {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
@@ -58,16 +58,7 @@ const YEARS_TO_DISPLAY = 8; // Current year + 7 future years for planning
         <h1 class="text-display-small truncate min-w-0 flex-shrink">
           {{ titleDisplay.currentTitle() }}
         </h1>
-        <div class="flex gap-2 flex-shrink-0">
-          <button
-            matIconButton
-            (click)="startPageTour()"
-            matTooltip="Découvrir cette page"
-            aria-label="Aide"
-            data-testid="help-button"
-          >
-            <mat-icon>help_outline</mat-icon>
-          </button>
+        <div class="flex gap-2 flex-shrink-0 ml-auto">
           <button
             matIconButton
             (click)="onExportBudgets()"
@@ -205,10 +196,6 @@ export default class BudgetListPage {
         );
       }
     });
-  }
-
-  startPageTour(): void {
-    this.#productTourService.startPageTour('budget-list');
   }
 
   protected readonly calendarYears = computed<CalendarYear[]>(() => {

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -99,16 +99,7 @@ type EditTransactionFormData = Pick<
         >
           {{ titleDisplay.currentTitle() }}
         </h1>
-        <div class="flex gap-2 flex-shrink-0">
-          <button
-            matIconButton
-            (click)="startPageTour()"
-            matTooltip="Découvrir cette page"
-            aria-label="Aide"
-            data-testid="help-button"
-          >
-            <mat-icon>help_outline</mat-icon>
-          </button>
+        <div class="flex gap-2 flex-shrink-0 ml-auto">
           <button
             matButton="tonal"
             class="icon-text-btn"
@@ -279,10 +270,6 @@ export default class CurrentMonth {
         );
       }
     });
-  }
-
-  startPageTour(): void {
-    this.#productTourService.startPageTour('current-month');
   }
 
   readonly recurringFinancialItems = computed<FinancialEntryModel[]>(() => {

--- a/frontend/projects/webapp/src/app/ui/calendar/month-tile.ts
+++ b/frontend/projects/webapp/src/app/ui/calendar/month-tile.ts
@@ -171,7 +171,8 @@ export class MonthTile {
       group: true,
       'opacity-60': vm.isPast,
       'ring-2': vm.isCurrent,
-      'ring-primary': vm.isCurrent,
+      'ring-primary': vm.isCurrent && vm.backgroundStyle !== 'negative',
+      'ring-error': vm.isCurrent && vm.backgroundStyle === 'negative',
       // Positive
       'bg-primary-container/20': vm.backgroundStyle === 'positive',
       'border-primary/30': vm.backgroundStyle === 'positive',


### PR DESCRIPTION
## Summary

• Dynamic ring color: Show ring-error for negative selected budgets instead of ring-primary
• Layout consistency: Right-align button containers on budget-list and current-month pages  
• UI cleanup: Remove redundant "Discover this page" help buttons from 3 pages
• Code quality: Remove dead code - unused startPageTour() methods after help button removal

## Type

feat