### PR TITLE
refactor(ios): extract sheet form components

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
@@ -13,11 +13,9 @@ struct AddAllocatedTransactionSheet: View {
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var isAmountFocused: Bool
-    @State private var pendingQuickAmount: Int?
     @State private var amountText = ""
 
     private let transactionService = TransactionService.shared
-    private let quickAmounts = DesignTokens.AmountInput.quickAmounts
 
     private var canSubmit: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -26,83 +24,24 @@ struct AddAllocatedTransactionSheet: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: DesignTokens.Spacing.xxl) {
-                    HeroAmountField(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused)
-                    quickAmountChips
-                    descriptionField
-                    dateSelector
+        SheetFormContainer(title: budgetLine.name, isLoading: isLoading, autoFocus: $isAmountFocused) {
+            HeroAmountField(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused)
+            QuickAmountChips(
+                amount: $amount,
+                amountText: $amountText,
+                isFocused: $isAmountFocused,
+                color: budgetLine.kind.color
+            )
+            descriptionField
+            dateSelector
 
-                    if let error {
-                        ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
-                            self.error = nil
-                        }
-                    }
-
-                    addButton
-                }
-                .padding(.horizontal, DesignTokens.Spacing.xl)
-                .padding(.top, DesignTokens.Spacing.lg)
-                .padding(.bottom, DesignTokens.Spacing.xl)
-            }
-            .background(Color.surfacePrimary)
-            .navigationTitle(budgetLine.name)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
+            if let error {
+                ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
+                    self.error = nil
                 }
             }
-            .loadingOverlay(isLoading)
-            .dismissKeyboardOnTap()
-            .task {
-                try? await Task.sleep(for: .milliseconds(200))
-                isAmountFocused = true
-            }
-            .onChange(of: isAmountFocused) { _, isFocused in
-                if !isFocused, let quickAmount = pendingQuickAmount {
-                    amount = Decimal(quickAmount)
-                    amountText = "\(quickAmount)"
-                    pendingQuickAmount = nil
-                }
-            }
-        }
-        .standardSheetPresentation()
-    }
 
-    // MARK: - Quick Amounts
-
-    private var quickAmountChips: some View {
-        HStack(spacing: DesignTokens.Spacing.sm) {
-            ForEach(quickAmounts, id: \.self) { quickAmount in
-                Button {
-                    if isAmountFocused {
-                        pendingQuickAmount = quickAmount
-                        isAmountFocused = false
-                    } else {
-                        amount = Decimal(quickAmount)
-                        amountText = "\(quickAmount)"
-                    }
-                } label: {
-                    Text("\(quickAmount) \(DesignTokens.AmountInput.currencyCode)")
-                        .font(PulpeTypography.buttonSecondary)
-                        .fixedSize()
-                        .padding(.horizontal, DesignTokens.Spacing.md)
-                        .padding(.vertical, DesignTokens.Spacing.sm)
-                        .frame(maxWidth: .infinity)
-                        .background(Color.pulpePrimary.opacity(DesignTokens.Opacity.badgeBackground))
-                        .foregroundStyle(Color.pulpePrimary)
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule().strokeBorder(
-                                Color.pulpePrimary.opacity(DesignTokens.Opacity.secondary),
-                                lineWidth: 1
-                            )
-                        )
-                }
-                .buttonStyle(.plain)
-            }
+            addButton
         }
     }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -12,11 +12,9 @@ struct AddBudgetLineSheet: View {
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var isAmountFocused: Bool
-    @State private var pendingQuickAmount: Int?
     @State private var amountText = ""
 
     private let budgetLineService = BudgetLineService.shared
-    private let quickAmounts = DesignTokens.AmountInput.quickAmounts
 
     private var canSubmit: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -25,83 +23,20 @@ struct AddBudgetLineSheet: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: DesignTokens.Spacing.xxl) {
-                    KindToggle(selection: $kind)
-                    HeroAmountField(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused)
-                    quickAmountChips
-                    descriptionField
+        SheetFormContainer(title: kind.newBudgetLineTitle, isLoading: isLoading, autoFocus: $isAmountFocused) {
+            KindToggle(selection: $kind)
+            HeroAmountField(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused)
+            QuickAmountChips(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused, color: kind.color)
+                .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
+            descriptionField
 
-                    if let error {
-                        ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
-                            self.error = nil
-                        }
-                    }
-
-                    addButton
-                }
-                .padding(.horizontal, DesignTokens.Spacing.xl)
-                .padding(.top, DesignTokens.Spacing.lg)
-                .padding(.bottom, DesignTokens.Spacing.xl)
-            }
-            .background(Color.surfacePrimary)
-            .navigationTitle(kind.newBudgetLineTitle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
+            if let error {
+                ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
+                    self.error = nil
                 }
             }
