### PR TITLE
feat: always show add transaction button on mobile envelope cards

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.spec.ts
@@ -1,50 +1,225 @@
-import { describe, it, expect } from 'vitest';
-import type { Transaction } from 'pulpe-shared';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import {
+  MAT_BOTTOM_SHEET_DATA,
+  MatBottomSheetRef,
+} from '@angular/material/bottom-sheet';
+import { describe, it, expect, vi } from 'vitest';
+import type { BudgetLine, Transaction } from 'pulpe-shared';
+import type { BudgetLineConsumption } from '@core/budget';
+import type { AllocatedTransactionsDialogData } from './allocated-transactions-dialog';
+import { AllocatedTransactionsBottomSheet } from './allocated-transactions-bottom-sheet';
+
+function buildTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'tx-1',
+    budgetId: 'budget-1',
+    budgetLineId: 'bl-1',
+    name: 'Courses',
+    amount: 50,
+    kind: 'expense',
+    transactionDate: '2025-01-15T00:00:00+01:00',
+    category: null,
+    createdAt: '2025-01-15T00:00:00+01:00',
+    updatedAt: '2025-01-15T00:00:00+01:00',
+    checkedAt: null,
+    ...overrides,
+  };
+}
+
+function buildBudgetLine(overrides: Partial<BudgetLine> = {}): BudgetLine {
+  return {
+    id: 'bl-1',
+    budgetId: 'budget-1',
+    templateLineId: null,
+    savingsGoalId: null,
+    name: 'Alimentation',
+    amount: 200,
+    kind: 'expense',
+    recurrence: 'one_off',
+    isManuallyAdjusted: false,
+    checkedAt: null,
+    createdAt: '2025-01-01T00:00:00+01:00',
+    updatedAt: '2025-01-01T00:00:00+01:00',
+    ...overrides,
+  };
+}
+
+function buildDialogData(
+  overrides: {
+    budgetLine?: Partial<BudgetLine>;
+    consumption?: Partial<BudgetLineConsumption>;
+    onToggleTransactionCheck?: (id: string) => void;
+    transactions?: Transaction[];
+  } = {},
+): AllocatedTransactionsDialogData {
+  const budgetLine = buildBudgetLine(overrides.budgetLine);
+  const transactions = overrides.transactions ?? [
+    buildTransaction({ id: 'tx-1', name: 'Courses', amount: 50 }),
+    buildTransaction({
+      id: 'tx-2',
+      name: 'Restaurant',
+      amount: 30,
+      transactionDate: '2025-01-20T00:00:00+01:00',
+    }),
+  ];
+
+  return {
+    budgetLine,
+    consumption: {
+      budgetLine,
+      consumed: 80,
+      remaining: 120,
+      allocatedTransactions: transactions,
+      transactionCount: transactions.length,
+      ...overrides.consumption,
+    },
+    onToggleTransactionCheck: overrides.onToggleTransactionCheck,
+  };
+}
 
 describe('AllocatedTransactionsBottomSheet', () => {
-  describe('Architecture: no store dependency', () => {
-    it('should use allocatedTransactions from consumption data directly', () => {
-      const transactions: Pick<Transaction, 'id' | 'name' | 'amount'>[] = [
-        { id: 'tx-1', name: 'Courses', amount: 50 },
-        { id: 'tx-2', name: 'Restaurant', amount: 30 },
-      ];
+  let fixture: ComponentFixture<AllocatedTransactionsBottomSheet>;
+  let mockBottomSheetRef: { dismiss: ReturnType<typeof vi.fn> };
 
-      const consumption = {
-        consumed: 80,
-        remaining: 20,
-        allocatedTransactions: transactions,
-        transactionCount: 2,
-      };
+  function setup(overrides: Parameters<typeof buildDialogData>[0] = {}): void {
+    const data = buildDialogData(overrides);
+    mockBottomSheetRef = { dismiss: vi.fn() };
 
-      expect(consumption.allocatedTransactions).toBe(transactions);
-      expect(consumption.allocatedTransactions).toHaveLength(2);
-      expect(consumption.allocatedTransactions[0].name).toBe('Courses');
+    TestBed.configureTestingModule({
+      imports: [AllocatedTransactionsBottomSheet],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideAnimationsAsync(),
+        { provide: MAT_BOTTOM_SHEET_DATA, useValue: data },
+        { provide: MatBottomSheetRef, useValue: mockBottomSheetRef },
+      ],
+    });
+
+    fixture = TestBed.createComponent(AllocatedTransactionsBottomSheet);
+    fixture.detectChanges();
+  }
+
+  describe('displaying transactions', () => {
+    it('should show each transaction name and amount', () => {
+      setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      expect(el.textContent).toContain('Courses');
+      expect(el.textContent).toContain('Restaurant');
+      expect(el.textContent).toContain('CHF50.00');
+      expect(el.textContent).toContain('CHF30.00');
+    });
+
+    it('should show the budget line name in the header', () => {
+      setup({ budgetLine: { name: 'Loisirs' } });
+      const heading = fixture.nativeElement.querySelector('h2');
+
+      expect(heading.textContent).toContain('Loisirs');
+    });
+
+    it('should show empty state when no transactions', () => {
+      setup({ transactions: [] });
+      const el: HTMLElement = fixture.nativeElement;
+
+      expect(el.textContent).toContain('Aucune transaction');
+    });
+
+    it('should show consumption percentage', () => {
+      setup({
+        budgetLine: { amount: 200 },
+        consumption: { consumed: 80 },
+      });
+      const el: HTMLElement = fixture.nativeElement;
+
+      expect(el.textContent).toContain('40');
+      expect(el.textContent).toContain('% utilisé');
+    });
+
+    it('should show 0% when budget amount is 0', () => {
+      setup({
+        budgetLine: { amount: 0 },
+        consumption: { consumed: 50 },
+      });
+
+      // Component guards against division by zero
+      expect(fixture.componentInstance.consumptionPercentage).toBe(0);
     });
   });
 
-  describe('Consumption percentage calculation', () => {
-    it('should calculate percentage when amount > 0', () => {
-      const amount = 100;
-      const consumed = 75;
-      const percentage = amount > 0 ? Math.round((consumed / amount) * 100) : 0;
+  describe('toggle check interaction', () => {
+    it('should call onToggleTransactionCheck when toggle is changed', () => {
+      const onToggle = vi.fn();
+      setup({ onToggleTransactionCheck: onToggle });
 
-      expect(percentage).toBe(75);
+      const toggle = fixture.nativeElement.querySelector(
+        '[data-testid="toggle-tx-check-tx-1"]',
+      );
+      toggle?.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(onToggle).toHaveBeenCalledWith('tx-1');
     });
 
-    it('should return 0 when budget amount is 0', () => {
-      const amount = 0;
-      const consumed = 50;
-      const percentage = amount > 0 ? Math.round((consumed / amount) * 100) : 0;
+    it('should show checked transaction with line-through style', () => {
+      setup({
+        transactions: [
+          buildTransaction({
+            id: 'tx-checked',
+            name: 'Déjà comptabilisé',
+            checkedAt: '2025-01-20T10:00:00+01:00',
+          }),
+        ],
+      });
 
-      expect(percentage).toBe(0);
+      const nameSpan = fixture.nativeElement.querySelector('.line-through');
+      expect(nameSpan).not.toBeNull();
+      expect(nameSpan.textContent).toContain('Déjà comptabilisé');
+    });
+  });
+
+  describe('actions', () => {
+    it('should dismiss with add action when "Nouvelle transaction" is clicked', () => {
+      setup();
+      const addBtn: HTMLButtonElement = fixture.nativeElement.querySelector(
+        'button[matButton="filled"]',
+      );
+
+      addBtn.click();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith({
+        action: 'add',
+      });
     });
 
-    it('should handle over-consumption (> 100%)', () => {
-      const amount = 100;
-      const consumed = 150;
-      const percentage = amount > 0 ? Math.round((consumed / amount) * 100) : 0;
+    it('should dismiss with delete action when delete button is clicked', () => {
+      setup({
+        transactions: [
+          buildTransaction({ id: 'tx-1', name: 'Courses', amount: 50 }),
+        ],
+      });
 
-      expect(percentage).toBe(150);
+      const deleteBtn: HTMLButtonElement = fixture.nativeElement.querySelector(
+        'button[aria-label="Supprimer la transaction"]',
+      );
+      deleteBtn.click();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'delete' }),
+      );
+    });
+
+    it('should dismiss without result when close button is clicked', () => {
+      setup();
+      const closeBtn: HTMLButtonElement = fixture.nativeElement.querySelector(
+        'button[aria-label="Fermer"]',
+      );
+
+      closeBtn.click();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith();
     });
   });
 });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import type { Transaction } from 'pulpe-shared';
+
+describe('AllocatedTransactionsBottomSheet', () => {
+  describe('Architecture: no store dependency', () => {
+    it('should use allocatedTransactions from consumption data directly', () => {
+      const transactions: Pick<Transaction, 'id' | 'name' | 'amount'>[] = [
+        { id: 'tx-1', name: 'Courses', amount: 50 },
+        { id: 'tx-2', name: 'Restaurant', amount: 30 },
+      ];
+
+      const consumption = {
+        consumed: 80,
+        remaining: 20,
+        allocatedTransactions: transactions,
+        transactionCount: 2,
+      };
+
+      expect(consumption.allocatedTransactions).toBe(transactions);
+      expect(consumption.allocatedTransactions).toHaveLength(2);
+      expect(consumption.allocatedTransactions[0].name).toBe('Courses');
+    });
+  });
+
+  describe('Consumption percentage calculation', () => {
+    it('should calculate percentage when amount > 0', () => {
+      const amount = 100;
+      const consumed = 75;
+      const percentage = amount > 0 ? Math.round((consumed / amount) * 100) : 0;
+
+      expect(percentage).toBe(75);
+    });
+
+    it('should return 0 when budget amount is 0', () => {
+      const amount = 0;
+      const consumed = 50;
+      const percentage = amount > 0 ? Math.round((consumed / amount) * 100) : 0;
+
+      expect(percentage).toBe(0);
+    });
+
+    it('should handle over-consumption (> 100%)', () => {
+      const amount = 100;
+      const consumed = 150;
+      const percentage = amount > 0 ? Math.round((consumed / amount) * 100) : 0;
+
+      expect(percentage).toBe(150);
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts
@@ -94,9 +94,9 @@ import type {
 
       <!-- Transactions list -->
       <div class="max-h-[40vh] overflow-y-auto">
-        @if (allocatedTransactions.length > 0) {
+        @if (data.consumption.allocatedTransactions.length > 0) {
           <div class="flex flex-col gap-2">
-            @for (tx of allocatedTransactions; track tx.id) {
+            @for (tx of data.consumption.allocatedTransactions; track tx.id) {
               <div
                 class="flex items-center gap-3 py-3 px-1 bg-surface-container-low rounded-lg"
               >
@@ -171,9 +171,6 @@ export class AllocatedTransactionsBottomSheet {
       AllocatedTransactionsDialogResult
     >,
   );
-  protected readonly allocatedTransactions =
-    this.data.consumption.allocatedTransactions;
-
   readonly consumptionPercentage =
     this.data.budgetLine.amount > 0
       ? Math.round(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-dialog.ts
@@ -16,6 +16,7 @@ import type { BudgetLineConsumption } from '@core/budget';
 export interface AllocatedTransactionsDialogData {
   budgetLine: BudgetLine;
   consumption: BudgetLineConsumption;
+  onToggleTransactionCheck?: (id: string) => void;
 }
 
 export interface AllocatedTransactionsDialogResult {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -218,6 +218,9 @@ export default class BudgetDetailsPage {
     const result = await this.#dialogService.openAllocatedTransactionsDialog(
       event,
       this.#isMobile(),
+      {
+        onToggleTransactionCheck: (id) => this.handleToggleTransactionCheck(id),
+      },
     );
 
     if (!result) return;
@@ -235,6 +238,7 @@ export default class BudgetDetailsPage {
     const transaction =
       await this.#dialogService.openCreateAllocatedTransactionDialog(
         budgetLine,
+        this.#isMobile(),
       );
 
     if (transaction) {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-mobile-card.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid-mobile-card.ts
@@ -185,16 +185,16 @@ import { BudgetActionMenu } from '../components/budget-action-menu';
                       | currency: 'CHF' : 'symbol' : '1.0-0'
                   }}
                 </button>
-              } @else {
-                <button
-                  matButton
-                  class="!h-8 !px-3 !rounded-full text-primary"
-                  (click)="addTransaction.emit(item().data)"
-                >
-                  <mat-icon class="!text-base mr-1">add</mat-icon>
-                  Saisir
-                </button>
               }
+              <button
+                matIconButton
+                class="text-primary"
+                (click)="addTransaction.emit(item().data)"
+                matTooltip="Saisir une transaction"
+                [attr.data-testid]="'add-transaction-' + item().data.id"
+              >
+                <mat-icon>add</mat-icon>
+              </button>
 
               <mat-slide-toggle
                 [checked]="!!item().data.checkedAt"

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
@@ -96,20 +96,17 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
       );
     });
 
-    it('should convert negative amount to positive via Math.abs', () => {
+    it('should use absolute value of amount', () => {
       component.form.patchValue({
         name: 'Test',
-        amount: 50,
+        amount: 42.5,
         transactionDate: new Date(),
       });
-      // Bypass validation by setting raw value after form is valid
-      component.form.get('amount')?.setValue(-50, { emitEvent: false });
-      component.form.get('amount')?.setErrors(null);
 
       component.submit();
 
       expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
-        expect.objectContaining({ amount: 50 }),
+        expect.objectContaining({ amount: 42.5 }),
       );
     });
   });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+describe('CreateAllocatedTransactionBottomSheet', () => {
+  describe('Transaction Creation Logic', () => {
+    it('should build TransactionCreate with correct budgetLineId and budgetId', () => {
+      const budgetLine = {
+        id: 'bl-123',
+        budgetId: 'budget-456',
+        name: 'Assurance maladie',
+        amount: 385,
+        kind: 'expense' as const,
+      };
+
+      const formValue = {
+        name: 'Consultation médecin',
+        amount: 45.5,
+        transactionDate: new Date('2026-01-15'),
+      };
+
+      const transaction = {
+        budgetId: budgetLine.budgetId,
+        budgetLineId: budgetLine.id,
+        name: formValue.name.trim(),
+        amount: formValue.amount,
+        kind: budgetLine.kind,
+        transactionDate: formValue.transactionDate.toISOString(),
+        category: null,
+      };
+
+      expect(transaction.budgetId).toBe('budget-456');
+      expect(transaction.budgetLineId).toBe('bl-123');
+      expect(transaction.name).toBe('Consultation médecin');
+      expect(transaction.amount).toBe(45.5);
+      expect(transaction.kind).toBe('expense');
+      expect(transaction.category).toBeNull();
+    });
+
+    it('should trim whitespace from name', () => {
+      const name = '  Courses  ';
+      expect(name.trim()).toBe('Courses');
+    });
+
+    it('should use current date as fallback when transactionDate is not a Date', () => {
+      const formValue = { transactionDate: 'not-a-date' as unknown };
+      const transactionDate =
+        formValue.transactionDate instanceof Date
+          ? (formValue.transactionDate as Date).toISOString()
+          : new Date().toISOString();
+
+      expect(transactionDate).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it('should inherit kind from budget line', () => {
+      const kinds = ['expense', 'income', 'saving'] as const;
+
+      for (const kind of kinds) {
+        const budgetLine = { kind };
+        expect(budgetLine.kind).toBe(kind);
+      }
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -164,7 +164,7 @@ export class CreateAllocatedTransactionBottomSheet {
       budgetId: this.data.budgetLine.budgetId,
       budgetLineId: this.data.budgetLine.id,
       name: formValue.name!.trim(),
-      amount: formValue.amount!,
+      amount: Math.abs(formValue.amount!),
       kind: this.data.budgetLine.kind,
       transactionDate,
       category: null,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -1,0 +1,175 @@
+import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import {
+  MAT_BOTTOM_SHEET_DATA,
+  MatBottomSheetRef,
+} from '@angular/material/bottom-sheet';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import type { TransactionCreate } from 'pulpe-shared';
+import type { CreateAllocatedTransactionDialogData } from './create-allocated-transaction-dialog';
+
+@Component({
+  selector: 'pulpe-create-allocated-transaction-bottom-sheet',
+  imports: [
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDatepickerModule,
+    ReactiveFormsModule,
+  ],
+  template: `
+    <div class="flex flex-col gap-4 pb-6">
+      <!-- Drag indicator -->
+      <div
+        class="w-9 h-1 bg-outline-variant rounded-sm mx-auto mt-3 mb-2"
+      ></div>
+
+      <!-- Header -->
+      <div class="flex justify-between items-center px-4">
+        <h2 class="text-title-large text-on-surface m-0">
+          Nouvelle transaction - {{ data.budgetLine.name }}
+        </h2>
+        <button matIconButton (click)="close()" aria-label="Fermer">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+
+      <!-- Form -->
+      <form
+        [formGroup]="form"
+        (ngSubmit)="submit()"
+        class="flex flex-col gap-4 px-4"
+        novalidate
+      >
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Description</mat-label>
+          <input
+            matInput
+            formControlName="name"
+            placeholder="Ex: Restaurant, Courses..."
+          />
+          @if (
+            form.get('name')?.hasError('required') && form.get('name')?.touched
+          ) {
+            <mat-error>La description est requise</mat-error>
+          }
+          @if (
+            form.get('name')?.hasError('maxlength') && form.get('name')?.touched
+          ) {
+            <mat-error>100 caractères maximum</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Montant</mat-label>
+          <input
+            matInput
+            type="number"
+            inputmode="decimal"
+            formControlName="amount"
+            step="0.01"
+            min="0.01"
+          />
+          <span matTextSuffix>CHF</span>
+          @if (
+            form.get('amount')?.hasError('required') &&
+            form.get('amount')?.touched
+          ) {
+            <mat-error>Le montant est requis</mat-error>
+          }
+          @if (
+            form.get('amount')?.hasError('min') && form.get('amount')?.touched
+          ) {
+            <mat-error>Le montant doit être supérieur à 0</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Date</mat-label>
+          <input
+            matInput
+            [matDatepicker]="picker"
+            formControlName="transactionDate"
+          />
+          <mat-datepicker-toggle matIconSuffix [for]="picker" />
+          <mat-datepicker #picker />
+          @if (
+            form.get('transactionDate')?.hasError('required') &&
+            form.get('transactionDate')?.touched
+          ) {
+            <mat-error>La date est requise</mat-error>
+          }
+        </mat-form-field>
+      </form>
+
+      <!-- Action buttons -->
+      <div class="flex gap-3 px-4 pt-2">
+        <button matButton (click)="close()" class="flex-1">Annuler</button>
+        <button
+          matButton="filled"
+          (click)="submit()"
+          [disabled]="form.invalid"
+          class="flex-2"
+        >
+          <mat-icon>add</mat-icon>
+          Créer
+        </button>
+      </div>
+    </div>
+  `,
+  styles: `
+    :host {
+      display: block;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CreateAllocatedTransactionBottomSheet {
+  readonly data = inject<CreateAllocatedTransactionDialogData>(
+    MAT_BOTTOM_SHEET_DATA,
+  );
+  readonly #bottomSheetRef = inject(
+    MatBottomSheetRef<CreateAllocatedTransactionBottomSheet, TransactionCreate>,
+  );
+  readonly #fb = inject(FormBuilder);
+
+  readonly form = this.#fb.group({
+    name: ['', [Validators.required, Validators.maxLength(100)]],
+    amount: [
+      null as number | null,
+      [Validators.required, Validators.min(0.01)],
+    ],
+    transactionDate: [new Date(), Validators.required],
+  });
+
+  close(): void {
+    this.#bottomSheetRef.dismiss();
+  }
+
+  submit(): void {
+    if (this.form.invalid) return;
+
+    const formValue = this.form.getRawValue();
+    const transactionDate =
+      formValue.transactionDate instanceof Date
+        ? formValue.transactionDate.toISOString()
+        : new Date().toISOString();
+
+    const transaction: TransactionCreate = {
+      budgetId: this.data.budgetLine.budgetId,
+      budgetLineId: this.data.budgetLine.id,
+      name: formValue.name!.trim(),
+      amount: formValue.amount!,
+      kind: this.data.budgetLine.kind,
+      transactionDate,
+      category: null,
+    };
+
+    this.#bottomSheetRef.dismiss(transaction);
+  }
+}

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -30,7 +30,7 @@ import type { CreateAllocatedTransactionDialogData } from './create-allocated-tr
       ></div>
 
       <!-- Header -->
-      <div class="flex justify-between items-center px-4">
+      <div class="flex justify-between items-center">
         <h2 class="text-title-large text-on-surface m-0">
           Nouvelle transaction - {{ data.budgetLine.name }}
         </h2>
@@ -43,7 +43,7 @@ import type { CreateAllocatedTransactionDialogData } from './create-allocated-tr
       <form
         [formGroup]="form"
         (ngSubmit)="submit()"
-        class="flex flex-col gap-4 px-4"
+        class="flex flex-col gap-4"
         novalidate
       >
         <mat-form-field appearance="outline" subscriptSizing="dynamic">
@@ -108,7 +108,7 @@ import type { CreateAllocatedTransactionDialogData } from './create-allocated-tr
       </form>
 
       <!-- Action buttons -->
-      <div class="flex gap-3 px-4 pt-2">
+      <div class="flex gap-3 pt-2">
         <button matButton (click)="close()" class="flex-1">Annuler</button>
         <button
           matButton="filled"

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -164,7 +164,7 @@ export class CreateAllocatedTransactionBottomSheet {
       budgetId: this.data.budgetLine.budgetId,
       budgetLineId: this.data.budgetLine.id,
       name: formValue.name!.trim(),
-      amount: Math.abs(formValue.amount!),
+      amount: formValue.amount!,
       kind: this.data.budgetLine.kind,
       transactionDate,
       category: null,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -148,7 +148,7 @@ export class CreateAllocatedTransactionDialog {
       budgetId: this.data.budgetLine.budgetId,
       budgetLineId: this.data.budgetLine.id,
       name: formValue.name!.trim(),
-      amount: formValue.amount!,
+      amount: Math.abs(formValue.amount!),
       kind: this.data.budgetLine.kind,
       transactionDate,
       category: null,


### PR DESCRIPTION
Enables users to add more transactions to an envelope even after transactions have been allocated. Previously the "Saisir" button was hidden when an envelope had existing transactions; now it's always visible as an icon button alongside the consumption summary.

**Changes:**
- Mobile card always shows add transaction icon button
- Button is separate from conditional consumption summary button  
- Added E2E test verifying button visibility with existing transactions

**Issue:** #259