### PR TITLE
fix(budget): inclure le report réalisé des mois précédents dans le Solde actuel

### DIFF
--- a/frontend/projects/webapp/src/app/ui/realized-balance-tooltip/realized-balance-tooltip.ts
+++ b/frontend/projects/webapp/src/app/ui/realized-balance-tooltip/realized-balance-tooltip.ts
@@ -7,7 +7,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
   imports: [MatIconModule, MatTooltipModule],
   template: `
     <mat-icon
-      matTooltip="Ce solde est calculé à partir des dépenses que tu as cochées. Compare-le à ton solde bancaire pour vérifier que tout colle."
+      matTooltip="Ce solde est calculé à partir des éléments cochés, report compris. Compare-le à ton solde bancaire pour vérifier que tout colle."
       matTooltipPosition="above"
       matTooltipTouchGestures="auto"
       matTooltipClass="text-center"

--- a/shared/src/calculators/budget-formulas.spec.ts
+++ b/shared/src/calculators/budget-formulas.spec.ts
@@ -533,7 +533,7 @@ describe('BudgetFormulas', () => {
       expect(result).toBe(125);
     });
 
-    it('should skip virtual rollover lines', () => {
+    it('should include rollover lines in realized expenses', () => {
       const budgetLines = [
         createBudgetLineWithId('line-1', 'expense', 100, '2025-01-15'),
         {
@@ -555,8 +555,8 @@ describe('BudgetFormulas', () => {
         transactions,
       );
 
-      // Only non-rollover line counted
-      expect(result).toBe(100);
+      // Both lines counted including rollover
+      expect(result).toBe(150);
     });
 
     it('should apply envelope logic to savings (treated as expenses)', () => {
@@ -1247,7 +1247,7 @@ describe('BudgetFormulas', () => {
           expect(result).toBe(800);
         });
 
-        it('should skip rollover budget lines', () => {
+        it('should include rollover budget lines in expenses', () => {
           const budgetLines = [
             createBudgetLine('line-1', 'expense', 500),
             {
@@ -1261,7 +1261,7 @@ describe('BudgetFormulas', () => {
             [],
           );
 
-          expect(result).toBe(500);
+          expect(result).toBe(600);
         });
 
         it('should handle transactions without budgetLineId field', () => {

--- a/shared/src/calculators/budget-formulas.spec.ts
+++ b/shared/src/calculators/budget-formulas.spec.ts
@@ -794,6 +794,84 @@ describe('BudgetFormulas', () => {
       ];
       expect(BudgetFormulas.calculateRealizedBalance(budgetLines)).toBe(-1000);
     });
+
+    it('should include checked negative rollover (expense) in realized balance', () => {
+      const budgetLines = [
+        {
+          id: 'line-1',
+          kind: 'income' as const,
+          amount: 5000,
+          checkedAt: '2025-01-15',
+        },
+        {
+          id: 'line-2',
+          kind: 'expense' as const,
+          amount: 3000,
+          checkedAt: '2025-01-15',
+        },
+        {
+          id: 'rollover-display',
+          kind: 'expense' as const,
+          amount: 1950,
+          checkedAt: '2025-01-15',
+          isRollover: true,
+        },
+      ];
+      // 5000 income - (3000 + 1950) expenses = 50
+      expect(BudgetFormulas.calculateRealizedBalance(budgetLines)).toBe(50);
+    });
+
+    it('should include checked positive rollover (income) in realized balance', () => {
+      const budgetLines = [
+        {
+          id: 'line-1',
+          kind: 'income' as const,
+          amount: 5000,
+          checkedAt: '2025-01-15',
+        },
+        {
+          id: 'rollover-display',
+          kind: 'income' as const,
+          amount: 3094,
+          checkedAt: '2025-01-15',
+          isRollover: true,
+        },
+        {
+          id: 'line-2',
+          kind: 'expense' as const,
+          amount: 8000,
+          checkedAt: '2025-01-15',
+        },
+      ];
+      // (5000 + 3094) income - 8000 expenses = 94
+      expect(BudgetFormulas.calculateRealizedBalance(budgetLines)).toBe(94);
+    });
+
+    it('should not include unchecked rollover in realized balance', () => {
+      const budgetLines = [
+        {
+          id: 'line-1',
+          kind: 'income' as const,
+          amount: 5000,
+          checkedAt: '2025-01-15',
+        },
+        {
+          id: 'rollover-display',
+          kind: 'expense' as const,
+          amount: 1950,
+          checkedAt: null,
+          isRollover: true,
+        },
+        {
+          id: 'line-2',
+          kind: 'expense' as const,
+          amount: 3000,
+          checkedAt: '2025-01-15',
+        },
+      ];
+      // Rollover unchecked → ignored. 5000 - 3000 = 2000
+      expect(BudgetFormulas.calculateRealizedBalance(budgetLines)).toBe(2000);
+    });
   });
 
   describe('validateMetricsCoherence', () => {

--- a/shared/src/calculators/budget-formulas.ts
+++ b/shared/src/calculators/budget-formulas.ts
@@ -121,9 +121,6 @@ export class BudgetFormulas {
     // For each expense/saving budget line, use max(envelope, consumed)
     budgetLines.forEach((line) => {
       if (line.kind === 'expense' || line.kind === 'saving') {
-        // Skip virtual rollover lines
-        if (line.isRollover) return;
-
         // Calculate consumed amount for this envelope
         const consumed = transactions
           .filter((tx) => tx.budgetLineId === line.id)
@@ -187,7 +184,6 @@ export class BudgetFormulas {
 
     budgetLines.forEach((line) => {
       if (line.kind !== 'expense' && line.kind !== 'saving') return;
-      if (line.isRollover) return;
 
       const consumed = transactions
         .filter(


### PR DESCRIPTION
## Summary

• Les lignes de rollover étaient skippées dans `calculateRealizedExpenses()` et `calculateTotalExpensesWithEnvelopes()`
• Un rollover négatif (dépense) n'était donc jamais compté dans le "Solde actuel" 
• Couverture : 3 nouveaux tests pour les scénarios métier du bug

## Changements

| Fichier | Description |
|---------|-------------|
| `shared/.../budget-formulas.ts` | Retrait du `if (line.isRollover) return;` (2 endroits) |
| `shared/.../budget-formulas.spec.ts` | +3 tests (rollover négatif coché, positif coché, décoché) + mise à jour ancien test |
| `frontend/.../realized-balance-tooltip.ts` | Tooltip clarifié ("report compris") |

## Scénarios couverts

- Rollover négatif coché → compté comme dépense (mars: -1950)
- Rollover positif coché → compté comme revenu 
- Rollover décoché → exclu du solde réalisé

Closes #318