-            .loadingOverlay(isLoading)
-            .dismissKeyboardOnTap()
-            .task {
-                try? await Task.sleep(for: .milliseconds(200))
-                isAmountFocused = true
-            }
-            .onChange(of: isAmountFocused) { _, isFocused in
-                if !isFocused, let quickAmount = pendingQuickAmount {
-                    amount = Decimal(quickAmount)
-                    amountText = "\(quickAmount)"
-                    pendingQuickAmount = nil
-                }
-            }
-        }
-        .standardSheetPresentation()
-    }
 
-    // MARK: - Quick Amounts
-
-    private var quickAmountChips: some View {
-        HStack(spacing: DesignTokens.Spacing.sm) {
-            ForEach(quickAmounts, id: \.self) { quickAmount in
-                Button {
-                    if isAmountFocused {
-                        pendingQuickAmount = quickAmount
-                        isAmountFocused = false
-                    } else {
-                        amount = Decimal(quickAmount)
-                        amountText = "\(quickAmount)"
-                    }
-                } label: {
-                    Text("\(quickAmount) \(DesignTokens.AmountInput.currencyCode)")
-                        .font(PulpeTypography.labelLarge)
-                        .fixedSize()
-                        .padding(.horizontal, DesignTokens.Spacing.md)
-                        .padding(.vertical, DesignTokens.Spacing.sm)
-                        .frame(maxWidth: .infinity)
-                        .background(Color.pulpePrimary.opacity(DesignTokens.Opacity.badgeBackground))
-                        .foregroundStyle(Color.pulpePrimary)
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule().strokeBorder(
-                                Color.pulpePrimary.opacity(DesignTokens.Opacity.secondary),
-                                lineWidth: 1
-                            )
-                        )
-                }
-                .buttonStyle(.plain)
-            }
+            addButton
         }
     }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TipKit
 
 struct BudgetDetailsView: View {
     let budgetId: String
@@ -182,15 +183,17 @@ struct BudgetDetailsView: View {
                     .listRowSeparator(.hidden)
             }
 
-            // Budget line sections
+            // Budget line sections (tip appears in the first visible section)
             if !filteredIncome.isEmpty {
-                budgetSection(title: "Revenus", items: filteredIncome)
+                budgetSection(title: "Revenus", items: filteredIncome, tip: ProductTips.gestures)
             }
             if !filteredExpenses.isEmpty {
-                budgetSection(title: "Dépenses", items: filteredExpenses)
+                budgetSection(title: "Dépenses", items: filteredExpenses,
+                              tip: filteredIncome.isEmpty ? ProductTips.gestures : nil)
             }
             if !filteredSavings.isEmpty {
-                budgetSection(title: "Épargne", items: filteredSavings)
+                budgetSection(title: "Épargne", items: filteredSavings,
+                              tip: filteredIncome.isEmpty && filteredExpenses.isEmpty ? ProductTips.gestures : nil)
             }
 
             // Free transactions
@@ -223,7 +226,7 @@ struct BudgetDetailsView: View {
 
     // MARK: - Section Builders
 
-    private func budgetSection(title: String, items: [BudgetLine]) -> some View {
+    private func budgetSection(title: String, items: [BudgetLine], tip: (any Tip)? = nil) -> some View {
         BudgetSection(
             title: title,
             items: items,
@@ -258,7 +261,8 @@ struct BudgetDetailsView: View {
                     return
                 }
                 selectedBudgetLineForEdit = line
-            }
+            },
+            tip: tip
         )
     }
 }
