### PR TITLE
feat: restrict date range for prévisions to current month

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-dialog.service.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-dialog.service.ts
@@ -88,8 +88,16 @@ export class BudgetDetailsDialogService {
   async openCreateAllocatedTransactionDialog(
     budgetLine: BudgetLine,
     isMobile: boolean,
+    budgetPeriod: {
+      budgetMonth: number;
+      budgetYear: number;
+      payDayOfMonth: number | null;
+    },
   ): Promise<TransactionCreate | undefined> {
-    const data: CreateAllocatedTransactionDialogData = { budgetLine };
+    const data: CreateAllocatedTransactionDialogData = {
+      budgetLine,
+      ...budgetPeriod,
+    };
 
     if (isMobile) {
       const bottomSheetRef = this.#bottomSheet.open(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -235,10 +235,18 @@ export default class BudgetDetailsPage {
   async openCreateAllocatedTransactionDialog(
     budgetLine: BudgetLine,
   ): Promise<void> {
+    const budget = this.store.budgetDetails();
+    if (!budget) return;
+
     const transaction =
       await this.#dialogService.openCreateAllocatedTransactionDialog(
         budgetLine,
         this.#isMobile(),
+        {
+          budgetMonth: budget.month,
+          budgetYear: budget.year,
+          payDayOfMonth: this.#userSettingsApi.payDayOfMonth(),
+        },
       );
 
     if (transaction) {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -236,7 +236,12 @@ export default class BudgetDetailsPage {
     budgetLine: BudgetLine,
   ): Promise<void> {
     const budget = this.store.budgetDetails();
-    if (!budget) return;
+    if (!budget) {
+      this.#logger.warn(
+        'Cannot open create transaction dialog: budget not loaded',
+      );
+      return;
+    }
 
     const transaction =
       await this.#dialogService.openCreateAllocatedTransactionDialog(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.spec.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FormControl } from '@angular/forms';
+import {
+  computeBudgetPeriodDateConstraints,
+  createDateRangeValidator,
+} from './budget-period-date-constraints';
+
+describe('computeBudgetPeriodDateConstraints', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return isCurrentMonth true with min/max dates for current month budget', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 15)); // 15 Jan 2026
+
+    const result = computeBudgetPeriodDateConstraints(1, 2026, null);
+
+    expect(result.isCurrentMonth).toBe(true);
+    expect(result.minDate).toBeDefined();
+    expect(result.maxDate).toBeDefined();
+    expect(result.minDate!.getTime()).toBeLessThanOrEqual(
+      result.maxDate!.getTime(),
+    );
+  });
+
+  it('should return isCurrentMonth false with undefined dates for past month', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 15)); // 15 Jan 2026
+
+    const result = computeBudgetPeriodDateConstraints(6, 2025, null);
+
+    expect(result.isCurrentMonth).toBe(false);
+    expect(result.minDate).toBeUndefined();
+    expect(result.maxDate).toBeUndefined();
+  });
+
+  it('should return isCurrentMonth false with undefined dates for future month', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 15)); // 15 Jan 2026
+
+    const result = computeBudgetPeriodDateConstraints(3, 2026, null);
+
+    expect(result.isCurrentMonth).toBe(false);
+    expect(result.minDate).toBeUndefined();
+    expect(result.maxDate).toBeUndefined();
+  });
+
+  it('should handle year boundary with null payDayOfMonth', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 11, 20)); // 20 Dec 2025
+
+    const result = computeBudgetPeriodDateConstraints(12, 2025, null);
+
+    expect(result.isCurrentMonth).toBe(true);
+    expect(result.minDate).toBeDefined();
+    expect(result.maxDate).toBeDefined();
+  });
+
+  it('should handle custom payDayOfMonth in first half of month', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 10)); // 10 Jan 2026
+
+    // payDay=5, first half: period is named after start month
+    // Current date Jan 10, payDay 5 → current period = Jan 2026
+    const result = computeBudgetPeriodDateConstraints(1, 2026, 5);
+
+    expect(result.isCurrentMonth).toBe(true);
+    expect(result.minDate).toBeDefined();
+    expect(result.maxDate).toBeDefined();
+    expect(result.minDate!.getDate()).toBe(5);
+  });
+
+  it('should handle custom payDayOfMonth in second half of month', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 5, 27)); // 27 Jun 2025
+
+    // payDay=25, second half: period named after end month
+    // Current date Jun 27, payDay 25 → dayOfMonth >= payDay → resultMonth = Jun
+    // payDay > 15 → add 1 month → current period = Jul 2025
+    const result = computeBudgetPeriodDateConstraints(7, 2025, 25);
+
+    expect(result.isCurrentMonth).toBe(true);
+    expect(result.minDate).toBeDefined();
+    expect(result.maxDate).toBeDefined();
+    expect(result.minDate!.getDate()).toBe(25);
+  });
+
+  it('should return correct period dates for standard calendar month', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15)); // 15 Mar 2026
+
+    const result = computeBudgetPeriodDateConstraints(3, 2026, null);
+
+    expect(result.isCurrentMonth).toBe(true);
+    expect(result.minDate!.getMonth()).toBe(2); // March (0-indexed)
+    expect(result.minDate!.getDate()).toBe(1);
+    expect(result.maxDate!.getMonth()).toBe(2);
+    expect(result.maxDate!.getDate()).toBe(31);
+  });
+});
+
+describe('createDateRangeValidator', () => {
+  it('should return null when date is within range', () => {
+    const min = new Date(2026, 0, 1);
+    const max = new Date(2026, 0, 31);
+    const validator = createDateRangeValidator(min, max);
+
+    const control = new FormControl(new Date(2026, 0, 15));
+
+    expect(validator(control)).toBeNull();
+  });
+
+  it('should return error when date is before min', () => {
+    const min = new Date(2026, 0, 5);
+    const max = new Date(2026, 1, 4);
+    const validator = createDateRangeValidator(min, max);
+
+    const control = new FormControl(new Date(2026, 0, 3));
+
+    expect(validator(control)).toEqual({ dateOutOfRange: true });
+  });
+
+  it('should return error when date is after max', () => {
+    const min = new Date(2026, 0, 5);
+    const max = new Date(2026, 1, 4);
+    const validator = createDateRangeValidator(min, max);
+
+    const control = new FormControl(new Date(2026, 1, 10));
+
+    expect(validator(control)).toEqual({ dateOutOfRange: true });
+  });
+
+  it('should return null when date equals min boundary', () => {
+    const min = new Date(2026, 0, 5);
+    const max = new Date(2026, 1, 4);
+    const validator = createDateRangeValidator(min, max);
+
+    const control = new FormControl(new Date(2026, 0, 5));
+
+    expect(validator(control)).toBeNull();
+  });
+
+  it('should return null when date equals max boundary', () => {
+    const min = new Date(2026, 0, 5);
+    const max = new Date(2026, 1, 4);
+    const validator = createDateRangeValidator(min, max);
+
+    const control = new FormControl(new Date(2026, 1, 4));
+
+    expect(validator(control)).toBeNull();
+  });
+
+  it('should return null when control value is null', () => {
+    const min = new Date(2026, 0, 1);
+    const max = new Date(2026, 0, 31);
+    const validator = createDateRangeValidator(min, max);
+
+    const control = new FormControl(null);
+
+    expect(validator(control)).toBeNull();
+  });
+
+  it('should return null when min is undefined', () => {
+    const validator = createDateRangeValidator(
+      undefined,
+      new Date(2026, 0, 31),
+    );
+
+    const control = new FormControl(new Date(2025, 0, 1));
+
+    expect(validator(control)).toBeNull();
+  });
+
+  it('should return null when max is undefined', () => {
+    const validator = createDateRangeValidator(new Date(2026, 0, 1), undefined);
+
+    const control = new FormControl(new Date(2027, 0, 1));
+
+    expect(validator(control)).toBeNull();
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { FormControl } from '@angular/forms';
 import {
   computeBudgetPeriodDateConstraints,
@@ -6,15 +6,10 @@ import {
 } from './budget-period-date-constraints';
 
 describe('computeBudgetPeriodDateConstraints', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it('should return min/max dates for current month budget', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 0, 15)); // 15 Jan 2026
+    const now = new Date(2026, 0, 15); // 15 Jan 2026
 
-    const result = computeBudgetPeriodDateConstraints(1, 2026, null);
+    const result = computeBudgetPeriodDateConstraints(1, 2026, null, now);
 
     expect(result.minDate).toBeDefined();
     expect(result.maxDate).toBeDefined();
@@ -24,10 +19,9 @@ describe('computeBudgetPeriodDateConstraints', () => {
   });
 
   it('should return min/max dates for past month budget', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 0, 15)); // 15 Jan 2026
+    const now = new Date(2026, 0, 15); // 15 Jan 2026
 
-    const result = computeBudgetPeriodDateConstraints(6, 2025, null);
+    const result = computeBudgetPeriodDateConstraints(6, 2025, null, now);
 
     expect(result.minDate).toBeDefined();
     expect(result.maxDate).toBeDefined();
@@ -36,10 +30,9 @@ describe('computeBudgetPeriodDateConstraints', () => {
   });
 
   it('should return min/max dates for future month budget', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 0, 15)); // 15 Jan 2026
+    const now = new Date(2026, 0, 15); // 15 Jan 2026
 
-    const result = computeBudgetPeriodDateConstraints(3, 2026, null);
+    const result = computeBudgetPeriodDateConstraints(3, 2026, null, now);
 
     expect(result.minDate).toBeDefined();
     expect(result.maxDate).toBeDefined();
@@ -48,21 +41,19 @@ describe('computeBudgetPeriodDateConstraints', () => {
   });
 
   it('should handle year boundary with null payDayOfMonth', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2025, 11, 20)); // 20 Dec 2025
+    const now = new Date(2025, 11, 20); // 20 Dec 2025
 
-    const result = computeBudgetPeriodDateConstraints(12, 2025, null);
+    const result = computeBudgetPeriodDateConstraints(12, 2025, null, now);
 
     expect(result.minDate).toBeDefined();
     expect(result.maxDate).toBeDefined();
   });
 
   it('should handle custom payDayOfMonth in first half of month', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 0, 10)); // 10 Jan 2026
