### PR TITLE
refactor(ios): enhance amount input forms with quick chips and design tokens

### DIFF
--- a/ios/Pulpe.xcodeproj/project.pbxproj
+++ b/ios/Pulpe.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -15,6 +15,7 @@
 		0439BC81EC87CB64E4D2A804 /* StoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32141CA4F575218D6B417EF /* StoreProtocol.swift */; };
 		0ED5E397D5D72B1D9A1F5421 /* TestDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162414A0A3971BB9C2DC434B /* TestDataFactory.swift */; };
 		102AE579FE67D6F209FD2CF4 /* BudgetListStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CFD332A0AB9A168D1A6F /* BudgetListStore.swift */; };
+		11FAC305478C80D495BDE0E0 /* StringParsedAsAmountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F77BA6BE7228F88ED96032 /* StringParsedAsAmountTests.swift */; };
 		1623C2D7A07E71A04BAF5EB9 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A8C7ACFFD4118A786F4A2C /* View+Extensions.swift */; };
 		194F56EEAE3B2C2EF5B15A3A /* PhonePlanStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6D73BC1D11C6EC1A1E313C /* PhonePlanStep.swift */; };
 		19A14676593410AFA5021013 /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE2934837CC4349E12F1EE2 /* Decimal+Extensions.swift */; };
@@ -216,6 +217,7 @@
 		24760BF421846CAFAD51DF62 /* TransportStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportStep.swift; sourceTree = "<group>"; };
 		27F72011B11153235E828030 /* BudgetTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BudgetTemplate.swift; sourceTree = "<group>"; };
 		2880F0C22312339FA0DA2633 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		28F77BA6BE7228F88ED96032 /* StringParsedAsAmountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringParsedAsAmountTests.swift; sourceTree = "<group>"; };
 		2947DBEF8A6264E9FF73AEDA /* RecurringExpensesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurringExpensesList.swift; sourceTree = "<group>"; };
 		29D91A4D1401A217165EAD49 /* CreateBudgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBudgetView.swift; sourceTree = "<group>"; };
 		2D05E8BCE893AAA486F2F8BE /* AddBudgetLineSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBudgetLineSheet.swift; sourceTree = "<group>"; };
@@ -256,7 +258,7 @@
 		6B68A90534D06367C77B1427 /* DashboardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStore.swift; sourceTree = "<group>"; };
 		6E4F47F7A88B6744CA6D788C /* Color+Pulpe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Pulpe.swift"; sourceTree = "<group>"; };
 		6E873F06201D0A4D69F356ED /* AddAllocatedTransactionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAllocatedTransactionSheet.swift; sourceTree = "<group>"; };
-		723AB344C1BB78CCBA3446C8 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		723AB344C1BB78CCBA3446C8 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		76DBD55125DA1270DC47F0BE /* CheckedFilterPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckedFilterPickerTests.swift; sourceTree = "<group>"; };
 		77C8421EEBFDB74A00EE05B5 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		7D01817526FAA87D773269A9 /* TransactionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionService.swift; sourceTree = "<group>"; };
@@ -267,7 +269,7 @@
 		88250064A726B3B6AAAE9ADF /* welcome-animation.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "welcome-animation.json"; sourceTree = "<group>"; };
 		8C9C2806F868DBC404A44317 /* OnboardingNavigationButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNavigationButtons.swift; sourceTree = "<group>"; };
 		8E370F96AA76DABDBB00B7DC /* maintenance-animation.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "maintenance-animation.json"; sourceTree = "<group>"; };
-		94570CEB6CD57FB35C06DE92 /* Pulpe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pulpe.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		94570CEB6CD57FB35C06DE92 /* Pulpe.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Pulpe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		94DA9F16798B6DC1691A2DB8 /* CreateTemplateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTemplateView.swift; sourceTree = "<group>"; };
 		955B1199FD862E3761B3435A /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		9A05FA792057CD53B266EE9F /* TransactionEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionEnums.swift; sourceTree = "<group>"; };
@@ -276,7 +278,7 @@
 		9E56340C03DD8EE1F7DF7638 /* BudgetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BudgetService.swift; sourceTree = "<group>"; };
 		A1A0EA391775C63723A83BF3 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		A3D2CDB198623A6C39D6F3EF /* PulpeUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PulpeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		A40110A09E6DF69EDAD88EFA /* PulpeWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PulpeWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		A40110A09E6DF69EDAD88EFA /* PulpeWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PulpeWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4090237752EF9DF63F659AA /* Transaction+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transaction+Extensions.swift"; sourceTree = "<group>"; };
 		A4952E464DEEA5F04D784FD0 /* NetworkUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkUnavailableView.swift; sourceTree = "<group>"; };
 		A77FEC48FC6CEA8465118A09 /* ToastManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastManager.swift; sourceTree = "<group>"; };
@@ -394,6 +396,7 @@
 			isa = PBXGroup;
 			children = (
 				CAEE16A3F433B50FF474CC42 /* MonthYearTests.swift */,