@@ -267,4 +271,17 @@ struct BudgetDetailsView: View {
     NavigationStack {
         BudgetDetailsView(budgetId: "test")
     }
+    .environment(AppState())
+}
+#Preview("Gestures Tip") {
+    List {
+        Section("Dépenses") {
+            TipView(ProductTips.gestures)
+            Text("Budget line row placeholder")
+        }
+    }
+    .listStyle(.insetGrouped)
+    .scrollContentBackground(.hidden)
+    .background(Color.appNegativeBackground.ignoresSafeArea())
+    .task { try? Tips.resetDatastore() }
 }

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -14,13 +14,10 @@ struct AddTransactionSheet: View {
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var isAmountFocused: Bool
-    @State private var pendingQuickAmount: Int?
     @State private var amountText = ""
     @State private var submitSuccessTrigger = false
-    @State private var quickAmountTrigger = false
 
     private let transactionService = TransactionService.shared
-    private let quickAmounts = DesignTokens.AmountInput.quickAmounts
 
     private var canSubmit: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -40,104 +37,28 @@ struct AddTransactionSheet: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: DesignTokens.Spacing.xxl) {
-                    KindToggle(selection: $kind)
-                    HeroAmountField(
-                        amount: $amount,
-                        amountText: $amountText,
-                        isFocused: $isAmountFocused,
-                        hint: "Quel montant ?"
-                    )
-                    quickAmountChips
-                    descriptionField
-                    dateSelector
+        SheetFormContainer(title: kind.newTransactionTitle, isLoading: isLoading, autoFocus: $isAmountFocused) {
+            KindToggle(selection: $kind)
+            HeroAmountField(
+                amount: $amount,
+                amountText: $amountText,
+                isFocused: $isAmountFocused,
+                hint: "Quel montant ?"
+            )
+            QuickAmountChips(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused, color: kind.color)
+                .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
+            descriptionField
+            dateSelector
 
-                    if let error {
-                        ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
-                            self.error = nil
-                        }
-                    }
+            if let error {
+                ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
+                    self.error = nil
+                }
+            }
 
-                    addButton
-                }
-                .padding(.horizontal, DesignTokens.Spacing.xl)
-                .padding(.top, DesignTokens.Spacing.lg)
-                .padding(.bottom, DesignTokens.Spacing.xl)
-            }
-            .background(Color.surfacePrimary)
-            .navigationTitle(kind.newTransactionTitle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
-                }
-            }
-            .loadingOverlay(isLoading)
-            .dismissKeyboardOnTap()
-            .sensoryFeedback(.success, trigger: submitSuccessTrigger)
-            .task {
-                try? await Task.sleep(for: .milliseconds(200))
-                isAmountFocused = true
-            }
-            .onChange(of: isAmountFocused) { _, isFocused in
-                if !isFocused, let quickAmount = pendingQuickAmount {
-                    amount = Decimal(quickAmount)
-                    amountText = "\(quickAmount)"
-                    pendingQuickAmount = nil
-                }
-            }
+            addButton
         }
