### PR TITLE
feat(auth): add app version display and apply Angular 21 clean code improvements

### DIFF
--- a/frontend/e2e/tests/features/budget-line-creation.spec.ts
+++ b/frontend/e2e/tests/features/budget-line-creation.spec.ts
@@ -399,7 +399,11 @@ test.describe('Budget Line Creation', () => {
 
     await authenticatedPage.locator('[data-testid="new-line-name"]').fill('Courses');
     await authenticatedPage.locator('[data-testid="new-line-amount"]').fill('500');
-    await authenticatedPage.getByTestId('add-new-line').click();
+    // Blur triggers Angular form control finalization (CI timing)
+    await authenticatedPage.locator('[data-testid="new-line-amount"]').blur();
+    const submitButton = authenticatedPage.getByTestId('add-new-line');
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
     await expect(dialog).not.toBeVisible();
 
     // After creation: income=5000, expenses=1500+500=2000, remaining=3000

--- a/frontend/projects/webapp/src/app/app.routes.ts
+++ b/frontend/projects/webapp/src/app/app.routes.ts
@@ -9,60 +9,67 @@ import { PAGE_TITLES, ROUTES } from '@core/routing';
 export const routes: Routes = [
   {
     path: '',
-    pathMatch: 'full',
-    redirectTo: ROUTES.WELCOME,
-  },
-  {
-    path: ROUTES.WELCOME,
-    title: PAGE_TITLES.WELCOME,
-    canActivate: [maintenanceGuard, publicGuard],
-    loadChildren: () => import('./feature/welcome'),
-  },
-  {
-    path: ROUTES.LOGIN,
-    title: PAGE_TITLES.LOGIN,
-    canActivate: [maintenanceGuard, publicGuard],
-    loadComponent: () => import('./feature/auth/login/login'),
-  },
-  {
-    path: ROUTES.SIGNUP,
-    title: PAGE_TITLES.SIGNUP,
-    canActivate: [maintenanceGuard, publicGuard],
-    loadComponent: () => import('./feature/auth/signup/signup'),
-  },
-  {
-    path: ROUTES.FORGOT_PASSWORD,
-    title: PAGE_TITLES.FORGOT_PASSWORD,
-    canActivate: [maintenanceGuard, publicGuard],
-    loadComponent: () =>
-      import('./feature/auth/forgot-password/forgot-password'),
-  },
-  {
-    path: ROUTES.RESET_PASSWORD,
-    title: PAGE_TITLES.RESET_PASSWORD,
-    canActivate: [maintenanceGuard],
-    loadComponent: () => import('./feature/auth/reset-password/reset-password'),
-  },
-  {
-    path: ROUTES.SETUP_VAULT_CODE,
-    title: PAGE_TITLES.SETUP_VAULT_CODE,
-    canActivate: [maintenanceGuard, authGuard],
-    loadComponent: () =>
-      import('./feature/auth/setup-vault-code/setup-vault-code'),
-  },
-  {
-    path: ROUTES.ENTER_VAULT_CODE,
-    title: PAGE_TITLES.ENTER_VAULT_CODE,
-    canActivate: [maintenanceGuard, authGuard],
-    loadComponent: () =>
-      import('./feature/auth/enter-vault-code/enter-vault-code'),
-  },
-  {
-    path: ROUTES.RECOVER_VAULT_CODE,
-    title: PAGE_TITLES.RECOVER_VAULT_CODE,
-    canActivate: [maintenanceGuard, authGuard],
-    loadComponent: () =>
-      import('./feature/auth/recover-vault-code/recover-vault-code'),
+    loadComponent: () => import('@layout/auth-layout'),
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        redirectTo: ROUTES.WELCOME,
+      },
+      {
+        path: ROUTES.WELCOME,
+        title: PAGE_TITLES.WELCOME,
+        canActivate: [maintenanceGuard, publicGuard],
+        loadChildren: () => import('./feature/welcome'),
+      },
+      {
+        path: ROUTES.LOGIN,
+        title: PAGE_TITLES.LOGIN,
+        canActivate: [maintenanceGuard, publicGuard],
+        loadComponent: () => import('./feature/auth/login/login'),
+      },
+      {
+        path: ROUTES.SIGNUP,
+        title: PAGE_TITLES.SIGNUP,
+        canActivate: [maintenanceGuard, publicGuard],
+        loadComponent: () => import('./feature/auth/signup/signup'),
+      },
+      {
+        path: ROUTES.FORGOT_PASSWORD,
+        title: PAGE_TITLES.FORGOT_PASSWORD,
+        canActivate: [maintenanceGuard, publicGuard],
+        loadComponent: () =>
+          import('./feature/auth/forgot-password/forgot-password'),
+      },
+      {
+        path: ROUTES.RESET_PASSWORD,
+        title: PAGE_TITLES.RESET_PASSWORD,
+        canActivate: [maintenanceGuard],
+        loadComponent: () =>
+          import('./feature/auth/reset-password/reset-password'),
+      },
+      {
+        path: ROUTES.SETUP_VAULT_CODE,
+        title: PAGE_TITLES.SETUP_VAULT_CODE,
+        canActivate: [maintenanceGuard, authGuard],
+        loadComponent: () =>
+          import('./feature/auth/setup-vault-code/setup-vault-code'),
+      },
+      {
+        path: ROUTES.ENTER_VAULT_CODE,
+        title: PAGE_TITLES.ENTER_VAULT_CODE,
+        canActivate: [maintenanceGuard, authGuard],
+        loadComponent: () =>
+          import('./feature/auth/enter-vault-code/enter-vault-code'),
+      },
+      {
+        path: ROUTES.RECOVER_VAULT_CODE,
+        title: PAGE_TITLES.RECOVER_VAULT_CODE,
+        canActivate: [maintenanceGuard, authGuard],
+        loadComponent: () =>
+          import('./feature/auth/recover-vault-code/recover-vault-code'),
+      },
+    ],
   },
   {
     path: ROUTES.MAINTENANCE,

--- a/frontend/projects/webapp/src/app/feature/auth/enter-vault-code/enter-vault-code.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/enter-vault-code/enter-vault-code.ts
@@ -47,116 +47,114 @@ import { PostHogService } from '@core/analytics';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="pulpe-entry-shell pulpe-gradient">
-      <div
-        class="pulpe-entry-card w-full max-w-md"
-        data-testid="enter-vault-code-page"
-      >
-        <div class="text-center mb-8">
-          <mat-icon class="text-6xl! w-auto! h-auto! text-primary"
-            >lock_open</mat-icon
-          >
-          <h1
-            class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
-          >
-            Saisis ton code PIN
-          </h1>
-          <p class="text-body-large text-on-surface-variant">
-            Entre ton code pour accéder à tes données.
-          </p>
-        </div>
-
-        <form
-          [formGroup]="form"
-          (ngSubmit)="onSubmit()"
-          class="space-y-4"
-          data-testid="enter-vault-code-form"
+    <div
+      class="pulpe-entry-card w-full max-w-md"
+      data-testid="enter-vault-code-page"
+    >
+      <div class="text-center mb-8">
+        <mat-icon class="text-6xl! w-auto! h-auto! text-primary"
+          >lock_open</mat-icon
         >
-          <mat-form-field appearance="outline" class="w-full">
-            <mat-label>Code PIN</mat-label>
-            <input
-              matInput
-              [type]="isCodeHidden() ? 'password' : 'text'"
-              inputmode="numeric"
-              formControlName="vaultCode"
-              data-testid="vault-code-input"
-              (input)="clearError()"
-              placeholder="Code PIN"
-            />
-            <mat-icon matPrefix>lock</mat-icon>
-            <button
-              type="button"
-              matIconButton
-              matSuffix
-              (click)="isCodeHidden.set(!isCodeHidden())"
-              [attr.aria-label]="'Afficher le code'"
-              [attr.aria-pressed]="!isCodeHidden()"
-            >
-              <mat-icon>{{
-                isCodeHidden() ? 'visibility_off' : 'visibility'
-              }}</mat-icon>
-            </button>
-            @if (
-              form.get('vaultCode')?.invalid && form.get('vaultCode')?.touched
-            ) {
-              <mat-error>
-                @if (form.get('vaultCode')?.hasError('required')) {
-                  Ton code PIN est nécessaire
-                } @else if (form.get('vaultCode')?.hasError('minlength')) {
-                  4 chiffres minimum
-                } @else if (form.get('vaultCode')?.hasError('pattern')) {
-                  Le code PIN ne doit contenir que des chiffres
-                }
-              </mat-error>
-            }
-          </mat-form-field>
+        <h1
+          class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
+        >
+          Saisis ton code PIN
+        </h1>
+        <p class="text-body-large text-on-surface-variant">
+          Entre ton code pour accéder à tes données.
+        </p>
+      </div>
 
-          <div class="flex items-center">
-            <mat-checkbox
-              formControlName="rememberDevice"
-              data-testid="remember-device-checkbox"
-            >
-              <span class="text-body-medium text-on-surface">
-                Ne plus me demander sur cet appareil
-              </span>
-            </mat-checkbox>
-          </div>
-
-          <pulpe-error-alert [message]="errorMessage()" />
-
-          <pulpe-loading-button
-            [loading]="isSubmitting()"
-            [disabled]="!canSubmit()"
-            loadingText="Vérification..."
-            icon="arrow_forward"
-            testId="enter-vault-code-submit-button"
-          >
-            <span class="ml-2">Continuer</span>
-          </pulpe-loading-button>
-
-          <div class="text-center mt-2">
-            <a
-              [routerLink]="['/', ROUTES.RECOVER_VAULT_CODE]"
-              class="text-body-small text-primary hover:underline"
-              data-testid="lost-code-link"
-            >
-              Code perdu ?
-            </a>
-          </div>
-        </form>
-
-        <div class="text-center mt-4 pt-4 border-t border-outline-variant">
+      <form
+        [formGroup]="form"
+        (ngSubmit)="onSubmit()"
+        class="space-y-4"
+        data-testid="enter-vault-code-form"
+      >
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Code PIN</mat-label>
+          <input
+            matInput
+            [type]="isCodeHidden() ? 'password' : 'text'"
+            inputmode="numeric"
+            formControlName="vaultCode"
+            data-testid="vault-code-input"
+            (input)="clearError()"
+            placeholder="Code PIN"
+          />
+          <mat-icon matPrefix>lock</mat-icon>
           <button
-            matButton
             type="button"
-            (click)="onLogout()"
-            [disabled]="isLoggingOut()"
-            data-testid="vault-code-logout-button"
+            matIconButton
+            matSuffix
+            (click)="isCodeHidden.set(!isCodeHidden())"
+            [attr.aria-label]="'Afficher le code'"
+            [attr.aria-pressed]="!isCodeHidden()"
           >
-            <mat-icon>logout</mat-icon>
-            Se déconnecter
+            <mat-icon>{{
+              isCodeHidden() ? 'visibility_off' : 'visibility'
+            }}</mat-icon>
           </button>
+          @if (
+            form.get('vaultCode')?.invalid && form.get('vaultCode')?.touched
+          ) {
+            <mat-error>
+              @if (form.get('vaultCode')?.hasError('required')) {
+                Ton code PIN est nécessaire
+              } @else if (form.get('vaultCode')?.hasError('minlength')) {
+                4 chiffres minimum
+              } @else if (form.get('vaultCode')?.hasError('pattern')) {
+                Le code PIN ne doit contenir que des chiffres
+              }
+            </mat-error>
+          }
+        </mat-form-field>
+
+        <div class="flex items-center">
+          <mat-checkbox
+            formControlName="rememberDevice"
+            data-testid="remember-device-checkbox"
+          >
+            <span class="text-body-medium text-on-surface">
+              Ne plus me demander sur cet appareil
+            </span>
+          </mat-checkbox>
         </div>
+
+        <pulpe-error-alert [message]="errorMessage()" />
+
+        <pulpe-loading-button
+          [loading]="isSubmitting()"
+          [disabled]="!canSubmit()"
+          loadingText="Vérification..."
+          icon="arrow_forward"
+          testId="enter-vault-code-submit-button"
+        >
+          <span class="ml-2">Continuer</span>
+        </pulpe-loading-button>
+
+        <div class="text-center mt-2">
+          <a
+            [routerLink]="['/', ROUTES.RECOVER_VAULT_CODE]"
+            class="text-body-small text-primary hover:underline"
+            data-testid="lost-code-link"
+          >
+            Code perdu ?
+          </a>
+        </div>
+      </form>
+
+      <div class="text-center mt-4 pt-4 border-t border-outline-variant">
+        <button
+          matButton
+          type="button"
+          (click)="onLogout()"
+          [disabled]="isLoggingOut()"
+          data-testid="vault-code-logout-button"
+        >
+          <mat-icon>logout</mat-icon>
+          Se déconnecter
+        </button>
       </div>
     </div>
   `,

--- a/frontend/projects/webapp/src/app/feature/auth/forgot-password/forgot-password.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/forgot-password/forgot-password.ts
@@ -16,6 +16,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { AuthSessionService } from '@core/auth';
 import { ROUTES } from '@core/routing/routes-constants';
 import { Logger } from '@core/logging/logger';
+import { AppVersionLabel } from '@ui/app-version-label';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
 
@@ -28,6 +29,7 @@ import { LoadingButton } from '@ui/loading-button';
     MatButtonModule,
     MatIconModule,
     RouterLink,
+    AppVersionLabel,
     ErrorAlert,
     LoadingButton,
   ],
@@ -127,6 +129,7 @@ import { LoadingButton } from '@ui/loading-button';
           </div>
         }
       </div>
+      <pulpe-app-version-label />
     </div>
   `,
 })