+    const now = new Date(2026, 0, 10); // 10 Jan 2026
 
     // payDay=5, first half: period is named after start month
-    const result = computeBudgetPeriodDateConstraints(1, 2026, 5);
+    const result = computeBudgetPeriodDateConstraints(1, 2026, 5, now);
 
     expect(result.minDate).toBeDefined();
     expect(result.maxDate).toBeDefined();
@@ -70,11 +61,10 @@ describe('computeBudgetPeriodDateConstraints', () => {
   });
 
   it('should handle custom payDayOfMonth in second half of month', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2025, 5, 27)); // 27 Jun 2025
+    const now = new Date(2025, 5, 27); // 27 Jun 2025
 
     // payDay=25, second half: period named after end month
-    const result = computeBudgetPeriodDateConstraints(7, 2025, 25);
+    const result = computeBudgetPeriodDateConstraints(7, 2025, 25, now);
 
     expect(result.minDate).toBeDefined();
     expect(result.maxDate).toBeDefined();
@@ -82,10 +72,9 @@ describe('computeBudgetPeriodDateConstraints', () => {
   });
 
   it('should return correct period dates for standard calendar month', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 2, 15)); // 15 Mar 2026
+    const now = new Date(2026, 2, 15); // 15 Mar 2026
 
-    const result = computeBudgetPeriodDateConstraints(3, 2026, null);
+    const result = computeBudgetPeriodDateConstraints(3, 2026, null, now);
 
     expect(result.minDate.getMonth()).toBe(2); // March (0-indexed)
     expect(result.minDate.getDate()).toBe(1);
