### PR TITLE
fix(budget): fix mobile button ripple effects - use matIconButton

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.html
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.html
@@ -24,16 +24,28 @@
   <!-- Header: Month navigation with chevrons -->
   <header class="relative">
     <div class="flex items-center justify-center gap-2 min-w-0">
+      <!-- Mobile: icon button only -->
+      <button
+        matIconButton
+        [disabled]="!store.hasPrevious()"
+        (click)="navigateToPrevious()"
+        aria-label="Mois précédent"
+        data-testid="previous-month-button"
+        class="flex-shrink-0 lg:hidden"
+      >
+        <mat-icon>chevron_left</mat-icon>
+      </button>
+      <!-- Desktop: text button -->
       <button
         matButton
         [disabled]="!store.hasPrevious()"
         (click)="navigateToPrevious()"
         aria-label="Mois précédent"
-        data-testid="previous-month-button"
-        class="flex-shrink-0"
+        data-testid="previous-month-button-desktop"
+        class="hidden lg:flex flex-shrink-0"
       >
         <mat-icon>chevron_left</mat-icon>
-        <span class="hidden lg:inline">Mois précédent</span>
+        <span>Mois précédent</span>
       </button>
       <div class="flex-1 min-w-0 text-center">
         <h1
@@ -54,15 +66,27 @@
         </p>
         }
       </div>
+      <!-- Mobile: icon button only -->
+      <button
+        matIconButton
+        [disabled]="!store.hasNext()"
+        (click)="navigateToNext()"
+        aria-label="Mois suivant"
+        data-testid="next-month-button"
+        class="flex-shrink-0 lg:hidden"
+      >
+        <mat-icon>chevron_right</mat-icon>
+      </button>
+      <!-- Desktop: text button -->
       <button
         matButton
         [disabled]="!store.hasNext()"
         (click)="navigateToNext()"
         aria-label="Mois suivant"
-        data-testid="next-month-button"
-        class="flex-shrink-0"
+        data-testid="next-month-button-desktop"
+        class="hidden lg:flex flex-shrink-0"
       >
-        <span class="hidden lg:inline">Mois suivant</span>
+        <span>Mois suivant</span>
         <mat-icon>chevron_right</mat-icon>
       </button>
     </div>

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.html
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.html
@@ -31,7 +31,7 @@
         (click)="navigateToPrevious()"
         aria-label="Mois précédent"
         data-testid="previous-month-button"
-        class="flex-shrink-0 lg:hidden"
+        class="flex-shrink-0 lg:hidden!"
       >
         <mat-icon>chevron_left</mat-icon>
       </button>
@@ -42,7 +42,7 @@
         (click)="navigateToPrevious()"
         aria-label="Mois précédent"
         data-testid="previous-month-button-desktop"
-        class="hidden lg:flex flex-shrink-0"
+        class="hidden! lg:flex! flex-shrink-0"
       >
         <mat-icon>chevron_left</mat-icon>
         <span>Mois précédent</span>
@@ -73,7 +73,7 @@
         (click)="navigateToNext()"
         aria-label="Mois suivant"
         data-testid="next-month-button"
-        class="flex-shrink-0 lg:hidden"
+        class="flex-shrink-0 lg:hidden!"
       >
         <mat-icon>chevron_right</mat-icon>
       </button>
@@ -84,10 +84,10 @@
         (click)="navigateToNext()"
         aria-label="Mois suivant"
         data-testid="next-month-button-desktop"
-        class="hidden lg:flex flex-shrink-0"
+        class="hidden! lg:flex! flex-shrink-0"
       >
         <span>Mois suivant</span>
-        <mat-icon>chevron_right</mat-icon>
+        <mat-icon iconPositionEnd>chevron_right</mat-icon>
       </button>
     </div>
   </header>

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-card.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-card.ts
@@ -5,6 +5,7 @@ import {
   input,
   output,
 } from '@angular/core';