--- a/frontend/projects/webapp/src/app/feature/auth/forgot-password/forgot-password.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/forgot-password/forgot-password.ts
@@ -16,7 +16,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { AuthSessionService } from '@core/auth';
 import { ROUTES } from '@core/routing/routes-constants';
 import { Logger } from '@core/logging/logger';
-import { AppVersionLabel } from '@ui/app-version-label';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
 
@@ -29,107 +28,103 @@ import { LoadingButton } from '@ui/loading-button';
     MatButtonModule,
     MatIconModule,
     RouterLink,
-    AppVersionLabel,
     ErrorAlert,
     LoadingButton,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="pulpe-entry-shell pulpe-gradient">
-      <div
-        class="pulpe-entry-card w-full max-w-md"
-        data-testid="forgot-password-page"
+    <div
+      class="pulpe-entry-card w-full max-w-md"
+      data-testid="forgot-password-page"
+    >
+      <button
+        matButton
+        [routerLink]="['/', ROUTES.LOGIN]"
+        class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
       >
-        <button
-          matButton
-          [routerLink]="['/', ROUTES.LOGIN]"
-          class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+        <mat-icon class="text-lg">arrow_back</mat-icon>
+        <span>Retour à la connexion</span>
+      </button>
+
+      <div class="text-center mb-8 mt-4">
+        <h1
+          class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
         >
-          <mat-icon class="text-lg">arrow_back</mat-icon>
-          <span>Retour à la connexion</span>
-        </button>
-
-        <div class="text-center mb-8 mt-4">
-          <h1
-            class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
-          >
-            Mot de passe oublié
-          </h1>
-          @if (!isSuccess()) {
-            <p class="text-body-large text-on-surface-variant">
-              Entre ton email pour recevoir un lien de réinitialisation
-            </p>
-          }
-        </div>
-
+          Mot de passe oublié
+        </h1>
         @if (!isSuccess()) {
-          <form
-            [formGroup]="form"
-            (ngSubmit)="onSubmit()"
-            class="space-y-6"
-            data-testid="forgot-password-form"
-          >
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Email</mat-label>
-              <input
-                matInput
-                type="email"
-                formControlName="email"
-                data-testid="email-input"
-                (input)="clearError()"
-                placeholder="ton@email.com"
-                [disabled]="isSubmitting()"
-              />
-              <mat-icon matPrefix>email</mat-icon>
-              @if (form.get('email')?.invalid && form.get('email')?.touched) {
-                <mat-error>
-                  @if (form.get('email')?.hasError('required')) {
-                    Ton email est nécessaire pour continuer
-                  } @else if (form.get('email')?.hasError('email')) {
-                    Cette adresse email ne semble pas valide
-                  }
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <pulpe-error-alert [message]="errorMessage()" />
-
-            <pulpe-loading-button
-              [loading]="isSubmitting()"
-              [disabled]="!canSubmit()"
-              loadingText="Envoi en cours..."
-              icon="send"
-              testId="forgot-password-submit-button"
-            >
-              <span class="ml-2">Envoyer le lien</span>
-            </pulpe-loading-button>
-          </form>
-        } @else {
-          <div
-            class="text-center space-y-6"
-            data-testid="forgot-password-success"
-          >
-            <mat-icon class="text-6xl text-primary">mark_email_read</mat-icon>
-            <p class="text-body-large text-on-surface">
-              Si un compte existe avec cette adresse, tu recevras un email avec
-              un lien de réinitialisation.
-            </p>
-            <p class="text-body-medium text-on-surface-variant">
-              Pense à vérifier tes spams si tu ne le vois pas.
-            </p>
-            <button
-              [routerLink]="['/', ROUTES.LOGIN]"
-              matButton
-              color="primary"
-              class="w-full"
-              data-testid="back-to-login-button"
-            >
-              Retour à la connexion
-            </button>
-          </div>
+          <p class="text-body-large text-on-surface-variant">
+            Entre ton email pour recevoir un lien de réinitialisation
+          </p>
         }
       </div>
-      <pulpe-app-version-label />
+
+      @if (!isSuccess()) {
+        <form
+          [formGroup]="form"
+          (ngSubmit)="onSubmit()"
+          class="space-y-6"
+          data-testid="forgot-password-form"
+        >
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Email</mat-label>
+            <input
+              matInput
+              type="email"
+              formControlName="email"
+              data-testid="email-input"
+              (input)="clearError()"
+              placeholder="ton@email.com"
+              [disabled]="isSubmitting()"
+            />
+            <mat-icon matPrefix>email</mat-icon>
+            @if (form.get('email')?.invalid && form.get('email')?.touched) {
+              <mat-error>
+                @if (form.get('email')?.hasError('required')) {
+                  Ton email est nécessaire pour continuer
+                } @else if (form.get('email')?.hasError('email')) {
+                  Cette adresse email ne semble pas valide
+                }
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <pulpe-error-alert [message]="errorMessage()" />
+
+          <pulpe-loading-button
+            [loading]="isSubmitting()"
+            [disabled]="!canSubmit()"
+            loadingText="Envoi en cours..."
+            icon="send"
+            testId="forgot-password-submit-button"
+          >
+            <span class="ml-2">Envoyer le lien</span>
+          </pulpe-loading-button>
+        </form>
+      } @else {
+        <div
+          class="text-center space-y-6"
+          data-testid="forgot-password-success"
+        >
+          <mat-icon class="text-6xl text-primary">mark_email_read</mat-icon>
+          <p class="text-body-large text-on-surface">
+            Si un compte existe avec cette adresse, tu recevras un email avec un
+            lien de réinitialisation.
+          </p>
+          <p class="text-body-medium text-on-surface-variant">
+            Pense à vérifier tes spams si tu ne le vois pas.
+          </p>
+          <button
+            [routerLink]="['/', ROUTES.LOGIN]"
+            matButton
+            color="primary"
+            class="w-full"
+            data-testid="back-to-login-button"
+          >
+            Retour à la connexion
+          </button>
+        </div>
+      }
     </div>
   `,
 })

--- a/frontend/projects/webapp/src/app/feature/auth/login/login.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/login/login.ts
@@ -24,7 +24,6 @@ import { ROUTES } from '@core/routing/routes-constants';
 import { Logger } from '@core/logging/logger';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
-import { AppVersionLabel } from '@ui/app-version-label';
 
 @Component({
   selector: 'pulpe-login',
@@ -40,151 +39,147 @@ import { AppVersionLabel } from '@ui/app-version-label';
     GoogleOAuthButton,
     ErrorAlert,
     LoadingButton,
-    AppVersionLabel,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="pulpe-entry-shell pulpe-gradient">
-      <div class="pulpe-entry-card w-full max-w-md">
-        <button
-          matButton
-          [routerLink]="['/', ROUTES.WELCOME]"
-          class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+    <div class="pulpe-entry-card w-full max-w-md">
+      <button
+        matButton
+        [routerLink]="['/', ROUTES.WELCOME]"
+        class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+      >
+        <mat-icon class="text-lg">arrow_back</mat-icon>
+        <span>Retour à l'accueil</span>
+      </button>
+
+      <div class="text-center mb-8 mt-4">
+        <h1
+          class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
         >
-          <mat-icon class="text-lg">arrow_back</mat-icon>
-          <span>Retour à l'accueil</span>
-        </button>
-
-        <div class="text-center mb-8 mt-4">
-          <h1
-            class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
-          >
-            Content de te revoir
-          </h1>
-          <p class="text-body-large text-on-surface-variant">
-            Retrouve ton budget là où tu l'as laissé
-          </p>
-        </div>
-
-        <form
-          [formGroup]="loginForm"
-          (ngSubmit)="signIn()"
-          class="space-y-6"
-          data-testid="login-form"
-        >
-          <mat-form-field appearance="outline" class="w-full">
-            <mat-label>Email</mat-label>
-            <input
-              matInput
-              type="email"
-              formControlName="email"
-              data-testid="email-input"
-              (input)="clearMessages()"
-              placeholder="ton@email.com"
-              [disabled]="isSubmitting()"
-            />
-            <mat-icon matPrefix>email</mat-icon>
-            @if (
-              loginForm.get('email')?.invalid && loginForm.get('email')?.touched
-            ) {
-              <mat-error>
-                @if (loginForm.get('email')?.hasError('required')) {
-                  Ton email est nécessaire pour continuer
-                } @else if (loginForm.get('email')?.hasError('email')) {
-                  Cette adresse email ne semble pas valide
-                }
-              </mat-error>
-            }
-          </mat-form-field>
-
-          <mat-form-field appearance="outline" class="w-full">
-            <mat-label>Mot de passe</mat-label>
-            <input
-              matInput
-              [type]="isPasswordHidden() ? 'password' : 'text'"
-              formControlName="password"
-              data-testid="password-input"
-              (input)="clearMessages()"
-              placeholder="Mot de passe"
-              [disabled]="isSubmitting()"
-            />
-            <mat-icon matPrefix>lock</mat-icon>
-            <button
-              type="button"
-              matIconButton
-              matSuffix
-              (click)="togglePasswordVisibility()"
-              [attr.aria-label]="'Afficher le mot de passe'"
-              [attr.aria-pressed]="!isPasswordHidden()"
-            >
-              <mat-icon>{{
-                isPasswordHidden() ? 'visibility_off' : 'visibility'
-              }}</mat-icon>
-            </button>
-            @if (
-              loginForm.get('password')?.invalid &&
-              loginForm.get('password')?.touched
-            ) {
-              <mat-error>
-                @if (loginForm.get('password')?.hasError('required')) {
-                  Ton mot de passe est nécessaire
-                } @else if (loginForm.get('password')?.hasError('minlength')) {
-                  8 caractères minimum
-                }
-              </mat-error>
-            }
-          </mat-form-field>
-
-          <div class="flex justify-end -mt-2">
-            <a
-              [routerLink]="['/', ROUTES.FORGOT_PASSWORD]"
-              class="text-body-small text-primary hover:underline"
-              data-testid="forgot-password-link"
-            >
-              Mot de passe oublié ?
-            </a>
-          </div>
-
-          <pulpe-error-alert [message]="errorMessage()" />
-
-          <pulpe-loading-button
-            [loading]="isSubmitting()"
-            [disabled]="!canSubmit()"
-            loadingText="Connexion..."
-            icon="login"
-            testId="login-submit-button"
-          >
-            <span class="ml-2">Se connecter</span>
-          </pulpe-loading-button>
-        </form>
-
-        <div class="flex items-center gap-4 my-6">
-          <mat-divider class="flex-1" />
-          <span class="text-body-medium text-on-surface-variant">ou</span>
-          <mat-divider class="flex-1" />
-        </div>
-
-        <pulpe-google-oauth-button
-          testId="google-login-button"
-          (authError)="errorMessage.set($event)"
-          (loadingChange)="isSubmitting.set($event)"
-        />
-
-        <div class="text-center mt-6">
-          <p class="text-body-medium text-on-surface-variant">
-            Nouveau sur Pulpe ?
-            <button
-              matButton
-              color="primary"
-              class="ml-1"
-              [routerLink]="['/', ROUTES.SIGNUP]"
-            >
-              Créer un compte
-            </button>
-          </p>
-        </div>
+          Content de te revoir
+        </h1>
+        <p class="text-body-large text-on-surface-variant">
+          Retrouve ton budget là où tu l'as laissé
+        </p>
       </div>
-      <pulpe-app-version-label />
+
+      <form
+        [formGroup]="loginForm"
+        (ngSubmit)="signIn()"
+        class="space-y-6"
+        data-testid="login-form"
+      >
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Email</mat-label>
+          <input
+            matInput
+            type="email"
+            formControlName="email"
+            data-testid="email-input"
+            (input)="clearMessages()"
+            placeholder="ton@email.com"
+            [disabled]="isSubmitting()"
+          />
+          <mat-icon matPrefix>email</mat-icon>
+          @if (
+            loginForm.get('email')?.invalid && loginForm.get('email')?.touched
+          ) {
+            <mat-error>
+              @if (loginForm.get('email')?.hasError('required')) {
+                Ton email est nécessaire pour continuer
+              } @else if (loginForm.get('email')?.hasError('email')) {
+                Cette adresse email ne semble pas valide
+              }
+            </mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Mot de passe</mat-label>
+          <input
+            matInput
+            [type]="isPasswordHidden() ? 'password' : 'text'"
+            formControlName="password"
+            data-testid="password-input"
+            (input)="clearMessages()"
+            placeholder="Mot de passe"
+            [disabled]="isSubmitting()"
+          />
+          <mat-icon matPrefix>lock</mat-icon>
+          <button
+            type="button"
+            matIconButton
+            matSuffix
+            (click)="togglePasswordVisibility()"
+            [attr.aria-label]="'Afficher le mot de passe'"
+            [attr.aria-pressed]="!isPasswordHidden()"
+          >
+            <mat-icon>{{
+              isPasswordHidden() ? 'visibility_off' : 'visibility'
+            }}</mat-icon>
+          </button>
+          @if (
+            loginForm.get('password')?.invalid &&
+            loginForm.get('password')?.touched
+          ) {
+            <mat-error>
+              @if (loginForm.get('password')?.hasError('required')) {
+                Ton mot de passe est nécessaire
+              } @else if (loginForm.get('password')?.hasError('minlength')) {
+                8 caractères minimum
+              }
+            </mat-error>
+          }
+        </mat-form-field>
+
+        <div class="flex justify-end -mt-2">
+          <a
+            [routerLink]="['/', ROUTES.FORGOT_PASSWORD]"
+            class="text-body-small text-primary hover:underline"
+            data-testid="forgot-password-link"
+          >
+            Mot de passe oublié ?
+          </a>
+        </div>
+
+        <pulpe-error-alert [message]="errorMessage()" />
+
+        <pulpe-loading-button
+          [loading]="isSubmitting()"
+          [disabled]="!canSubmit()"
+          loadingText="Connexion..."
+          icon="login"
+          testId="login-submit-button"
+        >
+          <span class="ml-2">Se connecter</span>
+        </pulpe-loading-button>
+      </form>
+
+      <div class="flex items-center gap-4 my-6">
+        <mat-divider class="flex-1" />
+        <span class="text-body-medium text-on-surface-variant">ou</span>
+        <mat-divider class="flex-1" />
+      </div>
+
+      <pulpe-google-oauth-button
+        testId="google-login-button"
+        (authError)="errorMessage.set($event)"
+        (loadingChange)="isSubmitting.set($event)"
+      />
+
+      <div class="text-center mt-6">
+        <p class="text-body-medium text-on-surface-variant">
+          Nouveau sur Pulpe ?
+          <button
+            matButton
+            color="primary"
+            class="ml-1"
+            [routerLink]="['/', ROUTES.SIGNUP]"
+          >
+            Créer un compte
+          </button>
+        </p>
+      </div>
     </div>
   `,
 })
