### PR TITLE
fix(product-tour): cleanup Driver.js artifacts and reset scroll position

### DIFF
--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -20,6 +20,16 @@ const SCROLL_RESET_SELECTORS = [
   '[data-testid="main-content"] > div',
 ] as const;
 
+/** Driver.js CSS class applied to highlighted elements (driver.js v1.x) */
+const DRIVER_ACTIVE_ELEMENT_CLASS = 'driver-active-element';
+
+/** Driver.js CSS classes applied to document body (driver.js v1.x) */
+const DRIVER_BODY_CLASSES = [
+  'driver-active',
+  'driver-fade',
+  'driver-simple',
+] as const;
+
 export type TourPageId =
   | 'current-month'
   | 'budget-list'
@@ -142,19 +152,17 @@ export class ProductTourService {
   }
 
   #removeDriverClasses(): void {
-    this.#document.querySelectorAll('.driver-active-element').forEach((el) => {
-      el.classList.remove('driver-active-element');
-    });
-    this.#document.body.classList.remove(
-      'driver-active',
-      'driver-fade',
-      'driver-simple',
-    );
+    this.#document
+      .querySelectorAll(`.${DRIVER_ACTIVE_ELEMENT_CLASS}`)
+      .forEach((el) => {
+        el.classList.remove(DRIVER_ACTIVE_ELEMENT_CLASS);
+      });
+    this.#document.body.classList.remove(...DRIVER_BODY_CLASSES);
   }
 
   #resetScrollPositions(): void {
     for (const selector of SCROLL_RESET_SELECTORS) {
-      const element = this.#document.querySelector(selector);
+      const element = this.#document.querySelector<HTMLElement>(selector);
       if (element) {
         element.scrollTop = 0;
       }

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -120,6 +120,46 @@ export class ProductTourService {
   }
 
   /**
+   * Clean up Driver.js artifacts that may persist after tour ends.
+   * Delayed execution ensures cleanup runs after Driver.js completes its own teardown.
+   */
+  #cleanupDriverArtifacts(): void {
+    setTimeout(() => {
+      this.#removeDriverClasses();
+      this.#resetScrollPositions();
+    }, 0);
+  }
+
+  #removeDriverClasses(): void {
+    document.querySelectorAll('.driver-active-element').forEach((el) => {
+      el.classList.remove('driver-active-element');
+    });
+    document.body.classList.remove(
+      'driver-active',
+      'driver-fade',
+      'driver-simple',
+    );
+  }
+
+  /**
+   * Reset scroll on layout containers.
+   * scrollIntoView() used by Driver.js scrolls ALL ancestors, not just the intended one.
+   */
+  #resetScrollPositions(): void {
+    const selectors = [
+      '[data-testid="page-content"]',
+      '[data-testid="main-content"] > div',
+    ];
+
+    for (const selector of selectors) {
+      const element = document.querySelector(selector);
+      if (element) {
+        element.scrollTop = 0;
+      }
+    }
+  }
+
+  /**
    * Start a page-specific tour
    * Includes intro steps if user hasn't seen them yet
    * Does nothing if user is not authenticated or a tour is already active
@@ -154,6 +194,7 @@ export class ProductTourService {
       popoverOffset: 16,
       onDestroyed: () => {
         this.#activeDriver = null;
+        this.#cleanupDriverArtifacts();
         if (includeIntro) {
           this.#markIntroCompleted();
         }


### PR DESCRIPTION
## Summary

• Restore scroll position on layout containers after product tour completes
• Clean up Driver.js CSS classes that persist after tour ends
• Extract hardcoded selectors to `SCROLL_RESET_SELECTORS` constant for maintainability
• Use Angular's `DOCUMENT` token instead of global `document` for testability

## Changes

- Add `#cleanupDriverArtifacts()` to handle post-tour cleanup with proper delay
- Extract `#removeDriverClasses()` to remove lingering Driver.js styles
- Extract `#resetScrollPositions()` to reset scroll on affected containers
- Inject `DOCUMENT` token for DOM access (improves testability)
- Export `SCROLL_RESET_SELECTORS` constant for easier maintenance

## Type

fix + refactor