### PR TITLE
feat(ios): persist session in debug mode - skip re-login on app restart

### DIFF
--- a/ios/Pulpe/App/AppState.swift
+++ b/ios/Pulpe/App/AppState.swift
@@ -62,6 +62,16 @@ final class AppState {
     func checkAuthState() async {
         authState = .loading
 
+        #if DEBUG
+        // In DEBUG mode, try regular token-based session first (no biometric prompt)
+        // This keeps developers logged in across app restarts from Xcode
+        if let user = try? await authService.validateSession() {
+            currentUser = user
+            authState = .authenticated
+            return
+        }
+        #endif
+
         guard biometricEnabled else {
             // Clear any stale tokens from previous install
             await authService.clearBiometricTokens()


### PR DESCRIPTION
## Summary

• Keep developers logged in when running app from Xcode (DEBUG mode)
• Uses existing token-based session validation instead of forcing biometric flow
• Production behavior unchanged - biometric flow remains default in Release builds

## Type

feat