### PR TITLE
fix: use budget period instead of calendar month for initial budget

### DIFF
--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
@@ -1,15 +1,16 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { of } from 'rxjs';
 import { ProfileSetupService } from './profile-setup.service';
 import { ApplicationConfiguration } from '@core/config/application-configuration';
+import { ApiClient } from '@core/api/api-client';
 import { BudgetApi } from '@core/budget';
 import { PostHogService } from '@core/analytics/posthog';
 import { Logger } from '@core/logging/logger';
 
 describe('ProfileSetupService', () => {
   let service: ProfileSetupService;
+  let mockApiClient: { post$: ReturnType<typeof vi.fn> };
   let mockBudgetApi: { createBudget$: ReturnType<typeof vi.fn> };
   let mockPostHogService: { enableTracking: ReturnType<typeof vi.fn> };
   let mockLogger: {
@@ -18,6 +19,14 @@ describe('ProfileSetupService', () => {
   };
 
   beforeEach(() => {
+    mockApiClient = {
+      post$: vi.fn().mockReturnValue(
+        of({
+          data: { template: { id: 'template-123' } },
+        }),
+      ),
+    };
+
     mockBudgetApi = {
       createBudget$: vi
         .fn()
@@ -34,13 +43,13 @@ describe('ProfileSetupService', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
         ProfileSetupService,
         {
           provide: ApplicationConfiguration,
           useValue: { backendApiUrl: () => 'http://localhost:3000/api/v1' },
         },
+        { provide: ApiClient, useValue: mockApiClient },
         { provide: BudgetApi, useValue: mockBudgetApi },
         { provide: PostHogService, useValue: mockPostHogService },
         { provide: Logger, useValue: mockLogger },
@@ -83,6 +92,63 @@ describe('ProfileSetupService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Données obligatoires manquantes');
+    });
+  });
+
+  describe('budget period computation', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should pass payDayOfMonth to getBudgetPeriodForDate and use result', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-02-02'));
+
+      const result = await service.createInitialBudget({
+        firstName: 'Test',
+        monthlyIncome: 3000,
+        payDayOfMonth: 4,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockBudgetApi.createBudget$).toHaveBeenCalledWith(
+        expect.objectContaining({ month: 1, year: 2026 }),
+      );
+    });
+
+    it('should use calendar month when payDayOfMonth is undefined', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-02-15'));
+
+      const result = await service.createInitialBudget({
+        firstName: 'Test',
+        monthlyIncome: 3000,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockBudgetApi.createBudget$).toHaveBeenCalledWith(
+        expect.objectContaining({ month: 2, year: 2026 }),
+      );
+    });
+
+    it('should handle year boundary and use period year in description', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-02'));
+
+      const result = await service.createInitialBudget({
+        firstName: 'Test',
+        monthlyIncome: 3000,
+        payDayOfMonth: 4,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockBudgetApi.createBudget$).toHaveBeenCalledWith(
+        expect.objectContaining({
+          month: 12,
+          year: 2025,
+          description: 'Budget initial de Test pour 2025',
+        }),
+      );
     });
   });
 });

--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.ts
@@ -4,6 +4,7 @@ import {
   type BudgetCreate,
   type BudgetTemplateCreateFromOnboarding,
   budgetTemplateCreateResponseSchema,
+  getBudgetPeriodForDate,
 } from 'pulpe-shared';
 import { ApiClient } from '@core/api/api-client';
 import { BudgetApi } from '@core/budget';
@@ -59,11 +60,15 @@ export class ProfileSetupService {
 
       // 2. Create budget
       const currentDate = new Date();
+      const { month, year } = getBudgetPeriodForDate(
+        currentDate,
+        profileData.payDayOfMonth,
+      );
       const budgetRequest: BudgetCreate = {
         templateId: templateResponse.data.template.id,
-        month: currentDate.getMonth() + 1,
-        year: currentDate.getFullYear(),
-        description: `Budget initial de ${profileData.firstName} pour ${currentDate.getFullYear()}`,
+        month,
+        year,
+        description: `Budget initial de ${profileData.firstName} pour ${year}`,
       };
 
       await firstValueFrom(this.#budgetApi.createBudget$(budgetRequest));

--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.types.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.types.ts
@@ -7,6 +7,7 @@ export interface ProfileData {
   internetPlan?: number;
   transportCosts?: number;
   leasingCredit?: number;
+  payDayOfMonth?: number;
 }
 
 export interface ProfileSetupResult {

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.spec.ts
@@ -321,7 +321,24 @@ describe('CompleteProfileStore', () => {
         internetPlan: undefined,
         transportCosts: undefined,
         leasingCredit: undefined,
+        payDayOfMonth: undefined,
       });
+    });
+
+    it('should pass payDayOfMonth to createInitialBudget when set', async () => {
+      mockProfileSetupService.createInitialBudget.mockResolvedValue({
+        success: true,
+      });
+
+      store.updateFirstName('John');
+      store.updateMonthlyIncome(5000);
+      store.updatePayDayOfMonth(4);
+
+      await store.submitProfile();
+
+      expect(mockProfileSetupService.createInitialBudget).toHaveBeenCalledWith(
+        expect.objectContaining({ payDayOfMonth: 4 }),
+      );
     });
 
     it('should return false when profileSetupService fails', async () => {

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.ts
@@ -180,6 +180,7 @@ export class CompleteProfileStore {
       internetPlan: state.internetPlan ?? undefined,
       transportCosts: state.transportCosts ?? undefined,
       leasingCredit: state.leasingCredit ?? undefined,
+      payDayOfMonth: state.payDayOfMonth ?? undefined,
     };
 
     try {


### PR DESCRIPTION
## Summary

• Fix onboarding bug where initial budget was created with calendar month instead of user's budget period
• Integrate `getBudgetPeriodForDate` from shared lib to account for pay day and quinzaine rule
• Simplify type hints and remove test redundancy

## Changes

- **profile-setup.service.ts**: Use `getBudgetPeriodForDate()` instead of `getMonth() + 1` for budget period computation
- **profile-setup.types.ts**: Add optional `payDayOfMonth` field to `ProfileData`
- **complete-profile-store.ts**: Pass `payDayOfMonth` through to service
- **Tests**: Add representative integration tests for budget period wiring + year boundary handling
- **Cleanup**: Remove unused `HttpClientTestingModule`, simplify type hints, eliminate test redundancy

## Type

fix