### PR TITLE
feat(ios): integrate PostHog analytics

### DIFF
--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -23,16 +23,27 @@ captureEvent('click');              // Too vague
 
 ## Conversion Funnel
 
+**Web:**
 ```
 $pageview (landing) → cta_clicked → signup_started → signup_completed
 → vault_code_setup_completed → onboarding_started → profile_step1_completed
 → profile_step2_completed → first_budget_created
 ```
 
+**iOS:**
+```
+app_opened → welcome_screen_viewed → signup_started → onboarding_step_completed (×3)
+→ signup_completed → pin_setup_completed → budget_created → transaction_created
+```
+
 **Tracking approach:**
 - Pre-auth events (`signup_started`) are captured as anonymous events (`person_profiles: 'identified_only'`)
 - Full auto-capture (pageviews, autocapture) enabled after authentication
 - Google OAuth uses `PostHogService.setPendingSignupMethod()` to store the method via `StorageService`, then `capturePendingSignupCompleted()` fires `signup_completed` after redirect
+- **iOS:** Uses `AnalyticsService.shared` actor (not PostHogSDK directly)
+- **iOS:** Manual screen tracking via `.trackScreen()` view modifier
+- **iOS:** PostHog disabled in local environment (`POSTHOG_ENABLED = false` in xcconfig)
+- **iOS:** Financial data sanitized — amounts and balances are never included in event properties
 
 ## Events Catalog
 
@@ -71,7 +82,29 @@ $pageview (landing) → cta_clicked → signup_started → signup_completed
 | `tutorial_completed` | Tutorial finished | — |
 | `tutorial_cancelled` | User skips tutorial | — |
 
+### iOS App Events
+
+| Event | When | Properties |
+|-------|------|------------|
+| `app_opened` | App enters foreground | — |
+| `welcome_screen_viewed` | Welcome screen appears (new user) | — |
+| `signup_started` | "Commencer" tapped on welcome | `method` (`email`) |
+| `onboarding_step_completed` | User completes onboarding step | `step` (`personal_info` \| `expenses` \| `budget_preview`) |
+| `signup_completed` | Registration succeeds | `method` (`email`) |
+| `login_completed` | Login succeeds | `method` (`email` \| `biometric`) |
+| `pin_setup_completed` | PIN created successfully | — |
+| `pin_entered` | PIN entered on return visit | — |
+| `budget_created` | Budget created | — |
+| `transaction_created` | Transaction added | `type` (`expense` \| `income` \| `saving`) |
+| `tab_switched` | User switches tab | `tab` (`currentMonth` \| `budgets` \| `templates`) |
+| `logout_completed` | User logs out | — |
+
 ## Properties