@@ -212,7 +207,7 @@ export default class Login {
     }
   }
 
-  protected loginForm = this.#formBuilder.nonNullable.group({
+  protected readonly loginForm = this.#formBuilder.nonNullable.group({
     email: ['', [Validators.required, Validators.email]],
     password: [
       '',
@@ -220,14 +215,12 @@ export default class Login {
     ],
   });
 
-  protected readonly formStatus = toSignal(this.loginForm.statusChanges, {
+  readonly #formStatus = toSignal(this.loginForm.statusChanges, {
     initialValue: this.loginForm.status,
   });
 
   protected readonly canSubmit = computed(() => {
-    const isValid = this.formStatus() === 'VALID';
-    const isNotSubmitting = !this.isSubmitting();
-    return isValid && isNotSubmitting;
+    return this.#formStatus() === 'VALID' && !this.isSubmitting();
   });
 
   protected togglePasswordVisibility(): void {

--- a/frontend/projects/webapp/src/app/feature/auth/login/login.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/login/login.ts
@@ -24,6 +24,7 @@ import { ROUTES } from '@core/routing/routes-constants';
 import { Logger } from '@core/logging/logger';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
+import { AppVersionLabel } from '@ui/app-version-label';
 
 @Component({
   selector: 'pulpe-login',
@@ -39,6 +40,7 @@ import { LoadingButton } from '@ui/loading-button';
     GoogleOAuthButton,
     ErrorAlert,
     LoadingButton,
+    AppVersionLabel,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -182,6 +184,7 @@ import { LoadingButton } from '@ui/loading-button';
           </p>
         </div>
       </div>
+      <pulpe-app-version-label />
     </div>
   `,
 })

--- a/frontend/projects/webapp/src/app/feature/auth/recover-vault-code/recover-vault-code.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/recover-vault-code/recover-vault-code.ts
@@ -58,194 +58,190 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (isRedirecting()) {
-      <div class="pulpe-entry-shell pulpe-gradient">
+      <div
+        class="pulpe-entry-card w-full max-w-md"
+        data-testid="recover-vault-code-redirecting"
+      >
         <div
-          class="pulpe-entry-card w-full max-w-md"
-          data-testid="recover-vault-code-redirecting"
+          class="flex flex-col items-center justify-center py-12 gap-6"
+          role="status"
+          aria-live="polite"
         >
-          <div
-            class="flex flex-col items-center justify-center py-12 gap-6"
-            role="status"
-            aria-live="polite"
-          >
-            <mat-progress-spinner
-              mode="indeterminate"
-              [diameter]="40"
-              aria-label="Redirection en cours"
-            />
-            <p class="text-body-large text-on-surface-variant animate-pulse">
-              Redirection vers ton tableau de bord...
-            </p>
-          </div>
+          <mat-progress-spinner
+            mode="indeterminate"
+            [diameter]="40"
+            aria-label="Redirection en cours"
+          />
+          <p class="text-body-large text-on-surface-variant animate-pulse">
+            Redirection vers ton tableau de bord...
+          </p>
         </div>
       </div>
     } @else {
-      <div class="pulpe-entry-shell pulpe-gradient">
-        <div
-          class="pulpe-entry-card w-full max-w-md"
-          data-testid="recover-vault-code-page"
+      <div
+        class="pulpe-entry-card w-full max-w-md"
+        data-testid="recover-vault-code-page"
+      >
+        <button
+          matButton
+          [routerLink]="['/', ROUTES.ENTER_VAULT_CODE]"
+          class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
         >
-          <button
-            matButton
-            [routerLink]="['/', ROUTES.ENTER_VAULT_CODE]"
-            class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
-          >
-            <mat-icon class="text-lg">arrow_back</mat-icon>
-            <span>Retour</span>
-          </button>
+          <mat-icon class="text-lg">arrow_back</mat-icon>
+          <span>Retour</span>
+        </button>
 
-          <div class="text-center mb-8">
-            <mat-icon class="text-6xl! w-auto! h-auto! text-primary"
-              >key</mat-icon
+        <div class="text-center mb-8">
+          <mat-icon class="text-6xl! w-auto! h-auto! text-primary"
+            >key</mat-icon
+          >
+          <h1
+            class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
+          >
+            Récupère ton code PIN
+          </h1>
+          <p class="text-body-large text-on-surface-variant">
+            Entre ta clé de récupération et ton nouveau code
+          </p>
+        </div>
+
+        <form
+          [formGroup]="form"
+          (ngSubmit)="onSubmit()"
+          class="space-y-4"
+          data-testid="recover-vault-code-form"
+        >
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Clé de récupération</mat-label>
+            <input
+              matInput
+              formControlName="recoveryKey"
+              data-testid="recovery-key-input"
+              (input)="onRecoveryKeyInput()"
+              placeholder="XXXX-XXXX-XXXX-XXXX-..."
+              class="font-mono text-sm uppercase tracking-wide"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <mat-icon matPrefix>key</mat-icon>
+            @if (
+              form.get('recoveryKey')?.invalid &&
+              form.get('recoveryKey')?.touched
+            ) {
+              <mat-error>
+                @if (form.get('recoveryKey')?.hasError('required')) {
+                  Ta clé de récupération est nécessaire
+                } @else if (form.get('recoveryKey')?.hasError('pattern')) {
+                  Format invalide — vérifie que tu as bien copié la clé
+                }
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Nouveau code PIN</mat-label>
+            <input
+              matInput
+              [type]="isVaultCodeHidden() ? 'password' : 'text'"
+              inputmode="numeric"
+              formControlName="newVaultCode"
+              data-testid="new-vault-code-input"
+              (input)="clearError()"
+              placeholder="Nouveau code PIN"
+            />
+            <mat-icon matPrefix>lock</mat-icon>
+            <button
+              type="button"
+              matIconButton
+              matSuffix
+              (click)="isVaultCodeHidden.set(!isVaultCodeHidden())"
+              [attr.aria-label]="'Afficher le code'"
+              [attr.aria-pressed]="!isVaultCodeHidden()"
             >
-            <h1
-              class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
+              <mat-icon>{{
+                isVaultCodeHidden() ? 'visibility_off' : 'visibility'
+              }}</mat-icon>
+            </button>
+            <mat-hint>4 chiffres minimum (6+ recommandé)</mat-hint>
+            @if (
+              form.get('newVaultCode')?.invalid &&
+              form.get('newVaultCode')?.touched
+            ) {
+              <mat-error>
+                @if (form.get('newVaultCode')?.hasError('required')) {
+                  Ton nouveau code est nécessaire
+                } @else if (form.get('newVaultCode')?.hasError('minlength')) {
+                  4 chiffres minimum
+                } @else if (form.get('newVaultCode')?.hasError('pattern')) {
+                  Le code PIN ne doit contenir que des chiffres
+                }
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Confirmer le code PIN</mat-label>
+            <input
+              matInput
+              [type]="isConfirmCodeHidden() ? 'password' : 'text'"
+              inputmode="numeric"
+              formControlName="confirmCode"
+              data-testid="confirm-vault-code-input"
+              (input)="clearError()"
+              placeholder="Confirmer le code PIN"
+            />
+            <mat-icon matPrefix>lock</mat-icon>
+            <button
+              type="button"
+              matIconButton
+              matSuffix
+              (click)="isConfirmCodeHidden.set(!isConfirmCodeHidden())"
+              [attr.aria-label]="'Afficher le code'"
+              [attr.aria-pressed]="!isConfirmCodeHidden()"
             >
-              Récupère ton code PIN
-            </h1>
-            <p class="text-body-large text-on-surface-variant">
-              Entre ta clé de récupération et ton nouveau code
-            </p>
+              <mat-icon>{{
+                isConfirmCodeHidden() ? 'visibility_off' : 'visibility'
+              }}</mat-icon>
+            </button>
+            @if (
+              form.get('confirmCode')?.invalid &&
+              form.get('confirmCode')?.touched
+            ) {
+              <mat-error>
+                @if (form.get('confirmCode')?.hasError('required')) {
+                  Confirme ton code
+                } @else if (
+                  form.get('confirmCode')?.hasError('fieldsMismatch')
+                ) {
+                  Les codes ne correspondent pas
+                }
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <div class="flex items-center">
+            <mat-checkbox
+              formControlName="rememberDevice"
+              data-testid="remember-device-checkbox"
+            >
+              <span class="text-body-medium text-on-surface">
+                Ne plus me demander sur cet appareil
+              </span>
+            </mat-checkbox>
           </div>
 
-          <form
-            [formGroup]="form"
-            (ngSubmit)="onSubmit()"
-            class="space-y-4"
-            data-testid="recover-vault-code-form"
+          <pulpe-error-alert [message]="errorMessage()" />
+
+          <pulpe-loading-button
+            [loading]="isSubmitting()"
+            [disabled]="!canSubmit()"
+            loadingText="Récupération..."
+            icon="lock_reset"
+            testId="recover-vault-code-submit-button"
           >
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Clé de récupération</mat-label>
-              <input
-                matInput
-                formControlName="recoveryKey"
-                data-testid="recovery-key-input"
-                (input)="onRecoveryKeyInput()"
-                placeholder="XXXX-XXXX-XXXX-XXXX-..."
-                class="font-mono text-sm uppercase tracking-wide"
-                autocomplete="off"
-                spellcheck="false"
-              />
-              <mat-icon matPrefix>key</mat-icon>
-              @if (
-                form.get('recoveryKey')?.invalid &&
-                form.get('recoveryKey')?.touched
-              ) {
-                <mat-error>
-                  @if (form.get('recoveryKey')?.hasError('required')) {
-                    Ta clé de récupération est nécessaire
-                  } @else if (form.get('recoveryKey')?.hasError('pattern')) {
-                    Format invalide — vérifie que tu as bien copié la clé
-                  }
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Nouveau code PIN</mat-label>
-              <input
-                matInput
-                [type]="isVaultCodeHidden() ? 'password' : 'text'"
-                inputmode="numeric"
-                formControlName="newVaultCode"
-                data-testid="new-vault-code-input"
-                (input)="clearError()"
-                placeholder="Nouveau code PIN"
-              />
-              <mat-icon matPrefix>lock</mat-icon>
-              <button
-                type="button"
-                matIconButton
-                matSuffix
-                (click)="isVaultCodeHidden.set(!isVaultCodeHidden())"
-                [attr.aria-label]="'Afficher le code'"
-                [attr.aria-pressed]="!isVaultCodeHidden()"
-              >
-                <mat-icon>{{
-                  isVaultCodeHidden() ? 'visibility_off' : 'visibility'
-                }}</mat-icon>
-              </button>
-              <mat-hint>4 chiffres minimum (6+ recommandé)</mat-hint>
-              @if (
-                form.get('newVaultCode')?.invalid &&
-                form.get('newVaultCode')?.touched
-              ) {
-                <mat-error>
-                  @if (form.get('newVaultCode')?.hasError('required')) {
-                    Ton nouveau code est nécessaire
-                  } @else if (form.get('newVaultCode')?.hasError('minlength')) {
-                    4 chiffres minimum
-                  } @else if (form.get('newVaultCode')?.hasError('pattern')) {
-                    Le code PIN ne doit contenir que des chiffres
-                  }
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Confirmer le code PIN</mat-label>
-              <input
-                matInput
-                [type]="isConfirmCodeHidden() ? 'password' : 'text'"
-                inputmode="numeric"
-                formControlName="confirmCode"
-                data-testid="confirm-vault-code-input"
-                (input)="clearError()"
-                placeholder="Confirmer le code PIN"
-              />
-              <mat-icon matPrefix>lock</mat-icon>
-              <button
-                type="button"
-                matIconButton
-                matSuffix
-                (click)="isConfirmCodeHidden.set(!isConfirmCodeHidden())"
-                [attr.aria-label]="'Afficher le code'"
-                [attr.aria-pressed]="!isConfirmCodeHidden()"
-              >
-                <mat-icon>{{
-                  isConfirmCodeHidden() ? 'visibility_off' : 'visibility'
-                }}</mat-icon>
-              </button>
-              @if (
-                form.get('confirmCode')?.invalid &&
-                form.get('confirmCode')?.touched
-              ) {
-                <mat-error>
-                  @if (form.get('confirmCode')?.hasError('required')) {
-                    Confirme ton code
-                  } @else if (
-                    form.get('confirmCode')?.hasError('fieldsMismatch')
-                  ) {
-                    Les codes ne correspondent pas
-                  }
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <div class="flex items-center">
-              <mat-checkbox
-                formControlName="rememberDevice"
-                data-testid="remember-device-checkbox"
-              >
-                <span class="text-body-medium text-on-surface">
-                  Ne plus me demander sur cet appareil
-                </span>
-              </mat-checkbox>
-            </div>
-
-            <pulpe-error-alert [message]="errorMessage()" />
-
-            <pulpe-loading-button
-              [loading]="isSubmitting()"
-              [disabled]="!canSubmit()"
-              loadingText="Récupération..."
-              icon="lock_reset"
-              testId="recover-vault-code-submit-button"
-            >
-              <span class="ml-2">Récupérer</span>
-            </pulpe-loading-button>
-          </form>
-        </div>
+            <span class="ml-2">Récupérer</span>
+          </pulpe-loading-button>
+        </form>
       </div>
     }
   `,

--- a/frontend/projects/webapp/src/app/feature/auth/reset-password/reset-password.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/reset-password/reset-password.ts
@@ -22,6 +22,7 @@ import {
 } from '@core/auth';
 import { ROUTES } from '@core/routing/routes-constants';
 import { Logger } from '@core/logging/logger';
+import { AppVersionLabel } from '@ui/app-version-label';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
 import { createFieldsMatchValidator } from '@core/validators';
@@ -36,6 +37,7 @@ import { createFieldsMatchValidator } from '@core/validators';
     MatIconModule,
     MatProgressSpinnerModule,
     RouterLink,
+    AppVersionLabel,
     ErrorAlert,
     LoadingButton,
   ],
@@ -215,6 +217,7 @@ import { createFieldsMatchValidator } from '@core/validators';
           </form>
         }
       </div>
+      <pulpe-app-version-label />
     </div>
   `,
 })

--- a/frontend/projects/webapp/src/app/feature/auth/reset-password/reset-password.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/reset-password/reset-password.ts
@@ -22,7 +22,6 @@ import {
 } from '@core/auth';
 import { ROUTES } from '@core/routing/routes-constants';
 import { Logger } from '@core/logging/logger';
-import { AppVersionLabel } from '@ui/app-version-label';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
 import { createFieldsMatchValidator } from '@core/validators';
@@ -37,187 +36,181 @@ import { createFieldsMatchValidator } from '@core/validators';
     MatIconModule,
     MatProgressSpinnerModule,
     RouterLink,
-    AppVersionLabel,
     ErrorAlert,
     LoadingButton,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="pulpe-entry-shell pulpe-gradient">
-      <div
-        class="pulpe-entry-card w-full max-w-md"
-        data-testid="reset-password-page"
-      >
-        @if (isCheckingSession()) {
-          <div class="flex flex-col items-center gap-4 py-8">
-            <mat-spinner diameter="40" />
-            <p class="text-body-medium text-on-surface-variant">
-              Vérification de ton lien...
-            </p>
-          </div>
-        } @else if (!isSessionValid()) {
-          <div class="text-center space-y-6" data-testid="invalid-link-message">
-            <mat-icon class="text-6xl text-error">link_off</mat-icon>
-            <h1 class="text-2xl font-bold text-on-surface">
-              Lien invalide ou expiré
-            </h1>
-            <p class="text-body-medium text-on-surface-variant">
-              Ce lien de réinitialisation n'est plus valide. Demande-en un
-              nouveau.
-            </p>
-            <a
-              [routerLink]="['/', ROUTES.FORGOT_PASSWORD]"
-              mat-flat-button
-              color="primary"
-              class="w-full"
-              data-testid="back-to-forgot-password-button"
-            >
-              Demander un nouveau lien
-            </a>
-          </div>
-        } @else if (isOAuthOnly()) {
-          <div class="text-center space-y-6" data-testid="oauth-user-blocked">
-            <mat-icon class="text-6xl text-error">block</mat-icon>
-            <h1 class="text-2xl font-bold text-on-surface">
-              Réinitialisation non disponible
-            </h1>
-            <p class="text-body-medium text-on-surface-variant">
-              Ton compte utilise une connexion via un fournisseur externe
-              (Google, Apple...). Tu ne peux pas définir de mot de passe.
-            </p>
-            <a
-              [routerLink]="['/', ROUTES.LOGIN]"
-              matButton="filled"
-              color="primary"
-              class="w-full"
-              data-testid="back-to-login-button"
-            >
-              Retour à la connexion
-            </a>
-          </div>
-        } @else {
-          <button
-            matButton
+    <div
+      class="pulpe-entry-card w-full max-w-md"
+      data-testid="reset-password-page"
+    >
+      @if (isCheckingSession()) {
+        <div class="flex flex-col items-center gap-4 py-8">
+          <mat-spinner diameter="40" />
+          <p class="text-body-medium text-on-surface-variant">
+            Vérification de ton lien...
+          </p>
+        </div>
+      } @else if (!isSessionValid()) {
+        <div class="text-center space-y-6" data-testid="invalid-link-message">
+          <mat-icon class="text-6xl text-error">link_off</mat-icon>
+          <h1 class="text-2xl font-bold text-on-surface">
+            Lien invalide ou expiré
+          </h1>
+          <p class="text-body-medium text-on-surface-variant">
+            Ce lien de réinitialisation n'est plus valide. Demande-en un
+            nouveau.
+          </p>
+          <a
+            [routerLink]="['/', ROUTES.FORGOT_PASSWORD]"
+            matButton="filled"
+            color="primary"
+            class="w-full"
+            data-testid="back-to-forgot-password-button"
+          >
+            Demander un nouveau lien
+          </a>
+        </div>
+      } @else if (isOAuthOnly()) {
+        <div class="text-center space-y-6" data-testid="oauth-user-blocked">
+          <mat-icon class="text-6xl text-error">block</mat-icon>
+          <h1 class="text-2xl font-bold text-on-surface">
+            Réinitialisation non disponible
+          </h1>
+          <p class="text-body-medium text-on-surface-variant">
+            Ton compte utilise une connexion via un fournisseur externe (Google,
+            Apple...). Tu ne peux pas définir de mot de passe.
+          </p>
+          <a
             [routerLink]="['/', ROUTES.LOGIN]"
-            class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+            matButton="filled"
+            color="primary"
+            class="w-full"
+            data-testid="back-to-login-button"
           >
-            <mat-icon class="text-lg">arrow_back</mat-icon>
-            <span>Retour à la connexion</span>
-          </button>
+            Retour à la connexion
+          </a>
+        </div>
+      } @else {
+        <button
+          matButton
+          [routerLink]="['/', ROUTES.LOGIN]"
+          class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+        >
+          <mat-icon class="text-lg">arrow_back</mat-icon>
+          <span>Retour à la connexion</span>
+        </button>
 
-          <div class="text-center mb-8 mt-4">
-            <h1
-              class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
-            >
-              Réinitialiser le mot de passe
-            </h1>
-            <p class="text-body-large text-on-surface-variant">
-              Entre ton nouveau mot de passe
-            </p>
-          </div>
-
-          <form
-            [formGroup]="form"
-            (ngSubmit)="onSubmit()"
-            class="space-y-4"
-            data-testid="reset-password-form"
+        <div class="text-center mb-8 mt-4">
+          <h1
+            class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
           >
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Nouveau mot de passe</mat-label>
-              <input
-                matInput
-                [type]="isPasswordHidden() ? 'password' : 'text'"
-                formControlName="newPassword"
-                data-testid="new-password-input"
-                (input)="clearError()"
-                placeholder="Nouveau mot de passe"
-                [disabled]="isSubmitting()"
-              />
-              <mat-icon matPrefix>lock</mat-icon>
-              <button
-                type="button"
-                matIconButton
-                matSuffix
-                (click)="isPasswordHidden.set(!isPasswordHidden())"
-                [attr.aria-label]="'Afficher le mot de passe'"
-                [attr.aria-pressed]="!isPasswordHidden()"
-              >
-                <mat-icon>{{
-                  isPasswordHidden() ? 'visibility_off' : 'visibility'
-                }}</mat-icon>
-              </button>
-              <mat-hint>8 caractères minimum</mat-hint>
-              @if (
-                form.get('newPassword')?.invalid &&
-                form.get('newPassword')?.touched
-              ) {
-                <mat-error>
-                  @if (form.get('newPassword')?.hasError('required')) {
-                    Ton nouveau mot de passe est nécessaire
-                  } @else if (form.get('newPassword')?.hasError('minlength')) {
-                    8 caractères minimum
-                  }
-                </mat-error>
-              }
-            </mat-form-field>
+            Réinitialiser le mot de passe
+          </h1>
+          <p class="text-body-large text-on-surface-variant">
+            Entre ton nouveau mot de passe
+          </p>
+        </div>
 
-            <mat-form-field appearance="outline" class="w-full">
-              <mat-label>Confirmer le mot de passe</mat-label>
-              <input
-                matInput
-                [type]="isConfirmPasswordHidden() ? 'password' : 'text'"
-                formControlName="confirmPassword"
-                data-testid="confirm-password-input"
-                (input)="clearError()"
-                placeholder="Confirmer le mot de passe"
-                [disabled]="isSubmitting()"
-              />
-              <mat-icon matPrefix>lock</mat-icon>
-              <button
-                type="button"
-                matIconButton
-                matSuffix
-                (click)="
-                  isConfirmPasswordHidden.set(!isConfirmPasswordHidden())
-                "
-                [attr.aria-label]="'Afficher le mot de passe'"
-                [attr.aria-pressed]="!isConfirmPasswordHidden()"
-              >
-                <mat-icon>{{
-                  isConfirmPasswordHidden() ? 'visibility_off' : 'visibility'
-                }}</mat-icon>
-              </button>
-              @if (
-                form.get('confirmPassword')?.invalid &&
-                form.get('confirmPassword')?.touched
-              ) {
-                <mat-error>
-                  @if (form.get('confirmPassword')?.hasError('required')) {
-                    Confirme ton mot de passe
-                  } @else if (
-                    form.get('confirmPassword')?.hasError('passwordsMismatch')
-                  ) {
-                    Les mots de passe ne correspondent pas
-                  }
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <pulpe-error-alert [message]="errorMessage()" />
-
-            <pulpe-loading-button
-              [loading]="isSubmitting()"
-              [disabled]="!canSubmit()"
-              loadingText="Réinitialisation..."
-              icon="lock_reset"
-              testId="reset-password-submit-button"
+        <form
+          [formGroup]="form"
+          (ngSubmit)="onSubmit()"
+          class="space-y-4"
+          data-testid="reset-password-form"
+        >
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Nouveau mot de passe</mat-label>
+            <input
+              matInput
+              [type]="isPasswordHidden() ? 'password' : 'text'"
+              formControlName="newPassword"
+              data-testid="new-password-input"
+              (input)="clearError()"
+              placeholder="Nouveau mot de passe"
+              [disabled]="isSubmitting()"
+            />
+            <mat-icon matPrefix>lock</mat-icon>
+            <button
+              type="button"
+              matIconButton
+              matSuffix
+              (click)="isPasswordHidden.set(!isPasswordHidden())"
+              [attr.aria-label]="'Afficher le mot de passe'"
+              [attr.aria-pressed]="!isPasswordHidden()"
             >
-              <span class="ml-2">Réinitialiser le mot de passe</span>
-            </pulpe-loading-button>
-          </form>
-        }
-      </div>
-      <pulpe-app-version-label />
+              <mat-icon>{{
+                isPasswordHidden() ? 'visibility_off' : 'visibility'
+              }}</mat-icon>
+            </button>
+            <mat-hint>8 caractères minimum</mat-hint>
+            @if (
+              form.get('newPassword')?.invalid &&
+              form.get('newPassword')?.touched
+            ) {
+              <mat-error>
+                @if (form.get('newPassword')?.hasError('required')) {
+                  Ton nouveau mot de passe est nécessaire
+                } @else if (form.get('newPassword')?.hasError('minlength')) {
+                  8 caractères minimum
+                }
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Confirmer le mot de passe</mat-label>
+            <input
+              matInput
+              [type]="isConfirmPasswordHidden() ? 'password' : 'text'"
+              formControlName="confirmPassword"
+              data-testid="confirm-password-input"
+              (input)="clearError()"
+              placeholder="Confirmer le mot de passe"
+              [disabled]="isSubmitting()"
+            />
+            <mat-icon matPrefix>lock</mat-icon>
+            <button
+              type="button"
+              matIconButton
+              matSuffix
+              (click)="isConfirmPasswordHidden.set(!isConfirmPasswordHidden())"
+              [attr.aria-label]="'Afficher le mot de passe'"
+              [attr.aria-pressed]="!isConfirmPasswordHidden()"
+            >
+              <mat-icon>{{
+                isConfirmPasswordHidden() ? 'visibility_off' : 'visibility'
+              }}</mat-icon>
+            </button>
+            @if (
+              form.get('confirmPassword')?.invalid &&
+              form.get('confirmPassword')?.touched
+            ) {
+              <mat-error>
+                @if (form.get('confirmPassword')?.hasError('required')) {
+                  Confirme ton mot de passe
+                } @else if (
+                  form.get('confirmPassword')?.hasError('passwordsMismatch')
+                ) {
+                  Les mots de passe ne correspondent pas
+                }
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <pulpe-error-alert [message]="errorMessage()" />
+
+          <pulpe-loading-button
+            [loading]="isSubmitting()"
+            [disabled]="!canSubmit()"
+            loadingText="Réinitialisation..."
+            icon="lock_reset"
+            testId="reset-password-submit-button"
+          >
+            <span class="ml-2">Réinitialiser le mot de passe</span>
+          </pulpe-loading-button>
+        </form>
+      }
     </div>
   `,
 })

