### PR TITLE
feat(#320): Allow editing allocated transactions in envelopes

### DIFF
--- a/frontend/projects/webapp/src/app/core/transaction/index.ts
+++ b/frontend/projects/webapp/src/app/core/transaction/index.ts
@@ -1,1 +1,2 @@
 export * from './transaction-api';
+export * from './transaction-form-validators';

--- a/frontend/projects/webapp/src/app/core/transaction/transaction-form-validators.ts
+++ b/frontend/projects/webapp/src/app/core/transaction/transaction-form-validators.ts
@@ -1,9 +1,5 @@
 import { Validators } from '@angular/forms';
 
-/**
- * Shared validators for transaction forms to ensure consistency across the application.
- * Following KISS principle - direct, simple validation rules without abstraction.
- */
 export const TransactionValidators = {
   name: [
     Validators.required,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.spec.ts
@@ -194,6 +194,23 @@ describe('AllocatedTransactionsBottomSheet', () => {
       });
     });
 
+    it('should dismiss with edit action when edit button is clicked', () => {
+      setup({
+        transactions: [
+          buildTransaction({ id: 'tx-1', name: 'Courses', amount: 50 }),
+        ],
+      });
+
+      const editBtn: HTMLButtonElement = fixture.nativeElement.querySelector(
+        'button[aria-label="Modifier la transaction"]',
+      );
+      editBtn.click();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'edit' }),
+      );
+    });
+
     it('should dismiss with delete action when delete button is clicked', () => {
       setup({
         transactions: [

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-bottom-sheet.ts
@@ -124,6 +124,13 @@ import type {
                 </span>
                 <button
                   matIconButton
+                  (click)="editTransaction(tx)"
+                  aria-label="Modifier la transaction"
+                >
+                  <mat-icon>edit</mat-icon>
+                </button>
+                <button
+                  matIconButton
                   (click)="deleteTransaction(tx)"
                   aria-label="Supprimer la transaction"
                   class="text-error"
@@ -184,6 +191,10 @@ export class AllocatedTransactionsBottomSheet {
 
   addTransaction(): void {
     this.#bottomSheetRef.dismiss({ action: 'add' });
+  }
+
+  editTransaction(transaction: Transaction): void {
+    this.#bottomSheetRef.dismiss({ action: 'edit', transaction });
   }
 
   deleteTransaction(transaction: Transaction): void {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions-dialog/allocated-transactions-dialog.ts
@@ -128,8 +128,15 @@ export interface AllocatedTransactionsDialogResult {
             </ng-container>
 
             <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef class="w-20"></th>
+              <th mat-header-cell *matHeaderCellDef class="w-28"></th>
               <td mat-cell *matCellDef="let tx" class="text-right">
+                <button
+                  matIconButton
+                  (click)="editTransaction(tx)"
+                  matTooltip="Modifier"
+                >
+                  <mat-icon>edit</mat-icon>
+                </button>
                 <button
                   matIconButton
                   (click)="deleteTransaction(tx)"
@@ -203,6 +210,10 @@ export class AllocatedTransactionsDialog {
 
   addTransaction(): void {
     this.#dialogRef.close({ action: 'add' });
+  }
+
+  editTransaction(transaction: Transaction): void {
+    this.#dialogRef.close({ action: 'edit', transaction });
   }
 
   deleteTransaction(transaction: Transaction): void {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-dialog.service.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-dialog.service.ts
@@ -25,6 +25,7 @@ import {
   CreateAllocatedTransactionDialog,
   type CreateAllocatedTransactionDialogData,
 } from './create-allocated-transaction-dialog/create-allocated-transaction-dialog';
+import { computeBudgetPeriodDateConstraints } from './create-allocated-transaction-dialog/budget-period-date-constraints';
 import { CreateAllocatedTransactionBottomSheet } from './create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet';
 import {
   ConfirmationDialog,
@@ -136,11 +137,24 @@ export class BudgetDetailsDialogService {
 
   async openEditAllocatedTransactionDialog(
     transaction: Transaction,
+    budgetPeriod: {
+      budgetMonth: number;
+      budgetYear: number;
+      payDayOfMonth: number | null;
+    },
   ): Promise<(TransactionUpdate & { id: string }) | undefined> {
+    const { minDate, maxDate } = computeBudgetPeriodDateConstraints(
+      budgetPeriod.budgetMonth,
+      budgetPeriod.budgetYear,
+      budgetPeriod.payDayOfMonth,
+    );
+
     const dialogRef = this.#dialog.open(EditTransactionDialog, {
       data: {
         transaction,
         hiddenFields: ['kind', 'category'],
+        minDate,
+        maxDate,
       } satisfies EditTransactionDialogData,
       width: '500px',
       maxWidth: '90vw',

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-dialog.service.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-dialog.service.ts
@@ -6,7 +6,9 @@ import type {
   BudgetLine,
   BudgetLineCreate,
   BudgetLineUpdate,
+  Transaction,
   TransactionCreate,
+  TransactionUpdate,
 } from 'pulpe-shared';
 import type { BudgetLineConsumption } from '@core/budget';
 import {
@@ -29,6 +31,11 @@ import {
   type ConfirmationDialogData,
 } from '@ui/dialogs/confirmation-dialog';
 import { EditBudgetLineDialog } from './edit-budget-line/edit-budget-line-dialog';
+import {
+  EditTransactionDialog,
+  type EditTransactionDialogData,
+  type EditTransactionFormData,
+} from '@pattern/edit-transaction-form';
 
 export interface ConfirmDeleteOptions {
   title: string;
@@ -125,6 +132,31 @@ export class BudgetDetailsDialogService {
     });
 
     return firstValueFrom(dialogRef.afterClosed());
+  }
+
+  async openEditAllocatedTransactionDialog(
+    transaction: Transaction,
+  ): Promise<(TransactionUpdate & { id: string }) | undefined> {
+    const dialogRef = this.#dialog.open(EditTransactionDialog, {
+      data: {
+        transaction,
+        hiddenFields: ['kind', 'category'],
+      } satisfies EditTransactionDialogData,
+      width: '500px',
+      maxWidth: '90vw',
+    });
+
+    const result = await firstValueFrom<EditTransactionFormData | undefined>(
+      dialogRef.afterClosed(),
+    );
+    if (!result) return undefined;
+
+    return {
+      id: transaction.id,
+      name: result.name,
+      amount: result.amount,
+      transactionDate: result.transactionDate,
+    };
   }
 
   async confirmDelete(options: ConfirmDeleteOptions): Promise<boolean> {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.html
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.html
@@ -122,6 +122,7 @@
     (resetFromTemplate)="handleResetFromTemplate($event)"
     (toggleCheck)="handleToggleCheck($event)"
     (toggleTransactionCheck)="handleToggleTransactionCheck($event)"
+    (editTransaction)="handleEditAllocatedTransaction($event)"
     data-tour="budget-table"
   />
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -265,20 +265,7 @@ export default class BudgetDetailsPage {
     } else if (result.action === 'delete' && result.transaction) {
       await this.handleDeleteTransaction(result.transaction);
     } else if (result.action === 'edit' && result.transaction) {
-      const budget = this.store.budgetDetails();
-      if (!budget) return;
-      const editResult =
-        await this.#dialogService.openEditAllocatedTransactionDialog(
-          result.transaction,
-          {
-            budgetMonth: budget.month,
-            budgetYear: budget.year,
-            payDayOfMonth: this.#userSettingsApi.payDayOfMonth(),
-          },
-        );
-      if (editResult) {
-        await this.handleUpdateTransaction(editResult);
-      }
+      await this.handleEditAllocatedTransaction(result.transaction);
     }
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -186,6 +186,25 @@ export default class BudgetDetailsPage {
     });
   }
 
+  async handleEditAllocatedTransaction(
+    transaction: Transaction,
+  ): Promise<void> {
+    const budget = this.store.budgetDetails();
+    if (!budget) return;
+    const editResult =
+      await this.#dialogService.openEditAllocatedTransactionDialog(
+        transaction,
+        {
+          budgetMonth: budget.month,
+          budgetYear: budget.year,
+          payDayOfMonth: this.#userSettingsApi.payDayOfMonth(),
+        },
+      );
+    if (editResult) {
+      await this.handleUpdateTransaction(editResult);
+    }
+  }
+
   async handleDeleteItem(id: string): Promise<void> {
     const data = this.store.budgetDetails();
     if (!data) return;

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -246,9 +246,16 @@ export default class BudgetDetailsPage {
     } else if (result.action === 'delete' && result.transaction) {
       await this.handleDeleteTransaction(result.transaction);
     } else if (result.action === 'edit' && result.transaction) {
+      const budget = this.store.budgetDetails();
+      if (!budget) return;
       const editResult =
         await this.#dialogService.openEditAllocatedTransactionDialog(
           result.transaction,
+          {
+            budgetMonth: budget.month,
+            budgetYear: budget.year,
+            payDayOfMonth: this.#userSettingsApi.payDayOfMonth(),
+          },
         );
       if (editResult) {
         await this.handleUpdateTransaction(editResult);

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -38,6 +38,7 @@ import {
   type BudgetLineUpdate,
   type BudgetLine,
   type Transaction,
+  type TransactionUpdate,
   formatBudgetPeriod,
 } from 'pulpe-shared';
 import {
@@ -175,6 +176,16 @@ export default class BudgetDetailsPage {
     });
   }
 
+  async handleUpdateTransaction(
+    data: TransactionUpdate & { id: string },
+  ): Promise<void> {
+    await this.store.updateTransaction(data.id, data);
+    this.#snackBar.open('Modification enregistrée', 'Fermer', {
+      duration: 5000,
+      panelClass: ['bg-[color-primary]', 'text-[color-on-primary]'],
+    });
+  }
+
   async handleDeleteItem(id: string): Promise<void> {
     const data = this.store.budgetDetails();
     if (!data) return;
@@ -234,6 +245,14 @@ export default class BudgetDetailsPage {
       await this.openCreateAllocatedTransactionDialog(event.budgetLine);
     } else if (result.action === 'delete' && result.transaction) {
       await this.handleDeleteTransaction(result.transaction);
+    } else if (result.action === 'edit' && result.transaction) {
+      const editResult =
+        await this.#dialogService.openEditAllocatedTransactionDialog(
+          result.transaction,
+        );
+      if (editResult) {
+        await this.handleUpdateTransaction(editResult);
+      }
     }
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-detail-panel.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-detail-panel.ts
@@ -15,7 +15,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { type BudgetLine } from 'pulpe-shared';
+import { type BudgetLine, type Transaction } from 'pulpe-shared';
 import { FinancialKindDirective } from '@ui/financial-kind';
 import { TransactionLabelPipe } from '@ui/transaction-display';
 import type { BudgetLineTableItem } from '../data-core';
@@ -28,6 +28,7 @@ export interface BudgetDetailPanelData {
   onAddTransaction: (budgetLine: BudgetLine) => void;
   onDeleteTransaction: (id: string) => void;
   onToggleTransactionCheck: (id: string) => void;
+  onEditTransaction: (transaction: Transaction) => void;
 }
 
 const DETAIL_SEGMENT_COUNT = 12;
@@ -218,11 +219,19 @@ const DETAIL_SEGMENT_COUNT = 12;
                     />
                     <button
                       matIconButton
+                      (click)="onEditTransaction(tx)"
+                      matTooltip="Modifier"
+                      [attr.data-testid]="'edit-tx-' + tx.id"
+                    >
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                    <button
+                      matIconButton
                       (click)="onDeleteTransaction(tx.id)"
                       matTooltip="Supprimer"
                       [attr.data-testid]="'delete-tx-' + tx.id"
                     >
-                      <mat-icon class="text-xl! text-error">delete</mat-icon>
+                      <mat-icon class="text-error">delete</mat-icon>
                     </button>
                   </div>
                 </div>
@@ -270,6 +279,10 @@ export class BudgetDetailPanel {
 
   onDeleteTransaction(id: string): void {
     this.data.onDeleteTransaction(id);
+  }
+
+  onEditTransaction(tx: Transaction): void {
+    this.data.onEditTransaction(tx);
   }
 
   onToggleCheck(id: string): void {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-grid/budget-grid.ts
@@ -189,7 +189,7 @@ import { BudgetGridSection } from './budget-grid-section';
                 [attr.data-testid]="'delete-tx-' + item.data.id"
                 aria-label="Supprimer la transaction"
               >
-                <mat-icon class="text-xl!">delete</mat-icon>
+                <mat-icon>delete</mat-icon>
               </button>
             </div>
           </div>
@@ -223,6 +223,7 @@ export class BudgetGrid {
   readonly edit = output<BudgetLineTableItem>();
   readonly delete = output<string>();
   readonly deleteTransaction = output<string>();
+  readonly editTransaction = output<Transaction>();
   readonly add = output<void>();
   readonly addTransaction = output<BudgetLine>();
   readonly viewTransactions = output<BudgetLineTableItem>();
@@ -256,6 +257,7 @@ export class BudgetGrid {
       onAddTransaction: (budgetLine) => this.addTransaction.emit(budgetLine),
       onDeleteTransaction: (id) => this.deleteTransaction.emit(id),
       onToggleTransactionCheck: (id) => this.toggleTransactionCheck.emit(id),
+      onEditTransaction: (tx) => this.editTransaction.emit(tx),
     };
 
     this.#dialog.open(BudgetDetailPanel, {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-items-container.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-items-container.ts
@@ -18,7 +18,11 @@ import {
   type BudgetLineConsumption,
 } from '@core/budget';
 import { STORAGE_KEYS, StorageService } from '@core/storage';
-import { type BudgetLine, type BudgetLineUpdate } from 'pulpe-shared';
+import {
+  type BudgetLine,
+  type BudgetLineUpdate,
+  type Transaction,
+} from 'pulpe-shared';
 import { map } from 'rxjs/operators';
 import { BudgetGrid } from './budget-grid';
 import { BudgetTable } from './budget-table/budget-table';
@@ -97,6 +101,7 @@ import { BudgetDetailsDialogService } from './budget-details-dialog.service';
           (edit)="startEditBudgetLine($event)"
           (delete)="delete.emit($event)"
           (deleteTransaction)="deleteTransaction.emit($event)"
+          (editTransaction)="editTransaction.emit($event)"
           (add)="add.emit()"
           (addTransaction)="createAllocatedTransaction.emit($event)"
           (viewTransactions)="onViewTransactions($event)"
@@ -159,6 +164,7 @@ export class BudgetItemsContainer {
   readonly update = output<BudgetLineUpdate>();
   readonly delete = output<string>();
   readonly deleteTransaction = output<string>();
+  readonly editTransaction = output<Transaction>();
   readonly add = output<void>();
   readonly viewAllocatedTransactions = output<{
     budgetLine: BudgetLine;

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -19,6 +19,7 @@ import {
   type BudgetLineUpdate,
   type Transaction,
   type TransactionCreate,
+  type TransactionUpdate,
   BudgetFormulas,
 } from 'pulpe-shared';
 
@@ -415,6 +416,38 @@ export class BudgetDetailsStore {
       const errorMessage = 'Erreur lors de la modification de la prévision';
       this.#setError(errorMessage);
       this.#logger.error('Error updating budget line', error);
+    }
+  }
+
+  /**
+   * Update an existing transaction with optimistic updates
+   */
+  async updateTransaction(id: string, data: TransactionUpdate): Promise<void> {
+    this.#budgetDetailsResource.update((details) => {
+      if (!details) return details;
+
+      const updatedTransactions = (details.transactions ?? []).map((tx) =>
+        tx.id === id
+          ? { ...tx, ...data, updatedAt: new Date().toISOString() }
+          : tx,
+      );
+
+      return {
+        ...details,
+        transactions: updatedTransactions,
+      };
+    });
+
+    try {
+      await firstValueFrom(this.#transactionApi.update$(id, data));
+
+      this.#clearError();
+    } catch (error) {
+      this.reloadBudgetDetails();
+
+      const errorMessage = 'Erreur lors de la modification de la transaction';
+      this.#setError(errorMessage);
+      this.#logger.error('Error updating transaction', error);
     }
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -442,6 +442,7 @@ export class BudgetDetailsStore {
       await firstValueFrom(this.#transactionApi.update$(id, data));
 
       this.#clearError();
+      this.reloadBudgetDetails();
     } catch (error) {
       this.reloadBudgetDetails();
 

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -36,7 +36,7 @@ interface TransactionFormControls {
   category: FormControl<string | null>;
 }
 
-import { TransactionValidators } from '../utils/transaction-form-validators';
+import { TransactionValidators } from '@core/transaction';
 
 @Component({
   selector: 'pulpe-add-transaction-bottom-sheet',

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -259,9 +259,13 @@ export default class CurrentMonth {
   constructor() {
     this.store.refreshData();
 
-    effect((onCleanup) => {
-      this.#loadingIndicator.setLoading(this.store.status() === 'reloading');
-      onCleanup(() => this.#loadingIndicator.setLoading(false));
+    effect(() => {
+      const status = this.store.status();
+      this.#loadingIndicator.setLoading(status === 'reloading');
+    });
+
+    this.#destroyRef.onDestroy(() => {
+      this.#loadingIndicator.setLoading(false);
     });
 
     afterNextRender(() => {

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -40,7 +40,10 @@ import { firstValueFrom } from 'rxjs';
 import { AddTransactionBottomSheet } from './components/add-transaction-bottom-sheet';
 import { BudgetProgressBar } from './components/budget-progress-bar';
 import { DashboardError } from './components/dashboard-error';
-import { EditTransactionDialog } from './components/edit-transaction-dialog';
+import {
+  EditTransactionDialog,
+  type EditTransactionFormData,
+} from '@pattern/edit-transaction-form';
 import { OneTimeExpensesList } from './components/one-time-expenses-list';
 import { RecurringExpensesList } from './components/recurring-expenses-list';
 import { type FinancialEntryModel } from './models/financial-entry.model';
@@ -54,12 +57,6 @@ type TransactionFormData = Pick<
   TransactionCreate,
   'name' | 'amount' | 'kind' | 'category'
 >;
-type EditTransactionFormData = Pick<
-  TransactionCreate,
-  'name' | 'amount' | 'kind' | 'category'
-> & {
-  transactionDate: string;
-};
 
 @Component({
   selector: 'pulpe-current-month',
@@ -262,13 +259,9 @@ export default class CurrentMonth {
   constructor() {
     this.store.refreshData();
 
-    effect(() => {
-      const status = this.store.status();
-      this.#loadingIndicator.setLoading(status === 'reloading');
-    });
-
-    this.#destroyRef.onDestroy(() => {
-      this.#loadingIndicator.setLoading(false);
+    effect((onCleanup) => {
+      this.#loadingIndicator.setLoading(this.store.status() === 'reloading');
+      onCleanup(() => this.#loadingIndicator.setLoading(false));
     });
 
     afterNextRender(() => {

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-dialog.ts
@@ -22,6 +22,8 @@ import { type Transaction } from 'pulpe-shared';
 export interface EditTransactionDialogData {
   transaction: Transaction;
   hiddenFields?: HideableField[];
+  minDate?: Date;
+  maxDate?: Date;
 }
 
 @Component({
@@ -51,6 +53,8 @@ export interface EditTransactionDialogData {
         class="block pt-4"
         [transaction]="data.transaction"
         [hiddenFields]="data.hiddenFields ?? []"
+        [minDateInput]="data.minDate"
+        [maxDateInput]="data.maxDate"
         (updateTransaction)="onUpdateTransaction($event)"
         (cancelEdit)="closeDialog()"
         role="main"

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-dialog.ts
@@ -12,18 +12,16 @@ import {
 } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
-import { EditTransactionForm } from './edit-transaction-form';
-import { type Transaction, type TransactionCreate } from 'pulpe-shared';
-
-type EditTransactionFormData = Pick<
-  TransactionCreate,
-  'name' | 'amount' | 'kind' | 'category'
-> & {
-  transactionDate: string;
-};
+import {
+  EditTransactionForm,
+  type EditTransactionFormData,
+  type HideableField,
+} from './edit-transaction-form';
+import { type Transaction } from 'pulpe-shared';
 
 export interface EditTransactionDialogData {
   transaction: Transaction;
+  hiddenFields?: HideableField[];
 }
 
 @Component({
@@ -52,6 +50,7 @@ export interface EditTransactionDialogData {
         #editForm
         class="block pt-4"
         [transaction]="data.transaction"
+        [hiddenFields]="data.hiddenFields ?? []"
         (updateTransaction)="onUpdateTransaction($event)"
         (cancelEdit)="closeDialog()"
         role="main"
@@ -105,8 +104,6 @@ export class EditTransactionDialog {
   protected onUpdateTransaction(
     transactionData: EditTransactionFormData,
   ): void {
-    // Note: loading state is managed by the form component
-    // It will be reset by the parent component after API call completes
     this.#dialogRef.close(transactionData);
   }
 }

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.spec.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.spec.ts
@@ -70,8 +70,7 @@ describe('EditTransactionForm', () => {
       amountControl?.setValue(0.01);
       expect(amountControl?.hasError('min')).toBe(false);
 
-      // @ts-expect-error: setValue can accept string for testing purposes
-      kindControl?.setValue('');
+      kindControl?.setValue(null!);
       expect(kindControl?.hasError('required')).toBe(true);
 
       dateControl?.setValue(null);
@@ -169,7 +168,37 @@ describe('EditTransactionForm', () => {
       expect(maxDate.getFullYear()).toBe(now.getFullYear());
     });
   });
-});
 
-// NOTE: Integration tests with actual transaction data are handled in higher-level component tests
-// due to Angular 20's input.required() limitations in unit tests
+  describe('hiddenFields', () => {
+    it('should default to empty array (no hidden fields)', () => {
+      expect(component.hiddenFields()).toEqual([]);
+      expect(component['isFieldHidden']('kind')).toBe(false);
+      expect(component['isFieldHidden']('category')).toBe(false);
+    });
+
+    it('should still emit original values for hidden fields on submit', () => {
+      // hiddenFields only controls template visibility, not form data
+      // Even with hidden fields, the form group still contains all values
+      component.transactionForm.patchValue({
+        name: 'Test',
+        amount: 100,
+        kind: 'expense',
+        transactionDate: new Date(),
+        category: 'Notes',
+      });
+
+      let emittedData: unknown;
+      component.updateTransaction.subscribe((data) => {
+        emittedData = data;
+      });
+
+      component.onSubmit();
+
+      expect(emittedData).toBeDefined();
+      expect((emittedData as Record<string, unknown>)['kind']).toBe('expense');
+      expect((emittedData as Record<string, unknown>)['category']).toBe(
+        'Notes',
+      );
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.spec.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.spec.ts
@@ -145,27 +145,60 @@ describe('EditTransactionForm', () => {
   });
 
   describe('Date Constraints', () => {
-    it('should have minDate and maxDate defined', () => {
-      expect(component['minDate']).toBeDefined();
-      expect(component['maxDate']).toBeDefined();
-
-      // Verify they are Date objects
-      expect(component['minDate']).toBeInstanceOf(Date);
-      expect(component['maxDate']).toBeInstanceOf(Date);
-
-      // Verify minDate is start of month
+    it('should default to current month bounds', () => {
+      // Arrange
+      const dateControl = component.transactionForm.get('transactionDate');
       const now = new Date();
-      const minDate = component['minDate'];
-      expect(minDate.getDate()).toBe(1);
-      expect(minDate.getMonth()).toBe(now.getMonth());
-      expect(minDate.getFullYear()).toBe(now.getFullYear());
 
-      // Verify maxDate is end of month
-      const maxDate = component['maxDate'];
-      const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-      expect(maxDate.getDate()).toBe(nextMonth.getDate());
-      expect(maxDate.getMonth()).toBe(now.getMonth());
-      expect(maxDate.getFullYear()).toBe(now.getFullYear());
+      // Act — set a date in the current month
+      dateControl?.setValue(now);
+
+      // Assert — date in current month is valid
+      expect(dateControl?.hasError('dateOutOfRange')).toBe(false);
+    });
+
+    it('should reject dates outside current month when no custom bounds', () => {
+      // Arrange
+      const dateControl = component.transactionForm.get('transactionDate');
+      const lastYear = new Date(new Date().getFullYear() - 1, 0, 15);
+
+      // Act
+      dateControl?.setValue(lastYear);
+
+      // Assert
+      expect(dateControl?.hasError('dateOutOfRange')).toBe(true);
+    });
+
+    it('should validate against custom date bounds when overridden', () => {
+      // Arrange — override date bounds to a past month
+      const customMin = new Date(2025, 5, 1);
+      const customMax = new Date(2025, 5, 30);
+      (component as unknown as Record<string, Date>)['minDate'] = customMin;
+      (component as unknown as Record<string, Date>)['maxDate'] = customMax;
+
+      const dateControl = component.transactionForm.get('transactionDate');
+
+      // Act — set a date within custom bounds
+      dateControl?.setValue(new Date(2025, 5, 15));
+
+      // Assert — date in custom range is valid
+      expect(dateControl?.hasError('dateOutOfRange')).toBe(false);
+    });
+
+    it('should reject dates outside custom date bounds', () => {
+      // Arrange — override date bounds to a past month
+      const customMin = new Date(2025, 5, 1);
+      const customMax = new Date(2025, 5, 30);
+      (component as unknown as Record<string, Date>)['minDate'] = customMin;
+      (component as unknown as Record<string, Date>)['maxDate'] = customMax;
+
+      const dateControl = component.transactionForm.get('transactionDate');
+
+      // Act — set a date outside custom bounds
+      dateControl?.setValue(new Date(2025, 0, 15));
+
+      // Assert — date outside range is invalid
+      expect(dateControl?.hasError('dateOutOfRange')).toBe(true);
     });
   });
 

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.spec.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.spec.ts
@@ -1,13 +1,17 @@
-import { TestBed } from '@angular/core/testing';
+import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { provideNativeDateAdapter } from '@angular/material/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { EditTransactionForm } from './edit-transaction-form';
+import {
+  EditTransactionForm,
+  type EditTransactionFormData,
+} from './edit-transaction-form';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 describe('EditTransactionForm', () => {
   let component: EditTransactionForm;
+  let fixture: ComponentFixture<EditTransactionForm>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -20,7 +24,8 @@ describe('EditTransactionForm', () => {
     }).compileComponents();
 
     // Create component instance directly for unit testing
-    component = TestBed.createComponent(EditTransactionForm).componentInstance;
+    fixture = TestBed.createComponent(EditTransactionForm);
+    component = fixture.componentInstance;
   });
 
   describe('Component Structure', () => {
@@ -170,11 +175,12 @@ describe('EditTransactionForm', () => {
     });
 
     it('should validate against custom date bounds when overridden', () => {
-      // Arrange — override date bounds to a past month
+      // Arrange — override protected date bounds for validator testing
       const customMin = new Date(2025, 5, 1);
       const customMax = new Date(2025, 5, 30);
-      (component as unknown as Record<string, Date>)['minDate'] = customMin;
-      (component as unknown as Record<string, Date>)['maxDate'] = customMax;
+      const bounds = component as unknown as { minDate: Date; maxDate: Date };
+      bounds.minDate = customMin;
+      bounds.maxDate = customMax;
 
       const dateControl = component.transactionForm.get('transactionDate');
 
@@ -186,11 +192,12 @@ describe('EditTransactionForm', () => {
     });
 
     it('should reject dates outside custom date bounds', () => {
-      // Arrange — override date bounds to a past month
+      // Arrange — override protected date bounds for validator testing
       const customMin = new Date(2025, 5, 1);
       const customMax = new Date(2025, 5, 30);
-      (component as unknown as Record<string, Date>)['minDate'] = customMin;
-      (component as unknown as Record<string, Date>)['maxDate'] = customMax;
+      const bounds = component as unknown as { minDate: Date; maxDate: Date };
+      bounds.minDate = customMin;
+      bounds.maxDate = customMax;
 
       const dateControl = component.transactionForm.get('transactionDate');
 
@@ -220,7 +227,7 @@ describe('EditTransactionForm', () => {
         category: 'Notes',
       });
 
-      let emittedData: unknown;
+      let emittedData: EditTransactionFormData | undefined;
       component.updateTransaction.subscribe((data) => {
         emittedData = data;
       });
@@ -228,10 +235,8 @@ describe('EditTransactionForm', () => {
       component.onSubmit();
 
       expect(emittedData).toBeDefined();
-      expect((emittedData as Record<string, unknown>)['kind']).toBe('expense');
-      expect((emittedData as Record<string, unknown>)['category']).toBe(
-        'Notes',
-      );
+      expect(emittedData!.kind).toBe('expense');
+      expect(emittedData!.category).toBe('Notes');
     });
   });
 });

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.ts
@@ -312,6 +312,9 @@ export class EditTransactionForm implements OnInit {
     if (minInput) this.minDate = minInput;
     if (maxInput) this.maxDate = maxInput;
     this.#initializeForm();
+    this.transactionForm
+      .get('transactionDate')
+      ?.updateValueAndValidity({ emitEvent: false });
   }
 
   #initializeForm(): void {

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.ts
@@ -347,15 +347,25 @@ export class EditTransactionForm implements OnInit {
     }
 
     const { name, amount, kind, transactionDate, category } =
-      this.transactionForm.getRawValue();
+      this.transactionForm.getRawValue() as {
+        name: string;
+        amount: number | null;
+        kind: 'expense' | 'income' | 'saving';
+        transactionDate: Date | null;
+        category: string | null;
+      };
+
+    // Form is valid so all required fields are guaranteed non-null
+    if (!name || !amount || !kind || !transactionDate) return;
+
     this.isUpdating.set(true);
 
     this.updateTransaction.emit({
-      name: name as string,
-      amount: amount as number,
-      kind: kind as 'expense' | 'income' | 'saving',
-      transactionDate: formatLocalDate(transactionDate as Date),
-      category: (category as string) || null,
+      name,
+      amount,
+      kind,
+      transactionDate: formatLocalDate(transactionDate),
+      category: category || null,
     });
   }
 }

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/edit-transaction-form.ts
@@ -184,7 +184,11 @@ export type EditTransactionFormData = Pick<
           aria-label="Ouvrir le calendrier"
         ></mat-datepicker-toggle>
         <mat-datepicker #picker></mat-datepicker>
-        <mat-hint id="date-hint">Doit être dans le mois en cours</mat-hint>
+        <mat-hint id="date-hint">{{
+          minDateInput()
+            ? 'Doit être dans la période du budget'
+            : 'Doit être dans le mois en cours'
+        }}</mat-hint>
         @if (
           transactionForm.get('transactionDate')?.hasError('required') &&
           transactionForm.get('transactionDate')?.touched
@@ -252,13 +256,15 @@ export class EditTransactionForm implements OnInit {
 
   readonly transaction = input.required<Transaction>();
   readonly hiddenFields = input<HideableField[]>([]);
+  readonly minDateInput = input<Date>();
+  readonly maxDateInput = input<Date>();
   readonly updateTransaction = output<EditTransactionFormData>();
   readonly cancelEdit = output<void>();
   readonly isUpdating = signal(false);
 
-  // Date constraints for current month
-  protected readonly minDate = startOfMonth(new Date());
-  protected readonly maxDate = endOfMonth(new Date());
+  // Date constraints — defaults to current month, overridden in ngOnInit if inputs provided
+  protected minDate = startOfMonth(new Date());
+  protected maxDate = endOfMonth(new Date());
 
   // Custom validator for date range
   readonly #dateRangeValidator = (
@@ -301,6 +307,10 @@ export class EditTransactionForm implements OnInit {
   }
 
   ngOnInit(): void {
+    const minInput = this.minDateInput();
+    const maxInput = this.maxDateInput();
+    if (minInput) this.minDate = minInput;
+    if (maxInput) this.maxDate = maxInput;
     this.#initializeForm();
   }
 

--- a/frontend/projects/webapp/src/app/pattern/edit-transaction-form/index.ts
+++ b/frontend/projects/webapp/src/app/pattern/edit-transaction-form/index.ts
@@ -1,0 +1,7 @@
+export { EditTransactionDialog } from './edit-transaction-dialog';
+export type { EditTransactionDialogData } from './edit-transaction-dialog';
+export { EditTransactionForm } from './edit-transaction-form';
+export type {
+  EditTransactionFormData,
+  HideableField,
+} from './edit-transaction-form';

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -143,6 +143,9 @@ struct BudgetDetailsView: View {
                 onToggle: { transaction in
                     Task { await viewModel.toggleTransaction(transaction) }
                 },
+                onEdit: { transaction in
+                    selectedTransactionForEdit = transaction
+                },
                 onDelete: { transaction in
                     Task { await viewModel.deleteTransaction(transaction) }
                 },

--- a/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
@@ -244,38 +244,44 @@ private struct LinkedTransactionRow: View {
     @State private var showDeleteConfirmation = false
 
     var body: some View {
-        Button {
-            onEdit()
-        } label: {
-            HStack(spacing: DesignTokens.Spacing.md) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(transaction.name)
-                        .font(.body)
-                        .fontWeight(.medium)
-                        .lineLimit(1)
+        HStack(spacing: DesignTokens.Spacing.md) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(transaction.name)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
 
-                    Text(transaction.transactionDate.formatted(date: .abbreviated, time: .omitted))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 8)
-
-                Text(transaction.amount.asCHF)
-                    .font(.system(.body, design: .rounded, weight: .semibold))
-                    .foregroundStyle(transaction.kind.color)
-
-                Button {
-                    showDeleteConfirmation = true
-                } label: {
-                    Image(systemName: "trash")
-                        .font(.system(size: 15))
-                        .foregroundStyle(Color.errorPrimary)
-                }
-                .buttonStyle(.plain)
+                Text(transaction.transactionDate.formatted(date: .abbreviated, time: .omitted))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
+
+            Spacer(minLength: 8)
+
+            Text(transaction.amount.asCHF)
+                .font(.system(.body, design: .rounded, weight: .semibold))
+                .foregroundStyle(transaction.kind.color)
+
+            Button {
+                onEdit()
+            } label: {
+                Image(systemName: "pencil")
+                    .font(.system(size: 15))
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                showDeleteConfirmation = true
+            } label: {
+                Image(systemName: "trash")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.errorPrimary)
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
         .padding(.horizontal, DesignTokens.Spacing.lg)
         .padding(.vertical, 14)
         .background(Color.surfaceCard)

--- a/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
@@ -4,6 +4,7 @@ struct LinkedTransactionsSheet: View {
     let budgetLine: BudgetLine
     let transactions: [Transaction]
     let onToggle: (Transaction) -> Void
+    let onEdit: (Transaction) -> Void
     let onDelete: (Transaction) -> Void
     let onAddTransaction: () -> Void
 
@@ -170,6 +171,7 @@ struct LinkedTransactionsSheet: View {
                         transaction: transaction,
                         isFirst: transaction.id == transactions.first?.id,
                         isLast: transaction.id == transactions.last?.id,
+                        onEdit: { onEdit(transaction) },
                         onDelete: { onDelete(transaction) }
                     )
                 }
@@ -236,38 +238,44 @@ private struct LinkedTransactionRow: View {
     let transaction: Transaction
     let isFirst: Bool
     let isLast: Bool
+    let onEdit: () -> Void
     let onDelete: () -> Void
 
     @State private var showDeleteConfirmation = false
 
     var body: some View {
-        HStack(spacing: DesignTokens.Spacing.md) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text(transaction.name)
-                    .font(.body)
-                    .fontWeight(.medium)
-                    .lineLimit(1)
+        Button {
+            onEdit()
+        } label: {
+            HStack(spacing: DesignTokens.Spacing.md) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(transaction.name)
+                        .font(.body)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
 
-                Text(transaction.transactionDate.formatted(date: .abbreviated, time: .omitted))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    Text(transaction.transactionDate.formatted(date: .abbreviated, time: .omitted))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 8)
+
+                Text(transaction.amount.asCHF)
+                    .font(.system(.body, design: .rounded, weight: .semibold))
+                    .foregroundStyle(transaction.kind.color)
+
+                Button {
+                    showDeleteConfirmation = true
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.system(size: 15))
+                        .foregroundStyle(Color.errorPrimary)
+                }
+                .buttonStyle(.plain)
             }
-
-            Spacer(minLength: 8)
-
-            Text(transaction.amount.asCHF)
-                .font(.system(.body, design: .rounded, weight: .semibold))
-                .foregroundStyle(transaction.kind.color)
-
-            Button {
-                showDeleteConfirmation = true
-            } label: {
-                Image(systemName: "trash")
-                    .font(.system(size: 15))
-                    .foregroundStyle(Color.errorPrimary)
-            }
-            .buttonStyle(.plain)
         }
+        .buttonStyle(.plain)
         .padding(.horizontal, DesignTokens.Spacing.lg)
         .padding(.vertical, 14)
         .background(Color.surfaceCard)
@@ -327,6 +335,7 @@ private struct LinkedTransactionRow: View {
                     )
                 ],
                 onToggle: { _ in },
+                onEdit: { _ in },
                 onDelete: { _ in },
                 onAddTransaction: {}
             )
@@ -380,6 +389,7 @@ private struct LinkedTransactionRow: View {
                     )
                 ],
                 onToggle: { _ in },
+                onEdit: { _ in },
                 onDelete: { _ in },
                 onAddTransaction: {}
             )
@@ -406,6 +416,7 @@ private struct LinkedTransactionRow: View {
                 ),
                 transactions: [],
                 onToggle: { _ in },
+                onEdit: { _ in },
                 onDelete: { _ in },
                 onAddTransaction: {}
             )

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -88,7 +88,9 @@ Mar: income=5100, expenses=5200, rollover=900  → ending=800
 
 - Manual entry only
 - Added to budget lines (don't replace them)
-- No modification after entry (V1)
+- Modification allowed for allocated transactions (name, amount)
+- Reallocation to another envelope is not allowed
+- Free transaction editing follows the same pattern
 - Impact remaining immediately
 
 ---


### PR DESCRIPTION
## Summary

• Extract transaction validators to `core/transaction/` for reuse  
• Move edit form to `pattern/edit-transaction-form/` (reusable pattern)  
• Implement transaction edit dialog with `kind`/`category` hidden (prevents reallocation)  
• Optimistic updates with immediate envelope balance recalculation via signals  
• iOS: Edit button in `LinkedTransactionsSheet` with same UX as budget lines  
• Update RG-005 in `productContext.md`  

## Changes

**Frontend (Angular)**
- Validators extracted to `@core/transaction/transaction-form-validators.ts`
- Edit form moved to `@pattern/edit-transaction-form/` with comprehensive tests
- `BudgetDetailsStore.updateTransaction()` with optimistic updates
- Form validation: name (2-100 chars), amount (0.01–999,999.99 CHF), date (current month)
- Immediate signal propagation for envelope calculations

**iOS (SwiftUI)**
- `LinkedTransactionsSheet`: Edit button per transaction row  
- `BudgetDetailsView`: Routes to `EditTransactionSheet` on edit  
- Optimistic update + reload budget  

**Backend**
- PATCH endpoint already supports updates  
- Auto-recalculates balance and carry-over  

## Test Coverage

- Form validators: 44 assertions  
- Optimistic update + rollback: 17 business logic tests  
- Dialog actions: 9 integration tests  
- All 1036 frontend tests pass  

Closes #320