### PR TITLE
fix: Display actual budget period month instead of static label

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
@@ -31,7 +31,10 @@ import { BudgetListStore } from './budget-list-store';
 import { CreateBudgetDialogComponent } from './create-budget/budget-creation-dialog';
 import SearchTransactionsDialogComponent from './search-transactions-dialog/search-transactions-dialog';
 import { Logger } from '@core/logging/logger';
-import type { TransactionSearchResult } from 'pulpe-shared';
+import {
+  type TransactionSearchResult,
+  getBudgetPeriodForDate,
+} from 'pulpe-shared';
 import {
   ProductTourService,
   TOUR_START_DELAY,
@@ -234,10 +237,10 @@ export default class BudgetListPage {
     });
   });
 
-  // Calendar-specific signals
-  protected readonly currentDate = signal({
-    month: new Date().getMonth() + 1,
-    year: new Date().getFullYear(),
+  // Current budget period based on payday setting
+  protected readonly currentDate = computed(() => {
+    const payDay = this.#userSettingsApi.payDayOfMonth();
+    return getBudgetPeriodForDate(new Date(), payDay);
   });
 
   readonly #isHandset = toSignal(

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -1,4 +1,5 @@
-import { DatePipe } from '@angular/common';
+import { format } from 'date-fns';
+import { frCH } from 'date-fns/locale';
 import {
   afterNextRender,
   ChangeDetectionStrategy,
@@ -32,7 +33,6 @@ import {
   ProductTourService,
   TOUR_START_DELAY,
 } from '@core/product-tour/product-tour.service';
-import { TitleDisplay } from '@core/routing';
 import { type TransactionCreate } from 'pulpe-shared';
 import { ConfirmationDialog } from '@ui/dialogs/confirmation-dialog';
 import { BaseLoading } from '@ui/loading';
@@ -73,7 +73,6 @@ type EditTransactionFormData = Pick<
   ],
   imports: [
     BudgetProgressBar,
-    DatePipe,
     MatCardModule,
     MatButtonModule,
     MatBottomSheetModule,
@@ -97,7 +96,7 @@ type EditTransactionFormData = Pick<
           class="text-headline-medium md:text-display-small truncate min-w-0 flex-shrink"
           data-testid="page-title"
         >
-          {{ titleDisplay.currentTitle() }}
+          {{ budgetPeriodDisplayName() }}
         </h1>
         <div class="flex gap-2 flex-shrink-0 ml-auto">
           <button
@@ -200,7 +199,7 @@ type EditTransactionFormData = Pick<
                 data-testid="empty-state-description"
               >
                 Aucun budget n'a été créé pour
-                {{ store.budgetDate() | date: 'MMMM yyyy' : '' : 'fr-CH' }}.
+                {{ budgetPeriodDisplayName() }}.
               </p>
             </div>
           }
@@ -241,7 +240,6 @@ export default class CurrentMonth {
   readonly isCreatingTransaction = signal(false);
   readonly selectedTransactions = signal<string[]>([]);
   protected readonly store = inject(CurrentMonthStore);
-  protected readonly titleDisplay = inject(TitleDisplay);
   readonly #productTourService = inject(ProductTourService);
   readonly #destroyRef = inject(DestroyRef);
   readonly #loadingIndicator = inject(LoadingIndicator);
@@ -249,6 +247,17 @@ export default class CurrentMonth {
   readonly #dialog = inject(MatDialog);
   readonly #snackBar = inject(MatSnackBar);
   readonly #logger = inject(Logger);
+
+  /**
+   * Display name for the current budget period (e.g., "janvier 2025")
+   * Uses currentBudgetPeriod which accounts for the user's payday setting
+   */
+  protected readonly budgetPeriodDisplayName = computed(() => {
+    const period = this.store.currentBudgetPeriod();
+    return format(new Date(period.year, period.month - 1, 1), 'MMMM yyyy', {
+      locale: frCH,
+    });
+  });
 
   constructor() {
     this.store.refreshData();


### PR DESCRIPTION
## Summary
Display the actual budget period month name in the current month dashboard and calendar list, respecting the user's payday setting.

## Changes
- Update current-month page title to show budget period month (e.g., "janvier 2025") instead of static "Mois en cours"
- Fix budget list calendar to highlight the correct current month based on payday
- Use `currentBudgetPeriod()` which accounts for user's payday setting via `getBudgetPeriodForDate`

## Impact
The dashboard and calendar now correctly reflect the current budget period, not just the calendar month. This is especially important for users with custom payday settings (e.g., payday on the 27th).

Fixes #256