+				28F77BA6BE7228F88ED96032 /* StringParsedAsAmountTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -630,7 +633,9 @@
 		6D00927D5E35AD49432F228E /* PulpeWidget */ = {
 			isa = PBXGroup;
 			children = (
+				BF32797555067F58F521F8FD /* Models */,
 				AD0CAF35FBFF805D67F8AD1C /* Resources */,
+				35A07FFF4A09B0C4045409BF /* Services */,
 				5CCD294071AF1411A6856A16 /* Widgets */,
 				9C02340FB2A3D93553E9CA15 /* Info.plist */,
 				1D358058CCE0A379A8189DA6 /* PulpeWidget.entitlements */,
@@ -1055,9 +1060,11 @@
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					07BEE599D482CF9B6643DCEB = {
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					4E3C22AB1CE882331E727F8E = {
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					DE37C1D30CE2CD31E5FB0C65 = {
@@ -1085,6 +1092,7 @@
 				104B6E33E10617F89EF7ECD9 /* XCRemoteSwiftPackageReference "lottie-spm" */,
 				09998022D4D87255D2EAE15A /* XCRemoteSwiftPackageReference "supabase-swift" */,
 			);
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -1176,6 +1184,7 @@
 				9E4C5D319DB85E349A7923AF /* DesignTokensTests.swift in Sources */,
 				E6E71E80DF877A5B12551898 /* MonthYearTests.swift in Sources */,
 				E8DEE99514F84114E6915A37 /* OnboardingStateTests.swift in Sources */,
+				11FAC305478C80D495BDE0E0 /* StringParsedAsAmountTests.swift in Sources */,
 				0ED5E397D5D72B1D9A1F5421 /* TestDataFactory.swift in Sources */,
 				22145E1D27F9CDDAC582B2D7 /* TransactionTests.swift in Sources */,
 			);
@@ -1331,7 +1340,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Pulpe/Pulpe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = AJ37X7C82G;
 				INFOPLIST_FILE = Pulpe/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1421,7 +1429,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = "";
 				CODE_SIGN_ENTITLEMENTS = PulpeWidget/PulpeWidget.entitlements;
-				DEVELOPMENT_TEAM = AJ37X7C82G;
 				INFOPLIST_FILE = PulpeWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1459,7 +1466,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Pulpe/Pulpe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = AJ37X7C82G;
 				INFOPLIST_FILE = Pulpe/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1559,7 +1565,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = "";
 				CODE_SIGN_ENTITLEMENTS = PulpeWidget/PulpeWidget.entitlements;
-				DEVELOPMENT_TEAM = AJ37X7C82G;
 				INFOPLIST_FILE = PulpeWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/Pulpe.xcodeproj/project.pbxproj
+++ b/ios/Pulpe.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -256,7 +256,7 @@
 		6B68A90534D06367C77B1427 /* DashboardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStore.swift; sourceTree = "<group>"; };
 		6E4F47F7A88B6744CA6D788C /* Color+Pulpe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Pulpe.swift"; sourceTree = "<group>"; };
 		6E873F06201D0A4D69F356ED /* AddAllocatedTransactionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAllocatedTransactionSheet.swift; sourceTree = "<group>"; };
-		723AB344C1BB78CCBA3446C8 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		723AB344C1BB78CCBA3446C8 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		76DBD55125DA1270DC47F0BE /* CheckedFilterPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckedFilterPickerTests.swift; sourceTree = "<group>"; };
 		77C8421EEBFDB74A00EE05B5 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		7D01817526FAA87D773269A9 /* TransactionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionService.swift; sourceTree = "<group>"; };
@@ -267,7 +267,7 @@
 		88250064A726B3B6AAAE9ADF /* welcome-animation.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "welcome-animation.json"; sourceTree = "<group>"; };
 		8C9C2806F868DBC404A44317 /* OnboardingNavigationButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNavigationButtons.swift; sourceTree = "<group>"; };
 		8E370F96AA76DABDBB00B7DC /* maintenance-animation.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "maintenance-animation.json"; sourceTree = "<group>"; };
-		94570CEB6CD57FB35C06DE92 /* Pulpe.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Pulpe.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		94570CEB6CD57FB35C06DE92 /* Pulpe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pulpe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		94DA9F16798B6DC1691A2DB8 /* CreateTemplateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTemplateView.swift; sourceTree = "<group>"; };
 		955B1199FD862E3761B3435A /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		9A05FA792057CD53B266EE9F /* TransactionEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionEnums.swift; sourceTree = "<group>"; };
@@ -276,7 +276,7 @@
 		9E56340C03DD8EE1F7DF7638 /* BudgetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BudgetService.swift; sourceTree = "<group>"; };
 		A1A0EA391775C63723A83BF3 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		A3D2CDB198623A6C39D6F3EF /* PulpeUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PulpeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		A40110A09E6DF69EDAD88EFA /* PulpeWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PulpeWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		A40110A09E6DF69EDAD88EFA /* PulpeWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PulpeWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4090237752EF9DF63F659AA /* Transaction+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transaction+Extensions.swift"; sourceTree = "<group>"; };
 		A4952E464DEEA5F04D784FD0 /* NetworkUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkUnavailableView.swift; sourceTree = "<group>"; };
 		A77FEC48FC6CEA8465118A09 /* ToastManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastManager.swift; sourceTree = "<group>"; };
@@ -630,9 +630,7 @@
 		6D00927D5E35AD49432F228E /* PulpeWidget */ = {
 			isa = PBXGroup;
 			children = (
-				BF32797555067F58F521F8FD /* Models */,
 				AD0CAF35FBFF805D67F8AD1C /* Resources */,
-				35A07FFF4A09B0C4045409BF /* Services */,
 				5CCD294071AF1411A6856A16 /* Widgets */,
 				9C02340FB2A3D93553E9CA15 /* Info.plist */,
 				1D358058CCE0A379A8189DA6 /* PulpeWidget.entitlements */,
@@ -1057,11 +1055,9 @@
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					07BEE599D482CF9B6643DCEB = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					4E3C22AB1CE882331E727F8E = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					DE37C1D30CE2CD31E5FB0C65 = {
@@ -1089,7 +1085,6 @@
 				104B6E33E10617F89EF7ECD9 /* XCRemoteSwiftPackageReference "lottie-spm" */,
 				09998022D4D87255D2EAE15A /* XCRemoteSwiftPackageReference "supabase-swift" */,
 			);
-			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -1336,6 +1331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Pulpe/Pulpe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = AJ37X7C82G;
 				INFOPLIST_FILE = Pulpe/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1425,6 +1421,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = "";
 				CODE_SIGN_ENTITLEMENTS = PulpeWidget/PulpeWidget.entitlements;
+				DEVELOPMENT_TEAM = AJ37X7C82G;
 				INFOPLIST_FILE = PulpeWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1462,6 +1459,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Pulpe/Pulpe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = AJ37X7C82G;
 				INFOPLIST_FILE = Pulpe/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1561,6 +1559,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = "";
 				CODE_SIGN_ENTITLEMENTS = PulpeWidget/PulpeWidget.entitlements;
+				DEVELOPMENT_TEAM = AJ37X7C82G;
 				INFOPLIST_FILE = PulpeWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
@@ -25,18 +25,9 @@ struct AddAllocatedTransactionSheet: View {
         !isLoading
     }
 
-    private static let amountFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = 2
-        formatter.groupingSeparator = "'"
-        return formatter
-    }()
-
     private var displayAmount: String {
         if let amount, amount > 0 {
-            return Self.amountFormatter.string(from: amount as NSDecimalNumber) ?? "0"
+            return Formatters.amountInput.string(from: amount as NSDecimalNumber) ?? "0"
         }
         return "0.00"
     }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
@@ -17,7 +17,7 @@ struct AddAllocatedTransactionSheet: View {
     @State private var amountText = ""
 
     private let transactionService = TransactionService.shared
-    private let quickAmounts = [10, 15, 20, 30]
+    private let quickAmounts = DesignTokens.AmountInput.quickAmounts
 
     private var canSubmit: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -90,7 +90,7 @@ struct AddAllocatedTransactionSheet: View {
 
     private var heroAmountSection: some View {
         VStack(spacing: DesignTokens.Spacing.sm) {
-            Text("CHF")
+            Text(DesignTokens.AmountInput.currencyCode)
                 .font(PulpeTypography.labelLarge)
                 .foregroundStyle(Color.textTertiary)
 
@@ -137,7 +137,7 @@ struct AddAllocatedTransactionSheet: View {
                         amountText = "\(quickAmount)"
                     }
                 } label: {
-                    Text("\(quickAmount) CHF")
+                    Text("\(quickAmount) \(DesignTokens.AmountInput.currencyCode)")
                         .font(PulpeTypography.buttonSecondary)
                         .fixedSize()
                         .padding(.horizontal, DesignTokens.Spacing.md)
@@ -207,22 +207,9 @@ struct AddAllocatedTransactionSheet: View {
     // MARK: - Logic
 
     private func parseAmount(_ text: String) {
-        let cleaned = text
-            .replacingOccurrences(of: ",", with: ".")
-            .filter { $0.isNumber || $0 == "." }
-
-        let components = cleaned.split(separator: ".")
-        let sanitized: String
-        if components.count > 1 {
-            let fractional = String(components.dropFirst().joined().prefix(2))
-            sanitized = "\(components[0]).\(fractional)"
+        if let value = text.parsedAsAmount {
+            amount = value
         } else {
-            sanitized = cleaned
-        }
-
-        if let decimal = Decimal(string: sanitized) {
-            amount = decimal
-        } else if sanitized.isEmpty {
             amount = nil
         }
     }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
@@ -6,83 +6,224 @@ struct AddAllocatedTransactionSheet: View {
     let onAdd: (Transaction) -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(ToastManager.self) private var toastManager
     @State private var name = ""
     @State private var amount: Decimal?
     @State private var transactionDate = Date()
     @State private var isLoading = false
     @State private var error: Error?
+    @FocusState private var isAmountFocused: Bool
+    @State private var pendingQuickAmount: Int?
+    @State private var amountText = ""
 
     private let transactionService = TransactionService.shared
+    private let quickAmounts = [10, 15, 20, 30]
 
     private var canSubmit: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
-        amount != nil &&
-        amount! > 0 &&
+        (amount ?? 0) > 0 &&
         !isLoading
+    }
+
+    private static let amountFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.groupingSeparator = "'"
+        return formatter
+    }()
+
+    private var displayAmount: String {
+        if let amount, amount > 0 {
+            return Self.amountFormatter.string(from: amount as NSDecimalNumber) ?? "0"
+        }
+        return "0.00"
     }
 
     var body: some View {
         NavigationStack {
-            Form {
-                // Name
-                Section {
-                    TextField("Ex: Restaurant, Courses...", text: $name)
-                        .font(PulpeTypography.bodyLarge)
-                        .listRowBackground(Color.surfaceCard)
-                } header: {
-                    Text("Description")
-                        .font(PulpeTypography.labelLarge)
-                }
+            ScrollView {
+                VStack(spacing: DesignTokens.Spacing.xxl) {
+                    heroAmountSection
+                    quickAmountChips
+                    descriptionField
+                    dateSelector
 
-                // Amount
-                Section {
-                    CurrencyField(value: $amount, placeholder: "0.00")
-                        .listRowBackground(Color.surfaceCard)
-                } header: {
-                    Text("Montant")
-                        .font(PulpeTypography.labelLarge)
-                }
-
-                // Date
-                Section {
-                    DatePicker(
-                        "Date",
-                        selection: $transactionDate,
-                        displayedComponents: .date
-                    )
-                    .datePickerStyle(.graphical)
-                    .listRowBackground(Color.surfaceCard)
-                } header: {
-                    Text("Date")
-                        .font(PulpeTypography.labelLarge)
-                }
-
-                // Error
-                if let error {
-                    Section {
+                    if let error {
                         ErrorBanner(message: error.localizedDescription) {
                             self.error = nil
                         }
                     }
+
+                    addButton
                 }
+                .padding(.horizontal, DesignTokens.Spacing.xl)
+                .padding(.top, DesignTokens.Spacing.xxxl)
+                .padding(.bottom, DesignTokens.Spacing.xl)
             }
+            .background(Color.surfacePrimary)
             .navigationTitle(budgetLine.name)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Annuler") {
-                        dismiss()
-                    }
-                }
-
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Ajouter") {
-                        Task { await addTransaction() }
-                    }
-                    .disabled(!canSubmit)
+                    Button("Annuler") { dismiss() }
                 }
             }
             .loadingOverlay(isLoading)
+            .dismissKeyboardOnTap()
+            .task {
+                try? await Task.sleep(for: .milliseconds(200))
+                isAmountFocused = true
+            }
+            .onChange(of: isAmountFocused) { _, isFocused in
+                if !isFocused, let quickAmount = pendingQuickAmount {
+                    amount = Decimal(quickAmount)
+                    amountText = "\(quickAmount)"
+                    pendingQuickAmount = nil
+                }
+            }
+        }
+    }
+
+    // MARK: - Hero Amount
+
+    private var heroAmountSection: some View {
+        VStack(spacing: DesignTokens.Spacing.sm) {
+            Text("CHF")
+                .font(PulpeTypography.labelLarge)
+                .foregroundStyle(Color.textTertiary)
+
+            ZStack {
+                TextField("", text: $amountText)
+                    .keyboardType(.decimalPad)
+                    .focused($isAmountFocused)
+                    .opacity(0)
+                    .frame(width: 0, height: 0)
+                    .onChange(of: amountText) { _, newValue in
+                        parseAmount(newValue)
+                    }
+
+                Text(displayAmount)
+                    .font(PulpeTypography.amountHero)
+                    .foregroundStyle((amount ?? 0) > 0 ? Color.textPrimary : Color.textTertiary)
+                    .contentTransition(.numericText())
+                    .animation(.snappy(duration: DesignTokens.Animation.fast), value: amount)
+            }
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel("Montant")
+            .onTapGesture { isAmountFocused = true }
+
+            RoundedRectangle(cornerRadius: 1)
+                .fill(isAmountFocused ? Color.pulpePrimary : Color.textTertiary.opacity(DesignTokens.Opacity.strong))
+                .frame(width: 120, height: 2)
+                .animation(.easeInOut(duration: DesignTokens.Animation.fast), value: isAmountFocused)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, DesignTokens.Spacing.lg)
+    }
+
+    // MARK: - Quick Amounts
+
+    private var quickAmountChips: some View {
+        HStack(spacing: DesignTokens.Spacing.sm) {
+            ForEach(quickAmounts, id: \.self) { quickAmount in
+                Button {
+                    if isAmountFocused {
+                        pendingQuickAmount = quickAmount
+                        isAmountFocused = false
+                    } else {
+                        amount = Decimal(quickAmount)
+                        amountText = "\(quickAmount)"
+                    }
+                } label: {
+                    Text("\(quickAmount) CHF")
+                        .font(PulpeTypography.buttonSecondary)
+                        .fixedSize()
+                        .padding(.horizontal, DesignTokens.Spacing.md)
+                        .padding(.vertical, DesignTokens.Spacing.sm)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.pulpePrimary.opacity(DesignTokens.Opacity.accent))
+                        .foregroundStyle(Color.pulpePrimary)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Description
+
+    private var descriptionField: some View {
+        TextField("Ex: Restaurant, Courses...", text: $name)
+            .font(PulpeTypography.bodyLarge)
+            .padding(DesignTokens.Spacing.lg)
+            .background(Color.inputBackgroundSoft)
+            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+    }
+
+    // MARK: - Date Selector
+
+    private var dateSelector: some View {
+        HStack {
+            Label("Date", systemImage: "calendar")
+                .font(PulpeTypography.bodyLarge)
+                .foregroundStyle(Color.textPrimary)
+
+            Spacer()
+
+            DatePicker(
+                "",
+                selection: $transactionDate,
+                displayedComponents: .date
+            )
+            .labelsHidden()
+            .datePickerStyle(.compact)
+        }
+        .padding(DesignTokens.Spacing.lg)
+        .background(Color.inputBackgroundSoft)
+        .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+    }
+
+    // MARK: - Add Button
+
+    private var addButton: some View {
+        Button {
+            Task { await addTransaction() }
+        } label: {
+            Text("Ajouter")
+                .font(PulpeTypography.buttonPrimary)
+                .foregroundStyle(Color.textOnPrimary)
+                .frame(maxWidth: .infinity)
+                .frame(height: DesignTokens.FrameHeight.button)
+                .background(Color.pulpePrimary)
+                .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.button))
+                .opacity(canSubmit ? 1 : 0.4)
+        }
+        .disabled(!canSubmit)
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Logic
+
+    private func parseAmount(_ text: String) {
+        let cleaned = text
+            .replacingOccurrences(of: ",", with: ".")
+            .filter { $0.isNumber || $0 == "." }
+
+        let components = cleaned.split(separator: ".")
+        let sanitized: String
+        if components.count > 1 {
+            let fractional = String(components.dropFirst().joined().prefix(2))
+            sanitized = "\(components[0]).\(fractional)"
+        } else {
+            sanitized = cleaned
+        }
+
+        if let decimal = Decimal(string: sanitized) {
+            amount = decimal
+        } else if sanitized.isEmpty {
+            amount = nil
         }
     }
 
@@ -90,6 +231,7 @@ struct AddAllocatedTransactionSheet: View {
         guard let amount else { return }
 
         isLoading = true
+        defer { isLoading = false }
         error = nil
 
         let data = TransactionCreate(
@@ -104,10 +246,10 @@ struct AddAllocatedTransactionSheet: View {
         do {
             let transaction = try await transactionService.createTransaction(data)
             onAdd(transaction)
+            toastManager.show("Transaction ajoutée")
             dismiss()
         } catch {
             self.error = error
-            isLoading = false
         }
     }
 }
@@ -131,4 +273,5 @@ struct AddAllocatedTransactionSheet: View {
     ) { transaction in
         print("Added: \(transaction)")
     }
+    .environment(ToastManager())
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -16,7 +16,7 @@ struct AddBudgetLineSheet: View {
     @State private var amountText = ""
 
     private let budgetLineService = BudgetLineService.shared
-    private let quickAmounts = [10, 15, 20, 30]
+    private let quickAmounts = DesignTokens.AmountInput.quickAmounts
 
     private var canSubmit: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -89,7 +89,7 @@ struct AddBudgetLineSheet: View {
 
     private var heroAmountSection: some View {
         VStack(spacing: DesignTokens.Spacing.sm) {
-            Text("CHF")
+            Text(DesignTokens.AmountInput.currencyCode)
                 .font(PulpeTypography.labelLarge)
                 .foregroundStyle(Color.textTertiary)
 
@@ -136,7 +136,7 @@ struct AddBudgetLineSheet: View {
                         amountText = "\(quickAmount)"
                     }
                 } label: {
-                    Text("\(quickAmount) CHF")
+                    Text("\(quickAmount) \(DesignTokens.AmountInput.currencyCode)")
                         .font(PulpeTypography.buttonSecondary)
                         .fixedSize()
                         .padding(.horizontal, DesignTokens.Spacing.md)
@@ -207,22 +207,9 @@ struct AddBudgetLineSheet: View {
     // MARK: - Logic
 
     private func parseAmount(_ text: String) {
-        let cleaned = text
-            .replacingOccurrences(of: ",", with: ".")
-            .filter { $0.isNumber || $0 == "." }
-
-        let components = cleaned.split(separator: ".")
-        let sanitized: String
-        if components.count > 1 {
-            let fractional = String(components.dropFirst().joined().prefix(2))
-            sanitized = "\(components[0]).\(fractional)"
+        if let value = text.parsedAsAmount {
+            amount = value
         } else {
-            sanitized = cleaned
-        }
-
-        if let decimal = Decimal(string: sanitized) {
-            amount = decimal
-        } else if sanitized.isEmpty {
             amount = nil
         }
     }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -12,9 +12,11 @@ struct AddBudgetLineSheet: View {
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var isAmountFocused: Bool
+    @State private var pendingQuickAmount: Int?
     @State private var amountText = ""
 
     private let budgetLineService = BudgetLineService.shared
+    private let quickAmounts = [10, 15, 20, 30]
 
     private var canSubmit: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -43,6 +45,7 @@ struct AddBudgetLineSheet: View {
             ScrollView {
                 VStack(spacing: DesignTokens.Spacing.xxl) {
                     heroAmountSection
+                    quickAmountChips
                     descriptionField
                     kindSelector
 
@@ -72,6 +75,13 @@ struct AddBudgetLineSheet: View {
                 try? await Task.sleep(for: .milliseconds(200))
                 isAmountFocused = true
             }
+            .onChange(of: isAmountFocused) { _, isFocused in
+                if !isFocused, let quickAmount = pendingQuickAmount {
+                    amount = Decimal(quickAmount)
+                    amountText = "\(quickAmount)"
+                    pendingQuickAmount = nil
+                }
+            }
         }
     }
 
@@ -97,19 +107,48 @@ struct AddBudgetLineSheet: View {
                     .font(PulpeTypography.amountHero)
                     .foregroundStyle((amount ?? 0) > 0 ? Color.textPrimary : Color.textTertiary)
                     .contentTransition(.numericText())
-                    .animation(.snappy(duration: 0.2), value: amount)
+                    .animation(.snappy(duration: DesignTokens.Animation.fast), value: amount)
             }
             .accessibilityAddTraits(.isButton)
             .accessibilityLabel("Montant")
             .onTapGesture { isAmountFocused = true }
 
             RoundedRectangle(cornerRadius: 1)
-                .fill(isAmountFocused ? Color.pulpePrimary : Color.textTertiary.opacity(0.3))
+                .fill(isAmountFocused ? Color.pulpePrimary : Color.textTertiary.opacity(DesignTokens.Opacity.strong))
                 .frame(width: 120, height: 2)
-                .animation(.easeInOut(duration: 0.2), value: isAmountFocused)
+                .animation(.easeInOut(duration: DesignTokens.Animation.fast), value: isAmountFocused)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, DesignTokens.Spacing.lg)
+    }
+
+    // MARK: - Quick Amounts
+
+    private var quickAmountChips: some View {
+        HStack(spacing: DesignTokens.Spacing.sm) {
+            ForEach(quickAmounts, id: \.self) { quickAmount in
+                Button {
+                    if isAmountFocused {
+                        pendingQuickAmount = quickAmount
+                        isAmountFocused = false
+                    } else {
+                        amount = Decimal(quickAmount)
+                        amountText = "\(quickAmount)"
+                    }
+                } label: {
+                    Text("\(quickAmount) CHF")
+                        .font(PulpeTypography.buttonSecondary)
+                        .fixedSize()
+                        .padding(.horizontal, DesignTokens.Spacing.md)
+                        .padding(.vertical, DesignTokens.Spacing.sm)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.pulpePrimary.opacity(DesignTokens.Opacity.accent))
+                        .foregroundStyle(Color.pulpePrimary)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
     }
 
     // MARK: - Description
@@ -128,7 +167,7 @@ struct AddBudgetLineSheet: View {
         HStack(spacing: DesignTokens.Spacing.sm) {
             ForEach(TransactionKind.allCases, id: \.self) { type in
                 Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
+                    withAnimation(.easeInOut(duration: DesignTokens.Animation.fast)) {
                         kind = type
                     }
                 } label: {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -24,18 +24,9 @@ struct AddBudgetLineSheet: View {
         !isLoading
     }
 
-    private static let amountFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = 2
-        formatter.groupingSeparator = "'"
-        return formatter
-    }()
-
     private var displayAmount: String {
         if let amount, amount > 0 {
-            return Self.amountFormatter.string(from: amount as NSDecimalNumber) ?? "0"
+            return Formatters.amountInput.string(from: amount as NSDecimalNumber) ?? "0"
         }
         return "0.00"
     }

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -18,7 +18,7 @@ struct AddTransactionSheet: View {
     @State private var amountText = ""
 
     private let transactionService = TransactionService.shared
-    private let quickAmounts = [10, 15, 20, 30]
+    private let quickAmounts = DesignTokens.AmountInput.quickAmounts
 
     private var canSubmit: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -91,7 +91,7 @@ struct AddTransactionSheet: View {
 
     private var heroAmountSection: some View {
         VStack(spacing: DesignTokens.Spacing.sm) {
-            Text("CHF")
+            Text(DesignTokens.AmountInput.currencyCode)
                 .font(PulpeTypography.labelLarge)
                 .foregroundStyle(Color.textTertiary)
 
@@ -141,7 +141,7 @@ struct AddTransactionSheet: View {
                         amountText = "\(quickAmount)"
                     }
                 } label: {
-                    Text("\(quickAmount) CHF")
+                    Text("\(quickAmount) \(DesignTokens.AmountInput.currencyCode)")
                         .font(PulpeTypography.buttonSecondary)
                         .fixedSize()
                         .padding(.horizontal, DesignTokens.Spacing.md)
@@ -235,22 +235,9 @@ struct AddTransactionSheet: View {
     // MARK: - Logic
 
     private func parseAmount(_ text: String) {
-        let cleaned = text
-            .replacingOccurrences(of: ",", with: ".")
-            .filter { $0.isNumber || $0 == "." }
-
-        let components = cleaned.split(separator: ".")
-        let sanitized: String
-        if components.count > 1 {
-            let fractional = String(components.dropFirst().joined().prefix(2))
-            sanitized = "\(components[0]).\(fractional)"
+        if let value = text.parsedAsAmount {
+            amount = value
         } else {
-            sanitized = cleaned
-        }
-
-        if let decimal = Decimal(string: sanitized) {
-            amount = decimal
-        } else if sanitized.isEmpty {
             amount = nil
         }
     }

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -26,18 +26,9 @@ struct AddTransactionSheet: View {
         !isLoading
     }
 
-    private static let amountFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = 2
-        formatter.groupingSeparator = "'"
-        return formatter
-    }()
-
     private var displayAmount: String {
         if let amount, amount > 0 {
-            return Self.amountFormatter.string(from: amount as NSDecimalNumber) ?? "0"
+            return Formatters.amountInput.string(from: amount as NSDecimalNumber) ?? "0"
         }
         return "0.00"
     }

--- a/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Sheet for editing an existing template line
+/// Sheet for editing an existing template line — hero amount layout
 struct EditTemplateLineSheet: View {
     let templateLine: TemplateLine
     let onUpdate: (TemplateLine) -> Void
@@ -9,8 +9,11 @@ struct EditTemplateLineSheet: View {
     @State private var name: String
     @State private var amount: Decimal?
     @State private var kind: TransactionKind
+    @State private var recurrence: TransactionRecurrence
     @State private var isLoading = false
     @State private var error: Error?
+    @FocusState private var isAmountFocused: Bool
+    @State private var amountText: String
 
     private let templateService = TemplateService.shared
 
@@ -20,6 +23,8 @@ struct EditTemplateLineSheet: View {
         _name = State(initialValue: templateLine.name)
         _amount = State(initialValue: templateLine.amount)
         _kind = State(initialValue: templateLine.kind)
+        _recurrence = State(initialValue: templateLine.recurrence)
+        _amountText = State(initialValue: templateLine.amount > 0 ? "\(templateLine.amount)" : "")
     }
 
     private var canSubmit: Bool {
@@ -27,65 +32,187 @@ struct EditTemplateLineSheet: View {
         return !name.trimmingCharacters(in: .whitespaces).isEmpty && !isLoading
     }
 
+    private static let amountFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.groupingSeparator = "'"
+        return formatter
+    }()
+
+    private var displayAmount: String {
+        if let amount, amount > 0 {
+            return Self.amountFormatter.string(from: amount as NSDecimalNumber) ?? "0"
+        }
+        return "0.00"
+    }
+
     var body: some View {
         NavigationStack {
-            Form {
-                Section {
-                    TextField("Description", text: $name)
-                        .font(PulpeTypography.bodyLarge)
-                        .listRowBackground(Color.surfaceCard)
-                } header: {
-                    Text("Description")
-                        .font(PulpeTypography.labelLarge)
-                }
+            ScrollView {
+                VStack(spacing: DesignTokens.Spacing.xxl) {
+                    heroAmountSection
+                    descriptionField
+                    kindSelector
+                    recurrenceSelector
 
-                Section {
-                    CurrencyField(value: $amount, placeholder: "0.00")
-                        .listRowBackground(Color.surfaceCard)
-                } header: {
-                    Text("Montant")
-                        .font(PulpeTypography.labelLarge)
-                }
-
-                Section {
-                    Picker("Type", selection: $kind) {
-                        ForEach(TransactionKind.allCases, id: \.self) { type in
-                            Label(type.label, systemImage: type.icon)
-                                .tag(type)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .listRowBackground(Color.surfaceCard)
-                } header: {
-                    Text("Type")
-                        .font(PulpeTypography.labelLarge)
-                }
-
-                if let error {
-                    Section {
+                    if let error {
                         ErrorBanner(message: error.localizedDescription) {
                             self.error = nil
                         }
                     }
+
+                    saveButton
                 }
+                .padding(.horizontal, DesignTokens.Spacing.xl)
+                .padding(.top, DesignTokens.Spacing.xxxl)
+                .padding(.bottom, DesignTokens.Spacing.xl)
             }
+            .background(Color.surfacePrimary)
             .navigationTitle("Modifier la ligne")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Annuler") {
-                        dismiss()
-                    }
-                }
-
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Enregistrer") {
-                        Task { await updateTemplateLine() }
-                    }
-                    .disabled(!canSubmit)
+                    Button("Annuler") { dismiss() }
                 }
             }
             .loadingOverlay(isLoading)
+            .dismissKeyboardOnTap()
+            .task {
+                try? await Task.sleep(for: .milliseconds(200))
+                isAmountFocused = true
+            }
+        }
+    }
+
+    // MARK: - Hero Amount
+
+    private var heroAmountSection: some View {
+        VStack(spacing: DesignTokens.Spacing.sm) {
+            Text(DesignTokens.AmountInput.currencyCode)
+                .font(PulpeTypography.labelLarge)
+                .foregroundStyle(Color.textTertiary)
+
+            ZStack {
+                TextField("", text: $amountText)
+                    .keyboardType(.decimalPad)
+                    .focused($isAmountFocused)
+                    .opacity(0)
+                    .frame(width: 0, height: 0)
+                    .onChange(of: amountText) { _, newValue in
+                        parseAmount(newValue)
+                    }
+
+                Text(displayAmount)
+                    .font(PulpeTypography.amountHero)
+                    .foregroundStyle((amount ?? 0) > 0 ? Color.textPrimary : Color.textTertiary)
+                    .contentTransition(.numericText())
+                    .animation(.snappy(duration: DesignTokens.Animation.fast), value: amount)
+            }
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel("Montant")
+            .onTapGesture { isAmountFocused = true }
+
+            RoundedRectangle(cornerRadius: 1)
+                .fill(isAmountFocused ? Color.pulpePrimary : Color.textTertiary.opacity(DesignTokens.Opacity.strong))
+                .frame(width: 120, height: 2)
+                .animation(.easeInOut(duration: DesignTokens.Animation.fast), value: isAmountFocused)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, DesignTokens.Spacing.lg)
+    }
+
+    // MARK: - Description
+
+    private var descriptionField: some View {
+        TextField("Description", text: $name)
+            .font(PulpeTypography.bodyLarge)
+            .padding(DesignTokens.Spacing.lg)
+            .background(Color.inputBackgroundSoft)
+            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+    }
+
+    // MARK: - Kind Selector
+
+    private var kindSelector: some View {
+        HStack(spacing: DesignTokens.Spacing.sm) {
+            ForEach(TransactionKind.allCases, id: \.self) { type in
+                Button {
+                    withAnimation(.easeInOut(duration: DesignTokens.Animation.fast)) {
+                        kind = type
+                    }
+                } label: {
+                    Label(type.label, systemImage: type.icon)
+                        .font(PulpeTypography.buttonSecondary)
+                        .padding(.horizontal, DesignTokens.Spacing.md)
+                        .padding(.vertical, DesignTokens.Spacing.sm + 2)
+                        .frame(maxWidth: .infinity)
+                        .background(kind == type ? Color.pulpePrimary : Color.surfaceSecondary)
+                        .foregroundStyle(kind == type ? Color.textOnPrimary : Color.textPrimary)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Recurrence Selector
+
+    private var recurrenceSelector: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            Text("Récurrence")
+                .font(PulpeTypography.inputLabel)
+                .foregroundStyle(Color.textTertiary)
+
+            HStack(spacing: DesignTokens.Spacing.sm) {
+                ForEach(TransactionRecurrence.allCases, id: \.self) { type in
+                    Button {
+                        withAnimation(.easeInOut(duration: DesignTokens.Animation.fast)) {
+                            recurrence = type
+                        }
+                    } label: {
+                        Text(type.label)
+                            .font(PulpeTypography.buttonSecondary)
+                            .padding(.horizontal, DesignTokens.Spacing.md)
+                            .padding(.vertical, DesignTokens.Spacing.sm + 2)
+                            .frame(maxWidth: .infinity)
+                            .background(recurrence == type ? Color.pulpePrimary : Color.surfaceSecondary)
+                            .foregroundStyle(recurrence == type ? Color.textOnPrimary : Color.textPrimary)
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    // MARK: - Save Button
+
+    private var saveButton: some View {
+        Button {
+            Task { await updateTemplateLine() }
+        } label: {
+            Text("Enregistrer")
+                .font(PulpeTypography.buttonPrimary)
+                .foregroundStyle(Color.textOnPrimary)
+                .frame(maxWidth: .infinity)
+                .frame(height: DesignTokens.FrameHeight.button)
+                .background(Color.pulpePrimary)
+                .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.button))
+                .opacity(canSubmit ? 1 : 0.4)
+        }
+        .disabled(!canSubmit)
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Logic
+
+    private func parseAmount(_ text: String) {
+        if let value = text.parsedAsAmount {
+            amount = value
+        } else {
+            amount = nil
         }
     }
 
@@ -93,12 +220,14 @@ struct EditTemplateLineSheet: View {
         guard let amount else { return }
 
         isLoading = true
+        defer { isLoading = false }
         error = nil
 
         let data = TemplateLineUpdate(
             name: name.trimmingCharacters(in: .whitespaces),
             amount: amount,
-            kind: kind
+            kind: kind,
+            recurrence: recurrence
         )
 
         do {
@@ -107,7 +236,6 @@ struct EditTemplateLineSheet: View {
             dismiss()
         } catch {
             self.error = error
-            isLoading = false
         }
     }
 }

--- a/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
@@ -32,18 +32,9 @@ struct EditTemplateLineSheet: View {
         return !name.trimmingCharacters(in: .whitespaces).isEmpty && !isLoading
     }
 
-    private static let amountFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = 2
-        formatter.groupingSeparator = "'"
-        return formatter
-    }()
-
     private var displayAmount: String {
         if let amount, amount > 0 {
-            return Self.amountFormatter.string(from: amount as NSDecimalNumber) ?? "0"
+            return Formatters.amountInput.string(from: amount as NSDecimalNumber) ?? "0"
         }
         return "0.00"
     }

--- a/ios/Pulpe/Features/Templates/TemplateList/CreateTemplateView.swift
+++ b/ios/Pulpe/Features/Templates/TemplateList/CreateTemplateView.swift
@@ -235,7 +235,7 @@ struct AddTemplateLineSheet: View {
 
     private var heroAmountSection: some View {
         VStack(spacing: DesignTokens.Spacing.sm) {
-            Text("CHF")
+            Text(DesignTokens.AmountInput.currencyCode)
                 .font(PulpeTypography.labelLarge)
                 .foregroundStyle(Color.textTertiary)
 
@@ -369,22 +369,9 @@ struct AddTemplateLineSheet: View {
     // MARK: - Logic
 
     private func parseAmount(_ text: String) {
-        let cleaned = text
-            .replacingOccurrences(of: ",", with: ".")
-            .filter { $0.isNumber || $0 == "." }
-
-        let components = cleaned.split(separator: ".")
-        let sanitized: String
-        if components.count > 1 {
-            let fractional = String(components.dropFirst().joined().prefix(2))
-            sanitized = "\(components[0]).\(fractional)"
+        if let value = text.parsedAsAmount {
+            amount = value
         } else {
-            sanitized = cleaned
-        }
-
-        if let decimal = Decimal(string: sanitized) {
-            amount = decimal
-        } else if sanitized.isEmpty {
             amount = nil
         }
     }

--- a/ios/Pulpe/Features/Templates/TemplateList/CreateTemplateView.swift
+++ b/ios/Pulpe/Features/Templates/TemplateList/CreateTemplateView.swift
@@ -185,18 +185,9 @@ struct AddTemplateLineSheet: View {
         !name.trimmingCharacters(in: .whitespaces).isEmpty && (amount ?? 0) > 0
     }
 
-    private static let amountFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = 2
-        formatter.groupingSeparator = "'"
-        return formatter
-    }()
-
     private var displayAmount: String {
         if let amount, amount > 0 {
-            return Self.amountFormatter.string(from: amount as NSDecimalNumber) ?? "0"
+            return Formatters.amountInput.string(from: amount as NSDecimalNumber) ?? "0"
         }
         return "0.00"
     }

--- a/ios/Pulpe/Shared/Design/DesignTokens.swift
+++ b/ios/Pulpe/Shared/Design/DesignTokens.swift
@@ -165,6 +165,13 @@ enum DesignTokens {
         static let separator: CGFloat = 1
     }
 
+    // MARK: - Amount Input
+
+    enum AmountInput {
+        static let quickAmounts = [10, 15, 20, 30]
+        static let currencyCode = "CHF"
+    }
+
     // MARK: - Progress Bar
 
     enum ProgressBar {

--- a/ios/Pulpe/Shared/Extensions/Decimal+Extensions.swift
+++ b/ios/Pulpe/Shared/Extensions/Decimal+Extensions.swift
@@ -36,6 +36,30 @@ extension Decimal {
     }
 }
 
+// MARK: - Amount Parsing
+
+extension String {
+    /// Parses user-typed amount text into a Decimal value.
+    /// Supports comma as decimal separator and limits to 2 fractional digits.
+    /// Returns the parsed Decimal, or nil for empty/invalid input.
+    var parsedAsAmount: Decimal? {
+        let cleaned = self
+            .replacingOccurrences(of: ",", with: ".")
+            .filter { $0.isNumber || $0 == "." }
+
+        let components = cleaned.split(separator: ".")
+        let sanitized: String
+        if components.count > 1 {
+            let fractional = String(components.dropFirst().joined().prefix(2))
+            sanitized = "\(components[0]).\(fractional)"
+        } else {
+            sanitized = cleaned
+        }
+
+        return Decimal(string: sanitized)
+    }
+}
+
 // MARK: - Optional Decimal Helpers
 
 extension Optional where Wrapped == Decimal {

--- a/ios/Pulpe/Shared/Formatters/Formatters.swift
+++ b/ios/Pulpe/Shared/Formatters/Formatters.swift
@@ -23,6 +23,15 @@ enum Formatters {
         return f
     }()
 
+    static let amountInput: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.minimumFractionDigits = 0
+        f.maximumFractionDigits = 2
+        f.groupingSeparator = "'"
+        return f
+    }()
+
     static let percentage: NumberFormatter = {
         let f = NumberFormatter()
         f.numberStyle = .percent

--- a/ios/PulpeTests/Shared/Extensions/StringParsedAsAmountTests.swift
+++ b/ios/PulpeTests/Shared/Extensions/StringParsedAsAmountTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Pulpe
+
+final class StringParsedAsAmountTests: XCTestCase {
+
+    // MARK: - Valid Amounts
+
+    func testValidInteger() {
+        XCTAssertEqual("42".parsedAsAmount, Decimal(42))
+    }
+
+    func testValidDecimalWithDot() {
+        XCTAssertEqual("12.50".parsedAsAmount, Decimal(string: "12.50"))
+    }
+
+    func testValidDecimalWithComma() {
+        XCTAssertEqual("12,50".parsedAsAmount, Decimal(string: "12.50"))
+    }
+
+    func testSingleDigit() {
+        XCTAssertEqual("5".parsedAsAmount, Decimal(5))
+    }
+
+    func testLargeAmount() {
+        XCTAssertEqual("9999".parsedAsAmount, Decimal(9999))
+    }
+
+    // MARK: - Fractional Digit Limiting
+
+    func testLimitsToTwoFractionalDigits() {
+        XCTAssertEqual("10.999".parsedAsAmount, Decimal(string: "10.99"))
+    }
+
+    func testOneFractionalDigit() {
+        XCTAssertEqual("10.5".parsedAsAmount, Decimal(string: "10.5"))
+    }
+
+    func testExactlyTwoFractionalDigits() {
+        XCTAssertEqual("10.55".parsedAsAmount, Decimal(string: "10.55"))
+    }
+
+    // MARK: - Empty and Invalid Input
+
+    func testEmptyString() {
+        XCTAssertNil("".parsedAsAmount)
+    }
+
+    func testOnlyLetters() {
+        XCTAssertNil("abc".parsedAsAmount)
+    }
+
+    func testMixedLettersAndNumbers() {
+        XCTAssertEqual("1a2b3".parsedAsAmount, Decimal(123))
+    }
+
+    // MARK: - Edge Cases
+
+    func testLeadingZero() {
+        XCTAssertEqual("0.50".parsedAsAmount, Decimal(string: "0.50"))
+    }
+
+    func testZero() {
+        XCTAssertEqual("0".parsedAsAmount, Decimal(0))
+    }
+
+    func testDotOnly() {
+        // Swift's Decimal(string: ".") returns Decimal(0)
+        XCTAssertEqual(".".parsedAsAmount, Decimal(0))
+    }
+
+    func testMultipleDots() {
+        // "12.3.4" → cleaned = "12.3.4", components = ["12", "3", "4"]
+        // fractional = "34".prefix(2) = "34" → "12.34"
+        XCTAssertEqual("12.3.4".parsedAsAmount, Decimal(string: "12.34"))
+    }
+}


### PR DESCRIPTION
## Summary

• Refactored AddAllocatedTransactionSheet from Form to modern ScrollView hero amount layout
• Added quick amount chips (10, 15, 20, 30 CHF) to AddAllocatedTransactionSheet and AddBudgetLineSheet
• Aligned AddBudgetLineSheet with centralized design system (DesignTokens, DesignTokens.Opacity)
• Consistent visual patterns across all transaction/budget creation flows

## Changes

- **AddAllocatedTransactionSheet**: Complete visual refactor with hero amount input, quick chips, compact date picker
- **AddBudgetLineSheet**: Added quick amount chips + fixed hardcoded animation/opacity values
- **Consistency**: Both sheets now use DesignTokens for spacing, corners, animations, opacity
- **UX**: Auto-focus amount field, keyboard dismissal, deferred quick amount application

## Type

refactor