--- a/frontend/projects/webapp/src/app/feature/auth/setup-vault-code/setup-vault-code.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/setup-vault-code/setup-vault-code.ts
@@ -48,149 +48,142 @@ import { PostHogService } from '@core/analytics';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="pulpe-entry-shell pulpe-gradient">
-      <div
-        class="pulpe-entry-card w-full max-w-md"
-        data-testid="setup-vault-code-page"
-      >
-        <div class="text-center mb-8">
-          <mat-icon class="text-6xl! w-auto! h-auto! text-primary"
-            >lock</mat-icon
-          >
-          <h1
-            class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
-          >
-            Crée ton code PIN
-          </h1>
-          <p class="text-body-large text-on-surface-variant">
-            Ce code protège tes données chiffrées. Garde-le précieusement :
-            personne d'autre ne peut y accéder à ta place, et on ne pourra pas
-            le retrouver si tu l'oublies.
-          </p>
-        </div>
-
-        <form
-          [formGroup]="form"
-          (ngSubmit)="onSubmit()"
-          class="space-y-4"
-          data-testid="setup-vault-code-form"
+    <div
+      class="pulpe-entry-card w-full max-w-md"
+      data-testid="setup-vault-code-page"
+    >
+      <div class="text-center mb-8">
+        <mat-icon class="text-6xl! w-auto! h-auto! text-primary">lock</mat-icon>
+        <h1
+          class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
         >
