### PR TITLE
feat(layout): add changelog link and long-press debug toggle to about-dialog

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -132,7 +132,8 @@
               "buildTarget": "webapp:build:production"
             },
             "development": {
-              "buildTarget": "webapp:build:development"
+              "buildTarget": "webapp:build:development",
+              "proxyConfig": "proxy.conf.json"
             }
           },
           "defaultConfiguration": "development"

--- a/frontend/projects/webapp/src/app/layout/about-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/layout/about-dialog.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed, type ComponentFixture } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
@@ -19,6 +19,8 @@ describe('AboutDialog', () => {
   };
 
   beforeEach(async () => {
+    vi.useFakeTimers();
+
     TestBed.configureTestingModule({
       imports: [AboutDialog],
       providers: [
@@ -34,31 +36,91 @@ describe('AboutDialog', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function getSectionHeaders(): string[] {
+    const headers: NodeListOf<Element> =
+      fixture.nativeElement.querySelectorAll('h3');
+    return Array.from(headers).map((h: Element) => h.textContent?.trim() ?? '');
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display debug info sections', () => {
-    const sectionHeaders: NodeListOf<Element> =
-      fixture.nativeElement.querySelectorAll('h3');
-    const headerTexts = Array.from(sectionHeaders).map((h: Element) =>
-      h.textContent?.trim(),
-    );
+  it('should display only Build section and Liens utiles by default', () => {
+    const headerTexts = getSectionHeaders();
 
     expect(headerTexts).toContain('Build');
+    expect(headerTexts).toContain('Liens utiles');
+    expect(headerTexts).not.toContain('Environnement');
+    expect(headerTexts).not.toContain('Configuration');
+    expect(headerTexts).not.toContain('Analytics');
+  });
+
+  it('should reveal debug sections after 10s long press on title', async () => {
+    const title: HTMLElement = fixture.nativeElement.querySelector('h2');
+
+    title.dispatchEvent(new MouseEvent('mousedown'));
+    vi.advanceTimersByTime(10_000);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const headerTexts = getSectionHeaders();
+
     expect(headerTexts).toContain('Environnement');
     expect(headerTexts).toContain('Configuration');
     expect(headerTexts).toContain('Analytics');
   });
 
-  it('should display legal section with links', () => {
-    const sectionHeaders: NodeListOf<Element> =
-      fixture.nativeElement.querySelectorAll('h3');
-    const headerTexts = Array.from(sectionHeaders).map((h: Element) =>
-      h.textContent?.trim(),
+  it('should not reveal debug sections if press is released before 10s', async () => {
+    const title: HTMLElement = fixture.nativeElement.querySelector('h2');
+
+    title.dispatchEvent(new MouseEvent('mousedown'));
+    vi.advanceTimersByTime(5_000);
+    title.dispatchEvent(new MouseEvent('mouseup'));
+    vi.advanceTimersByTime(10_000);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const headerTexts = getSectionHeaders();
+
+    expect(headerTexts).not.toContain('Environnement');
+  });
+
+  it('should support touch events for long press', async () => {
+    const title: HTMLElement = fixture.nativeElement.querySelector('h2');
+
+    title.dispatchEvent(new TouchEvent('touchstart'));
+    vi.advanceTimersByTime(10_000);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const headerTexts = getSectionHeaders();
+
+    expect(headerTexts).toContain('Environnement');
+  });
+
+  it('should display useful links section', () => {
+    const headerTexts = getSectionHeaders();
+
+    expect(headerTexts).toContain('Liens utiles');
+  });
+
+  it('should have a changelog link opening in new tab', () => {
+    const links: HTMLAnchorElement[] = Array.from(
+      fixture.nativeElement.querySelectorAll('a'),
+    );
+    const changelogLink = links.find((a) =>
+      a.textContent?.includes('Nouveautés'),
     );
 
-    expect(headerTexts).toContain('Mentions légales');
+    expect(changelogLink).toBeTruthy();
+    expect(changelogLink?.getAttribute('href')).toBe('/changelog');
+    expect(changelogLink?.getAttribute('target')).toBe('_blank');
+    expect(changelogLink?.getAttribute('rel')).toBe('noopener');
   });
 
   it('should have a link to CGU', () => {

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,10 @@
+{
+  "/changelog": {
+    "target": "http://localhost:3001",
+    "secure": false
+  },
+  "/_next": {
+    "target": "http://localhost:3001",
+    "secure": false
+  }
+}


### PR DESCRIPTION
## Summary

• Add "Nouveautés" (changelog) link to about-dialog, opening in new tab
• Implement 10-second long-press detection on title to reveal debug info
• Refactor template to eliminate duplication using computed signals
• Remove unused MatIconModule import
• Add comprehensive tests for long-press behavior and all links

## Type

feat + refactor + test