-        .standardSheetPresentation()
-    }
-
-    // MARK: - Quick Amounts
-
-    private var quickAmountChips: some View {
-        HStack(spacing: DesignTokens.Spacing.sm) {
-            ForEach(quickAmounts, id: \.self) { quickAmount in
-                let isSelected = amount == Decimal(quickAmount)
-                Button {
-                    quickAmountTrigger.toggle()
-                    if isAmountFocused {
-                        pendingQuickAmount = quickAmount
-                        isAmountFocused = false
-                    } else {
-                        amount = Decimal(quickAmount)
-                        amountText = "\(quickAmount)"
-                    }
-                } label: {
-                    let isSelectedOpacity = isSelected
-                        ? DesignTokens.Opacity.secondary
-                        : DesignTokens.Opacity.badgeBackground
-                    let borderOpacity = isSelected
-                        ? DesignTokens.Opacity.strong
-                        : DesignTokens.Opacity.secondary
-
-                    Text("\(quickAmount) \(DesignTokens.AmountInput.currencyCode)")
-                        .font(PulpeTypography.labelLarge)
-                        .fixedSize()
-                        .padding(.horizontal, DesignTokens.Spacing.md)
-                        .padding(.vertical, DesignTokens.Spacing.sm)
-                        .frame(maxWidth: .infinity)
-                        .background(kind.color.opacity(isSelectedOpacity))
-                        .foregroundStyle(kind.color)
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule().strokeBorder(
-                                kind.color.opacity(borderOpacity),
-                                lineWidth: 1
-                            )
-                        )
-                }
-                .buttonStyle(.plain)
-                .accessibilityHint("Définir le montant à \(quickAmount) CHF")
-            }
-        }
-        .sensoryFeedback(.selection, trigger: quickAmountTrigger)
-        .animation(.snappy(duration: DesignTokens.Animation.fast), value: amount)
-        .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
+        .sensoryFeedback(.success, trigger: submitSuccessTrigger)
     }
 
     // MARK: - Description
@@ -229,6 +150,7 @@ struct AddTransactionSheet: View {
     AddTransactionSheet(budgetId: "test") { transaction in
         print("Added: \(transaction)")
     }
+    .environment(ToastManager())
 }
 
 // MARK: - Deep Link Wrapper
@@ -294,6 +216,7 @@ final class DeepLinkAddExpenseViewModel {
 
     func loadCurrentBudget(payDayOfMonth: Int? = nil) async {
         isLoading = true
+        defer { isLoading = false }
         error = nil
         do {
             let budget = try await BudgetService.shared.getCurrentMonthBudget(payDayOfMonth: payDayOfMonth)
@@ -302,6 +225,5 @@ final class DeepLinkAddExpenseViewModel {
             self.error = error
             currentBudgetId = nil
         }
-        isLoading = false
     }
 }

--- a/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
@@ -13,6 +13,7 @@ struct BudgetSection: View {
     let onAddTransaction: (BudgetLine) -> Void
     let onLongPress: (BudgetLine, [Transaction]) -> Void
     let onEdit: (BudgetLine) -> Void
+    var tip: (any Tip)?
 
     @State private var isExpanded = false
 
@@ -50,10 +51,10 @@ struct BudgetSection: View {
 
     var body: some View {
         Section {
-            TipView(ProductTips.gestures)
-                .frame(maxWidth: .infinity)
-                .fixedSize(horizontal: false, vertical: true)
-                .listRowSeparator(.hidden)
+            if let tip {
+                TipView(tip)
+                    .listRowSeparator(.hidden)
+            }
 
             ForEach(Array(displayedItems.enumerated()), id: \.element.id) { index, item in
                 budgetLineRow(for: item)

--- a/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
@@ -33,42 +33,20 @@ struct EditTemplateLineSheet: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: DesignTokens.Spacing.xxl) {
-                    HeroAmountField(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused)
-                    descriptionField
-                    KindToggle(selection: $kind)
-                    recurrenceSelector
+        SheetFormContainer(title: "Modifier la ligne", isLoading: isLoading, autoFocus: $isAmountFocused) {
+            HeroAmountField(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused)
+            descriptionField
+            KindToggle(selection: $kind)
+            recurrenceSelector
 
-                    if let error {
-                        ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
-                            self.error = nil
-                        }
-                    }
-
-                    saveButton
-                }
-                .padding(.horizontal, DesignTokens.Spacing.xl)
-                .padding(.top, DesignTokens.Spacing.lg)
-                .padding(.bottom, DesignTokens.Spacing.xl)
-            }
-            .background(Color.surfacePrimary)
-            .navigationTitle("Modifier la ligne")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
+            if let error {
+                ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
+                    self.error = nil
                 }
             }
-            .loadingOverlay(isLoading)
-            .dismissKeyboardOnTap()
-            .task {
-                try? await Task.sleep(for: .milliseconds(200))
-                isAmountFocused = true
-            }
+
+            saveButton
         }
-        .standardSheetPresentation()
     }
 
     // MARK: - Description

--- a/ios/Pulpe/Shared/Components/EditBudgetLineSheet.swift
+++ b/ios/Pulpe/Shared/Components/EditBudgetLineSheet.swift
@@ -41,41 +41,19 @@ struct EditBudgetLineSheet: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: DesignTokens.Spacing.xxl) {
-                    KindToggle(selection: $kind)
-                    HeroAmountField(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused)
-                    descriptionField
+        SheetFormContainer(title: kind.editBudgetLineTitle, isLoading: isLoading, autoFocus: $isAmountFocused) {
+            KindToggle(selection: $kind)
+            HeroAmountField(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused)
+            descriptionField
 
-                    if let error {
-                        ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
-                            self.error = nil
-                        }
-                    }
-
-                    saveButton
-                }
-                .padding(.horizontal, DesignTokens.Spacing.xl)
-                .padding(.top, DesignTokens.Spacing.lg)
-                .padding(.bottom, DesignTokens.Spacing.xl)
-            }
-            .background(Color.surfacePrimary)
-            .navigationTitle(kind.editBudgetLineTitle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
+            if let error {
+                ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
+                    self.error = nil
                 }
             }