@@ -94,11 +83,10 @@ describe('computeBudgetPeriodDateConstraints', () => {
   });
 
   it('should return correct period dates for past month with payDay', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 5, 15)); // 15 Jun 2026
+    const now = new Date(2026, 5, 15); // 15 Jun 2026
 
     // payDay=10, budget for March 2026
-    const result = computeBudgetPeriodDateConstraints(3, 2026, 10);
+    const result = computeBudgetPeriodDateConstraints(3, 2026, 10, now);
 
     expect(result.minDate).toBeDefined();
     expect(result.maxDate).toBeDefined();
@@ -106,19 +94,17 @@ describe('computeBudgetPeriodDateConstraints', () => {
   });
 
   it('should return today as defaultDate when today is within the period', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 0, 15)); // 15 Jan 2026
+    const now = new Date(2026, 0, 15); // 15 Jan 2026
 
-    const result = computeBudgetPeriodDateConstraints(1, 2026, null);
+    const result = computeBudgetPeriodDateConstraints(1, 2026, null, now);
 
     expect(result.defaultDate.getTime()).toBe(new Date(2026, 0, 15).getTime());
   });
 
   it('should return minDate as defaultDate when today is outside the period', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 5, 15)); // 15 Jun 2026
+    const now = new Date(2026, 5, 15); // 15 Jun 2026
 
