### PR TITLE
feat(ios): add previous month budget sheet in budget details with read-only UI

### DIFF
--- a/ios/Pulpe/Core/Background/BackgroundTaskService.swift
+++ b/ios/Pulpe/Core/Background/BackgroundTaskService.swift
@@ -20,7 +20,9 @@ actor BackgroundTaskService {
             // BGAppRefreshTask is not Sendable, but BGTaskScheduler guarantees
             // the handler runs on the main queue, so we can safely capture it.
             nonisolated(unsafe) let unsafeTask = refreshTask
-            Task { await BackgroundTaskService.shared.handleWidgetRefresh(task: unsafeTask) }
+            Task { @MainActor in
+                await BackgroundTaskService.shared.handleWidgetRefresh(task: unsafeTask)
+            }
         }
     }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import TipKit
 
+private struct PreviousBudgetItem: Identifiable {
+    let id: String
+}
+
 struct BudgetDetailsView: View {
     let budgetId: String
     @Environment(AppState.self) private var appState
@@ -10,6 +14,7 @@ struct BudgetDetailsView: View {
     @State private var linkedTransactionsContext: LinkedTransactionsContext?
     @State private var selectedBudgetLineForEdit: BudgetLine?
     @State private var selectedTransactionForEdit: Transaction?
+    @State private var previousBudgetItem: PreviousBudgetItem?
 
     @State private var searchText = ""
 
@@ -104,6 +109,9 @@ struct BudgetDetailsView: View {
                 Task { await viewModel.updateTransaction(updatedTransaction) }
             }
         }
+        .sheet(item: $previousBudgetItem) { item in
+            PreviousBudgetSheet(budgetId: item.id)
+        }
         .alert(
             "Pointer les transactions ?",
             isPresented: $viewModel.showCheckAllTransactionsAlert,
@@ -138,7 +146,6 @@ struct BudgetDetailsView: View {
         let filteredFree = viewModel.combinedFilteredFreeTransactions(searchText: searchText)
 
         let fullWidthInsets = EdgeInsets()
-        let heroCardInsets = EdgeInsets()
 
         return List {
             // Filter picker
@@ -150,7 +157,7 @@ struct BudgetDetailsView: View {
             .listSectionSeparator(.hidden)
             .listRowInsets(fullWidthInsets)
 
-            // Hero balance card (with horizontal padding to prevent edge clipping)
+            // Hero balance card
             Section {
                 HeroBalanceCard(
                     metrics: viewModel.metrics,
@@ -160,14 +167,14 @@ struct BudgetDetailsView: View {
             .listRowBackground(Color.clear)
             .listRowSeparator(.hidden)
             .listSectionSeparator(.hidden)
-            .listRowInsets(heroCardInsets)
+            .listRowInsets(fullWidthInsets)
 
             // Rollover section (toujours en premier)
             if let rolloverInfo = viewModel.rolloverInfo {
                 RolloverInfoRow(
                     amount: rolloverInfo.amount,
                     onTap: rolloverInfo.previousBudgetId.map { id in
-                        { appState.budgetPath.append(BudgetDestination.details(budgetId: id)) }
+                        { previousBudgetItem = PreviousBudgetItem(id: id) }
                     }
                 )
                 .listRowBackground(Color.clear)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/PreviousBudgetSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/PreviousBudgetSheet.swift
@@ -64,10 +64,10 @@ final class PreviousBudgetSheetViewModel {
 
         do {
             let details = try await budgetService.getBudgetWithDetails(id: budgetId)
+            cachedMetrics = nil
             budget = details.budget
             budgetLines = details.budgetLines
             transactions = details.transactions
-            cachedMetrics = nil
         } catch {
             self.error = error
         }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/PreviousBudgetSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/PreviousBudgetSheet.swift
@@ -13,7 +13,7 @@ final class PreviousBudgetSheetViewModel {
     let budgetId: String
     private let budgetService = BudgetService.shared
 
-    private var cachedMetrics: BudgetFormulas.Metrics?
+    @ObservationIgnored private var cachedMetrics: BudgetFormulas.Metrics?
 
     init(budgetId: String) {
         self.budgetId = budgetId
@@ -153,28 +153,32 @@ struct PreviousBudgetSheet: View {
 
     @ViewBuilder
     private var budgetLineSections: some View {
-        if !viewModel.incomeLines.isEmpty {
+        let income = viewModel.incomeLines
+        let expenses = viewModel.expenseLines
+        let savings = viewModel.savingLines
+
+        if !income.isEmpty {
             BudgetSection(
                 title: "Revenus",
-                items: viewModel.incomeLines,
+                items: income,
                 transactions: viewModel.transactions,
                 syncingIds: []
             )
         }
 
-        if !viewModel.expenseLines.isEmpty {
+        if !expenses.isEmpty {
             BudgetSection(
                 title: "Dépenses",
-                items: viewModel.expenseLines,
+                items: expenses,
                 transactions: viewModel.transactions,
                 syncingIds: []
             )
         }
 
-        if !viewModel.savingLines.isEmpty {
+        if !savings.isEmpty {
             BudgetSection(
                 title: "Épargne",
-                items: viewModel.savingLines,
+                items: savings,
                 transactions: viewModel.transactions,
                 syncingIds: []
             )
@@ -183,10 +187,11 @@ struct PreviousBudgetSheet: View {
 
     @ViewBuilder
     private var freeTransactionsSection: some View {
-        if !viewModel.freeTransactions.isEmpty {
+        let free = viewModel.freeTransactions
+        if !free.isEmpty {
             TransactionSection(
                 title: "Transactions libres",
-                transactions: viewModel.freeTransactions,
+                transactions: free,
                 syncingIds: []
             )
         }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/PreviousBudgetSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/PreviousBudgetSheet.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+
+// MARK: - ViewModel
+
+@Observable @MainActor
+final class PreviousBudgetSheetViewModel {
+    private(set) var budget: Budget?
+    private(set) var budgetLines: [BudgetLine] = []
+    private(set) var transactions: [Transaction] = []
+    private(set) var isLoading = false
+    private(set) var error: Error?
+
+    let budgetId: String
+    private let budgetService = BudgetService.shared
+
+    private var cachedMetrics: BudgetFormulas.Metrics?
+
+    init(budgetId: String) {
+        self.budgetId = budgetId
+    }
+
+    init(budgetId: String, budget: Budget, budgetLines: [BudgetLine], transactions: [Transaction]) {
+        self.budgetId = budgetId
+        self.budget = budget
+        self.budgetLines = budgetLines
+        self.transactions = transactions
+    }
+
+    var metrics: BudgetFormulas.Metrics {
+        if let cached = cachedMetrics { return cached }
+        let calculated = BudgetFormulas.calculateAllMetrics(
+            budgetLines: budgetLines,
+            transactions: transactions,
+            rollover: budget?.rollover.orZero ?? 0
+        )
+        cachedMetrics = calculated
+        return calculated
+    }
+
+    var incomeLines: [BudgetLine] {
+        budgetLines.filter { $0.kind == .income }.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    var expenseLines: [BudgetLine] {
+        budgetLines.filter { $0.kind == .expense }.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    var savingLines: [BudgetLine] {
+        budgetLines.filter { $0.kind == .saving }.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    var freeTransactions: [Transaction] {
+        transactions.filter { $0.budgetLineId == nil }.sorted { $0.transactionDate > $1.transactionDate }
+    }
+
+    var rolloverInfo: (amount: Decimal, previousBudgetId: String?)? {
+        guard let budget, let rollover = budget.rollover, rollover != 0 else { return nil }
+        return (amount: rollover, previousBudgetId: budget.previousBudgetId)
+    }
+
+    func loadDetails() async {
+        isLoading = true
+        error = nil
+
+        do {
+            let details = try await budgetService.getBudgetWithDetails(id: budgetId)
+            budget = details.budget
+            budgetLines = details.budgetLines
+            transactions = details.transactions
+            cachedMetrics = nil
+        } catch {
+            self.error = error
+        }
+
+        isLoading = false
+    }
+}
+
+// MARK: - View
+
+struct PreviousBudgetSheet: View {
+    @State private var viewModel: PreviousBudgetSheetViewModel
+    @State private var detent: PresentationDetent = .large
+    @Environment(\.dismiss) private var dismiss
+
+    init(budgetId: String) {
+        self._viewModel = State(initialValue: PreviousBudgetSheetViewModel(budgetId: budgetId))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading && viewModel.budget == nil {
+                    LoadingView(message: "Chargement...")
+                } else if let error = viewModel.error, viewModel.budget == nil {
+                    ErrorView(error: error) {
+                        await viewModel.loadDetails()
+                    }
+                } else if viewModel.budget != nil {
+                    content
+                }
+            }
+            .navigationTitle(viewModel.budget?.monthYear ?? "Budget")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Fermer") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large], selection: $detent)
+        .presentationDragIndicator(.visible)
+        .task { await viewModel.loadDetails() }
+    }
+
+    private var content: some View {
+        List {
+            heroSection
+            rolloverSection
+            budgetLineSections
+            freeTransactionsSection
+        }
+        .listStyle(.insetGrouped)
+        .listSectionSpacing(DesignTokens.Spacing.lg)
+        .scrollContentBackground(.hidden)
+    }
+
+    private var heroSection: some View {
+        Section {
+            HeroBalanceCard(
+                metrics: viewModel.metrics,
+                onTapProgress: {}
+            )
+        }
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .listSectionSeparator(.hidden)
+        .listRowInsets(EdgeInsets())
+    }
+
+    @ViewBuilder
+    private var rolloverSection: some View {
+        if let rolloverInfo = viewModel.rolloverInfo {
+            RolloverInfoRow(
+                amount: rolloverInfo.amount,
+                onTap: nil
+            )
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets())
+        }
+    }
+
+    @ViewBuilder
+    private var budgetLineSections: some View {
+        if !viewModel.incomeLines.isEmpty {
+            BudgetSection(
+                title: "Revenus",
+                items: viewModel.incomeLines,
+                transactions: viewModel.transactions,
+                syncingIds: []
+            )
+        }
+
+        if !viewModel.expenseLines.isEmpty {
+            BudgetSection(
+                title: "Dépenses",
+                items: viewModel.expenseLines,
+                transactions: viewModel.transactions,
+                syncingIds: []
+            )
+        }
+
+        if !viewModel.savingLines.isEmpty {
+            BudgetSection(
+                title: "Épargne",
+                items: viewModel.savingLines,
+                transactions: viewModel.transactions,
+                syncingIds: []
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var freeTransactionsSection: some View {
+        if !viewModel.freeTransactions.isEmpty {
+            TransactionSection(
+                title: "Transactions libres",
+                transactions: viewModel.freeTransactions,
+                syncingIds: []
+            )
+        }
+    }
+}

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/PreviousBudgetSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/PreviousBudgetSheet.swift
@@ -98,6 +98,8 @@ struct PreviousBudgetSheet: View {
                     }
                 } else if viewModel.budget != nil {
                     content
+                } else {
+                    LoadingView(message: "Chargement...")
                 }
             }
             .navigationTitle(viewModel.budget?.monthYear ?? "Budget")

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -104,7 +104,7 @@ struct BudgetListView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: DesignTokens.Spacing.xl) {
-                    ForEach(Array(store.groupedByYear.enumerated()), id: \.element.year) { _, group in
+                    ForEach(store.groupedByYear, id: \.year) { group in
                         YearSection(
                             year: group.year,
                             budgets: group.budgets,
@@ -268,7 +268,7 @@ struct YearSection: View {
 
     private func monthListCard(months: [MonthSlot]) -> some View {
         VStack(spacing: 0) {
-            ForEach(Array(months.enumerated()), id: \.element.month) { index, slot in
+            ForEach(months, id: \.month) { slot in
                 if let budget = slot.budget {
                     BudgetMonthRow(
                         budget: budget,
@@ -289,7 +289,7 @@ struct YearSection: View {
                     }
                 }
 
-                if index < months.count - 1 {
+                if slot.month != months.last?.month {
                     Divider()
                         .padding(.leading, 34)
                 }
@@ -323,7 +323,7 @@ private struct YearSectionLayoutData {
         }
         if year >= currentPeriod.year {
             let startMonth = (year == currentPeriod.year) ? currentPeriod.month : 1
-            for month in startMonth ... 12 where !budgets.contains { $0.month == month } {
+            for month in startMonth ... 12 where !budgets.contains(where: { $0.month == month }) {
                 slots.append(MonthSlot(month: month, budget: nil))
                 break
             }

--- a/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
@@ -39,10 +39,6 @@ struct BudgetSection: View {
         self.tip = tip
     }
 
-    private var isReadOnly: Bool {
-        onToggle == nil && onDelete == nil && onAddTransaction == nil && onLongPress == nil && onEdit == nil
-    }
-
     @State private var isExpanded = false
 
     private let collapsedItemCount = 3

--- a/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
@@ -8,12 +8,40 @@ struct BudgetSection: View {
     let items: [BudgetLine]
     let transactions: [Transaction]
     let syncingIds: Set<String>
-    let onToggle: (BudgetLine) -> Void
-    let onDelete: (BudgetLine) -> Void
-    let onAddTransaction: (BudgetLine) -> Void
-    let onLongPress: (BudgetLine, [Transaction]) -> Void
-    let onEdit: (BudgetLine) -> Void
+    let onToggle: ((BudgetLine) -> Void)?
+    let onDelete: ((BudgetLine) -> Void)?
+    let onAddTransaction: ((BudgetLine) -> Void)?
+    let onLongPress: ((BudgetLine, [Transaction]) -> Void)?
+    let onEdit: ((BudgetLine) -> Void)?
     var tip: (any Tip)?
+
+    init(
+        title: String,
+        items: [BudgetLine],
+        transactions: [Transaction],
+        syncingIds: Set<String>,
+        onToggle: ((BudgetLine) -> Void)? = nil,
+        onDelete: ((BudgetLine) -> Void)? = nil,
+        onAddTransaction: ((BudgetLine) -> Void)? = nil,
+        onLongPress: ((BudgetLine, [Transaction]) -> Void)? = nil,
+        onEdit: ((BudgetLine) -> Void)? = nil,
+        tip: (any Tip)? = nil
+    ) {
+        self.title = title
+        self.items = items
+        self.transactions = transactions
+        self.syncingIds = syncingIds
+        self.onToggle = onToggle
+        self.onDelete = onDelete
+        self.onAddTransaction = onAddTransaction
+        self.onLongPress = onLongPress
+        self.onEdit = onEdit
+        self.tip = tip
+    }
+
+    private var isReadOnly: Bool {
+        onToggle == nil && onDelete == nil && onAddTransaction == nil && onLongPress == nil && onEdit == nil
+    }
 
     @State private var isExpanded = false
 
@@ -60,7 +88,9 @@ struct BudgetSection: View {
                 budgetLineRow(for: item)
                     .listRowSeparator(.hidden)
                     .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        swipeActions(for: item)
+                        if onToggle != nil || onDelete != nil {
+                            swipeActions(for: item)
+                        }
                     }
                     .transition(.opacity.combined(with: .move(edge: .bottom)))
                     .animation(
@@ -85,46 +115,49 @@ struct BudgetSection: View {
     @ViewBuilder
     private func swipeActions(for item: BudgetLine) -> some View {
         if !item.isVirtualRollover {
-            Button {
-                onDelete(item)
-                ProductTips.gestures.invalidate(reason: .actionPerformed)
-            } label: {
-                Label("Supprimer", systemImage: "trash")
+            if let onDelete {
+                Button {
+                    onDelete(item)
+                    ProductTips.gestures.invalidate(reason: .actionPerformed)
+                } label: {
+                    Label("Supprimer", systemImage: "trash")
+                }
+                .tint(Color.errorPrimary)
             }
-            .tint(Color.errorPrimary)
 
-            Button {
-                onToggle(item)
-                ProductTips.gestures.invalidate(reason: .actionPerformed)
-            } label: {
-                Label(
-                    item.isChecked ? "Annuler" : "Comptabiliser",
-                    systemImage: item.isChecked ? "arrow.uturn.backward" : "checkmark.circle"
-                )
+            if let onToggle {
+                Button {
+                    onToggle(item)
+                    ProductTips.gestures.invalidate(reason: .actionPerformed)
+                } label: {
+                    Label(
+                        item.isChecked ? "Annuler" : "Comptabiliser",
+                        systemImage: item.isChecked ? "arrow.uturn.backward" : "checkmark.circle"
+                    )
+                }
+                .tint(item.isChecked ? Color.financialOverBudget : .pulpePrimary)
             }
-            .tint(item.isChecked ? Color.financialOverBudget : .pulpePrimary)
         }
     }
 
+    @ViewBuilder
     private var expandCollapseButton: some View {
-        Group {
-            if hasMoreItems {
-                Button {
-                    withAnimation(.easeInOut(duration: DesignTokens.Animation.fast)) {
-                        isExpanded.toggle()
-                    }
-                } label: {
-                    HStack {
-                        Text(isExpanded ? "Voir moins" : "Voir plus (+\(hiddenItemsCount))")
-                            .font(PulpeTypography.subheadline)
-                        Spacer()
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(PulpeTypography.caption)
-                            .foregroundStyle(.secondary)
-                    }
+        if hasMoreItems {
+            Button {
+                withAnimation(.easeInOut(duration: DesignTokens.Animation.fast)) {
+                    isExpanded.toggle()
                 }
-                .listRowSeparator(.hidden)
+            } label: {
+                HStack {
+                    Text(isExpanded ? "Voir moins" : "Voir plus (+\(hiddenItemsCount))")
+                        .font(PulpeTypography.subheadline)
+                    Spacer()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(PulpeTypography.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
+            .listRowSeparator(.hidden)
         }
     }
 
@@ -134,12 +167,10 @@ struct BudgetSection: View {
             consumption: BudgetFormulas.calculateConsumption(for: item, transactions: transactions),
             allTransactions: transactions,
             isSyncing: syncingIds.contains(item.id),
-            onToggle: { onToggle(item) },
-            onAddTransaction: { onAddTransaction(item) },
-            onLongPress: { linkedTransactions in
-                onLongPress(item, linkedTransactions)
-            },
-            onEdit: { onEdit(item) }
+            onToggle: onToggle.map { callback in { callback(item) } },
+            onAddTransaction: onAddTransaction.map { callback in { callback(item) } },
+            onLongPress: onLongPress.map { callback in { linkedTransactions in callback(item, linkedTransactions) } },
+            onEdit: onEdit.map { callback in { callback(item) } }
         )
     }
 }
@@ -150,10 +181,30 @@ struct BudgetLineRow: View {
     let consumption: BudgetFormulas.Consumption
     let allTransactions: [Transaction]
     let isSyncing: Bool
-    let onToggle: () -> Void
-    let onAddTransaction: () -> Void
-    let onLongPress: ([Transaction]) -> Void
-    let onEdit: () -> Void
+    let onToggle: (() -> Void)?
+    let onAddTransaction: (() -> Void)?
+    let onLongPress: (([Transaction]) -> Void)?
+    let onEdit: (() -> Void)?
+
+    init(
+        line: BudgetLine,
+        consumption: BudgetFormulas.Consumption,
+        allTransactions: [Transaction],
+        isSyncing: Bool,
+        onToggle: (() -> Void)? = nil,
+        onAddTransaction: (() -> Void)? = nil,
+        onLongPress: (([Transaction]) -> Void)? = nil,
+        onEdit: (() -> Void)? = nil
+    ) {
+        self.line = line
+        self.consumption = consumption
+        self.allTransactions = allTransactions
+        self.isSyncing = isSyncing
+        self.onToggle = onToggle
+        self.onAddTransaction = onAddTransaction
+        self.onLongPress = onLongPress
+        self.onEdit = onEdit
+    }
 
     @State private var isPressed = false
     @State private var triggerSuccessFeedback = false
@@ -236,8 +287,8 @@ struct BudgetLineRow: View {
                 }
             }
 
-            // Add button (only for non-rollover lines)
-            if !line.isVirtualRollover {
+            // Add button (only for non-rollover lines with callback)
+            if let onAddTransaction, !line.isVirtualRollover {
                 Button(action: onAddTransaction) {
                     Image(systemName: "plus")
                         .font(.system(size: 12, weight: .bold))
@@ -261,6 +312,7 @@ struct BudgetLineRow: View {
             minimumDuration: 0.4,
             maximumDistance: 10,
             pressing: { pressing in
+                guard onLongPress != nil else { return }
                 withAnimation(.spring(duration: DesignTokens.Animation.fast)) {
                     isPressed = pressing
                 }
@@ -268,7 +320,7 @@ struct BudgetLineRow: View {
             perform: handleLongPress
         )
         .onTapGesture {
-            guard !line.isVirtualRollover else { return }
+            guard let onEdit, !line.isVirtualRollover else { return }
             ProductTips.gestures.invalidate(reason: .actionPerformed)
             onEdit()
         }
@@ -277,14 +329,17 @@ struct BudgetLineRow: View {
         .sensoryFeedback(.success, trigger: triggerSuccessFeedback)
         .sensoryFeedback(.error, trigger: triggerWarningFeedback)
         .accessibilityIdentifier("budgetLineRow-\(line.id)")
-        .accessibilityAddTraits(.isButton)
-        .accessibilityAction { onEdit() }
-        .accessibilityHint(
-            hasConsumption
-                ? "Montant restant: \(consumption.available.asCHF). " +
-                  "Touche pour modifier, maintiens pour voir les transactions"
-                : "Touche pour modifier, maintiens pour voir les transactions"
-        )
+        .ifLet(onEdit) { view, onEdit in
+            view
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction { onEdit() }
+                .accessibilityHint(
+                    hasConsumption
+                        ? "Montant restant: \(consumption.available.asCHF). " +
+                          "Touche pour modifier, maintiens pour voir les transactions"
+                        : "Touche pour modifier, maintiens pour voir les transactions"
+                )
+        }
     }
 
     // MARK: - Kind Icon Circle (Revolut-style)
@@ -331,7 +386,7 @@ struct BudgetLineRow: View {
     }
 
     private func handleLongPress() {
-        guard !line.isVirtualRollover else { return }
+        guard let onLongPress, !line.isVirtualRollover else { return }
 
         ProductTips.gestures.invalidate(reason: .actionPerformed)
 

--- a/ios/Pulpe/Features/CurrentMonth/Components/OneTimeExpensesList.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/OneTimeExpensesList.swift
@@ -6,9 +6,25 @@ struct TransactionSection: View {
     let title: String
     let transactions: [Transaction]
     let syncingIds: Set<String>
-    let onToggle: (Transaction) -> Void
-    let onDelete: (Transaction) -> Void
-    let onEdit: (Transaction) -> Void
+    let onToggle: ((Transaction) -> Void)?
+    let onDelete: ((Transaction) -> Void)?
+    let onEdit: ((Transaction) -> Void)?
+
+    init(
+        title: String,
+        transactions: [Transaction],
+        syncingIds: Set<String>,
+        onToggle: ((Transaction) -> Void)? = nil,
+        onDelete: ((Transaction) -> Void)? = nil,
+        onEdit: ((Transaction) -> Void)? = nil
+    ) {
+        self.title = title
+        self.transactions = transactions
+        self.syncingIds = syncingIds
+        self.onToggle = onToggle
+        self.onDelete = onDelete
+        self.onEdit = onEdit
+    }
 
     @State private var isExpanded = false
 
@@ -46,22 +62,26 @@ struct TransactionSection: View {
 
     @ViewBuilder
     private func swipeActions(for transaction: Transaction) -> some View {
-        Button {
-            onDelete(transaction)
-        } label: {
-            Label("Supprimer", systemImage: "trash")
+        if let onDelete {
+            Button {
+                onDelete(transaction)
+            } label: {
+                Label("Supprimer", systemImage: "trash")
+            }
+            .tint(Color.errorPrimary)
         }
-        .tint(Color.errorPrimary)
 
-        Button {
-            onToggle(transaction)
-        } label: {
-            Label(
-                transaction.isChecked ? "Annuler" : "Comptabiliser",
-                systemImage: transaction.isChecked ? "arrow.uturn.backward" : "checkmark.circle"
-            )
+        if let onToggle {
+            Button {
+                onToggle(transaction)
+            } label: {
+                Label(
+                    transaction.isChecked ? "Annuler" : "Comptabiliser",
+                    systemImage: transaction.isChecked ? "arrow.uturn.backward" : "checkmark.circle"
+                )
+            }
+            .tint(transaction.isChecked ? Color.financialOverBudget : .pulpePrimary)
         }
-        .tint(transaction.isChecked ? Color.financialOverBudget : .pulpePrimary)
     }
 
     @ViewBuilder
@@ -91,11 +111,13 @@ struct TransactionSection: View {
                 TransactionRow(
                     transaction: transaction,
                     isSyncing: syncingIds.contains(transaction.id),
-                    onEdit: { onEdit(transaction) }
+                    onEdit: onEdit.map { callback in { callback(transaction) } }
                 )
                     .listRowSeparator(.hidden)
                     .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        swipeActions(for: transaction)
+                        if onToggle != nil || onDelete != nil {
+                            swipeActions(for: transaction)
+                        }
                     }
             }
 
@@ -116,44 +138,57 @@ struct TransactionSection: View {
 struct TransactionRow: View {
     let transaction: Transaction
     let isSyncing: Bool
-    let onEdit: () -> Void
+    let onEdit: (() -> Void)?
 
+    init(transaction: Transaction, isSyncing: Bool, onEdit: (() -> Void)? = nil) {
+        self.transaction = transaction
+        self.isSyncing = isSyncing
+        self.onEdit = onEdit
+    }
+
+    @ViewBuilder
     var body: some View {
-        Button(action: onEdit) {
-            HStack(spacing: DesignTokens.Spacing.md) {
-                // Kind icon circle (Revolut-style)
-                kindIconCircle
-
-                // Main content
-                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
-                    Text(transaction.name)
-                        .font(PulpeTypography.onboardingSubtitle)
-                        .foregroundStyle(transaction.isChecked ? .secondary : .primary)
-                        .strikethrough(transaction.isChecked, color: .secondary)
-                        .lineLimit(1)
-
-                    // Date (relative formatting)
-                    Text(transaction.transactionDate.relativeFormatted)
-                        .font(PulpeTypography.caption)
-                        .foregroundStyle(Color.textTertiary)
-                }
-
-                Spacer(minLength: 8)
-
-                // Sync indicator
-                SyncIndicator(isSyncing: isSyncing)
-
-                // Amount
-                Text(transaction.amount.asCHF)
-                    .font(PulpeTypography.callout.weight(.semibold))
-                    .foregroundStyle(transaction.isChecked ? .secondary : transaction.kind.color)
-                    .sensitiveAmount()
-            }
-            .padding(.vertical, DesignTokens.Spacing.sm)
-            .contentShape(Rectangle())
+        if let onEdit {
+            Button(action: onEdit) { content }
+                .buttonStyle(.plain)
+                .accessibilityHint("Touche pour modifier")
+        } else {
+            content
         }
-        .buttonStyle(.plain)
-        .accessibilityHint("Touche pour modifier")
+    }
+
+    private var content: some View {
+        HStack(spacing: DesignTokens.Spacing.md) {
+            // Kind icon circle (Revolut-style)
+            kindIconCircle
+
+            // Main content
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+                Text(transaction.name)
+                    .font(PulpeTypography.onboardingSubtitle)
+                    .foregroundStyle(transaction.isChecked ? .secondary : .primary)
+                    .strikethrough(transaction.isChecked, color: .secondary)
+                    .lineLimit(1)
+
+                // Date (relative formatting)
+                Text(transaction.transactionDate.relativeFormatted)
+                    .font(PulpeTypography.caption)
+                    .foregroundStyle(Color.textTertiary)
+            }
+
+            Spacer(minLength: 8)
+
+            // Sync indicator
+            SyncIndicator(isSyncing: isSyncing)
+
+            // Amount
+            Text(transaction.amount.asCHF)
+                .font(PulpeTypography.callout.weight(.semibold))
+                .foregroundStyle(transaction.isChecked ? .secondary : transaction.kind.color)
+                .sensitiveAmount()
+        }
+        .padding(.vertical, DesignTokens.Spacing.sm)
+        .contentShape(Rectangle())
     }
 
     // MARK: - Kind Icon Circle (Revolut-style)

--- a/ios/Pulpe/Shared/Extensions/View+Extensions.swift
+++ b/ios/Pulpe/Shared/Extensions/View+Extensions.swift
@@ -265,7 +265,7 @@ private struct KeyboardDismissView: UIViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    final class Coordinator {
+    @MainActor final class Coordinator {
         @objc func dismiss() {
             UIApplication.shared.sendAction(
                 #selector(UIResponder.resignFirstResponder),

--- a/ios/PulpeTests/Features/Budgets/PreviousBudgetSheetViewModelTests.swift
+++ b/ios/PulpeTests/Features/Budgets/PreviousBudgetSheetViewModelTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+@Suite("PreviousBudgetSheetViewModel Tests")
+@MainActor
+struct PreviousBudgetSheetViewModelTests {
+    // MARK: - Initialization
+
+    @Test
+    func init_storesBudgetId() {
+        let viewModel = PreviousBudgetSheetViewModel(budgetId: "prev-budget-123")
+
+        #expect(viewModel.budgetId == "prev-budget-123")
+    }
+
+    @Test
+    func init_startsInIdleState() {
+        let viewModel = PreviousBudgetSheetViewModel(budgetId: "test")
+
+        #expect(viewModel.isLoading == false)
+        #expect(viewModel.budget == nil)
+        #expect(viewModel.budgetLines.isEmpty)
+        #expect(viewModel.transactions.isEmpty)
+        #expect(viewModel.error == nil)
+    }
+
+    // MARK: - Line Categorization
+
+    @Test
+    func incomeLines_returnsOnlyIncomeKind() {
+        let income = TestDataFactory.createBudgetLine(id: "inc-1", kind: .income)
+        let expense = TestDataFactory.createBudgetLine(id: "exp-1", kind: .expense)
+        let saving = TestDataFactory.createBudgetLine(id: "sav-1", kind: .saving)
+        let budget = TestDataFactory.createBudget()
+
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [income, expense, saving],
+            transactions: []
+        )
+
+        #expect(viewModel.incomeLines.count == 1)
+        #expect(viewModel.incomeLines.first?.id == "inc-1")
+    }
+
+    @Test
+    func expenseLines_returnsOnlyExpenseKind() {
+        let income = TestDataFactory.createBudgetLine(id: "inc-1", kind: .income)
+        let expense1 = TestDataFactory.createBudgetLine(id: "exp-1", kind: .expense)
+        let expense2 = TestDataFactory.createBudgetLine(id: "exp-2", kind: .expense)
+        let budget = TestDataFactory.createBudget()
+
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [income, expense1, expense2],
+            transactions: []
+        )
+
+        #expect(viewModel.expenseLines.count == 2)
+        #expect(viewModel.expenseLines.allSatisfy { $0.kind == .expense })
+    }
+
+    @Test
+    func savingLines_returnsOnlySavingKind() {
+        let saving = TestDataFactory.createBudgetLine(id: "sav-1", kind: .saving)
+        let expense = TestDataFactory.createBudgetLine(id: "exp-1", kind: .expense)
+        let budget = TestDataFactory.createBudget()
+
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [saving, expense],
+            transactions: []
+        )
+
+        #expect(viewModel.savingLines.count == 1)
+        #expect(viewModel.savingLines.first?.id == "sav-1")
+    }
+
+    @Test
+    func categorizedLines_withEmptyData_allReturnEmpty() {
+        let budget = TestDataFactory.createBudget()
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [],
+            transactions: []
+        )
+
+        #expect(viewModel.incomeLines.isEmpty)
+        #expect(viewModel.expenseLines.isEmpty)
+        #expect(viewModel.savingLines.isEmpty)
+    }
+
+    // MARK: - Free Transactions
+
+    @Test
+    func freeTransactions_returnsOnlyUnlinkedTransactions() {
+        let freeTx = TestDataFactory.createTransaction(id: "tx-free", budgetLineId: nil)
+        let linkedTx = TestDataFactory.createTransaction(id: "tx-linked", budgetLineId: "line-1")
+        let budget = TestDataFactory.createBudget()
+
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [],
+            transactions: [freeTx, linkedTx]
+        )
+
+        #expect(viewModel.freeTransactions.count == 1)
+        #expect(viewModel.freeTransactions.first?.id == "tx-free")
+    }
+
+    @Test
+    func freeTransactions_whenAllLinked_returnsEmpty() {
+        let linkedTx1 = TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "line-1")
+        let linkedTx2 = TestDataFactory.createTransaction(id: "tx-2", budgetLineId: "line-2")
+        let budget = TestDataFactory.createBudget()
+
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [],
+            transactions: [linkedTx1, linkedTx2]
+        )
+
+        #expect(viewModel.freeTransactions.isEmpty)
+    }
+
+    // MARK: - Rollover Info
+
+    @Test
+    func rolloverInfo_whenBudgetIsNil_returnsNil() {
+        let viewModel = PreviousBudgetSheetViewModel(budgetId: "test")
+
+        #expect(viewModel.rolloverInfo == nil)
+    }
+
+    @Test
+    func rolloverInfo_whenRolloverIsZero_returnsNil() {
+        let budget = TestDataFactory.createBudget(rollover: 0)
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [],
+            transactions: []
+        )
+
+        #expect(viewModel.rolloverInfo == nil)
+    }
+
+    @Test
+    func rolloverInfo_whenRolloverIsPositive_returnsAmountAndPreviousBudgetId() {
+        let budget = TestDataFactory.createBudget(
+            rollover: 250,
+            previousBudgetId: "prev-budget-456"
+        )
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [],
+            transactions: []
+        )
+
+        let info = viewModel.rolloverInfo
+        #expect(info != nil)
+        #expect(info?.amount == 250)
+        #expect(info?.previousBudgetId == "prev-budget-456")
+    }
+
+    @Test
+    func rolloverInfo_whenRolloverIsNegative_returnsInfo() {
+        let budget = TestDataFactory.createBudget(
+            rollover: -100,
+            previousBudgetId: nil
+        )
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [],
+            transactions: []
+        )
+
+        let info = viewModel.rolloverInfo
+        #expect(info != nil)
+        #expect(info?.amount == -100)
+        #expect(info?.previousBudgetId == nil)
+    }
+
+    // MARK: - Metrics
+
+    @Test
+    func metrics_withEmptyData_returnsZeroedValues() {
+        let budget = TestDataFactory.createBudget()
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [],
+            transactions: []
+        )
+
+        let metrics = viewModel.metrics
+        #expect(metrics.totalIncome == 0)
+        #expect(metrics.totalExpenses == 0)
+        #expect(metrics.totalSavings == 0)
+    }
+
+    @Test
+    func metrics_reflectsBudgetLinesAndRollover() {
+        let income = TestDataFactory.createBudgetLine(id: "inc-1", amount: 5000, kind: .income)
+        let expense = TestDataFactory.createBudgetLine(id: "exp-1", amount: 2000, kind: .expense)
+        let budget = TestDataFactory.createBudget(rollover: 300)
+
+        let viewModel = PreviousBudgetSheetViewModel(
+            budgetId: budget.id,
+            budget: budget,
+            budgetLines: [income, expense],
+            transactions: []
+        )
+
+        let metrics = viewModel.metrics
+        #expect(metrics.totalIncome == 5000)
+        #expect(metrics.totalExpenses == 2000)
+        #expect(metrics.rollover == 300)
+    }
+}

--- a/ios/PulpeTests/Helpers/TestDataFactory.swift
+++ b/ios/PulpeTests/Helpers/TestDataFactory.swift
@@ -100,7 +100,8 @@ enum TestDataFactory {
         id: String = "test-budget-1",
         month: Int = 1,
         year: Int = 2025,
-        rollover: Decimal = 0
+        rollover: Decimal = 0,
+        previousBudgetId: String? = nil
     ) -> Budget {
         Budget(
             id: id,
@@ -112,7 +113,7 @@ enum TestDataFactory {
             endingBalance: nil,
             rollover: rollover,
             remaining: nil,
-            previousBudgetId: nil,
+            previousBudgetId: previousBudgetId,
             createdAt: fixedDate,
             updatedAt: fixedDate
         )


### PR DESCRIPTION
## Summary

• Add bottom sheet to view previous month budget data from the rollover info row
• Make BudgetSection, BudgetLineRow, TransactionSection, and TransactionRow reusable in read-only mode via optional callbacks
• Optimize PreviousBudgetSheet metrics caching and filter performance with @ObservationIgnored and local let bindings
• Add comprehensive tests for PreviousBudgetSheetViewModel

## Details

### New Feature
- New `PreviousBudgetSheet` view + ViewModel for displaying historical budget months
- Sheet opens from rollover info row tap (instead of navigating away)
- Shows same data structure as current month (income, expenses, savings, free transactions, metrics)
- Supports medium/large presentation detents with drag indicator

### API Changes
- `BudgetSection`, `BudgetLineRow`: Optional callbacks for read-only mode
- `TransactionSection`, `TransactionRow`: Optional callbacks for read-only mode
- Added convenience initializers with default nil for all callbacks

### Performance
- Marked `cachedMetrics` with `@ObservationIgnored` to prevent spurious change notifications
- Cache filter+sort results in local let bindings to avoid redundant computation

### Testing
- 14 new tests for ViewModel state, line categorization, free transactions, rollover info, metrics

## Type

feat (feature) + perf (performance optimization)