### PR TITLE
fix(PUL-57): use z.coerce.number() for Supabase numeric type coercion

### DIFF
--- a/backend-nest/src/modules/budget-template/budget-template.mappers.spec.ts
+++ b/backend-nest/src/modules/budget-template/budget-template.mappers.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'bun:test';
+import { templateLineSchema } from 'pulpe-shared';
+import {
+  toApiTemplateLine,
+  toApiTemplateLineList,
+} from './budget-template.mappers';
+import type { Tables } from '@/types/database.types';
+
+describe('BudgetTemplate Mappers', () => {
+  describe('toApiTemplateLine', () => {
+    it('should map all fields from DB row to API entity', () => {
+      const dbRow: Tables<'template_line'> = {
+        id: 'line-123',
+        template_id: 'template-123',
+        name: 'Salaire',
+        amount: 5000,
+        amount_encrypted: null,
+        kind: 'income',
+        recurrence: 'fixed',
+        description: 'Salaire mensuel',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+
+      const result = toApiTemplateLine(dbRow);
+
+      expect(result.id).toBe('line-123');
+      expect(result.templateId).toBe('template-123');
+      expect(result.name).toBe('Salaire');
+      expect(result.amount).toBe(5000);
+      expect(result.kind).toBe('income');
+      expect(result.recurrence).toBe('fixed');
+    });
+  });
+
+  describe('toApiTemplateLineList', () => {
+    it('should map all rows', () => {
+      const dbRows: Tables<'template_line'>[] = [
+        {
+          id: 'line-1',
+          template_id: 'template-123',
+          name: 'Salaire',
+          amount: 5000,
+          amount_encrypted: null,
+          kind: 'income',
+          recurrence: 'fixed',
+          description: '',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+        {
+          id: 'line-2',
+          template_id: 'template-123',
+          name: 'Loyer',
+          amount: 1200.5,
+          amount_encrypted: null,
+          kind: 'expense',
+          recurrence: 'fixed',
+          description: '',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ];
+
+      const results = toApiTemplateLineList(dbRows);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].name).toBe('Salaire');
+      expect(results[1].name).toBe('Loyer');
+    });
+  });
+
+  describe('templateLineSchema coercion (PUL-57)', () => {
+    it('should coerce string amount from Supabase numeric(12,2) to number', () => {
+      const apiData = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        templateId: '550e8400-e29b-41d4-a716-446655440001',
+        name: 'Salaire',
+        amount: '5000.00', // Supabase PostgREST returns numeric as string
+        kind: 'income',
+        recurrence: 'fixed',
+        description: 'Salaire mensuel',
+        createdAt: '2026-01-01T00:00:00+00:00',
+        updatedAt: '2026-01-01T00:00:00+00:00',
+      };
+
+      const result = templateLineSchema.parse(apiData);
+
+      expect(result.amount).toBe(5000);
+      expect(typeof result.amount).toBe('number');
+    });
+
+    it('should coerce zero string amount (encrypted mode)', () => {
+      const apiData = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        templateId: '550e8400-e29b-41d4-a716-446655440001',
+        name: 'Loyer',
+        amount: '0.00',
+        kind: 'expense',
+        recurrence: 'fixed',
+        description: 'Loyer',
+        createdAt: '2026-01-01T00:00:00+00:00',
+        updatedAt: '2026-01-01T00:00:00+00:00',
+      };
+
+      const result = templateLineSchema.parse(apiData);
+
+      expect(result.amount).toBe(0);
+      expect(typeof result.amount).toBe('number');
+    });
+
+    it('should pass through number amounts unchanged', () => {
+      const apiData = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        templateId: '550e8400-e29b-41d4-a716-446655440001',
+        name: 'Test',
+        amount: 1500,
+        kind: 'expense',
+        recurrence: 'fixed',
+        description: 'Test',
+        createdAt: '2026-01-01T00:00:00+00:00',
+        updatedAt: '2026-01-01T00:00:00+00:00',
+      };
+
+      const result = templateLineSchema.parse(apiData);
+
+      expect(result.amount).toBe(1500);
+      expect(typeof result.amount).toBe('number');
+    });
+  });
+});

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -146,7 +146,8 @@ export const savingsGoalSchema = z.object({
   id: z.uuid(),
   userId: z.uuid(),
   name: z.string().min(1).max(100).trim(),
-  targetAmount: z.number().nonnegative(),
+  // coerce: Supabase PostgREST returns numeric(12,2) columns as strings
+  targetAmount: z.coerce.number().nonnegative(),
   targetDate: z.string(), // Date in ISO format
   priority: priorityLevelSchema,
   status: savingsGoalStatusSchema,
@@ -294,7 +295,8 @@ export const transactionSearchResultSchema = z.object({
   id: z.uuid(),
   itemType: searchItemTypeSchema,
   name: z.string(),
-  amount: z.number(),
+  // coerce: Supabase PostgREST returns numeric(12,2) columns as strings
+  amount: z.coerce.number(),
   kind: transactionKindSchema,
   recurrence: transactionRecurrenceSchema.or(z.null()),
   transactionDate: z.iso.datetime({ offset: true }).or(z.null()),

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -73,7 +73,7 @@ export const budgetSchema = z.object({
   templateId: z.uuid(),
   // ending_balance : STOCKÉ en base selon SPECS.md section 3
   // Calculé par le backend, pas par le frontend
-  endingBalance: z.number().nullable().optional(),
+  endingBalance: z.coerce.number().nullable().optional(),
   // rollover : CALCULÉ par le backend, pas persisté en base
   // Report du mois précédent selon formule SPECS rollover_M = ending_balance_M-1
   rollover: z.number().optional(),
@@ -186,7 +186,8 @@ export const budgetLineSchema = z.object({
   savingsGoalId: z.uuid().nullable(),
   name: z.string().min(1).max(100).trim(),
   // nonnegative: API may return 0 when encryption is active (real value in *_encrypted)
-  amount: z.number().nonnegative(),
+  // coerce: Supabase PostgREST returns numeric(12,2) columns as strings
+  amount: z.coerce.number().nonnegative(),
   kind: transactionKindSchema,
   recurrence: transactionRecurrenceSchema,
   isManuallyAdjusted: z.boolean(),
@@ -245,7 +246,8 @@ export const transactionSchema = z.object({
   budgetLineId: z.uuid().nullable(),
   name: z.string().min(1).max(100).trim(),
   // nonnegative: API may return 0 when encryption is active (real value in *_encrypted)
-  amount: z.number().nonnegative(),
+  // coerce: Supabase PostgREST returns numeric(12,2) columns as strings
+  amount: z.coerce.number().nonnegative(),
   kind: transactionKindSchema,
   transactionDate: z.iso.datetime({ offset: true }),
   // NOTE: category pas définie dans SPECS V1 - "Pas de catégorisation avancée"
@@ -332,7 +334,8 @@ export const templateLineSchema = z.object({
   templateId: z.uuid(),
   name: z.string().min(1).max(100).trim(),
   // nonnegative: API may return 0 when encryption is active (real value in *_encrypted)
-  amount: z.number().nonnegative(),
+  // coerce: Supabase PostgREST returns numeric(12,2) columns as strings
+  amount: z.coerce.number().nonnegative(),
   kind: transactionKindSchema,
   recurrence: transactionRecurrenceSchema,
   description: z.string().max(500).trim(),


### PR DESCRIPTION
## Summary

• Fixes production onboarding bug where `POST /api/v1/budget-templates/from-onboarding` failed with `ZOD_PARSE_ERROR` on amount field
• Supabase PostgREST returns `numeric(12,2)` columns as strings; now using `z.coerce.number()` in entity schemas instead of manual `Number()` casting in mappers
• Single source of truth at response validation boundary (cleaner, type-safe)

## Changes

- `budgetSchema.endingBalance`: `z.coerce.number().nullable().optional()`
- `budgetLineSchema.amount`: `z.coerce.number().nonnegative()`
- `transactionSchema.amount`: `z.coerce.number().nonnegative()`
- `templateLineSchema.amount`: `z.coerce.number().nonnegative()`
- Reverted `Number()` from all 4 mappers (budget, budget-line, transaction, budget-template)
- Updated mapper tests to validate schema-level coercion

## Validation

✓ All quality checks pass  
✓ 486/486 relevant tests pass