-    const result = computeBudgetPeriodDateConstraints(3, 2026, null);
+    const result = computeBudgetPeriodDateConstraints(3, 2026, null, now);
 
     expect(result.defaultDate.getTime()).toBe(result.minDate.getTime());
   });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.ts
@@ -15,6 +15,7 @@ export function computeBudgetPeriodDateConstraints(
   budgetMonth: number,
   budgetYear: number,
   payDayOfMonth: number | null,
+  now = new Date(),
 ): BudgetPeriodDateConstraints {
   const { startDate, endDate } = getBudgetPeriodDates(
     budgetMonth,
@@ -22,9 +23,7 @@ export function computeBudgetPeriodDateConstraints(
     payDayOfMonth,
   );
 
-  const today = new Date();
-  const defaultDate =
-    today >= startDate && today <= endDate ? today : startDate;
+  const defaultDate = now >= startDate && now <= endDate ? now : startDate;
 
   return { minDate: startDate, maxDate: endDate, defaultDate };
 }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.ts
@@ -1,3 +1,8 @@
+import type {
+  AbstractControl,
+  ValidationErrors,
+  ValidatorFn,
+} from '@angular/forms';
 import { getBudgetPeriodDates, getBudgetPeriodForDate } from 'pulpe-shared';
 
 export interface BudgetPeriodDateConstraints {
@@ -26,4 +31,21 @@ export function computeBudgetPeriodDateConstraints(
   );
 
   return { isCurrentMonth, minDate: startDate, maxDate: endDate };
+}
+
+export function createDateRangeValidator(
+  min: Date | undefined,
+  max: Date | undefined,
+): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value;
+    if (!value || !(value instanceof Date)) return null;
+    if (!min && !max) return null;
+
+    const time = value.getTime();
+    if (min && time < min.getTime()) return { dateOutOfRange: true };
+    if (max && time > max.getTime()) return { dateOutOfRange: true };
+
+    return null;
+  };
 }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/budget-period-date-constraints.ts