-          <mat-form-field appearance="outline" class="w-full">
-            <mat-label>Ton code PIN</mat-label>
-            <input
-              matInput
-              [type]="isCodeHidden() ? 'password' : 'text'"
-              inputmode="numeric"
-              formControlName="vaultCode"
-              data-testid="vault-code-input"
-              (input)="clearError()"
-              placeholder="Ton code PIN"
-            />
-            <mat-icon matPrefix>lock</mat-icon>
-            <button
-              type="button"
-              matIconButton
-              matSuffix
-              (click)="isCodeHidden.set(!isCodeHidden())"
-              [attr.aria-label]="'Afficher le code PIN'"
-              [attr.aria-pressed]="!isCodeHidden()"
-            >
-              <mat-icon>{{
-                isCodeHidden() ? 'visibility_off' : 'visibility'
-              }}</mat-icon>
-            </button>
-            <mat-hint>4 chiffres minimum (6+ recommandé)</mat-hint>
-            @if (
-              form.get('vaultCode')?.invalid && form.get('vaultCode')?.touched
-            ) {
-              <mat-error>
-                @if (form.get('vaultCode')?.hasError('required')) {
-                  Ton code PIN est nécessaire
-                } @else if (form.get('vaultCode')?.hasError('minlength')) {
-                  4 chiffres minimum
-                } @else if (form.get('vaultCode')?.hasError('pattern')) {
-                  Le code PIN ne doit contenir que des chiffres
-                }
-              </mat-error>
-            }
-          </mat-form-field>
+          Crée ton code PIN
+        </h1>
+        <p class="text-body-large text-on-surface-variant">
+          Ce code protège tes données chiffrées. Garde-le précieusement :
+          personne d'autre ne peut y accéder à ta place, et on ne pourra pas le
+          retrouver si tu l'oublies.
+        </p>
+      </div>
 
