### PR TITLE
fix(frontend): fiabiliser la reprise d’onglet (soft recovery + fallback reload)

### DIFF
--- a/frontend/e2e/tests/critical-path/core-navigation.spec.ts
+++ b/frontend/e2e/tests/critical-path/core-navigation.spec.ts
@@ -1,41 +1,58 @@
 import { test, expect } from '../../fixtures/test-fixtures';
 
 test.describe('Core Application Navigation (Unauthenticated)', () => {
-  test('should show login form when accessing login page', async ({ page, loginPage }) => {
+  test('should show login form when accessing login page', async ({
+    page,
+    loginPage,
+  }) => {
     await loginPage.goto();
     await expect(page).toHaveURL(/.*login.*/);
   });
 
-  test('should show welcome page for unauthenticated users', async ({ page }) => {
+  test('should show welcome page for unauthenticated users', async ({
+    page,
+  }) => {
     await page.goto('/welcome');
     await expect(page).toHaveURL(/.*welcome.*/);
     await expect(page.getByTestId('welcome-page')).toBeVisible();
   });
 
-  test('should redirect unauthenticated users to welcome page', async ({ page }) => {
+  test('should redirect unauthenticated users to login page', async ({
+    page,
+  }) => {
     await page.goto('/dashboard');
-    await expect(page).toHaveURL(/.*welcome.*/);
+    await expect(page).toHaveURL(/.*login.*/);
   });
 });
 
 test.describe('Core Application Navigation (Authenticated)', () => {
-  test('should allow access to current month page', async ({ authenticatedPage, currentMonthPage }) => {
+  test('should allow access to current month page', async ({
+    authenticatedPage,
+    currentMonthPage,
+  }) => {
     await currentMonthPage.goto();
     await expect(authenticatedPage).toHaveURL(/\/dashboard/);
   });
 
-  test('should allow access to budget templates', async ({ authenticatedPage, budgetTemplatesPage }) => {
+  test('should allow access to budget templates', async ({
+    authenticatedPage,
+    budgetTemplatesPage,
+  }) => {
     await budgetTemplatesPage.goto();
     await expect(authenticatedPage).toHaveURL(/\/budget-templates/);
   });
 
-  test('should show user menu and allow logout', async ({ authenticatedPage }) => {
+  test('should show user menu and allow logout', async ({
+    authenticatedPage,
+  }) => {
     await authenticatedPage.goto('/dashboard');
-    await expect(authenticatedPage.getByTestId('user-menu-trigger')).toBeVisible();
-    
+    await expect(
+      authenticatedPage.getByTestId('user-menu-trigger'),
+    ).toBeVisible();
+
     await authenticatedPage.getByTestId('user-menu-trigger').click();
     await expect(authenticatedPage.getByTestId('logout-button')).toBeVisible();
-    
+
     await authenticatedPage.getByTestId('logout-button').click();
     await expect(authenticatedPage).toHaveURL(/.*login.*|.*welcome.*/);
   });

--- a/frontend/e2e/tests/features/navigation.spec.ts
+++ b/frontend/e2e/tests/features/navigation.spec.ts
@@ -28,9 +28,7 @@ test.describe('Core Application Navigation (Unauthenticated)', () => {
     });
   });
 
-  test('should allow new users to access welcome page', async ({
-    page,
-  }) => {
+  test('should allow new users to access welcome page', async ({ page }) => {
     await test.step('Navigate to welcome page', async () => {
       await page.goto('/welcome');
       await page.waitForLoadState('domcontentloaded');
@@ -53,8 +51,8 @@ test.describe('Core Application Navigation (Unauthenticated)', () => {
       await page.waitForLoadState('domcontentloaded');
     });
 
-    await test.step('Verify redirect to welcome page', async () => {
-      await expect(page).toHaveURL(/.*welcome.*/);
+    await test.step('Verify redirect to login page', async () => {
+      await expect(page).toHaveURL(/.*login.*/);
     });
   });
 });

--- a/frontend/projects/webapp/src/app/core/auth/auth-guard.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-guard.spec.ts
@@ -1,4 +1,4 @@
-import { signal } from '@angular/core';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   type ActivatedRouteSnapshot,
@@ -39,6 +39,7 @@ describe('authGuard', () => {
 
     TestBed.configureTestingModule({
       providers: [
+        provideZonelessChangeDetection(),
         { provide: AuthStateService, useValue: mockAuthState },
         { provide: Router, useValue: mockRouter },
       ],

--- a/frontend/projects/webapp/src/app/core/auth/auth-guard.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-guard.spec.ts
@@ -69,11 +69,8 @@ describe('authGuard', () => {
       isAuthenticated: false,
     });
 
-    const result = await TestBed.runInInjectionContext(() =>
-      authGuard(mockRoute, mockState),
-    );
+    await TestBed.runInInjectionContext(() => authGuard(mockRoute, mockState));
 
-    expect(result).toEqual({});
     expect(mockRouter.createUrlTree).toHaveBeenCalledWith([ROUTES.LOGIN]);
   });
 

--- a/frontend/projects/webapp/src/app/core/auth/auth-guard.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-guard.spec.ts
@@ -1,0 +1,116 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  type ActivatedRouteSnapshot,
+  Router,
+  type RouterStateSnapshot,
+  type UrlTree,
+} from '@angular/router';
+import { firstValueFrom, type Observable } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ROUTES } from '@core/routing/routes-constants';
+import { authGuard } from './auth-guard';
+import { type AuthState, AuthStateService } from './auth-state.service';
+
+describe('authGuard', () => {
+  let stateSignal: ReturnType<typeof signal<AuthState>>;
+  let mockRouter: {
+    createUrlTree: ReturnType<typeof vi.fn>;
+  };
+
+  const mockRoute = {} as ActivatedRouteSnapshot;
+  const mockState = {} as RouterStateSnapshot;
+
+  beforeEach(() => {
+    stateSignal = signal<AuthState>({
+      user: null,
+      session: null,
+      isLoading: true,
+      isAuthenticated: false,
+    });
+
+    mockRouter = {
+      createUrlTree: vi.fn().mockReturnValue({} as UrlTree),
+    };
+
+    const mockAuthState = {
+      authState: stateSignal.asReadonly(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthStateService, useValue: mockAuthState },
+        { provide: Router, useValue: mockRouter },
+      ],
+    });
+  });
+
+  it('should allow navigation synchronously when authenticated and resolved', async () => {
+    stateSignal.set({
+      user: {} as AuthState['user'],
+      session: {} as AuthState['session'],
+      isLoading: false,
+      isAuthenticated: true,
+    });
+
+    const result = await TestBed.runInInjectionContext(() =>
+      authGuard(mockRoute, mockState),
+    );
+
+    expect(result).toBe(true);
+    expect(mockRouter.createUrlTree).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to login synchronously when unauthenticated and resolved', async () => {
+    stateSignal.set({
+      user: null,
+      session: null,
+      isLoading: false,
+      isAuthenticated: false,
+    });
+
+    const result = await TestBed.runInInjectionContext(() =>
+      authGuard(mockRoute, mockState),
+    );
+
+    expect(result).toEqual({});
+    expect(mockRouter.createUrlTree).toHaveBeenCalledWith([ROUTES.LOGIN]);
+  });
+
+  it('should allow navigation asynchronously once auth state resolves to authenticated', async () => {
+    const result = await TestBed.runInInjectionContext(() =>
+      authGuard(mockRoute, mockState),
+    );
+
+    expect(typeof result).not.toBe('boolean');
+    expect(mockRouter.createUrlTree).not.toHaveBeenCalled();
+
+    stateSignal.set({
+      user: {} as AuthState['user'],
+      session: {} as AuthState['session'],
+      isLoading: false,
+      isAuthenticated: true,
+    });
+
+    await expect(
+      firstValueFrom(result as Observable<boolean | UrlTree>),
+    ).resolves.toBe(true);
+  });
+
+  it('should redirect to login asynchronously once auth state resolves to unauthenticated', async () => {
+    const result = await TestBed.runInInjectionContext(() =>
+      authGuard(mockRoute, mockState),
+    );
+
+    stateSignal.set({
+      user: null,
+      session: null,
+      isLoading: false,
+      isAuthenticated: false,
+    });
+
+    await firstValueFrom(result as Observable<boolean | UrlTree>);
+
+    expect(mockRouter.createUrlTree).toHaveBeenCalledWith([ROUTES.LOGIN]);
+  });
+});

--- a/frontend/projects/webapp/src/app/core/auth/auth-guard.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-guard.ts
@@ -9,7 +9,7 @@ import { AuthStateService } from './auth-state.service';
  * Protects routes from unauthenticated access.
  *
  * This guard is intended for private pages that require a logged-in user.
- * If the user is not authenticated, it redirects them to the welcome page.
+ * If the user is not authenticated, it redirects them to the login page.
  *
  * Optimized for zoneless: reads signal synchronously when auth state is already resolved,
  * only falls back to async observable for initial load (refresh, direct URL access).
@@ -23,7 +23,7 @@ export const authGuard: CanActivateFn = () => {
   if (!currentState.isLoading) {
     return currentState.isAuthenticated
       ? true
-      : router.createUrlTree([ROUTES.WELCOME]);
+      : router.createUrlTree([ROUTES.LOGIN]);
   }
 
   // ASYNC: Only for initial load when auth state is still loading
@@ -31,7 +31,7 @@ export const authGuard: CanActivateFn = () => {
     filter((state) => !state.isLoading),
     take(1),
     map((state) =>
-      state.isAuthenticated ? true : router.createUrlTree([ROUTES.WELCOME]),
+      state.isAuthenticated ? true : router.createUrlTree([ROUTES.LOGIN]),
     ),
   );
 };

--- a/frontend/projects/webapp/src/app/core/core.ts
+++ b/frontend/projects/webapp/src/app/core/core.ts
@@ -38,6 +38,7 @@ import { StorageMigrationRunnerService } from './storage/storage-migration-runne
 import { provideSplashRemoval } from './splash-removal';
 import { ClientKeyService } from './encryption/client-key.service';
 import { PreloadService } from './preload/preload.service';
+import { PageLifecycleRecoveryService } from './lifecycle/page-lifecycle-recovery.service';
 
 export interface CoreOptions {
   routes: Routes; // possible to extend options with more props in the future
@@ -135,12 +136,14 @@ export function provideCore({ routes }: CoreOptions) {
       const analyticsService = inject(AnalyticsService);
       const storageMigrationRunner = inject(StorageMigrationRunnerService);
       const clientKeyService = inject(ClientKeyService);
+      const pageLifecycleRecovery = inject(PageLifecycleRecoveryService);
       const injector = inject(Injector);
       const logger = inject(Logger);
 
       // Force instantiation — effect() inside will preload data when authenticated
       // Must be called before any await to stay in injection context
       inject(PreloadService);
+      pageLifecycleRecovery.initialize();
 
       // 0. Run storage migrations first (before any data is read)
       storageMigrationRunner.runMigrations();

--- a/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.spec.ts
@@ -203,4 +203,20 @@ describe('PageLifecycleRecoveryService', () => {
     expect(mockAuthSession.refreshSession).not.toHaveBeenCalled();
     expect(reloadSpy).not.toHaveBeenCalled();
   });
+
+  it('should fall back to location.pathname when router.url is "/" before navigation settles', async () => {
+    mockRouter.url = '/';
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, pathname: '/dashboard' },
+    });
+
+    dispatchPageShow(true);
+    await vi.waitFor(() => {
+      expect(mockAuthSession.refreshSession).toHaveBeenCalledOnce();
+    });
+    expect(mockBudgetInvalidation.invalidate).toHaveBeenCalledOnce();
+    expect(mockUserSettingsApi.reload).toHaveBeenCalledOnce();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.spec.ts
@@ -1,0 +1,206 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { Router } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PAGE_RELOAD,
+  PAGE_RESUME_THRESHOLD_MS,
+  PageLifecycleRecoveryService,
+} from './page-lifecycle-recovery.service';
+import { Logger } from '@core/logging/logger';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import { AuthStateService } from '@core/auth/auth-state.service';
+import { BudgetInvalidationService } from '@core/budget/budget-invalidation.service';
+import { UserSettingsApi } from '@core/user-settings';
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: state,
+  });
+}
+
+function dispatchPageShow(persisted: boolean): void {
+  const event = new Event('pageshow');
+  Object.defineProperty(event, 'persisted', {
+    configurable: true,
+    value: persisted,
+  });
+  window.dispatchEvent(event);
+}
+
+describe('PageLifecycleRecoveryService', () => {
+  const reloadSpy = vi.fn();
+  const mockRouter = { url: '/dashboard' };
+  const mockAuthState = {
+    isLoading: vi.fn<() => boolean>().mockReturnValue(false),
+    isAuthenticated: vi.fn<() => boolean>().mockReturnValue(true),
+  };
+  const mockAuthSession = {
+    refreshSession: vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
+  };
+  const mockBudgetInvalidation = {
+    invalidate: vi.fn(),
+  };
+  const mockUserSettingsApi = {
+    reload: vi.fn(),
+  };
+  const mockLogger = {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  };
+
+  let service: PageLifecycleRecoveryService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    vi.restoreAllMocks();
+    reloadSpy.mockReset();
+    mockAuthState.isLoading.mockReset();
+    mockAuthState.isAuthenticated.mockReset();
+    mockAuthState.isLoading.mockReturnValue(false);
+    mockAuthState.isAuthenticated.mockReturnValue(true);
+    mockAuthSession.refreshSession.mockReset();
+    mockAuthSession.refreshSession.mockResolvedValue(true);
+    mockBudgetInvalidation.invalidate.mockReset();
+    mockUserSettingsApi.reload.mockReset();
+    mockLogger.warn.mockReset();
+    mockLogger.info.mockReset();
+    mockLogger.debug.mockReset();
+    mockRouter.url = '/dashboard';
+    sessionStorage.clear();
+    setVisibilityState('visible');
+    Object.defineProperty(document, 'wasDiscarded', {
+      configurable: true,
+      value: false,
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        PageLifecycleRecoveryService,
+        { provide: PAGE_RELOAD, useValue: reloadSpy },
+        { provide: Router, useValue: mockRouter },
+        { provide: AuthStateService, useValue: mockAuthState },
+        { provide: AuthSessionService, useValue: mockAuthSession },
+        {
+          provide: BudgetInvalidationService,
+          useValue: mockBudgetInvalidation,
+        },
+        { provide: UserSettingsApi, useValue: mockUserSettingsApi },
+        { provide: Logger, useValue: mockLogger },
+      ],
+    });
+
+    service = TestBed.inject(PageLifecycleRecoveryService);
+    service.initialize();
+  });
+
+  it('should perform soft recovery on pageshow persisted for protected routes', async () => {
+    dispatchPageShow(true);
+    await vi.waitFor(() => {
+      expect(mockAuthSession.refreshSession).toHaveBeenCalledOnce();
+    });
+    expect(mockBudgetInvalidation.invalidate).toHaveBeenCalledOnce();
+    expect(mockUserSettingsApi.reload).toHaveBeenCalledOnce();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it('should perform soft recovery when document was discarded on pageshow', async () => {
+    Object.defineProperty(document, 'wasDiscarded', {
+      configurable: true,
+      value: true,
+    });
+
+    dispatchPageShow(false);
+    await vi.waitFor(() => {
+      expect(mockAuthSession.refreshSession).toHaveBeenCalledOnce();
+    });
+    expect(mockBudgetInvalidation.invalidate).toHaveBeenCalledOnce();
+    expect(mockUserSettingsApi.reload).toHaveBeenCalledOnce();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger recovery for short background/foreground switch', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+
+    setVisibilityState('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    nowSpy.mockReturnValue(1_000 + PAGE_RESUME_THRESHOLD_MS - 1);
+    setVisibilityState('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockAuthSession.refreshSession).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it('should perform soft recovery when tab resumes after long background period', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+
+    setVisibilityState('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    nowSpy.mockReturnValue(1_000 + PAGE_RESUME_THRESHOLD_MS + 1);
+    setVisibilityState('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await vi.waitFor(() => {
+      expect(mockAuthSession.refreshSession).toHaveBeenCalledOnce();
+    });
+    expect(mockBudgetInvalidation.invalidate).toHaveBeenCalledOnce();
+    expect(mockUserSettingsApi.reload).toHaveBeenCalledOnce();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it('should fallback to hard reload when soft recovery fails', async () => {
+    mockAuthSession.refreshSession.mockResolvedValue(false);
+
+    dispatchPageShow(true);
+
+    await vi.waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledOnce();
+    });
+    expect(mockBudgetInvalidation.invalidate).not.toHaveBeenCalled();
+    expect(mockUserSettingsApi.reload).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger duplicate reloads within cooldown window', async () => {
+    mockAuthSession.refreshSession.mockResolvedValue(false);
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(5_000);
+
+    dispatchPageShow(true);
+    await vi.waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledOnce();
+    });
+
+    nowSpy.mockReturnValue(5_500);
+    dispatchPageShow(true);
+
+    await vi.waitFor(() => {
+      expect(mockAuthSession.refreshSession).toHaveBeenCalledTimes(2);
+    });
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should skip recovery while auth is loading', async () => {
+    mockAuthState.isLoading.mockReturnValue(true);
+
+    dispatchPageShow(true);
+    await Promise.resolve();
+
+    expect(mockAuthSession.refreshSession).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not recover on non-protected routes', async () => {
+    mockRouter.url = '/welcome';
+    dispatchPageShow(true);
+    await Promise.resolve();
+
+    expect(mockAuthSession.refreshSession).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
@@ -8,8 +8,8 @@ import { Logger } from '@core/logging/logger';
 import { ROUTES } from '@core/routing/routes-constants';
 import { UserSettingsApi } from '@core/user-settings';
 
-export const PAGE_RESUME_THRESHOLD_MS = 10_000; //15 * 60 * 1000;
-export const PAGE_RELOAD_COOLDOWN_MS = 5_000; //60 * 1000;
+export const PAGE_RESUME_THRESHOLD_MS = 15 * 60 * 1000;
+export const PAGE_RELOAD_COOLDOWN_MS = 60 * 1000;
 const RELOAD_COOLDOWN_STORAGE_KEY = 'pulpe-page-reload-cooldown-at';
 
 export const PAGE_RELOAD = new InjectionToken<() => void>('PAGE_RELOAD', {

--- a/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
@@ -90,11 +90,13 @@ export class PageLifecycleRecoveryService {
       true;
 
     if (event.persisted) {
+      this.#lastHiddenAt = null;
       this.#triggerResumeRecovery('pageshow_persisted');
       return;
     }
 
     if (wasDiscarded) {
+      this.#lastHiddenAt = null;
       this.#triggerResumeRecovery('pageshow_discarded');
     }
   };

--- a/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
@@ -26,6 +26,9 @@ const PROTECTED_ROUTE_PREFIXES = [
   `/${ROUTES.BUDGET_TEMPLATES}`,
   `/${ROUTES.SETTINGS}`,
   `/${ROUTES.COMPLETE_PROFILE}`,
+  `/${ROUTES.SETUP_VAULT_CODE}`,
+  `/${ROUTES.ENTER_VAULT_CODE}`,
+  `/${ROUTES.RECOVER_VAULT_CODE}`,
 ] as const;
 
 type ResumeTriggerReason =
@@ -126,8 +129,11 @@ export class PageLifecycleRecoveryService {
   }
 
   #isOnProtectedRoute(): boolean {
+    const routerUrl = this.#router.url;
     const currentUrl =
-      this.#router.url || this.#document.defaultView?.location.pathname || '';
+      routerUrl && routerUrl !== '/'
+        ? routerUrl
+        : (this.#document.defaultView?.location.pathname ?? '/');
     const path = currentUrl.split('?')[0];
 
     return PROTECTED_ROUTE_PREFIXES.some(

--- a/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
@@ -1,0 +1,227 @@
+import { DOCUMENT } from '@angular/common';
+import { DestroyRef, inject, Injectable, InjectionToken } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import { AuthStateService } from '@core/auth/auth-state.service';
+import { BudgetInvalidationService } from '@core/budget/budget-invalidation.service';
+import { Logger } from '@core/logging/logger';
+import { ROUTES } from '@core/routing/routes-constants';
+import { UserSettingsApi } from '@core/user-settings';
+
+export const PAGE_RESUME_THRESHOLD_MS = 10_000; //15 * 60 * 1000;
+export const PAGE_RELOAD_COOLDOWN_MS = 5_000; //60 * 1000;
+const RELOAD_COOLDOWN_STORAGE_KEY = 'pulpe-page-reload-cooldown-at';
+
+export const PAGE_RELOAD = new InjectionToken<() => void>('PAGE_RELOAD', {
+  providedIn: 'root',
+  factory: () => {
+    const document = inject(DOCUMENT);
+    return () => document.defaultView?.location.reload();
+  },
+});
+
+const PROTECTED_ROUTE_PREFIXES = [
+  `/${ROUTES.DASHBOARD}`,
+  `/${ROUTES.BUDGET}`,
+  `/${ROUTES.BUDGET_TEMPLATES}`,
+  `/${ROUTES.SETTINGS}`,
+  `/${ROUTES.COMPLETE_PROFILE}`,
+] as const;
+
+type ResumeTriggerReason =
+  | 'pageshow_persisted'
+  | 'pageshow_discarded'
+  | 'visibility_long_background';
+
+@Injectable({ providedIn: 'root' })
+export class PageLifecycleRecoveryService {
+  readonly #document = inject(DOCUMENT);
+  readonly #destroyRef = inject(DestroyRef);
+  readonly #router = inject(Router);
+  readonly #authState = inject(AuthStateService);
+  readonly #authSession = inject(AuthSessionService);
+  readonly #budgetInvalidation = inject(BudgetInvalidationService);
+  readonly #userSettingsApi = inject(UserSettingsApi);
+  readonly #logger = inject(Logger);
+  readonly #reload = inject(PAGE_RELOAD);
+
+  #initialized = false;
+  #lastHiddenAt: number | null = null;
+  #recoveryInFlight = false;
+
+  readonly #onVisibilityChange = (): void => {
+    if (this.#document.visibilityState === 'hidden') {
+      this.#lastHiddenAt = Date.now();
+      return;
+    }
+
+    if (this.#document.visibilityState !== 'visible') {
+      return;
+    }
+
+    if (!this.#isOnProtectedRoute()) {
+      this.#lastHiddenAt = null;
+      return;
+    }
+
+    if (this.#lastHiddenAt === null) {
+      return;
+    }
+
+    const hiddenDuration = Date.now() - this.#lastHiddenAt;
+    this.#lastHiddenAt = null;
+
+    if (hiddenDuration >= PAGE_RESUME_THRESHOLD_MS) {
+      this.#triggerResumeRecovery('visibility_long_background');
+    }
+  };
+
+  readonly #onPageHide = (): void => {
+    this.#lastHiddenAt = Date.now();
+  };
+
+  readonly #onPageShow = (event: PageTransitionEvent): void => {
+    if (!this.#isOnProtectedRoute()) {
+      return;
+    }
+
+    const wasDiscarded =
+      (this.#document as Document & { wasDiscarded?: boolean }).wasDiscarded ===
+      true;
+
+    if (event.persisted) {
+      this.#triggerResumeRecovery('pageshow_persisted');
+      return;
+    }
+
+    if (wasDiscarded) {
+      this.#triggerResumeRecovery('pageshow_discarded');
+    }
+  };
+
+  initialize(): void {
+    if (this.#initialized) return;
+    this.#initialized = true;
+
+    const win = this.#document.defaultView;
+    if (!win) return;
+
+    this.#document.addEventListener(
+      'visibilitychange',
+      this.#onVisibilityChange,
+    );
+    win.addEventListener('pagehide', this.#onPageHide);
+    win.addEventListener('pageshow', this.#onPageShow);
+
+    this.#destroyRef.onDestroy(() => {
+      this.#document.removeEventListener(
+        'visibilitychange',
+        this.#onVisibilityChange,
+      );
+      win.removeEventListener('pagehide', this.#onPageHide);
+      win.removeEventListener('pageshow', this.#onPageShow);
+    });
+  }
+
+  #isOnProtectedRoute(): boolean {
+    const currentUrl =
+      this.#router.url || this.#document.defaultView?.location.pathname || '';
+    const path = currentUrl.split('?')[0];
+
+    return PROTECTED_ROUTE_PREFIXES.some(
+      (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+    );
+  }
+
+  #triggerResumeRecovery(reason: ResumeTriggerReason): void {
+    if (this.#recoveryInFlight) {
+      return;
+    }
+
+    this.#recoveryInFlight = true;
+    void this.#runResumeRecovery(reason).finally(() => {
+      this.#recoveryInFlight = false;
+    });
+  }
+
+  async #runResumeRecovery(reason: ResumeTriggerReason): Promise<void> {
+    if (!this.#isOnProtectedRoute()) {
+      return;
+    }
+
+    if (this.#authState.isLoading()) {
+      this.#logger.debug(
+        '[PageLifecycleRecovery] Skipping recovery while auth is loading',
+        {
+          reason,
+          route: this.#router.url,
+        },
+      );
+      return;
+    }
+
+    if (!this.#authState.isAuthenticated()) {
+      return;
+    }
+
+    try {
+      const sessionRefreshed = await this.#authSession.refreshSession();
+      if (!sessionRefreshed) {
+        this.#logger.warn(
+          '[PageLifecycleRecovery] Session refresh failed after resume, reloading app',
+          { reason, route: this.#router.url },
+        );
+        this.#triggerRecoveryReload(reason);
+        return;
+      }
+
+      this.#budgetInvalidation.invalidate();
+      this.#userSettingsApi.reload();
+      this.#logger.info(
+        '[PageLifecycleRecovery] Soft recovery completed after resume',
+        { reason, route: this.#router.url },
+      );
+    } catch (error) {
+      this.#logger.warn(
+        '[PageLifecycleRecovery] Soft recovery failed after resume, reloading app',
+        { reason, route: this.#router.url, error },
+      );
+      this.#triggerRecoveryReload(reason);
+    }
+  }
+
+  #triggerRecoveryReload(reason: ResumeTriggerReason): void {
+    if (!this.#shouldReload()) {
+      return;
+    }
+
+    this.#markReload();
+    this.#logger.warn('[PageLifecycleRecovery] Reloading app after resume', {
+      reason,
+      route: this.#router.url,
+    });
+    this.#reload();
+  }
+
+  #shouldReload(): boolean {
+    const storage = this.#document.defaultView?.sessionStorage;
+    if (!storage) return true;
+
+    const now = Date.now();
+    const lastReloadRaw = storage.getItem(RELOAD_COOLDOWN_STORAGE_KEY);
+    const lastReload = lastReloadRaw ? Number(lastReloadRaw) : 0;
+
+    if (!Number.isFinite(lastReload) || lastReload <= 0) {
+      return true;
+    }
+
+    return now - lastReload >= PAGE_RELOAD_COOLDOWN_MS;
+  }
+
+  #markReload(): void {
+    this.#document.defaultView?.sessionStorage.setItem(
+      RELOAD_COOLDOWN_STORAGE_KEY,
+      String(Date.now()),
+    );
+  }
+}


### PR DESCRIPTION
## Contexte
Corrige le cas PUL-59 : écran vide après reprise de l’app depuis un onglet inactif.

## Changements
- Ajout de `PageLifecycleRecoveryService` avec stratégie de reprise **soft-first** :
  - refresh session
  - invalidation des données budget
  - reload des user settings
- Fallback en hard reload seulement si la reprise soft échoue
- Conservation du cooldown anti-boucle de reload
- Cleanup explicite des listeners globaux via `DestroyRef`
- Mise à jour du guard auth (redirection login) + tests dédiés
- Ajout d’un test SWR `reloading` sur `CurrentMonthStore`

## Validation
- `pnpm quality` (workspace) ✅
- `pnpm test -- projects/webapp/src/app/core/auth/auth-guard.spec.ts projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.spec.ts projects/webapp/src/app/feature/current-month/services/current-month-store.spec.ts` ✅
- `pnpm lint` (frontend) ✅
- `pnpm typecheck` (frontend) ✅