+import { MatBadgeModule } from '@angular/material/badge';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { type BudgetLine } from 'pulpe-shared';
@@ -33,6 +34,7 @@ import { BudgetActionMenu } from '../components/budget-action-menu';
 @Component({
   selector: 'pulpe-budget-grid-card',
   imports: [
+    MatBadgeModule,
     MatChipsModule,
     MatSlideToggleModule,
     CurrencyPipe,
@@ -50,6 +52,10 @@ import { BudgetActionMenu } from '../components/budget-action-menu';
       [class.ring-2]="isSelected()"
       [class.ring-primary]="isSelected()"
       [class.opacity-60]="item().metadata.isLoading"
+      [matBadge]="item().consumption?.transactionCount"
+      [matBadgeHidden]="!item().consumption?.hasTransactions"
+      matBadgeColor="primary"
+      matBadgePosition="above after"
       role="button"
       tabindex="0"
       (click)="cardClick.emit(item())"

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-mobile-card.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-mobile-card.ts
@@ -170,14 +170,20 @@ import { BudgetActionMenu } from '../components/budget-action-menu';
             <div class="flex items-center gap-2">
               @if (item().consumption?.hasTransactions) {
                 <button
-                  matIconButton
+                  matButton
+                  class="text-body-small h-8! px-3!"
                   [matBadge]="item().consumption!.transactionCount"
                   matBadgeColor="primary"
-                  matBadgeSize="small"
                   (click)="viewTransactions.emit(item())"
-                  matTooltip="Voir les transactions"
+                  [matTooltip]="
+                    'Voir les ' + item().consumption!.transactionCountLabel
+                  "
                 >
-                  <mat-icon>receipt_long</mat-icon>
+                  <mat-icon class="text-base! mr-1">receipt_long</mat-icon>
+                  {{
+                    item().consumption!.consumed
+                      | currency: 'CHF' : 'symbol' : '1.0-0'
+                  }}
                 </button>
               } @else {
                 <button

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-mobile-card.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-mobile-card.ts
@@ -49,10 +49,10 @@ import { BudgetActionMenu } from '../components/budget-action-menu';
     <mat-card
       appearance="outlined"
       class="!rounded-2xl"
+      [class.ring-2]="isSelected()"
+      [class.ring-primary]="isSelected()"
       [class.opacity-60]="item().metadata.isLoading"
-      [attr.data-testid]="
-        'envelope-card-' + (item().data.name | rolloverFormat)
-      "
+      [attr.data-testid]="'envelope-card-' + item().data.id"
     >
       <mat-card-content class="p-4">
         <!-- Row 1: Name and Menu -->
@@ -217,6 +217,7 @@ import { BudgetActionMenu } from '../components/budget-action-menu';
 })
 export class BudgetGridMobileCard {
   readonly item = input.required<BudgetLineTableItem>();
+  readonly isSelected = input<boolean>(false);
 
   readonly edit = output<BudgetLineTableItem>();
   readonly delete = output<string>();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-mobile-card.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-mobile-card.ts
@@ -170,15 +170,14 @@ import { BudgetActionMenu } from '../components/budget-action-menu';
             <div class="flex items-center gap-2">
               @if (item().consumption?.hasTransactions) {
                 <button
-                  matButton
-                  class="!h-8 !px-3 !rounded-full !min-w-0"
+                  matIconButton
                   [matBadge]="item().consumption!.transactionCount"
                   matBadgeColor="primary"
                   matBadgeSize="small"
                   (click)="viewTransactions.emit(item())"
                   matTooltip="Voir les transactions"
                 >
-                  <mat-icon class="!text-lg">receipt_long</mat-icon>
+                  <mat-icon>receipt_long</mat-icon>
                 </button>
               } @else {
                 <button


### PR DESCRIPTION
## Summary

• Replace `matButton` with `matIconButton` for chevron navigation on mobile to fix circular ripple
• Separate mobile/desktop button variants in budget-details header
• Fix transactions button: use `matIconButton` and remove CSS hacks
• Closes #238

## Changes

- `budget-details-page.html`: Chevron buttons now use responsive directives (lg:hidden for mobile matIconButton, hidden lg:flex for desktop matButton)
- `budget-grid-mobile-card.ts`: Transactions button switched from matButton to matIconButton, removed CSS workarounds (!h-8, !px-3, !rounded-full, !min-w-0)

## Testing

- ✓ Typecheck passing
- ✓ Lint passing
- ✓ Buttons render with correct ripple styles on mobile and desktop