-          <mat-form-field appearance="outline" class="w-full mt-4">
-            <mat-label>Confirmer le code</mat-label>
-            <input
-              matInput
-              [type]="isConfirmCodeHidden() ? 'password' : 'text'"
-              inputmode="numeric"
-              formControlName="confirmCode"
-              data-testid="confirm-vault-code-input"
-              (input)="clearError()"
-              placeholder="Confirme ton code"
-            />
-            <mat-icon matPrefix>lock</mat-icon>
-            <button
-              type="button"
-              matIconButton
-              matSuffix
-              (click)="isConfirmCodeHidden.set(!isConfirmCodeHidden())"
-              [attr.aria-label]="'Afficher le code'"
-              [attr.aria-pressed]="!isConfirmCodeHidden()"
-            >
-              <mat-icon>{{
-                isConfirmCodeHidden() ? 'visibility_off' : 'visibility'
-              }}</mat-icon>
-            </button>
-            @if (
-              form.get('confirmCode')?.invalid &&
-              form.get('confirmCode')?.touched
-            ) {
-              <mat-error>
-                @if (form.get('confirmCode')?.hasError('required')) {
-                  Confirme ton code
-                } @else if (
-                  form.get('confirmCode')?.hasError('fieldsMismatch')
-                ) {
-                  Les deux codes ne sont pas identiques — réessaie
-                }
-              </mat-error>
-            }
-          </mat-form-field>
-
-          <div class="flex items-center">
-            <mat-checkbox
-              formControlName="rememberDevice"
-              data-testid="remember-device-checkbox"
-            >
-              <span class="text-body-medium text-on-surface">
-                Ne plus me demander sur cet appareil
-              </span>
-            </mat-checkbox>
-          </div>
-
-          <pulpe-error-alert [message]="errorMessage()" />
-
-          <pulpe-loading-button
-            [loading]="isSubmitting()"
-            [disabled]="!canSubmit()"
-            loadingText="On prépare ton espace..."
-            icon="arrow_forward"
-            testId="setup-vault-code-submit-button"
-          >
-            <span class="ml-2">Créer mon code PIN</span>
-          </pulpe-loading-button>
-        </form>
-
-        <div class="text-center mt-4 pt-4 border-t border-outline-variant">
+      <form
+        [formGroup]="form"
+        (ngSubmit)="onSubmit()"
+        class="space-y-4"
+        data-testid="setup-vault-code-form"
+      >
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Ton code PIN</mat-label>
+          <input
+            matInput
+            [type]="isCodeHidden() ? 'password' : 'text'"
+            inputmode="numeric"
+            formControlName="vaultCode"
+            data-testid="vault-code-input"
+            (input)="clearError()"
+            placeholder="Ton code PIN"
+          />
+          <mat-icon matPrefix>lock</mat-icon>
           <button
-            matButton
             type="button"
-            (click)="onLogout()"
-            [disabled]="isLoggingOut()"
-            data-testid="setup-vault-code-logout-button"
+            matIconButton
+            matSuffix
+            (click)="isCodeHidden.set(!isCodeHidden())"
+            [attr.aria-label]="'Afficher le code PIN'"
+            [attr.aria-pressed]="!isCodeHidden()"
           >
-            <mat-icon>logout</mat-icon>
-            Se déconnecter
+            <mat-icon>{{
+              isCodeHidden() ? 'visibility_off' : 'visibility'
+            }}</mat-icon>
           </button>
+          <mat-hint>4 chiffres minimum (6+ recommandé)</mat-hint>
+          @if (
+            form.get('vaultCode')?.invalid && form.get('vaultCode')?.touched
+          ) {
+            <mat-error>
+              @if (form.get('vaultCode')?.hasError('required')) {
+                Ton code PIN est nécessaire
+              } @else if (form.get('vaultCode')?.hasError('minlength')) {
+                4 chiffres minimum
+              } @else if (form.get('vaultCode')?.hasError('pattern')) {
+                Le code PIN ne doit contenir que des chiffres
+              }
+            </mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="w-full mt-4">
+          <mat-label>Confirmer le code</mat-label>
+          <input
+            matInput
+            [type]="isConfirmCodeHidden() ? 'password' : 'text'"
+            inputmode="numeric"
+            formControlName="confirmCode"
+            data-testid="confirm-vault-code-input"
+            (input)="clearError()"
+            placeholder="Confirme ton code"
+          />
+          <mat-icon matPrefix>lock</mat-icon>
+          <button
+            type="button"
+            matIconButton
+            matSuffix
+            (click)="isConfirmCodeHidden.set(!isConfirmCodeHidden())"
+            [attr.aria-label]="'Afficher le code'"
+            [attr.aria-pressed]="!isConfirmCodeHidden()"
+          >
+            <mat-icon>{{
+              isConfirmCodeHidden() ? 'visibility_off' : 'visibility'
+            }}</mat-icon>
+          </button>
+          @if (
+            form.get('confirmCode')?.invalid && form.get('confirmCode')?.touched
+          ) {
+            <mat-error>
+              @if (form.get('confirmCode')?.hasError('required')) {
+                Confirme ton code
+              } @else if (form.get('confirmCode')?.hasError('fieldsMismatch')) {
+                Les deux codes ne sont pas identiques — réessaie
+              }
+            </mat-error>
+          }
+        </mat-form-field>
+
+        <div class="flex items-center">
+          <mat-checkbox
+            formControlName="rememberDevice"
+            data-testid="remember-device-checkbox"
+          >
+            <span class="text-body-medium text-on-surface">
+              Ne plus me demander sur cet appareil
+            </span>
+          </mat-checkbox>
         </div>
+
+        <pulpe-error-alert [message]="errorMessage()" />
+
+        <pulpe-loading-button
+          [loading]="isSubmitting()"
+          [disabled]="!canSubmit()"
+          loadingText="On prépare ton espace..."
+          icon="arrow_forward"
+          testId="setup-vault-code-submit-button"
+        >
+          <span class="ml-2">Créer mon code PIN</span>
+        </pulpe-loading-button>
+      </form>
+
+      <div class="text-center mt-4 pt-4 border-t border-outline-variant">
+        <button
+          matButton
+          type="button"
+          (click)="onLogout()"
+          [disabled]="isLoggingOut()"
+          data-testid="setup-vault-code-logout-button"
+        >
+          <mat-icon>logout</mat-icon>
+          Se déconnecter
+        </button>
       </div>
     </div>
   `,

--- a/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
@@ -22,7 +22,6 @@ import { ROUTES } from '@core/routing/routes-constants';
 import { GoogleOAuthButton } from '@app/pattern/google-oauth';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
-import { AppVersionLabel } from '@ui/app-version-label';
 import { createFieldsMatchValidator } from '@core/validators';
 
 @Component({
@@ -39,223 +38,216 @@ import { createFieldsMatchValidator } from '@core/validators';
     GoogleOAuthButton,
     ErrorAlert,
     LoadingButton,
-    AppVersionLabel,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="pulpe-entry-shell pulpe-gradient">
-      <div class="pulpe-entry-card w-full max-w-md">
-        <button
-          matButton
-          [routerLink]="['/', ROUTES.WELCOME]"
-          class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+    <div class="pulpe-entry-card w-full max-w-md">
+      <button
+        matButton
+        [routerLink]="['/', ROUTES.WELCOME]"
+        class="flex items-center gap-1 text-body-medium text-on-surface-variant hover:text-primary self-start"
+      >
+        <mat-icon class="text-lg">arrow_back</mat-icon>
+        <span>Retour à l'accueil</span>
+      </button>
+
+      <div class="text-center mb-8 mt-4">
+        <h1
+          class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
         >
-          <mat-icon class="text-lg">arrow_back</mat-icon>
-          <span>Retour à l'accueil</span>
-        </button>
-
-        <div class="text-center mb-8 mt-4">
-          <h1
-            class="text-headline-large md:text-display-small font-bold text-on-surface mb-2 leading-tight"
-          >
-            Prêt en 3 minutes
-          </h1>
-          <p class="text-body-large text-on-surface-variant">
-            Crée ton espace et vois clair dans tes finances
-          </p>
-        </div>
-
-        <form
-          [formGroup]="signupForm"
-          (ngSubmit)="signUp()"
-          class="space-y-4"
-          data-testid="signup-form"
-        >
-          <mat-form-field appearance="outline" class="w-full">
-            <mat-label>Email</mat-label>
-            <input
-              matInput
-              type="email"
-              formControlName="email"
-              data-testid="email-input"
-              (input)="clearMessages()"
-              placeholder="ton@email.com"
-              [disabled]="isSubmitting()"
-            />
-            <mat-icon matPrefix>email</mat-icon>
-            @if (
-              signupForm.get('email')?.invalid &&
-              signupForm.get('email')?.touched
-            ) {
-              <mat-error>
-                @if (signupForm.get('email')?.hasError('required')) {
-                  Ton email est nécessaire pour continuer
-                } @else if (signupForm.get('email')?.hasError('email')) {
-                  Cette adresse email ne semble pas valide
-                }
-              </mat-error>
-            }
-          </mat-form-field>
-
-          <mat-form-field appearance="outline" class="w-full">
-            <mat-label>Mot de passe</mat-label>
-            <input
-              matInput
-              [type]="isPasswordHidden() ? 'password' : 'text'"
-              formControlName="password"
-              data-testid="password-input"
-              (input)="clearMessages()"
-              placeholder="Mot de passe"
-              [disabled]="isSubmitting()"
-            />
-            <mat-icon matPrefix>lock</mat-icon>
-            <button
-              type="button"
-              matIconButton
-              matSuffix
-              (click)="togglePasswordVisibility()"
-              [attr.aria-label]="'Afficher le mot de passe'"
-              [attr.aria-pressed]="!isPasswordHidden()"
-            >
-              <mat-icon>{{
-                isPasswordHidden() ? 'visibility_off' : 'visibility'
-              }}</mat-icon>
-            </button>
-            <mat-hint>8 caractères minimum pour sécuriser ton compte</mat-hint>
-            @if (
-              signupForm.get('password')?.invalid &&
-              signupForm.get('password')?.touched
-            ) {
-              <mat-error>
-                @if (signupForm.get('password')?.hasError('required')) {
-                  Ton mot de passe est nécessaire
-                } @else if (signupForm.get('password')?.hasError('minlength')) {
-                  8 caractères minimum
-                }
-              </mat-error>
-            }
-          </mat-form-field>
-
-          <mat-form-field appearance="outline" class="w-full">
-            <mat-label>Confirmer le mot de passe</mat-label>
-            <input
-              matInput
-              [type]="isConfirmPasswordHidden() ? 'password' : 'text'"
-              formControlName="confirmPassword"
-              data-testid="confirm-password-input"
-              (input)="clearMessages()"
-              placeholder="Confirmer le mot de passe"
-              [disabled]="isSubmitting()"
-            />
-            <mat-icon matPrefix>lock</mat-icon>
-            <button
-              type="button"
-              matIconButton
-              matSuffix
-              (click)="toggleConfirmPasswordVisibility()"
-              [attr.aria-label]="'Afficher le mot de passe'"
-              [attr.aria-pressed]="!isConfirmPasswordHidden()"
-            >
-              <mat-icon>{{
-                isConfirmPasswordHidden() ? 'visibility_off' : 'visibility'
-              }}</mat-icon>
-            </button>
-            @if (
-              signupForm.get('confirmPassword')?.invalid &&
-              signupForm.get('confirmPassword')?.touched
-            ) {
-              <mat-error>
-                @if (signupForm.get('confirmPassword')?.hasError('required')) {
-                  Confirme ton mot de passe
-                } @else if (
-                  signupForm
-                    .get('confirmPassword')
-                    ?.hasError('passwordsMismatch')
-                ) {
-                  Les mots de passe ne correspondent pas
-                }
-              </mat-error>
-            }
-          </mat-form-field>
-
-          <div class="pt-2">
-            <mat-checkbox
-              formControlName="acceptTerms"
-              [disabled]="isSubmitting()"
-              data-testid="accept-terms-checkbox"
-            >
-              <span class="text-body-medium">
-                J'accepte les
-                <a
-                  [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_TERMS]"
-                  target="_blank"
-                  class="text-primary underline"
-                  (click)="$event.stopPropagation()"
-                >
-                  Conditions d'Utilisation
-                </a>
-                et la
-                <a
-                  [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_PRIVACY]"
-                  target="_blank"
-                  class="text-primary underline"
-                  (click)="$event.stopPropagation()"
-                >
-                  Politique de Confidentialité
-                </a>
-              </span>
-            </mat-checkbox>
-            @if (
-              signupForm.get('acceptTerms')?.invalid &&
-              signupForm.get('acceptTerms')?.touched
-            ) {
-              <p class="text-error text-body-small mt-1">
-                Accepte les conditions pour continuer
-              </p>
-            }
-          </div>
-
-          <pulpe-error-alert [message]="errorMessage()" />
-
-          <pulpe-loading-button
-            [loading]="isSubmitting()"
-            [disabled]="!canSubmit()"
-            loadingText="Création en cours..."
-            icon="person_add"
-            testId="signup-submit-button"
-            class="mt-4"
-          >
-            <span class="ml-2">Créer mon compte</span>
-          </pulpe-loading-button>
-        </form>
-
-        <div class="flex items-center gap-4 my-6">
-          <mat-divider class="flex-1" />
-          <span class="text-body-medium text-on-surface-variant">ou</span>
-          <mat-divider class="flex-1" />
-        </div>
-
-        <pulpe-google-oauth-button
-          testId="google-signup-button"
-          (authError)="errorMessage.set($event)"
-          (loadingChange)="isSubmitting.set($event)"
-        />
-
-        <div class="text-center mt-6">
-          <p class="text-body-medium text-on-surface-variant">
-            Déjà un compte ?
-            <button
-              matButton
-              color="primary"
-              class="ml-1"
-              [routerLink]="['/', ROUTES.LOGIN]"
-            >
-              Se connecter
-            </button>
-          </p>
-        </div>
+          Prêt en 3 minutes
+        </h1>
+        <p class="text-body-large text-on-surface-variant">
+          Crée ton espace et vois clair dans tes finances
+        </p>
       </div>
-      <pulpe-app-version-label />
+
+      <form
+        [formGroup]="signupForm"
+        (ngSubmit)="signUp()"
+        class="space-y-4"
+        data-testid="signup-form"
+      >
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Email</mat-label>
+          <input
+            matInput
+            type="email"
+            formControlName="email"
+            data-testid="email-input"
+            (input)="clearMessages()"
+            placeholder="ton@email.com"
+            [disabled]="isSubmitting()"
+          />
+          <mat-icon matPrefix>email</mat-icon>
+          @if (
+            signupForm.get('email')?.invalid && signupForm.get('email')?.touched
+          ) {
+            <mat-error>
+              @if (signupForm.get('email')?.hasError('required')) {
+                Ton email est nécessaire pour continuer
+              } @else if (signupForm.get('email')?.hasError('email')) {
+                Cette adresse email ne semble pas valide
+              }
+            </mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Mot de passe</mat-label>
+          <input
+            matInput
+            [type]="isPasswordHidden() ? 'password' : 'text'"
+            formControlName="password"
+            data-testid="password-input"
+            (input)="clearMessages()"
+            placeholder="Mot de passe"
+            [disabled]="isSubmitting()"
+          />
+          <mat-icon matPrefix>lock</mat-icon>
+          <button
+            type="button"
+            matIconButton
+            matSuffix
+            (click)="togglePasswordVisibility()"
+            [attr.aria-label]="'Afficher le mot de passe'"
+            [attr.aria-pressed]="!isPasswordHidden()"
+          >
+            <mat-icon>{{
+              isPasswordHidden() ? 'visibility_off' : 'visibility'
+            }}</mat-icon>
+          </button>
+          <mat-hint>8 caractères minimum pour sécuriser ton compte</mat-hint>
+          @if (
+            signupForm.get('password')?.invalid &&
+            signupForm.get('password')?.touched
+          ) {
+            <mat-error>
+              @if (signupForm.get('password')?.hasError('required')) {
+                Ton mot de passe est nécessaire
+              } @else if (signupForm.get('password')?.hasError('minlength')) {
+                8 caractères minimum
+              }
+            </mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Confirmer le mot de passe</mat-label>
+          <input
+            matInput
+            [type]="isConfirmPasswordHidden() ? 'password' : 'text'"
+            formControlName="confirmPassword"
+            data-testid="confirm-password-input"
+            (input)="clearMessages()"
+            placeholder="Confirmer le mot de passe"
+            [disabled]="isSubmitting()"
+          />
+          <mat-icon matPrefix>lock</mat-icon>
+          <button
+            type="button"
+            matIconButton
+            matSuffix
+            (click)="toggleConfirmPasswordVisibility()"
+            [attr.aria-label]="'Afficher le mot de passe'"
+            [attr.aria-pressed]="!isConfirmPasswordHidden()"
+          >
+            <mat-icon>{{
+              isConfirmPasswordHidden() ? 'visibility_off' : 'visibility'
+            }}</mat-icon>
+          </button>
+          @if (
+            signupForm.get('confirmPassword')?.invalid &&
+            signupForm.get('confirmPassword')?.touched
+          ) {
+            <mat-error>
+              @if (signupForm.get('confirmPassword')?.hasError('required')) {
+                Confirme ton mot de passe
+              } @else if (
+                signupForm.get('confirmPassword')?.hasError('passwordsMismatch')
+              ) {
+                Les mots de passe ne correspondent pas
+              }
+            </mat-error>
+          }
+        </mat-form-field>
+
+        <div class="pt-2">
+          <mat-checkbox
+            formControlName="acceptTerms"
+            [disabled]="isSubmitting()"
+            data-testid="accept-terms-checkbox"
+          >
+            <span class="text-body-medium">
+              J'accepte les
+              <a
+                [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_TERMS]"
+                target="_blank"
+                class="text-primary underline"
+                (click)="$event.stopPropagation()"
+              >
+                Conditions d'Utilisation
+              </a>
+              et la
+              <a
+                [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_PRIVACY]"
+                target="_blank"
+                class="text-primary underline"
+                (click)="$event.stopPropagation()"
+              >
+                Politique de Confidentialité
+              </a>
+            </span>
+          </mat-checkbox>
+          @if (
+            signupForm.get('acceptTerms')?.invalid &&
+            signupForm.get('acceptTerms')?.touched
+          ) {
+            <p class="text-error text-body-small mt-1">
+              Accepte les conditions pour continuer
+            </p>
+          }
+        </div>
+
+        <pulpe-error-alert [message]="errorMessage()" />
+
+        <pulpe-loading-button
+          [loading]="isSubmitting()"
+          [disabled]="!canSubmit()"
+          loadingText="Création en cours..."
+          icon="person_add"
+          testId="signup-submit-button"
+          class="mt-4"
+        >
+          <span class="ml-2">Créer mon compte</span>
+        </pulpe-loading-button>
+      </form>
+
+      <div class="flex items-center gap-4 my-6">
+        <mat-divider class="flex-1" />
+        <span class="text-body-medium text-on-surface-variant">ou</span>
+        <mat-divider class="flex-1" />
+      </div>
+
+      <pulpe-google-oauth-button
+        testId="google-signup-button"
+        (authError)="errorMessage.set($event)"
+        (loadingChange)="isSubmitting.set($event)"
+      />
+
+      <div class="text-center mt-6">
+        <p class="text-body-medium text-on-surface-variant">
+          Déjà un compte ?
+          <button
+            matButton
+            color="primary"
+            class="ml-1"
+            [routerLink]="['/', ROUTES.LOGIN]"
+          >
+            Se connecter
+          </button>
+        </p>
+      </div>
     </div>
   `,
 })
