### PR TITLE
fix(mobile): ensure page content fills full viewport height

### DIFF
--- a/frontend/e2e/tests/features/mobile-scroll.spec.ts
+++ b/frontend/e2e/tests/features/mobile-scroll.spec.ts
@@ -131,6 +131,26 @@ test.describe('Mobile scroll behavior', () => {
       expect(afterScrollPosition!.y).toBe(initialPosition!.y);
     });
 
+    test('page content should fill full viewport height even with minimal content', async ({
+      authenticatedPage: page,
+    }) => {
+      await page.waitForLoadState('networkidle');
+
+      const { sidenavContentHeight, viewportHeight } = await page.evaluate(() => {
+        const sidenavContent = document.querySelector('[data-testid="main-content"]');
+        if (!sidenavContent) {
+          throw new Error('Element [data-testid="main-content"] not found in DOM.');
+        }
+        return {
+          sidenavContentHeight: sidenavContent.getBoundingClientRect().height,
+          viewportHeight: window.innerHeight,
+        };
+      });
+
+      // mat-sidenav-content should fill at least the full viewport height
+      expect(sidenavContentHeight).toBeGreaterThanOrEqual(viewportHeight);
+    });
+
     test('menu should open correctly after scrolling', async ({
       authenticatedPage: page,
     }) => {

--- a/frontend/e2e/tests/features/mobile-scroll.spec.ts
+++ b/frontend/e2e/tests/features/mobile-scroll.spec.ts
@@ -131,7 +131,7 @@ test.describe('Mobile scroll behavior', () => {
       expect(afterScrollPosition!.y).toBe(initialPosition!.y);
     });
 
-    test('page content should fill full viewport height even with minimal content', async ({
+    test('mat-sidenav-content should fill full viewport height even with minimal content', async ({
       authenticatedPage: page,
     }) => {
       await page.waitForLoadState('networkidle');

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-financial-overview.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-financial-overview.ts
@@ -50,7 +50,7 @@ import { RealizedBalanceTooltip } from '@ui/realized-balance-tooltip/realized-ba
           [class.text-on-primary-container]="totals().remaining >= 0"
           [class.text-on-error-container]="totals().remaining < 0"
         >
-          {{ Math.abs(totals().remaining) | number: '1.0-0' : 'de-CH' }}
+          {{ remainingAbsolute() | number: '1.0-0' : 'de-CH' }}
           <span class="text-headline-small font-normal">CHF</span>
         </div>
         <p
@@ -161,7 +161,6 @@ import { RealizedBalanceTooltip } from '@ui/realized-balance-tooltip/realized-ba
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BudgetFinancialOverview {
-  readonly Math = Math;
   readonly #budgetCalculator = inject(BudgetCalculator);
 
   readonly budgetLines = input.required<BudgetLine[]>();
@@ -207,4 +206,8 @@ export class BudgetFinancialOverview {
 
     return { income, expenses, savings, remaining };
   });
+
+  readonly remainingAbsolute = computed(() =>
+    Math.abs(this.totals().remaining),
+  );
 }

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -188,6 +188,7 @@ interface NavigationItem {
           class="flex flex-col bg-surface relative min-w-0"
           [class.h-full]="!isHandset()"
           [class.overflow-hidden]="!isHandset()"
+          [class.flex-1]="isHandset()"
           [class.p-2]="!isHandset()"
           [class.pt-0]="!isHandset() && !isDemoMode()"
           [class.rounded-xl]="!isHandset()"
@@ -457,6 +458,7 @@ interface NavigationItem {
         :host mat-sidenav-content {
           overflow: visible !important;
           height: auto !important;
+          min-height: 100dvh !important;
         }
       }
 

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -459,6 +459,9 @@ interface NavigationItem {
           overflow: visible !important;
           height: auto !important;
           min-height: 100dvh !important;
+          /* Force flex layout - Material overrides Tailwind classes */
+          display: flex !important;
+          flex-direction: column !important;
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes an issue introduced in commit 2d3ed93a where switching to body-level scrolling on mobile caused pages with minimal content (loading states, collapsed blocks) to not fill the viewport height.

## Changes

- Add `min-height: 100dvh` to `mat-sidenav-content` on mobile (CSS media query)
- Add `flex-1` binding to inner flex container on mobile to stretch to available space
- Add E2E test verifying content fills viewport on mobile with minimal content

The flex chain is now restored: viewport → mat-sidenav-content (min 100dvh) → inner div (flex-1) → main (flex-1) fills the available height while still allowing body-level scroll for navbar auto-hide.