@@ -1,0 +1,29 @@
+import { getBudgetPeriodDates, getBudgetPeriodForDate } from 'pulpe-shared';
+
+export interface BudgetPeriodDateConstraints {
+  isCurrentMonth: boolean;
+  minDate: Date | undefined;
+  maxDate: Date | undefined;
+}
+
+export function computeBudgetPeriodDateConstraints(
+  budgetMonth: number,
+  budgetYear: number,
+  payDayOfMonth: number | null,
+): BudgetPeriodDateConstraints {
+  const currentPeriod = getBudgetPeriodForDate(new Date(), payDayOfMonth);
+  const isCurrentMonth =
+    budgetMonth === currentPeriod.month && budgetYear === currentPeriod.year;
+
+  if (!isCurrentMonth) {
+    return { isCurrentMonth, minDate: undefined, maxDate: undefined };
+  }
+
+  const { startDate, endDate } = getBudgetPeriodDates(
+    budgetMonth,
+    budgetYear,
+    payDayOfMonth,
+  );
+
+  return { isCurrentMonth, minDate: startDate, maxDate: endDate };
+}

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
@@ -57,10 +57,15 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
 
   describe('submit', () => {
     it('should dismiss with transaction data when form is valid', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
       component.form.patchValue({
         name: 'Consultation médecin',
         amount: 45.5,
-        transactionDate: new Date('2026-01-15'),
+        transactionDate: midMonth,
       });
 
       component.submit();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
@@ -239,6 +239,7 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
       expect(customComponent.minDate).toBeDefined();
       expect(customComponent.maxDate).toBeDefined();
       expect(customComponent.minDate!.getDate()).toBe(25);
+      expect(customComponent.maxDate!.getDate()).toBe(24);
 
       vi.useRealTimers();
     });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
@@ -7,7 +7,6 @@ import {
   MAT_BOTTOM_SHEET_DATA,
   MatBottomSheetRef,
 } from '@angular/material/bottom-sheet';
-import { getBudgetPeriodForDate } from 'pulpe-shared';
 import { CreateAllocatedTransactionBottomSheet } from './create-allocated-transaction-bottom-sheet';
 import type { CreateAllocatedTransactionDialogData } from './create-allocated-transaction-dialog';
 
@@ -87,10 +86,15 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
     });
 
     it('should trim whitespace from name', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
       component.form.patchValue({
         name: '  Courses  ',
         amount: 20,
-        transactionDate: new Date(),
+        transactionDate: midMonth,
       });
 
       component.submit();
@@ -100,11 +104,16 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
       );
     });
 
-    it('should use absolute value of amount', () => {
+    it('should pass amount as-is to transaction', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
       component.form.patchValue({
         name: 'Test',
         amount: 42.5,
-        transactionDate: new Date(),
+        transactionDate: midMonth,
       });
 
       component.submit();
@@ -163,9 +172,8 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
     });
   });
 