@@ -268,12 +260,12 @@ export default class Signup {
 
   protected readonly ROUTES = ROUTES;
 
-  protected isPasswordHidden = signal<boolean>(true);
-  protected isConfirmPasswordHidden = signal<boolean>(true);
-  protected isSubmitting = signal<boolean>(false);
-  protected errorMessage = signal<string>('');
+  protected readonly isPasswordHidden = signal(true);
+  protected readonly isConfirmPasswordHidden = signal(true);
+  protected readonly isSubmitting = signal(false);
+  protected readonly errorMessage = signal('');
 
-  protected signupForm = this.#formBuilder.nonNullable.group(
+  protected readonly signupForm = this.#formBuilder.nonNullable.group(
     {
       email: ['', [Validators.required, Validators.email]],
       password: [
@@ -292,14 +284,12 @@ export default class Signup {
     },
   );
 
-  protected readonly formStatus = toSignal(this.signupForm.statusChanges, {
+  readonly #formStatus = toSignal(this.signupForm.statusChanges, {
     initialValue: this.signupForm.status,
   });
 
   protected readonly canSubmit = computed(() => {
-    const isValid = this.formStatus() === 'VALID';
-    const isNotSubmitting = !this.isSubmitting();
-    return isValid && isNotSubmitting;
+    return this.#formStatus() === 'VALID' && !this.isSubmitting();
   });
 
   protected togglePasswordVisibility(): void {

--- a/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
@@ -22,6 +22,7 @@ import { ROUTES } from '@core/routing/routes-constants';
 import { GoogleOAuthButton } from '@app/pattern/google-oauth';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
+import { AppVersionLabel } from '@ui/app-version-label';
 import { createFieldsMatchValidator } from '@core/validators';
 
 @Component({
@@ -38,6 +39,7 @@ import { createFieldsMatchValidator } from '@core/validators';
     GoogleOAuthButton,
     ErrorAlert,
     LoadingButton,
+    AppVersionLabel,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -253,6 +255,7 @@ import { createFieldsMatchValidator } from '@core/validators';
           </p>
         </div>
       </div>
+      <pulpe-app-version-label />
     </div>
   `,
 })

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-history-chart.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-history-chart.spec.ts
@@ -72,7 +72,9 @@ describe('DashboardHistoryChart', () => {
 
   it('should display empty message when no data is provided', () => {
     fixture.detectChanges();
-    expect(fixture.nativeElement.textContent).toContain('Pas assez de données');
+    expect(fixture.nativeElement.textContent).toContain(
+      "Pas encore d'historique",
+    );
   });
 
   it('should report hasData false when history is empty', () => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-savings-summary.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-savings-summary.spec.ts
@@ -161,7 +161,7 @@ describe('DashboardSavingsSummary', () => {
     });
 
     it('should show check_circle icon', () => {
-      const icon = fixture.debugElement.query(By.css('.large-icon'));
+      const icon = fixture.debugElement.query(By.css('mat-icon.scale-150'));
       expect(icon).toBeTruthy();
       expect(icon.nativeElement.textContent.trim()).toBe('check_circle');
     });

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
@@ -17,6 +17,7 @@ import { ROUTES } from '@core/routing';
 import { TurnstileService } from '@core/turnstile';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
+import { AppVersionLabel } from '@ui/app-version-label';
 import { LottieComponent, type AnimationOptions } from 'ngx-lottie';
 import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
 
@@ -31,6 +32,7 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
     GoogleOAuthButton,
     ErrorAlert,
     LoadingButton,
+    AppVersionLabel,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -199,6 +201,7 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
           </button>
         </p>
       </div>
+      <pulpe-app-version-label />
     </div>
   `,
 })

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
@@ -17,7 +17,6 @@ import { ROUTES } from '@core/routing';
 import { TurnstileService } from '@core/turnstile';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
-import { AppVersionLabel } from '@ui/app-version-label';
 import { LottieComponent, type AnimationOptions } from 'ngx-lottie';
 import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
 
@@ -32,176 +31,172 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
     GoogleOAuthButton,
     ErrorAlert,
     LoadingButton,
-    AppVersionLabel,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="pulpe-entry-shell pulpe-gradient">
-      <div
-        class="pulpe-entry-card w-full max-w-lg items-center"
-        data-testid="welcome-page"
+    <div
+      class="pulpe-entry-card w-full max-w-lg items-center"
+      data-testid="welcome-page"
+    >
+      <!-- Branding -->
+      <img src="/logo.svg" alt="Pulpe" class="h-14 md:h-16 mb-6" />
+
+      <!-- Eyebrow -->
+      <p
+        class="text-xs font-semibold tracking-widest uppercase text-primary mb-3"
       >
-        <!-- Branding -->
-        <img src="/logo.svg" alt="Pulpe" class="h-14 md:h-16 mb-6" />
+        Budget annuel en 3 minutes
+      </p>
 
-        <!-- Eyebrow -->
-        <p
-          class="text-xs font-semibold tracking-widest uppercase text-primary mb-3"
-        >
-          Budget annuel en 3 minutes
-        </p>
+      <!-- Title -->
+      <h1
+        class="text-headline-large md:text-display-small font-bold text-on-surface leading-tight text-center mb-2"
+        data-testid="welcome-title"
+      >
+        Vois clair dans tes finances
+      </h1>
 
-        <!-- Title -->
-        <h1
-          class="text-headline-large md:text-display-small font-bold text-on-surface leading-tight text-center mb-2"
-          data-testid="welcome-title"
-        >
-          Vois clair dans tes finances
-        </h1>
+      <!-- Subtitle -->
+      <p
+        class="text-body-large text-on-surface-variant text-center leading-relaxed mb-4"
+        data-testid="welcome-subtitle"
+      >
+        Planifie ton année, sache toujours ce que tu peux dépenser.
+      </p>
 
-        <!-- Subtitle -->
-        <p
-          class="text-body-large text-on-surface-variant text-center leading-relaxed mb-4"
-          data-testid="welcome-subtitle"
-        >
-          Planifie ton année, sache toujours ce que tu peux dépenser.
-        </p>
-
-        <!-- Lottie animation -->
-        @defer (on idle) {
-          <div class="flex justify-center mb-6">
-            <ng-lottie
-              [options]="lottieOptions"
-              class="hidden md:block w-60 h-44 md:w-120 md:h-80 -mt-10 md:-mt-20 bg-transparent"
-            />
-          </div>
-        } @placeholder {
-          <div class="flex justify-center mb-6">
-            <div
-              class="w-56 h-40 md:w-72 md:h-48 flex items-center justify-center"
-            >
-              <div
-                class="w-16 h-16 bg-primary/10 rounded-full animate-pulse"
-              ></div>
-            </div>
-          </div>
-        } @loading {
-          <div class="flex justify-center mb-6">
-            <div
-              class="w-56 h-40 md:w-72 md:h-48 flex items-center justify-center"
-            >
-              <div
-                class="w-16 h-16 bg-primary/20 rounded-full animate-pulse"
-              ></div>
-            </div>
-          </div>
-        } @error {
-          <div class="flex justify-center mb-6">
-            <div class="w-56 h-40 md:w-72 md:h-48"></div>
-          </div>
-        }
-
-        <!-- CTAs -->
-        <div class="flex flex-col gap-3 w-full">
-          <pulpe-google-oauth-button
-            class="w-full"
-            buttonType="outlined"
-            testId="google-oauth-button"
-            (authError)="errorMessage.set($event)"
-            (loadingChange)="onGoogleLoadingChange($event)"
+      <!-- Lottie animation -->
+      @defer (on idle) {
+        <div class="flex justify-center mb-6">
+          <ng-lottie
+            [options]="lottieOptions"
+            class="hidden md:block w-60 h-44 md:w-120 md:h-80 -mt-10 md:-mt-20 bg-transparent"
           />
-
-          <!-- Separator -->
-          <div class="flex items-center gap-4 my-1">
-            <div class="flex-1 h-px bg-outline-variant/30"></div>
-            <span
-              class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest"
-              >OU</span
-            >
-            <div class="flex-1 h-px bg-outline-variant/30"></div>
+        </div>
+      } @placeholder {
+        <div class="flex justify-center mb-6">
+          <div
+            class="w-56 h-40 md:w-72 md:h-48 flex items-center justify-center"
+          >
+            <div
+              class="w-16 h-16 bg-primary/10 rounded-full animate-pulse"
+            ></div>
           </div>
-
-          <button
-            matButton="filled"
-            class="w-full h-12"
-            data-testid="email-signup-button"
-            [disabled]="isLoading()"
-            [routerLink]="['/', ROUTES.SIGNUP]"
-            (click)="onEmailSignupClick()"
+        </div>
+      } @loading {
+        <div class="flex justify-center mb-6">
+          <div
+            class="w-56 h-40 md:w-72 md:h-48 flex items-center justify-center"
           >
-            <div class="flex items-center justify-center gap-2">
-              <mat-icon>email</mat-icon>
-              <span>S'inscrire par e-mail</span>
-            </div>
-          </button>
+            <div
+              class="w-16 h-16 bg-primary/20 rounded-full animate-pulse"
+            ></div>
+          </div>
+        </div>
+      } @error {
+        <div class="flex justify-center mb-6">
+          <div class="w-56 h-40 md:w-72 md:h-48"></div>
+        </div>
+      }
 
-          @if (
-            turnstileService.shouldRender() &&
-            turnstileService.shouldUseTurnstile()
-          ) {
-            <ngx-turnstile
-              #turnstileWidget
-              [siteKey]="turnstileService.siteKey()"
-              [appearance]="'interaction-only'"
-              [theme]="'light'"
-              (resolved)="turnstileService.handleResolved($event)"
-              (errored)="turnstileService.handleError()"
-              class="hidden"
-            />
-          }
+      <!-- CTAs -->
+      <div class="flex flex-col gap-3 w-full">
+        <pulpe-google-oauth-button
+          class="w-full"
+          buttonType="outlined"
+          testId="google-oauth-button"
+          (authError)="errorMessage.set($event)"
+          (loadingChange)="onGoogleLoadingChange($event)"
+        />
 
-          <pulpe-loading-button
-            [loading]="isDemoLoading()"
-            [disabled]="isLoading()"
-            variant=""
-            type="button"
-            loadingText="Préparation..."
-            icon="play_arrow"
-            testId="demo-mode-button"
-            data-testid="demo-link"
-            class="w-full"
-            (click)="startDemoMode()"
+        <!-- Separator -->
+        <div class="flex items-center gap-4 my-1">
+          <div class="flex-1 h-px bg-outline-variant/30"></div>
+          <span
+            class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest"
+            >OU</span
           >
-            Essayer sans compte
-          </pulpe-loading-button>
-
-          <pulpe-error-alert [message]="errorMessage()" class="w-full" />
+          <div class="flex-1 h-px bg-outline-variant/30"></div>
         </div>
 
-        <!-- Legal -->
-        <p
-          class="text-xs text-on-surface-variant text-center mt-5"
-          data-testid="app-version"
+        <button
+          matButton="filled"
+          class="w-full h-12"
+          data-testid="email-signup-button"
+          [disabled]="isLoading()"
+          [routerLink]="['/', ROUTES.SIGNUP]"
+          (click)="onEmailSignupClick()"
         >
-          En continuant, tu acceptes les
-          <a
-            [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_TERMS]"
-            target="_blank"
-            class="text-primary underline"
-            >CGU</a
-          >
-          et la
-          <a
-            [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_PRIVACY]"
-            target="_blank"
-            class="text-primary underline"
-            >Politique de Confidentialité</a
-          >
-        </p>
+          <div class="flex items-center justify-center gap-2">
+            <mat-icon>email</mat-icon>
+            <span>S'inscrire par e-mail</span>
+          </div>
+        </button>
 
-        <!-- Login link -->
-        <p class="text-sm text-on-surface-variant mt-4">
-          Déjà un compte ?
-          <button
-            matButton
-            [routerLink]="['/', ROUTES.LOGIN]"
-            class="text-primary font-semibold"
-          >
-            Se connecter
-          </button>
-        </p>
+        @if (
+          turnstileService.shouldRender() &&
+          turnstileService.shouldUseTurnstile()
+        ) {
+          <ngx-turnstile
+            #turnstileWidget
+            [siteKey]="turnstileService.siteKey()"
+            [appearance]="'interaction-only'"
+            [theme]="'light'"
+            (resolved)="turnstileService.handleResolved($event)"
+            (errored)="turnstileService.handleError()"
+            class="hidden"
+          />
+        }
+
+        <pulpe-loading-button
+          [loading]="isDemoLoading()"
+          [disabled]="isLoading()"
+          variant=""
+          type="button"
+          loadingText="Préparation..."
+          icon="play_arrow"
+          testId="demo-mode-button"
+          data-testid="demo-link"
+          class="w-full"
+          (click)="startDemoMode()"
+        >
+          Essayer sans compte
+        </pulpe-loading-button>
+
+        <pulpe-error-alert [message]="errorMessage()" class="w-full" />
       </div>
-      <pulpe-app-version-label />
+
+      <!-- Legal -->
+      <p
+        class="text-xs text-on-surface-variant text-center mt-5"
+        data-testid="app-version"
+      >
+        En continuant, tu acceptes les
+        <a
+          [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_TERMS]"
+          target="_blank"
+          class="text-primary underline"
+          >CGU</a
+        >
+        et la
+        <a
+          [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_PRIVACY]"
+          target="_blank"
+          class="text-primary underline"
+          >Politique de Confidentialité</a
+        >
+      </p>
+
+      <!-- Login link -->
+      <p class="text-sm text-on-surface-variant mt-4">
+        Déjà un compte ?
+        <button
+          matButton
+          [routerLink]="['/', ROUTES.LOGIN]"
+          class="text-primary font-semibold"
+        >
+          Se connecter
+        </button>
+      </p>
     </div>
   `,
 })

--- a/frontend/projects/webapp/src/app/layout/auth-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/auth-layout.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { AppVersionLabel } from '@ui/app-version-label';
+
+@Component({
+  selector: 'pulpe-auth-layout',
+  imports: [RouterOutlet, AppVersionLabel],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="pulpe-entry-shell pulpe-gradient">
+      <router-outlet />
+      <pulpe-app-version-label />
+    </div>
+  `,
+})
+export default class AuthLayout {}

--- a/frontend/projects/webapp/src/app/ui/app-version-label/app-version-label.ts
+++ b/frontend/projects/webapp/src/app/ui/app-version-label/app-version-label.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { buildInfo } from '@env/build-info';
 
 @Component({
@@ -7,8 +7,8 @@ import { buildInfo } from '@env/build-info';
   host: {
     class: 'block py-3 text-label-small text-on-surface-variant/50',
   },
-  template: `v{{ version }}`,
+  template: `v{{ version() }}`,
 })
 export class AppVersionLabel {
-  protected readonly version = buildInfo.version;
+  readonly version = input(buildInfo.version);
 }

--- a/frontend/projects/webapp/src/app/ui/app-version-label/app-version-label.ts
+++ b/frontend/projects/webapp/src/app/ui/app-version-label/app-version-label.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { buildInfo } from '@env/build-info';
+
+@Component({
+  selector: 'pulpe-app-version-label',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'block py-3 text-label-small text-on-surface-variant/50',
+  },
+  template: `v{{ version }}`,
+})
+export class AppVersionLabel {
+  protected readonly version = buildInfo.version;
+}