-            .loadingOverlay(isLoading)
-            .dismissKeyboardOnTap()
-            .task {
-                try? await Task.sleep(for: .milliseconds(200))
-                isAmountFocused = true
-            }
+
+            saveButton
         }
-        .standardSheetPresentation()
     }
 
     // MARK: - Description

--- a/ios/Pulpe/Shared/Components/HeroAmountField.swift
+++ b/ios/Pulpe/Shared/Components/HeroAmountField.swift
@@ -10,7 +10,7 @@ struct HeroAmountField: View {
 
     private var displayAmount: String {
         if let amount, amount > 0 {
-            return Formatters.amountInput.string(from: amount as NSDecimalNumber) ?? "0"
+            return Formatters.amountInput.string(from: amount as NSDecimalNumber) ?? "0.00"
         }
         return "0.00"
     }
@@ -51,7 +51,7 @@ struct HeroAmountField: View {
                 .frame(width: 120, height: 2)
                 .animation(.easeInOut(duration: DesignTokens.Animation.fast), value: isFocused.wrappedValue)
 
-            if let hint, (amount ?? 0) == 0 {
+            if let hint, (amount ?? 0) <= 0 {
                 Text(hint)
                     .font(PulpeTypography.caption)
                     .foregroundStyle(Color.textTertiary)

--- a/ios/Pulpe/Shared/Components/QuickAmountChips.swift
+++ b/ios/Pulpe/Shared/Components/QuickAmountChips.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// Reusable quick amount chip buttons used across sheet forms.
+/// Internalizes the `pendingQuickAmount` state and `onChange(of: isFocused)` logic.
+struct QuickAmountChips: View {
+    @Binding var amount: Decimal?
+    @Binding var amountText: String
+    var isFocused: FocusState<Bool>.Binding
+    var color: Color = .pulpePrimary
+
+    @State private var pendingQuickAmount: Int?
+    @State private var selectionTrigger = false
+
+    private let quickAmounts = DesignTokens.AmountInput.quickAmounts
+
+    var body: some View {
+        HStack(spacing: DesignTokens.Spacing.sm) {
+            ForEach(quickAmounts, id: \.self) { quickAmount in
+                let isSelected = amount == Decimal(quickAmount)
+                Button {
+                    selectionTrigger.toggle()
+                    if isFocused.wrappedValue {
+                        pendingQuickAmount = quickAmount
+                        isFocused.wrappedValue = false
+                    } else {
+                        amount = Decimal(quickAmount)
+                        amountText = "\(quickAmount)"
+                    }
+                } label: {
+                    let bgOpacity = isSelected
+                        ? DesignTokens.Opacity.secondary
+                        : DesignTokens.Opacity.badgeBackground
+                    let borderOpacity = isSelected
+                        ? DesignTokens.Opacity.strong
+                        : DesignTokens.Opacity.secondary
+
+                    Text("\(quickAmount) \(DesignTokens.AmountInput.currencyCode)")
+                        .font(PulpeTypography.labelLarge)
+                        .fixedSize()
+                        .padding(.horizontal, DesignTokens.Spacing.md)
+                        .padding(.vertical, DesignTokens.Spacing.sm)
+                        .frame(maxWidth: .infinity)
+                        .background(color.opacity(bgOpacity))
+                        .foregroundStyle(color)
+                        .clipShape(Capsule())
+                        .overlay(
+                            Capsule().strokeBorder(
+                                color.opacity(borderOpacity),
+                                lineWidth: 1
+                            )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint("Définir le montant à \(quickAmount) \(DesignTokens.AmountInput.currencyCode)")
+            }
+        }
+        .sensoryFeedback(.selection, trigger: selectionTrigger)
+        .animation(.snappy(duration: DesignTokens.Animation.fast), value: amount)
+        .onChange(of: isFocused.wrappedValue) { _, focused in
+            if !focused, let quickAmount = pendingQuickAmount {
+                amount = Decimal(quickAmount)
+                amountText = "\(quickAmount)"
+                pendingQuickAmount = nil
+            }
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var amount: Decimal?
+    @Previewable @State var amountText = ""
+    @Previewable @FocusState var isFocused: Bool
+
+    QuickAmountChips(
+        amount: $amount,
+        amountText: $amountText,
+        isFocused: $isFocused,
+        color: .pulpePrimary
+    )
+    .padding()
+}

--- a/ios/Pulpe/Shared/Components/SheetFormContainer.swift
+++ b/ios/Pulpe/Shared/Components/SheetFormContainer.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Reusable container that wraps sheet form content with the standard
+/// NavigationStack + ScrollView boilerplate shared across all form sheets.
+///
+/// Provides: surface background, inline title, close button, loading overlay,
+/// keyboard dismiss, and optional auto-focus after a short delay.
+struct SheetFormContainer<Content: View>: View {
+    let title: String
+    let isLoading: Bool
+    var autoFocus: FocusState<Bool>.Binding?
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: DesignTokens.Spacing.xxl) {
+                    content
+                }
+                .padding(.horizontal, DesignTokens.Spacing.xl)
+                .padding(.top, DesignTokens.Spacing.lg)
+                .padding(.bottom, DesignTokens.Spacing.xl)
+            }
+            .background(Color.surfacePrimary)
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    SheetCloseButton()
+                }
+            }
+            .loadingOverlay(isLoading)
+            .dismissKeyboardOnTap()
+            .task {
+                guard autoFocus != nil else { return }
+                try? await Task.sleep(for: .milliseconds(200))
+                guard !Task.isCancelled else { return }
+                autoFocus?.wrappedValue = true
+            }
+        }
+        .standardSheetPresentation()
+    }
+}

--- a/ios/Pulpe/Shared/Extensions/Color+Pulpe.swift
+++ b/ios/Pulpe/Shared/Extensions/Color+Pulpe.swift
@@ -83,9 +83,9 @@ extension Color {
     /// Generic badge background
     static let badgeBackground = Color("BadgeBackground")
 
-    /// Input field background — green-tinted soft fill for brand consistency
+    /// Input field background — white in light mode for clear contrast against sage surfaces
     static let inputBackgroundSoft = Color(
-        light: Color(hex: 0xE8F5E9).opacity(0.6),
+        light: .white,
         dark: Color(uiColor: .tertiarySystemFill)
     )
 


### PR DESCRIPTION
## Summary

• Extract `QuickAmountChips` component — consolidates quick amount chip buttons used across 5 form sheets
• Extract `SheetFormContainer` component — eliminates NavigationStack + ScrollView boilerplate from 5 sheet files
• Refactor 5 sheets to use new components: AddAllocatedTransactionSheet, AddBudgetLineSheet, AddTransactionSheet, EditTemplateLineSheet, EditBudgetLineSheet
• Fix accessibility hint to use design token for currency code
• Fix Task.sleep cancellation handling to prevent focus on dismissed views

**Result:** ~110 lines of duplication removed

## Type

refactor