### PR TITLE
fix: resolve date offset and transaction check bugs (#268)

### DIFF
--- a/frontend/projects/webapp/src/app/core/date/format-local-date.spec.ts
+++ b/frontend/projects/webapp/src/app/core/date/format-local-date.spec.ts
@@ -8,7 +8,7 @@ describe('formatLocalDate', () => {
 
     const result = formatLocalDate(date);
 
-    expect(result).toMatch(/^2026-01-29T00:00:00[+-]\d{2}:\d{2}$/);
+    expect(result).toMatch(/^2026-01-29T00:00:00([+-]\d{2}:\d{2}|Z)$/);
   });
 
   it('should preserve date when time is set', () => {
@@ -16,7 +16,7 @@ describe('formatLocalDate', () => {
 
     const result = formatLocalDate(date);
 
-    expect(result).toMatch(/^2026-06-15T14:30:45[+-]\d{2}:\d{2}$/);
+    expect(result).toMatch(/^2026-06-15T14:30:45([+-]\d{2}:\d{2}|Z)$/);
   });
 
   it('should include timezone offset suffix', () => {
@@ -24,7 +24,7 @@ describe('formatLocalDate', () => {
 
     const result = formatLocalDate(date);
 
-    expect(result).toMatch(/[+-]\d{2}:\d{2}$/);
+    expect(result).toMatch(/([+-]\d{2}:\d{2}|Z)$/);
   });
 
   it('should return a string that starts with the correct date regardless of timezone', () => {

--- a/frontend/projects/webapp/src/app/core/date/format-local-date.spec.ts
+++ b/frontend/projects/webapp/src/app/core/date/format-local-date.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { transactionCreateSchema } from 'pulpe-shared';
 import { formatLocalDate } from './format-local-date';
 
 describe('formatLocalDate', () => {
@@ -7,7 +8,7 @@ describe('formatLocalDate', () => {
 
     const result = formatLocalDate(date);
 
-    expect(result).toBe('2026-01-29T00:00:00');
+    expect(result).toMatch(/^2026-01-29T00:00:00[+-]\d{2}:\d{2}$/);
   });
 
   it('should preserve date when time is set', () => {
@@ -15,16 +16,15 @@ describe('formatLocalDate', () => {
 
     const result = formatLocalDate(date);
 
-    expect(result).toBe('2026-06-15T14:30:45');
+    expect(result).toMatch(/^2026-06-15T14:30:45[+-]\d{2}:\d{2}$/);
   });
 
-  it('should not include timezone suffix', () => {
+  it('should include timezone offset suffix', () => {
     const date = new Date(2026, 0, 1);
 
     const result = formatLocalDate(date);
 
-    expect(result).not.toContain('Z');
-    expect(result).not.toMatch(/[+-]\d{2}:\d{2}$/);
+    expect(result).toMatch(/[+-]\d{2}:\d{2}$/);
   });
 
   it('should return a string that starts with the correct date regardless of timezone', () => {
@@ -33,5 +33,15 @@ describe('formatLocalDate', () => {
     const result = formatLocalDate(date);
 
     expect(result).toMatch(/^2026-12-31/);
+  });
+
+  it('should produce a valid transactionDate for the backend schema', () => {
+    const date = new Date(2026, 0, 29, 12, 0, 0);
+
+    const result = formatLocalDate(date);
+
+    const parsed =
+      transactionCreateSchema.shape.transactionDate.safeParse(result);
+    expect(parsed.success).toBe(true);
   });
 });

--- a/frontend/projects/webapp/src/app/core/date/format-local-date.spec.ts
+++ b/frontend/projects/webapp/src/app/core/date/format-local-date.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { formatLocalDate } from './format-local-date';
+
+describe('formatLocalDate', () => {
+  it('should preserve the local date without UTC shift', () => {
+    const date = new Date(2026, 0, 29, 0, 0, 0); // Jan 29, 2026, midnight local
+
+    const result = formatLocalDate(date);
+
+    expect(result).toBe('2026-01-29T00:00:00');
+  });
+
+  it('should preserve date when time is set', () => {
+    const date = new Date(2026, 5, 15, 14, 30, 45); // Jun 15, 2026, 14:30:45
+
+    const result = formatLocalDate(date);
+
+    expect(result).toBe('2026-06-15T14:30:45');
+  });
+
+  it('should not include timezone suffix', () => {
+    const date = new Date(2026, 0, 1);
+
+    const result = formatLocalDate(date);
+
+    expect(result).not.toContain('Z');
+    expect(result).not.toMatch(/[+-]\d{2}:\d{2}$/);
+  });
+
+  it('should return a string that starts with the correct date regardless of timezone', () => {
+    const date = new Date(2026, 11, 31, 23, 59, 59); // Dec 31, 2026, 23:59:59
+
+    const result = formatLocalDate(date);
+
+    expect(result).toMatch(/^2026-12-31/);
+  });
+});

--- a/frontend/projects/webapp/src/app/core/date/format-local-date.ts
+++ b/frontend/projects/webapp/src/app/core/date/format-local-date.ts
@@ -1,0 +1,12 @@
+import { format } from 'date-fns';
+
+/**
+ * Formats a Date to a local datetime string (yyyy-MM-dd'T'HH:mm:ss)
+ * without UTC conversion, preserving the user's local date.
+ *
+ * Use this instead of Date.toISOString() when the calendar date matters
+ * (e.g., transaction dates from a datepicker).
+ */
+export function formatLocalDate(date: Date): string {
+  return format(date, "yyyy-MM-dd'T'HH:mm:ss");
+}

--- a/frontend/projects/webapp/src/app/core/date/format-local-date.ts
+++ b/frontend/projects/webapp/src/app/core/date/format-local-date.ts
@@ -1,12 +1,12 @@
 import { format } from 'date-fns';
 
 /**
- * Formats a Date to a local datetime string (yyyy-MM-dd'T'HH:mm:ss)
+ * Formats a Date to a local datetime string (yyyy-MM-dd'T'HH:mm:ssXXX)
  * without UTC conversion, preserving the user's local date.
  *
  * Use this instead of Date.toISOString() when the calendar date matters
  * (e.g., transaction dates from a datepicker).
  */
 export function formatLocalDate(date: Date): string {
-  return format(date, "yyyy-MM-dd'T'HH:mm:ss");
+  return format(date, "yyyy-MM-dd'T'HH:mm:ssXXX");
 }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts
@@ -126,7 +126,7 @@ import type {
           </div>
         } @else {
           <div class="text-center py-6 text-on-surface-variant">
-            <mat-icon class="text-4xl! mb-2!">receipt_long</mat-icon>
+            <mat-icon class="mb-2!">receipt_long</mat-icon>
             <p class="text-body-medium">Aucune transaction</p>
           </div>
         }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-detail-panel.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-detail-panel.ts
@@ -175,9 +175,7 @@ const DETAIL_SEGMENT_COUNT = 12;
 
           @if (allocatedTransactions().length === 0) {
             <div class="text-center py-8 text-on-surface-variant">
-              <mat-icon class="text-4xl! mb-2 opacity-50"
-                >receipt_long</mat-icon
-              >
+              <mat-icon class="mb-2 opacity-50">receipt_long</mat-icon>
               <p class="text-body-medium">Aucune transaction</p>
               <p class="text-body-small">
                 Ajoute une transaction pour suivre tes dépenses

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid.ts
@@ -177,11 +177,17 @@ import { BudgetGridSection } from './budget-grid-section';
                 (change)="toggleTransactionCheck.emit(item.data.id)"
                 (click)="$event.stopPropagation()"
                 [attr.data-testid]="'toggle-check-tx-' + item.data.id"
+                [attr.aria-label]="
+                  item.data.checkedAt
+                    ? 'Marquer comme non vérifié'
+                    : 'Marquer comme vérifié'
+                "
               />
               <button
                 matIconButton
                 (click)="deleteTransaction.emit(item.data.id)"
                 [attr.data-testid]="'delete-tx-' + item.data.id"
+                aria-label="Supprimer la transaction"
               >
                 <mat-icon class="text-xl!">delete</mat-icon>
               </button>

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid.ts
@@ -12,6 +12,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import type { BudgetLine, Transaction } from 'pulpe-shared';
 import type { TransactionViewModel } from '../models/transaction-view-model';
 import type { BudgetLineTableItem } from '../data-core';
@@ -37,6 +38,7 @@ import { BudgetGridSection } from './budget-grid-section';
     BudgetGridCard,
     BudgetGridMobileCard,
     BudgetGridSection,
+    MatSlideToggleModule,
   ],
   template: `
     @if (isMobile()) {
@@ -169,7 +171,13 @@ import { BudgetGridSection } from './budget-grid-section';
             >
               {{ item.data.amount }}
             </div>
-            <div>
+            <div class="flex items-center">
+              <mat-slide-toggle
+                [checked]="!!item.data.checkedAt"
+                (change)="toggleTransactionCheck.emit(item.data.id)"
+                (click)="$event.stopPropagation()"
+                [attr.data-testid]="'toggle-check-tx-' + item.data.id"
+              />
               <button
                 matIconButton
                 (click)="deleteTransaction.emit(item.data.id)"

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -11,6 +11,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import type { BudgetLine, TransactionCreate } from 'pulpe-shared';
+import { formatLocalDate } from '@core/date/format-local-date';
 
 export interface CreateAllocatedTransactionDialogData {
   budgetLine: BudgetLine;
@@ -141,8 +142,8 @@ export class CreateAllocatedTransactionDialog {
     const formValue = this.form.getRawValue();
     const transactionDate =
       formValue.transactionDate instanceof Date
-        ? formValue.transactionDate.toISOString()
-        : new Date().toISOString();
+        ? formatLocalDate(formValue.transactionDate)
+        : formatLocalDate(new Date());
 
     const transaction: TransactionCreate = {
       budgetId: this.data.budgetLine.budgetId,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -76,6 +76,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
     createBudgetLine$: ReturnType<typeof vi.fn>;
     updateBudgetLine$: ReturnType<typeof vi.fn>;
     deleteBudgetLine$: ReturnType<typeof vi.fn>;
+    toggleCheck$: ReturnType<typeof vi.fn>;
   };
   let mockTransactionApi: {
     create$: ReturnType<typeof vi.fn>;
@@ -123,6 +124,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       createBudgetLine$: vi.fn(),
       updateBudgetLine$: vi.fn(),
       deleteBudgetLine$: vi.fn(),
+      toggleCheck$: vi.fn(),
     };
 
     mockTransactionApi = {
@@ -688,7 +690,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
   });
 
   describe('User creates allocated transactions', () => {
-    it('should inherit checked state from parent budget line when creating allocated transaction', async () => {
+    it('should create transaction unchecked and uncheck parent budget line when parent was checked', async () => {
       const checkedTimestamp = '2024-01-15T10:00:00Z';
 
       // Parent budget line has checkedAt
@@ -726,12 +728,18 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         name: 'New Allocated Transaction',
         amount: 200,
         kind: 'expense',
-        checkedAt: checkedTimestamp,
+        checkedAt: null,
       });
 
       mockTransactionApi.create$ = vi
         .fn()
         .mockReturnValue(of({ data: serverTransaction }));
+
+      mockBudgetLineApi.toggleCheck$ = vi
+        .fn()
+        .mockReturnValue(
+          of({ data: { ...checkedParentLine, checkedAt: null } }),
+        );
 
       // User creates transaction linked to checked parent
       await service.createAllocatedTransaction({
@@ -742,21 +750,30 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         kind: 'expense',
       });
 
-      // Transaction should inherit checkedAt from parent
+      // Transaction should be created unchecked
       const transactions = service.budgetDetails()?.transactions ?? [];
       const createdTx = transactions.find(
         (tx) => tx.name === 'New Allocated Transaction',
       );
 
       expect(createdTx).toBeDefined();
-      expect(createdTx?.checkedAt).not.toBeNull();
+      expect(createdTx?.checkedAt).toBeNull();
 
-      // Verify API was called with inherited checkedAt
+      // Verify API was called with checkedAt: null
       expect(mockTransactionApi.create$).toHaveBeenCalledWith(
         expect.objectContaining({
-          checkedAt: expect.any(String),
+          checkedAt: null,
         }),
       );
+
+      // Parent budget line should have been unchecked
+      expect(mockBudgetLineApi.toggleCheck$).toHaveBeenCalledWith(
+        'line-checked',
+      );
+
+      const budgetLines = service.budgetDetails()?.budgetLines ?? [];
+      const parentLine = budgetLines.find((l) => l.id === 'line-checked');
+      expect(parentLine?.checkedAt).toBeNull();
     });
 
     it('should not inherit checked state when parent budget line is unchecked', async () => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/edit-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/edit-transaction-form.ts
@@ -26,6 +26,7 @@ import { startOfMonth, endOfMonth } from 'date-fns';
 import { TransactionValidators } from '../utils/transaction-form-validators';
 import { TransactionLabelPipe } from '@ui/transaction-display';
 import { Logger } from '@core/logging/logger';
+import { formatLocalDate } from '@core/date/format-local-date';
 
 type EditTransactionFormData = Pick<
   TransactionCreate,
@@ -329,7 +330,7 @@ export class EditTransactionForm implements OnInit {
       name: name as string,
       amount: amount as number,
       kind: kind as 'expense' | 'income' | 'saving',
-      transactionDate: (transactionDate as Date).toISOString(),
+      transactionDate: formatLocalDate(transactionDate as Date),
       category: (category as string) || null,
     });
   }


### PR DESCRIPTION
## Summary

• Fixed date offset bug: toISOString() converts local midnight to UTC, shifting dates by 1 day. Replaced with formatLocalDate() utility that preserves local date
• Added date utility: Created core/date/format-local-date.ts for shared use across features (budget-details, current-month)
• Fixed mobile toggle: Added mat-slide-toggle to mobile transaction card template for checking transactions
• Fixed inherited checkedAt: New transactions always start unchecked; parent budget line is auto-unchecked if needed
• Updated tests: Reflect new transaction check behavior; added 4 tests for formatLocalDate utility

## Type

fix