### PR TITLE
fix(frontend): blur keyboard on visibility change to fix bottom sheet on Samsung Browser

### DIFF
--- a/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.spec.ts
@@ -204,6 +204,43 @@ describe('PageLifecycleRecoveryService', () => {
     expect(reloadSpy).not.toHaveBeenCalled();
   });
 
+  it('should blur active element inside bottom sheet on visibility change to visible', () => {
+    const container = document.createElement('div');
+    container.classList.add('mat-bottom-sheet-container');
+    const input = document.createElement('input');
+    container.appendChild(input);
+    document.body.appendChild(container);
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    setVisibilityState('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+    setVisibilityState('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(document.activeElement).not.toBe(input);
+
+    container.remove();
+  });
+
+  it('should NOT blur active element outside bottom sheet on visibility change', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    setVisibilityState('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+    setVisibilityState('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(document.activeElement).toBe(input);
+
+    input.remove();
+  });
+
   it('should fall back to location.pathname when router.url is "/" before navigation settles', async () => {
     mockRouter.url = '/';
     Object.defineProperty(window, 'location', {

--- a/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/page-lifecycle-recovery.service.ts
@@ -62,6 +62,11 @@ export class PageLifecycleRecoveryService {
       return;
     }
 
+    const activeElement = this.#document.activeElement as HTMLElement | null;
+    if (activeElement?.closest('.mat-bottom-sheet-container')) {
+      activeElement.blur();
+    }
+
     if (!this.#isOnProtectedRoute()) {
       this.#lastHiddenAt = null;
       return;


### PR DESCRIPTION
## Summary

• Blur active element when returning from background if inside Material bottom sheet
• Fixes issue where virtual keyboard stays open and bottom sheet becomes unreadable on Samsung Browser after app goes to background
• Includes tests for blur behavior inside and outside bottom sheets

## Changes

- `page-lifecycle-recovery.service.ts`: Add keyboard blur logic in visibilitychange handler
- `page-lifecycle-recovery.service.spec.ts`: Add 2 new tests for blur behavior

## Type

fix