--- a/frontend/projects/webapp/src/app/ui/app-version-label/index.ts
+++ b/frontend/projects/webapp/src/app/ui/app-version-label/index.ts
@@ -1,0 +1,1 @@
+export { AppVersionLabel } from './app-version-label';

--- a/frontend/projects/webapp/src/styles.scss
+++ b/frontend/projects/webapp/src/styles.scss
@@ -114,6 +114,7 @@ body {
 .pulpe-entry-shell {
   min-height: 100vh;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: var(--pulpe-page-gutter-mobile);

--- a/landing/next-env.d.ts
+++ b/landing/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

• Add app version label component with mobile-friendly layout
• Create auth-layout wrapper for consistent authentication screen structure
• Integrate version display across authentication screens
• Refactor all auth components to Angular 21 best practices (readonly signals, modern inputs/outputs, OnPush detection)
• Update Material button syntax to modern API (matButton="filled")
• Apply TypeScript private field conventions (#field)

## Type

feat + refactor

## Changes

- **New Components**: auth-layout, app-version-label
- **Auth Routes**: Updated to use auth-layout wrapper
- **Auth Screens**: login, signup, reset-password, forgot-password, enter-vault-code, recover-vault-code, setup-vault-code
- **Quality**: All changes pass pnpm quality (type-check, lint, format)