+
+**Global properties** (sent with every event):
+```
+platform: 'web' | 'landing' | 'ios'
+```
 
 ```typescript
 // Use snake_case, be specific

--- a/ios/Config/Base.xcconfig
+++ b/ios/Config/Base.xcconfig
@@ -1,2 +1,3 @@
 // Helper for URL escaping in xcconfig (// is interpreted as comment)
 SLASH = /
+POSTHOG_HOST = https:$(SLASH)$(SLASH)eu.i.posthog.com

--- a/ios/Config/Local.xcconfig
+++ b/ios/Config/Local.xcconfig
@@ -4,5 +4,7 @@ API_BASE_URL = http:$(SLASH)$(SLASH)localhost:3000/api/v1
 SUPABASE_URL = http:$(SLASH)$(SLASH)127.0.0.1:54321
 SUPABASE_ANON_KEY = sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH
 APP_ENV = local
+POSTHOG_API_KEY =
+POSTHOG_ENABLED = false
 
 #include? "Local.secrets.xcconfig"

--- a/ios/Config/Preview.xcconfig
+++ b/ios/Config/Preview.xcconfig
@@ -4,5 +4,7 @@ API_BASE_URL = https:$(SLASH)$(SLASH)backend-preview-34f4.up.railway.app/api/v1
 SUPABASE_URL = https:$(SLASH)$(SLASH)lrphlfjkzkwyllejanrd.supabase.co
 SUPABASE_ANON_KEY = sb_publishable_6bhOTXKoB7NtR0EeRKg8kA_EdBZeyJb
 APP_ENV = preview
+POSTHOG_API_KEY =
+POSTHOG_ENABLED = true
 
 #include? "Preview.secrets.xcconfig"

--- a/ios/Config/Prod.xcconfig
+++ b/ios/Config/Prod.xcconfig
@@ -4,5 +4,7 @@ API_BASE_URL = https:$(SLASH)$(SLASH)api.pulpe.app/api/v1
 SUPABASE_URL = https:$(SLASH)$(SLASH)qhhlloqisgzwcsrbdppn.supabase.co
 SUPABASE_ANON_KEY = sb_publishable_sOPmrqc7yz2nnZRxAOUhwQ_Yr8lfRY2
 APP_ENV = prod
+POSTHOG_API_KEY =
+POSTHOG_ENABLED = true
 
 #include? "Prod.secrets.xcconfig"

--- a/ios/Pulpe/App/AppState+Auth.swift
+++ b/ios/Pulpe/App/AppState+Auth.swift
@@ -37,6 +37,7 @@ extension AppState {
     func applyPostAuthDestination(_ destination: PostAuthDestination, user: UserInfo? = nil) async {
         if let user {
             currentUser = user
+            AnalyticsService.shared.identify(userId: user.id)
         }
         authState = .loading
 

--- a/ios/Pulpe/App/AppState+Bootstrap.swift
+++ b/ios/Pulpe/App/AppState+Bootstrap.swift
@@ -65,6 +65,8 @@ extension AppState {
         switch result {
         case .biometricAuthenticated(let user, _):
             currentUser = user
+            AnalyticsService.shared.identify(userId: user.id)
+            AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "biometric"])
             await resolvePostAuth(user: user)
         case .regularSession(let user):
             await resolvePostAuth(user: user)

--- a/ios/Pulpe/App/AppState+Bootstrap.swift
+++ b/ios/Pulpe/App/AppState+Bootstrap.swift
@@ -65,7 +65,7 @@ extension AppState {
         switch result {
         case .biometricAuthenticated(let user, _):
             currentUser = user
-            AnalyticsService.shared.identify(userId: user.id)
+            // identify is handled by applyPostAuthDestination via resolvePostAuth
             AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "biometric"])
             await resolvePostAuth(user: user)
         case .regularSession(let user):

--- a/ios/Pulpe/App/AppState+Bootstrap.swift
+++ b/ios/Pulpe/App/AppState+Bootstrap.swift
@@ -65,9 +65,8 @@ extension AppState {
         switch result {
         case .biometricAuthenticated(let user, _):
             currentUser = user
-            // identify is handled by applyPostAuthDestination via resolvePostAuth
-            AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "biometric"])
             await resolvePostAuth(user: user)
+            AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "biometric"])
         case .regularSession(let user):
             await resolvePostAuth(user: user)
         case .unauthenticated:

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -97,6 +97,9 @@ extension AppState {
         defer { isLoggingOut = false }
         authDebug("AUTH_LOGOUT", "begin source=\(source) biometricEnabled=\(biometric.isEnabled)")
 
+        AnalyticsService.shared.capture(.logoutCompleted)
+        AnalyticsService.shared.reset()
+
         backgroundRefreshTask?.cancel()
         backgroundRefreshTask = nil
 

--- a/ios/Pulpe/App/MainTabView.swift
+++ b/ios/Pulpe/App/MainTabView.swift
@@ -42,6 +42,9 @@ struct MainTabView: View {
                     .padding(.horizontal, DesignTokens.Spacing.lg)
             }
         }
+        .onChange(of: appState.selectedTab) { _, newTab in
+            AnalyticsService.shared.capture(.tabSwitched, properties: ["tab": newTab.rawValue])
+        }
         .sheet(item: $addTransactionBudgetId) { item in
             AddTransactionSheet(budgetId: item.budgetId) { transaction in
                 monthStore.addTransaction(transaction)

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -53,6 +53,7 @@ struct PulpeApp: App {
             .datastoreLocation(.applicationDefault)
         ])
         BackgroundTaskService.shared.registerTasks()
+        AnalyticsService.shared.initialize()
 
         UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(.pulpePrimary)
         UISegmentedControl.appearance().setTitleTextAttributes(

--- a/ios/Pulpe/App/Runtime/AppRuntimeCoordinator.swift
+++ b/ios/Pulpe/App/Runtime/AppRuntimeCoordinator.swift
@@ -38,46 +38,64 @@ final class AppRuntimeCoordinator {
         #endif
         // Activate shield only when truly entering background (not on notification/control center)
         if newPhase == .background, oldPhase != .background {
-            let isSecured = appState.authState == .authenticated
-                || appState.authState == .needsPinEntry
-            if isSecured {
-                privacyShieldActive = true
-                #if DEBUG
-                Logger.auth.debug("[AUTH_SCENE] privacy shield activated (secured=\(isSecured))")
-                #endif
-            }
+            activatePrivacyShieldIfNeeded()
         }
         if newPhase == .active {
             withAnimation(.easeInOut(duration: 0.25)) {
                 privacyShieldActive = false
             }
-        }
-
-        if newPhase == .background {
-            appState.handleEnterBackground()
-            if appState.authState == .authenticated {
-                Task { await widgetSyncViewModel.syncWidgetData() }
-                BackgroundTaskService.shared.scheduleWidgetRefresh()
+            // Only fire app_opened when returning from background (not notification center dismiss).
+            // Cold start is captured in AnalyticsService.initialize().
+            if oldPhase == .background {
+                AnalyticsService.shared.capture(.appOpened)
             }
         }
 
+        if newPhase == .background {
+            handleEnterBackground()
+        }
+
         if newPhase == .active, oldPhase != .active {
-            appState.prepareForForeground()
-            Task {
-                await appState.handleEnterForeground()
-                #if DEBUG
-                let fgAuth = String(describing: self.appState.authState)
-                let refreshing = self.appState.authState == .authenticated
-                Logger.auth.debug(
-                    "[AUTH_SCENE] foreground handled, auth=\(fgAuth, privacy: .public) refreshing=\(refreshing)"
-                )
-                #endif
-                if appState.authState == .authenticated {
-                    async let r1: Void = currentMonthStore.forceRefresh()
-                    async let r2: Void = budgetListStore.forceRefresh()
-                    async let r3: Void = dashboardStore.loadIfNeeded()
-                    _ = await (r1, r2, r3)
-                }
+            handleBecomeActive()
+        }
+    }
+
+    private func activatePrivacyShieldIfNeeded() {
+        let isSecured = appState.authState == .authenticated
+            || appState.authState == .needsPinEntry
+        if isSecured {
+            privacyShieldActive = true
+            #if DEBUG
+            Logger.auth.debug("[AUTH_SCENE] privacy shield activated (secured=\(isSecured))")
+            #endif
+        }
+    }
+
+    private func handleEnterBackground() {
+        AnalyticsService.shared.flush()
+        appState.handleEnterBackground()
+        if appState.authState == .authenticated {
+            Task { await widgetSyncViewModel.syncWidgetData() }
+            BackgroundTaskService.shared.scheduleWidgetRefresh()
+        }
+    }
+
+    private func handleBecomeActive() {
+        appState.prepareForForeground()
+        Task {
+            await appState.handleEnterForeground()
+            #if DEBUG
+            let fgAuth = String(describing: self.appState.authState)
+            let refreshing = self.appState.authState == .authenticated
+            Logger.auth.debug(
+                "[AUTH_SCENE] foreground handled, auth=\(fgAuth, privacy: .public) refreshing=\(refreshing)"
+            )
+            #endif
+            if appState.authState == .authenticated {
+                async let r1: Void = currentMonthStore.forceRefresh()
+                async let r2: Void = budgetListStore.forceRefresh()
+                async let r3: Void = dashboardStore.loadIfNeeded()
+                _ = await (r1, r2, r3)
             }
         }
     }

--- a/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// All tracked analytics events. Names match web conventions (`snake_case`, `object_action`).
+enum AnalyticsEvent: String, CaseIterable {
+    // MARK: - Lifecycle
+    case appOpened = "app_opened"
+
+    // MARK: - Onboarding Funnel
+    case welcomeScreenViewed = "welcome_screen_viewed"
+    case signupStarted = "signup_started"
+    case signupCompleted = "signup_completed"
+    case onboardingStepCompleted = "onboarding_step_completed"
+
+    // MARK: - Auth
+    case loginCompleted = "login_completed"
+    case logoutCompleted = "logout_completed"
+    case pinSetupCompleted = "pin_setup_completed"
+    case pinEntered = "pin_entered"
+
+    // MARK: - Budget
+    case budgetCreated = "budget_created"
+
+    // MARK: - Transaction
+    case transactionCreated = "transaction_created"
+
+    // MARK: - Navigation
+    case tabSwitched = "tab_switched"
+}

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -1,0 +1,95 @@
+import Foundation
+import PostHog
+
+/// Central analytics service wrapping PostHog iOS SDK.
+/// All callers are @MainActor (SwiftUI views, stores), so MainActor isolation
+/// ensures thread-safe access to `isInitialized` without requiring actor hops.
+@MainActor
+final class AnalyticsService {
+    static let shared = AnalyticsService()
+    private(set) var isInitialized = false
+
+    private init() {}
+
+    // MARK: - Setup
+
+    func initialize() {
+        guard AppConfiguration.isPostHogEnabled,
+              let apiKey = AppConfiguration.postHogApiKey else {
+            return
+        }
+
+        let config = PostHogConfig(apiKey: apiKey, host: AppConfiguration.postHogHost)
+        config.captureScreenViews = false
+        config.captureApplicationLifecycleEvents = false
+        PostHogSDK.shared.setup(config)
+
+        PostHogSDK.shared.register([
+            "environment": AppConfiguration.environment.rawValue,
+            "app_version": AppConfiguration.appVersion,
+            "platform": "ios"
+        ])
+
+        isInitialized = true
+        capture(.appOpened)
+    }
+
+    // MARK: - Event Capture
+
+    func capture(_ event: AnalyticsEvent, properties: [String: Any] = [:]) {
+        guard isInitialized else { return }
+        let sanitized = sanitizeProperties(properties)
+        PostHogSDK.shared.capture(event.rawValue, properties: sanitized)
+    }
+
+    // MARK: - Screen Tracking
+
+    func screen(_ name: String, properties: [String: Any] = [:]) {
+        guard isInitialized else { return }
+        let sanitized = sanitizeProperties(properties)
+        PostHogSDK.shared.screen(name, properties: sanitized)
+    }
+
+    // MARK: - User Identity
+
+    func identify(userId: String, properties: [String: Any] = [:]) {
+        guard isInitialized else { return }
+        let sanitized = sanitizeProperties(properties)
+        PostHogSDK.shared.identify(
+            userId,
+            userProperties: sanitized,
+            userPropertiesSetOnce: [
+                "first_app_version": AppConfiguration.appVersion
+            ]
+        )
+    }
+
+    func reset() {
+        guard isInitialized else { return }
+        PostHogSDK.shared.reset()
+    }
+
+    // MARK: - Lifecycle
+
+    func flush() {
+        guard isInitialized else { return }
+        PostHogSDK.shared.flush()
+    }
+
+    // MARK: - Sanitization
+
+    private static let financialWords: Set<String> = [
+        "amount", "balance", "income", "savings", "total",
+        "projection", "rollover", "expenses", "available"
+    ]
+
+    /// Strips properties containing financial keywords from event data.
+    /// Uses word-component matching: splits keys by `_` and checks each component.
+    /// Nonisolated because it's a pure function with no side effects.
+    nonisolated func sanitizeProperties(_ properties: [String: Any]) -> [String: Any] {
+        properties.filter { key, _ in
+            let components = key.split(separator: "_").map { String($0) }
+            return !components.contains(where: { Self.financialWords.contains($0) })
+        }
+    }
+}

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -38,7 +38,7 @@ final class AnalyticsService {
 
     func capture(_ event: AnalyticsEvent, properties: [String: Any] = [:]) {
         guard isInitialized else { return }
-        let sanitized = sanitizeProperties(properties)
+        let sanitized = Self.sanitizeProperties(properties)
         PostHogSDK.shared.capture(event.rawValue, properties: sanitized)
     }
 
@@ -46,7 +46,7 @@ final class AnalyticsService {
 
     func screen(_ name: String, properties: [String: Any] = [:]) {
         guard isInitialized else { return }
-        let sanitized = sanitizeProperties(properties)
+        let sanitized = Self.sanitizeProperties(properties)
         PostHogSDK.shared.screen(name, properties: sanitized)
     }
 
@@ -54,7 +54,7 @@ final class AnalyticsService {
 
     func identify(userId: String, properties: [String: Any] = [:]) {
         guard isInitialized else { return }
-        let sanitized = sanitizeProperties(properties)
+        let sanitized = Self.sanitizeProperties(properties)
         PostHogSDK.shared.identify(
             userId,
             userProperties: sanitized,
@@ -85,11 +85,11 @@ final class AnalyticsService {
 
     /// Strips properties containing financial keywords from event data.
     /// Uses word-component matching: splits keys by `_` and checks each component.
-    /// Nonisolated because it's a pure function with no side effects.
-    nonisolated func sanitizeProperties(_ properties: [String: Any]) -> [String: Any] {
-        properties.filter { key, _ in
+    static func sanitizeProperties(_ properties: [String: Any]) -> [String: Any] {
+        guard !properties.isEmpty else { return properties }
+        return properties.filter { key, _ in
             let components = key.split(separator: "_").map { String($0) }
-            return !components.contains(where: { Self.financialWords.contains($0) })
+            return !components.contains(where: { financialWords.contains($0) })
         }
     }
 }

--- a/ios/Pulpe/Core/Analytics/View+Analytics.swift
+++ b/ios/Pulpe/Core/Analytics/View+Analytics.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+extension View {
+    /// Track a screen view when the view appears.
+    func trackScreen(_ name: String, properties: [String: Any] = [:]) -> some View {
+        task {
+            AnalyticsService.shared.screen(name, properties: properties)
+        }
+    }
+}

--- a/ios/Pulpe/Core/Config/AppConfiguration.swift
+++ b/ios/Pulpe/Core/Config/AppConfiguration.swift
@@ -118,6 +118,9 @@ enum AppConfiguration {
 
     private static func requiredValue(for key: String) -> String {
         guard let value = optionalValue(for: key) else {
+            if let raw = Bundle.main.object(forInfoDictionaryKey: key) as? String, raw.contains("$(") {
+                fatalError("\(key) is unresolved. Check your build configuration and xcconfig mapping.")
+            }
             fatalError("\(key) not configured in Info.plist")
         }
         return value

--- a/ios/Pulpe/Core/Config/AppConfiguration.swift
+++ b/ios/Pulpe/Core/Config/AppConfiguration.swift
@@ -117,24 +117,10 @@ enum AppConfiguration {
     // MARK: - Private
 
     private static func requiredValue(for key: String) -> String {
-        if let value = ProcessInfo.processInfo.environment[key], !value.isEmpty {
-            return value
+        guard let value = optionalValue(for: key) else {
+            fatalError("\(key) not configured in Info.plist")
         }
-
-        if let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
-           !value.isEmpty {
-            guard !value.contains("$(") else {
-                fatalError("\(key) is unresolved. Check your build configuration and xcconfig mapping.")
-            }
-
-            return value
-        }
-
-        if isRunningTests, let fallback = testFallbackValue(for: key) {
-            return fallback
-        }
-
-        fatalError("\(key) not configured in Info.plist")
+        return value
     }
 
     private static func optionalValue(for key: String) -> String? {

--- a/ios/Pulpe/Core/Config/AppConfiguration.swift
+++ b/ios/Pulpe/Core/Config/AppConfiguration.swift
@@ -52,6 +52,23 @@ enum AppConfiguration {
         environment != .prod
     }
 
+    // MARK: - PostHog Analytics
+
+    static var postHogApiKey: String? {
+        guard let value = optionalValue(for: "POSTHOG_API_KEY"), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    static var postHogHost: String {
+        optionalValue(for: "POSTHOG_HOST") ?? "https://eu.i.posthog.com"
+    }
+
+    static var isPostHogEnabled: Bool {
+        optionalValue(for: "POSTHOG_ENABLED") == "true"
+    }
+
     // MARK: - App Info
 
     static var appVersion: String {
@@ -120,6 +137,20 @@ enum AppConfiguration {
         fatalError("\(key) not configured in Info.plist")
     }
 
+    private static func optionalValue(for key: String) -> String? {
+        if let value = ProcessInfo.processInfo.environment[key], !value.isEmpty {
+            return value
+        }
+        if let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+           !value.isEmpty, !value.contains("$(") {
+            return value
+        }
+        if isRunningTests {
+            return testFallbackValue(for: key)
+        }
+        return nil
+    }
+
     private static var isRunningTests: Bool {
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
@@ -134,6 +165,12 @@ enum AppConfiguration {
             return "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH"
         case "APP_ENV":
             return "local"
+        case "POSTHOG_API_KEY":
+            return "phc_test_key"
+        case "POSTHOG_HOST":
+            return "https://eu.i.posthog.com"
+        case "POSTHOG_ENABLED":
+            return "false"
         default:
             return nil
         }

--- a/ios/Pulpe/Features/Account/AccountView.swift
+++ b/ios/Pulpe/Features/Account/AccountView.swift
@@ -72,6 +72,7 @@ struct AccountView: View {
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
             .background(Color.surfacePrimary)
+            .trackScreen("Account")
             .navigationTitle("Compte")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/ios/Pulpe/Features/Auth/LoginView.swift
+++ b/ios/Pulpe/Features/Auth/LoginView.swift
@@ -42,6 +42,7 @@ struct LoginView: View {
                     }
                 }
             }
+            .trackScreen("Login")
             .dismissKeyboardOnTap()
             .sheet(item: $forgotPasswordPresentation) { _ in
                 ForgotPasswordSheet {
@@ -253,6 +254,7 @@ extension LoginView {
 
         do {
             try await appState.login(email: viewModel.email, password: viewModel.password)
+            AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "email"])
             appState.biometricError = nil
             isPresented?.wrappedValue = false
         } catch {

--- a/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
@@ -207,6 +207,7 @@ final class PinEntryViewModel {
 
             digits = []
             hapticSuccess.toggle()
+            AnalyticsService.shared.capture(.pinEntered)
             authenticated = true
         } catch let error as APIError {
             handleAPIError(error)

--- a/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
@@ -282,29 +282,20 @@ final class PinSetupViewModel {
 
             // For existing PIN mode, skip recovery key setup
             if mode == .enterExistingPin {
-                digits = []
-                hapticSuccess.toggle()
-                AnalyticsService.shared.capture(.pinSetupCompleted)
-                completedWithoutRecovery = true
+                completeWithSuccess(showRecovery: false)
                 return
             }
 
             // Skip recovery setup if user already has one (edge case: vault-status 404)
             guard !result.saltResponse.hasRecoveryKey else {
                 Logger.encryption.info("Skipping recovery key setup — user already has one")
-                digits = []
-                hapticSuccess.toggle()
-                AnalyticsService.shared.capture(.pinSetupCompleted)
-                completedWithoutRecovery = true
+                completeWithSuccess(showRecovery: false)
                 return
             }
 
             let key = try await encryptionAPI.setupRecoveryKey()
             recoveryKey = key
-            digits = []
-            hapticSuccess.toggle()
-            AnalyticsService.shared.capture(.pinSetupCompleted)
-            showRecoverySheet = true
+            completeWithSuccess(showRecovery: true)
         } catch let apiError as APIError {
             handleAPIError(apiError)
         } catch {
@@ -337,6 +328,17 @@ final class PinSetupViewModel {
             try? await Task.sleep(for: .seconds(1))
             guard !Task.isCancelled else { return }
             isError = false
+        }
+    }
+
+    private func completeWithSuccess(showRecovery: Bool) {
+        digits = []
+        hapticSuccess.toggle()
+        AnalyticsService.shared.capture(.pinSetupCompleted)
+        if showRecovery {
+            showRecoverySheet = true
+        } else {
+            completedWithoutRecovery = true
         }
     }
 

--- a/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
@@ -284,6 +284,7 @@ final class PinSetupViewModel {
             if mode == .enterExistingPin {
                 digits = []
                 hapticSuccess.toggle()
+                AnalyticsService.shared.capture(.pinSetupCompleted)
                 completedWithoutRecovery = true
                 return
             }
@@ -293,6 +294,7 @@ final class PinSetupViewModel {
                 Logger.encryption.info("Skipping recovery key setup — user already has one")
                 digits = []
                 hapticSuccess.toggle()
+                AnalyticsService.shared.capture(.pinSetupCompleted)
                 completedWithoutRecovery = true
                 return
             }
@@ -301,6 +303,7 @@ final class PinSetupViewModel {
             recoveryKey = key
             digits = []
             hapticSuccess.toggle()
+            AnalyticsService.shared.capture(.pinSetupCompleted)
             showRecoverySheet = true
         } catch let apiError as APIError {
             handleAPIError(apiError)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -38,6 +38,7 @@ struct BudgetDetailsView: View {
                 content
             }
         }
+        .trackScreen("BudgetDetails")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -40,6 +40,7 @@ struct BudgetListView: View {
                 budgetList
             }
         }
+        .trackScreen("BudgetList")
         .navigationTitle("Budgets")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {

--- a/ios/Pulpe/Features/Budgets/BudgetList/CreateBudgetView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/CreateBudgetView.swift
@@ -234,6 +234,7 @@ struct CreateBudgetView: View {
 
     private func createBudget() async {
         if let budget = await viewModel.createBudget() {
+            AnalyticsService.shared.capture(.budgetCreated)
             onCreate(budget)
             dismiss()
         }

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -136,6 +136,7 @@ struct AddTransactionSheet: View {
 
         do {
             let transaction = try await transactionService.createTransaction(data)
+            AnalyticsService.shared.capture(.transactionCreated, properties: ["type": kind.rawValue])
             submitSuccessTrigger.toggle()
             onAdd(transaction)
             toastManager.show("Transaction ajoutée")

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -49,6 +49,7 @@ struct CurrentMonthView: View {
                 dashboardContent
             }
         }
+        .trackScreen("Dashboard")
         .navigationTitle("Accueil")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -179,6 +179,16 @@ enum OnboardingStep: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    var analyticsName: String {
+        switch self {
+        case .welcome: "welcome"
+        case .personalInfo: "personal_info"
+        case .expenses: "expenses"
+        case .budgetPreview: "budget_preview"
+        case .registration: "registration"
+        }
+    }
+
     var title: String {
         switch self {
         case .welcome: "Bienvenue"

--- a/ios/Pulpe/Features/Onboarding/Steps/BudgetPreviewStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/BudgetPreviewStep.swift
@@ -15,7 +15,8 @@ struct BudgetPreviewStep: View {
             state: state,
             canProceed: true,
             onNext: {
-                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": "budget_preview"])
+                let step = OnboardingStep.budgetPreview.analyticsName
+                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": step])
                 state.nextStep()
             },
             content: {

--- a/ios/Pulpe/Features/Onboarding/Steps/BudgetPreviewStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/BudgetPreviewStep.swift
@@ -14,7 +14,10 @@ struct BudgetPreviewStep: View {
             step: .budgetPreview,
             state: state,
             canProceed: true,
-            onNext: { state.nextStep() },
+            onNext: {
+                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": "budget_preview"])
+                state.nextStep()
+            },
             content: {
                 VStack(spacing: DesignTokens.Spacing.xxxl) {
                     heroSection
@@ -37,6 +40,7 @@ struct BudgetPreviewStep: View {
                 }
             }
         )
+        .trackScreen("Onboarding_BudgetPreview")
     }
 
     // MARK: - Hero Section

--- a/ios/Pulpe/Features/Onboarding/Steps/ExpensesStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/ExpensesStep.swift
@@ -8,7 +8,10 @@ struct ExpensesStep: View {
             step: .expenses,
             state: state,
             canProceed: true,
-            onNext: { state.nextStep() },
+            onNext: {
+                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": "expenses"])
+                state.nextStep()
+            },
             content: {
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
                 CurrencyField(
@@ -58,6 +61,7 @@ struct ExpensesStep: View {
                 }
             }
         )
+        .trackScreen("Onboarding_Expenses")
     }
 }
 

--- a/ios/Pulpe/Features/Onboarding/Steps/ExpensesStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/ExpensesStep.swift
@@ -9,7 +9,8 @@ struct ExpensesStep: View {
             state: state,
             canProceed: true,
             onNext: {
-                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": "expenses"])
+                let step = OnboardingStep.expenses.analyticsName
+                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": step])
                 state.nextStep()
             },
             content: {

--- a/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
@@ -9,7 +9,10 @@ struct PersonalInfoStep: View {
             step: .personalInfo,
             state: state,
             canProceed: state.isFirstNameValid && state.isIncomeValid,
-            onNext: { state.nextStep() },
+            onNext: {
+                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": "personal_info"])
+                state.nextStep()
+            },
             content: {
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
@@ -52,6 +55,7 @@ struct PersonalInfoStep: View {
                 }
             }
         )
+        .trackScreen("Onboarding_PersonalInfo")
     }
 }
 

--- a/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
@@ -10,7 +10,8 @@ struct PersonalInfoStep: View {
             state: state,
             canProceed: state.isFirstNameValid && state.isIncomeValid,
             onNext: {
-                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": "personal_info"])
+                let step = OnboardingStep.personalInfo.analyticsName
+                AnalyticsService.shared.capture(.onboardingStepCompleted, properties: ["step": step])
                 state.nextStep()
             },
             content: {

--- a/ios/Pulpe/Features/Onboarding/Steps/RegistrationStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/RegistrationStep.swift
@@ -55,6 +55,7 @@ struct RegistrationStep: View {
                 }
             }
         )
+        .trackScreen("Onboarding_Registration")
     }
 }
 
@@ -193,6 +194,7 @@ extension RegistrationStep {
             let authService = AuthService.shared
             let user = try await authService.signup(email: state.email, password: password)
 
+            AnalyticsService.shared.capture(.signupCompleted, properties: ["method": "email"])
             state.isLoading = false
             onComplete(user)
         } catch let apiError as APIError {

--- a/ios/Pulpe/Features/Onboarding/Steps/WelcomeStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/WelcomeStep.swift
@@ -57,6 +57,7 @@ struct WelcomeStep: View {
                 VStack(spacing: DesignTokens.Spacing.md) {
                     // Primary CTA - vibrant and eye-catching
                     Button {
+                        AnalyticsService.shared.capture(.signupStarted, properties: ["method": "email"])
                         state.nextStep()
                     } label: {
                         HStack(spacing: DesignTokens.Spacing.sm) {
@@ -99,6 +100,8 @@ struct WelcomeStep: View {
                 .offset(y: isAppeared ? 0 : 10)
             }
         }
+        .trackScreen("Welcome")
+        .task { AnalyticsService.shared.capture(.welcomeScreenViewed) }
         .sheet(isPresented: $showLogin) {
             LoginView(isPresented: $showLogin)
         }

--- a/ios/Pulpe/Features/Onboarding/Steps/WelcomeStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/WelcomeStep.swift
@@ -100,7 +100,6 @@ struct WelcomeStep: View {
                 .offset(y: isAppeared ? 0 : 10)
             }
         }
-        .trackScreen("Welcome")
         .task { AnalyticsService.shared.capture(.welcomeScreenViewed) }
         .sheet(isPresented: $showLogin) {
             LoginView(isPresented: $showLogin)

--- a/ios/Pulpe/Features/Templates/TemplateList/TemplateListView.swift
+++ b/ios/Pulpe/Features/Templates/TemplateList/TemplateListView.swift
@@ -38,6 +38,7 @@ struct TemplateListView: View {
                 templateList
             }
         }
+        .trackScreen("TemplateList")
         .navigationTitle("Modèles")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {

--- a/ios/Pulpe/Resources/Info.plist
+++ b/ios/Pulpe/Resources/Info.plist
@@ -45,6 +45,12 @@
 	<true/>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Utilisez Face ID pour vous connecter rapidement et en toute sécurité.</string>
+	<key>POSTHOG_API_KEY</key>
+	<string>$(POSTHOG_API_KEY)</string>
+	<key>POSTHOG_ENABLED</key>
+	<string>$(POSTHOG_ENABLED)</string>
+	<key>POSTHOG_HOST</key>
+	<string>$(POSTHOG_HOST)</string>
 	<key>SUPABASE_ANON_KEY</key>
 	<string>$(SUPABASE_ANON_KEY)</string>
 	<key>SUPABASE_URL</key>

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -54,7 +54,7 @@ struct AnalyticsServiceTests {
             "step": "2"
         ]
 
-        let sanitized = sut.sanitizeProperties(properties)
+        let sanitized = AnalyticsService.sanitizeProperties(properties)
 
         #expect(sanitized["amount"] == nil)
         #expect(sanitized["balance"] == nil)
@@ -83,7 +83,7 @@ struct AnalyticsServiceTests {
             "type": "expense"
         ]
 
-        let sanitized = sut.sanitizeProperties(properties)
+        let sanitized = AnalyticsService.sanitizeProperties(properties)
 
         #expect(sanitized["total_amount"] == nil)
         #expect(sanitized["current_balance"] == nil)
@@ -102,7 +102,7 @@ struct AnalyticsServiceTests {
             "screen_name": "dashboard"
         ]
 
-        let sanitized = sut.sanitizeProperties(properties)
+        let sanitized = AnalyticsService.sanitizeProperties(properties)
 
         #expect(sanitized["type"] as? String == "expense")
         #expect(sanitized["step"] as? String == "2")
@@ -112,7 +112,7 @@ struct AnalyticsServiceTests {
     }
 
     @Test func sanitizeProperties_emptyInput_returnsEmpty() {
-        let sanitized = sut.sanitizeProperties([:])
+        let sanitized = AnalyticsService.sanitizeProperties([:])
         #expect(sanitized.isEmpty)
     }
 

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+@MainActor
+struct AnalyticsServiceTests {
+    private let sut = AnalyticsService.shared
+
+    // MARK: - Event Naming Convention
+
+    @Test func allEventRawValues_areSnakeCase() {
+        let snakeCasePattern = /^[a-z][a-z0-9_]*$/
+        for event in AnalyticsEvent.allCases {
+            #expect(
+                event.rawValue.wholeMatch(of: snakeCasePattern) != nil,
+                "\(event) raw value '\(event.rawValue)' is not snake_case"
+            )
+        }
+    }
+
+    @Test func eventRawValues_matchWebConvention() {
+        #expect(AnalyticsEvent.appOpened.rawValue == "app_opened")
+        #expect(AnalyticsEvent.welcomeScreenViewed.rawValue == "welcome_screen_viewed")
+        #expect(AnalyticsEvent.signupStarted.rawValue == "signup_started")
+        #expect(AnalyticsEvent.signupCompleted.rawValue == "signup_completed")
+        #expect(AnalyticsEvent.onboardingStepCompleted.rawValue == "onboarding_step_completed")
+        #expect(AnalyticsEvent.loginCompleted.rawValue == "login_completed")
+        #expect(AnalyticsEvent.pinSetupCompleted.rawValue == "pin_setup_completed")
+        #expect(AnalyticsEvent.budgetCreated.rawValue == "budget_created")
+        #expect(AnalyticsEvent.transactionCreated.rawValue == "transaction_created")
+        #expect(AnalyticsEvent.tabSwitched.rawValue == "tab_switched")
+    }
+
+    // MARK: - Sanitization
+
+    @Test func sanitizeProperties_removesFinancialData() {
+        let properties: [String: Any] = [
+            "amount": 1500,
+            "balance": 3000,
+            "income": 5000,
+            "savings": 200,
+            "total": 9000,
+            "ending_balance": 1234,
+            "target_amount": 500,
+            "available": 800,
+            "projection": 1200,
+            "rollover": 100,
+            "net_income": 4000,
+            "expenses_total": 2000,
+            "income_total": 6000,
+            "savings_total": 1500,
+            "budget_amount": 3500,
+            "type": "expense",
+            "step": "2"
+        ]
+
+        let sanitized = sut.sanitizeProperties(properties)
+
+        #expect(sanitized["amount"] == nil)
+        #expect(sanitized["balance"] == nil)
+        #expect(sanitized["income"] == nil)
+        #expect(sanitized["savings"] == nil)
+        #expect(sanitized["total"] == nil)
+        #expect(sanitized["ending_balance"] == nil)
+        #expect(sanitized["target_amount"] == nil)
+        #expect(sanitized["available"] == nil)
+        #expect(sanitized["projection"] == nil)
+        #expect(sanitized["rollover"] == nil)
+        #expect(sanitized["net_income"] == nil)
+        #expect(sanitized["expenses_total"] == nil)
+        #expect(sanitized["income_total"] == nil)
+        #expect(sanitized["savings_total"] == nil)
+        #expect(sanitized["budget_amount"] == nil)
+    }
+
+    @Test func sanitizeProperties_removesCompoundFinancialKeys() {
+        let properties: [String: Any] = [
+            "total_amount": 9000,
+            "current_balance": 3000,
+            "monthly_income": 5000,
+            "monthly_savings": 200,
+            "available_budget": 800,
+            "type": "expense"
+        ]
+
+        let sanitized = sut.sanitizeProperties(properties)
+
+        #expect(sanitized["total_amount"] == nil)
+        #expect(sanitized["current_balance"] == nil)
+        #expect(sanitized["monthly_income"] == nil)
+        #expect(sanitized["monthly_savings"] == nil)
+        #expect(sanitized["available_budget"] == nil)
+        #expect(sanitized["type"] as? String == "expense")
+    }
+
+    @Test func sanitizeProperties_preservesNonFinancialData() {
+        let properties: [String: Any] = [
+            "type": "expense",
+            "step": "2",
+            "method": "email",
+            "tab": "budgets",
+            "screen_name": "dashboard"
+        ]
+
+        let sanitized = sut.sanitizeProperties(properties)
+
+        #expect(sanitized["type"] as? String == "expense")
+        #expect(sanitized["step"] as? String == "2")
+        #expect(sanitized["method"] as? String == "email")
+        #expect(sanitized["tab"] as? String == "budgets")
+        #expect(sanitized["screen_name"] as? String == "dashboard")
+    }
+
+    @Test func sanitizeProperties_emptyInput_returnsEmpty() {
+        let sanitized = sut.sanitizeProperties([:])
+        #expect(sanitized.isEmpty)
+    }
+
+    // MARK: - Guard Paths (not initialized in test environment)
+
+    @Test func capture_whenNotInitialized_doesNotCrash() {
+        sut.capture(.appOpened)
+        sut.capture(.budgetCreated, properties: ["type": "expense"])
+    }
+
+    @Test func screen_whenNotInitialized_doesNotCrash() {
+        sut.screen("TestScreen")
+        sut.screen("Dashboard", properties: ["tab": "budgets"])
+    }
+
+    @Test func identify_whenNotInitialized_doesNotCrash() {
+        sut.identify(userId: "test-user")
+        sut.identify(userId: "test-user", properties: ["plan": "free"])
+    }
+
+    @Test func reset_whenNotInitialized_doesNotCrash() {
+        sut.reset()
+    }
+
+    @Test func flush_whenNotInitialized_doesNotCrash() {
+        sut.flush()
+    }
+
+    @Test func isInitialized_isFalseInTestEnvironment() {
+        #expect(sut.isInitialized == false)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -20,6 +20,9 @@ packages:
   lottie-spm:
     url: https://github.com/airbnb/lottie-spm
     from: "4.0.0"
+  posthog-ios:
+    url: https://github.com/PostHog/posthog-ios
+    from: "3.0.0"
 
 settings:
   base:
@@ -60,6 +63,8 @@ targets:
         product: Supabase
       - package: lottie-spm
         product: Lottie
+      - package: posthog-ios
+        product: PostHog
       - target: PulpeWidget
         embed: true
     entitlements:
@@ -121,6 +126,9 @@ targets:
         SUPABASE_URL: $(SUPABASE_URL)
         SUPABASE_ANON_KEY: $(SUPABASE_ANON_KEY)
         APP_ENV: $(APP_ENV)
+        POSTHOG_API_KEY: $(POSTHOG_API_KEY)
+        POSTHOG_HOST: $(POSTHOG_HOST)
+        POSTHOG_ENABLED: $(POSTHOG_ENABLED)
 
   PulpeWidget:
     type: app-extension

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -210,6 +210,33 @@ Each domain in `src/modules/[domain]/`:
 | Logout (biometric off) | `authenticated` | `unauthenticated` | Full clear via logout flow |
 | Password reset | any | `unauthenticated` | `clearAll()` + biometric disabled |
 
+### Analytics (PostHog — Cross-Platform)
+
+Both frontend (Angular) and iOS (SwiftUI) share a PostHog project (EU region).
+
+| Aspect | Frontend (Angular) | iOS (SwiftUI) |
+|--------|-------------------|---------------|
+| Service | `PostHogService` (`core/analytics/`) | `AnalyticsService` (`Core/Analytics/`) |
+| Pattern | Injectable service | `@MainActor final class` singleton |
+| SDK | `posthog-js` | `posthog-ios` (SPM) |
+| Screen tracking | Auto-capture | Manual via `.trackScreen()` view modifier |
+| Sanitization | `posthog-sanitizer.ts` | `AnalyticsService.sanitizeProperties()` — word-component matching |
+| Config | `environment.ts` | `AppConfiguration` + xcconfig files |
+| Disabled in | — | Local env (`POSTHOG_ENABLED = false`) |
+
+**Event naming**: `snake_case`, `object_action` pattern — shared across platforms.
+
+**Onboarding funnel (iOS)**:
+```
+app_opened → welcome_screen_viewed → signup_started
+→ onboarding_step_completed (×3) → signup_completed
+→ pin_setup_completed → budget_created → transaction_created
+```
+
+**Financial data sanitization**: Properties split by `_`, each component checked against a word set (`amount`, `balance`, `income`, `savings`, `total`, `projection`, `rollover`, `expenses`, `available`). Catches compound keys like `total_amount`, `current_balance`.
+
+**User identification**: `identify(userId:)` called in `applyPostAuthDestination()` (covers both login and signup). Reset on logout.
+
 ### Error Handling Pattern
 
 - `BusinessException` for domain errors


### PR DESCRIPTION
## Summary

• Add `AnalyticsService` (@MainActor wrapper) for PostHog event tracking across iOS app
• Track key funnel events: `app_opened`, `welcome_screen_viewed`, `signup_started`, `onboarding_step_completed`, `signup_completed`, `login_completed`, `pin_setup_completed`, `budget_created`, `transaction_created`, `tab_switched`, `logout_completed`
• Financial data sanitization: amounts, balances, and related keywords stripped from event properties before sending
• Environment-based configuration (Local: disabled, Preview/Prod: enabled) via xcconfig + Info.plist
• Manual screen tracking via `.trackScreen()` view modifier
• Simplifications: deduplicate onboarding step tracking, extract PIN setup success handler, optimize sanitization function

## Type

feat