-  describe('date constraints for current month', () => {
-    it('should set minDate and maxDate when budget is current month', () => {
-      expect(component.isCurrentMonth).toBe(true);
+  describe('date constraints', () => {
+    it('should set minDate and maxDate for current month budget', () => {
       expect(component.minDate).toBeDefined();
       expect(component.maxDate).toBeDefined();
       expect(component.minDate!.getTime()).toBeLessThanOrEqual(
@@ -173,7 +181,7 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
       );
     });
 
-    it('should not set date constraints when budget is past month', async () => {
+    it('should set minDate and maxDate for past month budget', async () => {
       const pastData: CreateAllocatedTransactionDialogData = {
         ...createDialogData(),
         budgetMonth: 1,
@@ -199,20 +207,20 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         CreateAllocatedTransactionBottomSheet,
       ).componentInstance;
 
-      expect(pastComponent.isCurrentMonth).toBe(false);
-      expect(pastComponent.minDate).toBeUndefined();
-      expect(pastComponent.maxDate).toBeUndefined();
+      expect(pastComponent.minDate).toBeDefined();
+      expect(pastComponent.maxDate).toBeDefined();
+      expect(pastComponent.minDate!.getMonth()).toBe(0); // January
+      expect(pastComponent.minDate!.getFullYear()).toBe(2020);
     });
 
     it('should respect custom payDayOfMonth', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2025, 5, 27));
 
-      const currentPeriod = getBudgetPeriodForDate(new Date(), 25);
       const customPayDayData: CreateAllocatedTransactionDialogData = {
         ...createDialogData(),
-        budgetMonth: currentPeriod.month,
-        budgetYear: currentPeriod.year,
+        budgetMonth: 7,
+        budgetYear: 2025,
         payDayOfMonth: 25,
       };
 
@@ -235,7 +243,6 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         CreateAllocatedTransactionBottomSheet,
       ).componentInstance;
 
-      expect(customComponent.isCurrentMonth).toBe(true);
       expect(customComponent.minDate).toBeDefined();
       expect(customComponent.maxDate).toBeDefined();
       expect(customComponent.minDate!.getDate()).toBe(25);

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -12,7 +12,10 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import type { TransactionCreate } from 'pulpe-shared';
 import { formatLocalDate } from '@core/date/format-local-date';
 import type { CreateAllocatedTransactionDialogData } from './create-allocated-transaction-dialog';
-import { computeBudgetPeriodDateConstraints } from './budget-period-date-constraints';
+import {
+  computeBudgetPeriodDateConstraints,
+  createDateRangeValidator,
+} from './budget-period-date-constraints';
 
 @Component({
   selector: 'pulpe-create-allocated-transaction-bottom-sheet',
@@ -112,6 +115,12 @@ import { computeBudgetPeriodDateConstraints } from './budget-period-date-constra
           ) {
             <mat-error>La date est requise</mat-error>
           }
+          @if (
+            form.get('transactionDate')?.hasError('dateOutOfRange') &&
+            form.get('transactionDate')?.touched
+          ) {
+            <mat-error>La date doit être dans la période en cours</mat-error>
+          }
         </mat-form-field>
       </form>
 
@@ -161,7 +170,13 @@ export class CreateAllocatedTransactionBottomSheet {
       null as number | null,
       [Validators.required, Validators.min(0.01)],
     ],
-    transactionDate: [new Date(), Validators.required],
+    transactionDate: [
+      new Date(),
+      [
+        Validators.required,
+        createDateRangeValidator(this.minDate, this.maxDate),
+      ],
+    ],
   });
 
   close(): void {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -191,7 +191,7 @@ export class CreateAllocatedTransactionBottomSheet {
       name: formValue.name!.trim(),
       amount: formValue.amount!,
       kind: this.data.budgetLine.kind,
-      transactionDate: formatLocalDate(formValue.transactionDate as Date),
+      transactionDate: formatLocalDate(formValue.transactionDate!),
       category: null,
     };
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -106,9 +106,7 @@ import {
           />
           <mat-datepicker-toggle matIconSuffix [for]="picker" />
           <mat-datepicker #picker />
-          @if (isCurrentMonth) {
-            <mat-hint>Doit être dans la période en cours</mat-hint>
-          }
+          <mat-hint>Doit être dans la période du budget</mat-hint>
           @if (
             form.get('transactionDate')?.hasError('required') &&
             form.get('transactionDate')?.touched
@@ -119,7 +117,7 @@ import {
             form.get('transactionDate')?.hasError('dateOutOfRange') &&
             form.get('transactionDate')?.touched
           ) {
-            <mat-error>La date doit être dans la période en cours</mat-error>
+            <mat-error>La date doit être dans la période du budget</mat-error>
           }
         </mat-form-field>
       </form>
@@ -160,7 +158,6 @@ export class CreateAllocatedTransactionBottomSheet {
     this.data.budgetYear,
     this.data.payDayOfMonth,
   );
-  readonly isCurrentMonth = this.#dateConstraints.isCurrentMonth;
   readonly minDate = this.#dateConstraints.minDate;
   readonly maxDate = this.#dateConstraints.maxDate;
 
@@ -171,7 +168,7 @@ export class CreateAllocatedTransactionBottomSheet {
       [Validators.required, Validators.min(0.01)],
     ],
     transactionDate: [
-      new Date(),
+      this.#dateConstraints.defaultDate,
       [
         Validators.required,
         createDateRangeValidator(this.minDate, this.maxDate),
@@ -187,10 +184,6 @@ export class CreateAllocatedTransactionBottomSheet {
     if (this.form.invalid) return;
 
     const formValue = this.form.getRawValue();
-    const transactionDate =
-      formValue.transactionDate instanceof Date
-        ? formatLocalDate(formValue.transactionDate)
-        : formatLocalDate(new Date());
 
     const transaction: TransactionCreate = {
       budgetId: this.data.budgetLine.budgetId,
@@ -198,7 +191,7 @@ export class CreateAllocatedTransactionBottomSheet {
       name: formValue.name!.trim(),
       amount: formValue.amount!,
       kind: this.data.budgetLine.kind,
-      transactionDate,
+      transactionDate: formatLocalDate(formValue.transactionDate as Date),
       category: null,
     };
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -12,7 +12,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { type BudgetLine, type TransactionCreate } from 'pulpe-shared';
 import { formatLocalDate } from '@core/date/format-local-date';
-import { computeBudgetPeriodDateConstraints } from './budget-period-date-constraints';
+import {
+  computeBudgetPeriodDateConstraints,
+  createDateRangeValidator,
+} from './budget-period-date-constraints';
 
 export interface CreateAllocatedTransactionDialogData {
   budgetLine: BudgetLine;
@@ -105,6 +108,12 @@ export interface CreateAllocatedTransactionDialogData {
           ) {
             <mat-error>La date est requise</mat-error>
           }
+          @if (
+            form.get('transactionDate')?.hasError('dateOutOfRange') &&
+            form.get('transactionDate')?.touched
+          ) {
+            <mat-error>La date doit être dans la période en cours</mat-error>
+          }
         </mat-form-field>
       </form>
     </mat-dialog-content>
@@ -148,7 +157,13 @@ export class CreateAllocatedTransactionDialog {
       null as number | null,
       [Validators.required, Validators.min(0.01)],
     ],
-    transactionDate: [new Date(), Validators.required],
+    transactionDate: [
+      new Date(),
+      [
+        Validators.required,
+        createDateRangeValidator(this.minDate, this.maxDate),
+      ],
+    ],
   });
 
   cancel(): void {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -99,9 +99,7 @@ export interface CreateAllocatedTransactionDialogData {
           />
           <mat-datepicker-toggle matIconSuffix [for]="picker" />
           <mat-datepicker #picker />
-          @if (isCurrentMonth) {
-            <mat-hint>Doit être dans la période en cours</mat-hint>
-          }
+          <mat-hint>Doit être dans la période du budget</mat-hint>
           @if (
             form.get('transactionDate')?.hasError('required') &&
             form.get('transactionDate')?.touched
@@ -112,7 +110,7 @@ export interface CreateAllocatedTransactionDialogData {
             form.get('transactionDate')?.hasError('dateOutOfRange') &&
             form.get('transactionDate')?.touched
           ) {
-            <mat-error>La date doit être dans la période en cours</mat-error>
+            <mat-error>La date doit être dans la période du budget</mat-error>
           }
         </mat-form-field>
       </form>
@@ -147,7 +145,6 @@ export class CreateAllocatedTransactionDialog {
     this.data.budgetYear,
     this.data.payDayOfMonth,
   );
-  readonly isCurrentMonth = this.#dateConstraints.isCurrentMonth;
   readonly minDate = this.#dateConstraints.minDate;
   readonly maxDate = this.#dateConstraints.maxDate;
 
@@ -158,7 +155,7 @@ export class CreateAllocatedTransactionDialog {
       [Validators.required, Validators.min(0.01)],
     ],
     transactionDate: [
-      new Date(),
+      this.#dateConstraints.defaultDate,
       [
         Validators.required,
         createDateRangeValidator(this.minDate, this.maxDate),
@@ -174,18 +171,14 @@ export class CreateAllocatedTransactionDialog {
     if (this.form.invalid) return;
 
     const formValue = this.form.getRawValue();
-    const transactionDate =
-      formValue.transactionDate instanceof Date
-        ? formatLocalDate(formValue.transactionDate)
-        : formatLocalDate(new Date());
 
     const transaction: TransactionCreate = {
       budgetId: this.data.budgetLine.budgetId,
       budgetLineId: this.data.budgetLine.id,
       name: formValue.name!.trim(),
-      amount: Math.abs(formValue.amount!),
+      amount: formValue.amount!,
       kind: this.data.budgetLine.kind,
-      transactionDate,
+      transactionDate: formatLocalDate(formValue.transactionDate as Date),
       category: null,
     };
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -178,7 +178,7 @@ export class CreateAllocatedTransactionDialog {
       name: formValue.name!.trim(),
       amount: formValue.amount!,
       kind: this.data.budgetLine.kind,
-      transactionDate: formatLocalDate(formValue.transactionDate as Date),
+      transactionDate: formatLocalDate(formValue.transactionDate!),
       category: null,
     };
 


### PR DESCRIPTION
## Summary

• Add date constraints for budget period date picker to restrict allocating transactions to the current month only
• Create reusable `computeBudgetPeriodDateConstraints()` utility for date validation
• Update budget dialogs and bottom sheet to apply date constraints
• Add comprehensive test coverage for date constraint computation

## Type

feat