### PR TITLE
fix(budget): implement envelope logic to prevent double counting in budget calculations

### DIFF
--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -1,0 +1,27 @@
+# Backend Developer Memory
+
+## Envelope Logic (Budget Aggregation)
+- `BudgetFormulas.calculateTotalExpensesWithEnvelopes()` combines expense+saving kinds
+- For each budget line: `max(line.amount, sum_of_allocated_transactions)`
+- Free transactions (no `budget_line_id`) are added separately
+- `totalExpenses` in `BudgetAggregates` includes savings via envelope logic
+- `remaining = totalIncome - totalExpenses + rollover` (NOT minus totalSavings separately)
+- `totalSavings` is display-only (sum of saving budget line amounts)
+
+## Test Patterns
+- Budget tests use `bun:test` with `describe/it/expect/beforeEach`
+- Mock Supabase via inline objects or `MockSupabaseClient` from `test/test-mocks.ts`
+- NestJS DI tests use `Test.createTestingModule` with `provide/useValue` pairs
+- Logger injection token: `INFO_LOGGER:${ClassName.name}`
+- `createMockPinoLogger()` for mock loggers
+
+## Key File Locations
+- `backend-nest/src/modules/budget/budget.repository.ts` - Data access + aggregation
+- `backend-nest/src/modules/budget/budget.calculator.ts` - Uses BudgetFormulas for ending balance
+- `backend-nest/src/modules/budget/budget.mappers.ts` - `toSparseApi` computes remaining
+- `shared/src/calculators/budget-formulas.ts` - Single source of truth for formulas
+- `backend-nest/src/test/test-mocks.ts` - Shared test utilities
+
+## Lint Rules
+- Max 50 lines per function. Extract helpers to stay under limit.
+- Pre-existing warnings in other files are acceptable; don't fix unrelated code.

--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -1,12 +1,14 @@
 # Backend Developer Memory
 
 ## Envelope Logic (Budget Aggregation)
-- `BudgetFormulas.calculateTotalExpensesWithEnvelopes()` combines expense+saving kinds
-- For each budget line: `max(line.amount, sum_of_allocated_transactions)`
+- `BudgetFormulas.calculateTotalExpenses()` combines expense+saving kinds with envelope logic
+- `BudgetFormulas.calculateTotalIncome()` uses envelope logic for income
+- `BudgetFormulas.calculateTotalSavings()` uses envelope logic + free saving transactions
+- `BudgetFormulas.calculateAllMetrics()` returns all metrics including `totalSavings`
+- For each budget line: `max(line.amount, consumed)` with kind filter on consumed
 - Free transactions (no `budget_line_id`) are added separately
 - `totalExpenses` in `BudgetAggregates` includes savings via envelope logic
-- `remaining = totalIncome - totalExpenses + rollover` (NOT minus totalSavings separately)
-- `totalSavings` is display-only (sum of saving budget line amounts)
+- `remaining` computed via `BudgetFormulas.calculateRemaining(available, totalExpenses)`
 
 ## Test Patterns
 - Budget tests use `bun:test` with `describe/it/expect/beforeEach`

--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -25,9 +25,14 @@ captureEvent('click');              // Too vague
 
 **Web:**
 ```
-$pageview (landing) → cta_clicked → signup_started → signup_completed
-→ vault_code_setup_completed → onboarding_started → profile_step1_completed
-→ profile_step2_completed → first_budget_created
+$pageview (landing) → cta_clicked → welcome_page_viewed → signup_started
+→ signup_completed → vault_code_setup_completed → onboarding_started
+→ profile_step1_completed → profile_step2_completed → first_budget_created
+```
+
+**Web (with demo):**
+```
+welcome_page_viewed → demo_started → signup_started → signup_completed → ...
 ```
 
 **iOS:**
@@ -54,10 +59,11 @@ app_opened → welcome_screen_viewed → signup_started → onboarding_step_comp
 | `$pageview` | Auto-captured on page load | `$current_url` |
 | `cta_clicked` | User clicks CTA button | `cta_name`, `cta_location`, `destination` |
 
-### Auth Flow Events
+### Welcome & Auth Flow Events
 
 | Event | When | Properties |
 |-------|------|------------|
+| `welcome_page_viewed` | User lands on /welcome | `$referrer`, `$utm_source` (auto) |
 | `signup_started` | User clicks signup button | `method` (`email` \| `google`) |
 | `signup_completed` | Signup succeeds (email direct, Google via pending method) | `method` (`email` \| `google`) |
 | `vault_code_setup_completed` | New user creates vault code | — |

--- a/backend-nest/src/modules/budget/budget.calculator.ts
+++ b/backend-nest/src/modules/budget/budget.calculator.ts
@@ -51,22 +51,15 @@ export class BudgetCalculator {
       clientKey,
     );
 
-    // Map snake_case budget_line_id to camelCase budgetLineId for shared calculation
     const mappedTransactions = decryptedTransactions.map((tx) => ({
       ...tx,
       budgetLineId: tx.budget_line_id,
     }));
-
-    const totalIncome = BudgetFormulas.calculateTotalIncome(
-      decryptedBudgetLines,
-      decryptedTransactions,
-    );
-    const totalExpenses = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+    const metrics = BudgetFormulas.calculateAllMetrics(
       decryptedBudgetLines,
       mappedTransactions,
     );
-
-    return totalIncome - totalExpenses;
+    return metrics.endingBalance;
   }
 
   async recalculateAndPersist(

--- a/backend-nest/src/modules/budget/budget.mappers.ts
+++ b/backend-nest/src/modules/budget/budget.mappers.ts
@@ -135,11 +135,9 @@ export function toSparseApi(
       sparse.totalIncome = aggregates.totalIncome;
     }
     if (requestedFields.includes('remaining')) {
+      // totalExpenses already includes savings via envelope logic
       sparse.remaining =
-        aggregates.totalIncome -
-        aggregates.totalExpenses -
-        aggregates.totalSavings +
-        (rollover ?? 0);
+        aggregates.totalIncome - aggregates.totalExpenses + (rollover ?? 0);
     }
   }
 

--- a/backend-nest/src/modules/budget/budget.mappers.ts
+++ b/backend-nest/src/modules/budget/budget.mappers.ts
@@ -3,6 +3,7 @@ import {
   type BudgetCreate,
   type BudgetUpdate,
   type BudgetSparse,
+  BudgetFormulas,
 } from 'pulpe-shared';
 import type { BudgetAggregates } from './budget.repository';
 import { Tables, TablesInsert } from '@/types/database.types';
@@ -135,9 +136,14 @@ export function toSparseApi(
       sparse.totalIncome = aggregates.totalIncome;
     }
     if (requestedFields.includes('remaining')) {
-      // totalExpenses already includes savings via envelope logic
-      sparse.remaining =
-        aggregates.totalIncome - aggregates.totalExpenses + (rollover ?? 0);
+      const available = BudgetFormulas.calculateAvailable(
+        aggregates.totalIncome,
+        rollover ?? 0,
+      );
+      sparse.remaining = BudgetFormulas.calculateRemaining(
+        available,
+        aggregates.totalExpenses,
+      );
     }
   }
 

--- a/backend-nest/src/modules/budget/budget.repository.spec.ts
+++ b/backend-nest/src/modules/budget/budget.repository.spec.ts
@@ -252,18 +252,34 @@ describe('BudgetRepository', () => {
       expect(result.size).toBe(0);
     });
 
-    it('should calculate correct aggregates from budget_lines and transactions', async () => {
+    it('should calculate correct aggregates with envelope logic (free transactions)', async () => {
+      // All transactions are free (no budget_line_id), so they add on top of budget lines
       const mockBudgetLines = [
-        { budget_id: 'budget-1', kind: 'expense', amount: 500 },
-        { budget_id: 'budget-1', kind: 'income', amount: 3000 },
-        { budget_id: 'budget-1', kind: 'saving', amount: 200 },
-        { budget_id: 'budget-2', kind: 'expense', amount: 1000 },
+        { id: 'line-1', budget_id: 'budget-1', kind: 'expense', amount: 500 },
+        { id: 'line-2', budget_id: 'budget-1', kind: 'income', amount: 3000 },
+        { id: 'line-3', budget_id: 'budget-1', kind: 'saving', amount: 200 },
+        { id: 'line-4', budget_id: 'budget-2', kind: 'expense', amount: 1000 },
       ];
 
       const mockTransactions = [
-        { budget_id: 'budget-1', kind: 'expense', amount: 100 },
-        { budget_id: 'budget-1', kind: 'income', amount: 500 },
-        { budget_id: 'budget-2', kind: 'saving', amount: 300 },
+        {
+          budget_id: 'budget-1',
+          kind: 'expense',
+          amount: 100,
+          budget_line_id: null,
+        },
+        {
+          budget_id: 'budget-1',
+          kind: 'income',
+          amount: 500,
+          budget_line_id: null,
+        },
+        {
+          budget_id: 'budget-2',
+          kind: 'saving',
+          amount: 300,
+          budget_line_id: null,
+        },
       ];
 
       const mockSupabase = {
@@ -289,15 +305,19 @@ describe('BudgetRepository', () => {
 
       const budget1 = result.get('budget-1');
       expect(budget1).toBeDefined();
-      expect(budget1?.totalExpenses).toBe(600); // 500 + 100
-      expect(budget1?.totalIncome).toBe(3500); // 3000 + 500
+      // Envelope: max(500,0)=500 + max(200,0)=200 + 100 (free expense) = 800
+      expect(budget1?.totalExpenses).toBe(800);
+      // Income: 3000 (line) + 500 (free tx) = 3500
+      expect(budget1?.totalIncome).toBe(3500);
+      // totalSavings: sum of saving budget lines = 200
       expect(budget1?.totalSavings).toBe(200);
 
       const budget2 = result.get('budget-2');
       expect(budget2).toBeDefined();
-      expect(budget2?.totalExpenses).toBe(1000);
+      // Envelope: max(1000,0)=1000 + 300 (free saving tx) = 1300
+      expect(budget2?.totalExpenses).toBe(1300);
       expect(budget2?.totalIncome).toBe(0);
-      expect(budget2?.totalSavings).toBe(300);
+      expect(budget2?.totalSavings).toBe(0);
     });
 
     it('should return zero aggregates when no budget_lines or transactions exist', async () => {
@@ -370,6 +390,231 @@ describe('BudgetRepository', () => {
       expect(budget2?.totalExpenses).toBe(0);
       expect(budget2?.totalIncome).toBe(0);
       expect(budget2?.totalSavings).toBe(0);
+    });
+
+    it('should not double-count allocated transactions (envelope logic)', async () => {
+      // ARRANGE — budget line of 500 with an allocated transaction of 100
+      // Envelope logic: max(500, 100) = 500, NOT 500 + 100 = 600
+      const mockBudgetLines = [
+        { id: 'line-1', budget_id: 'budget-1', kind: 'expense', amount: 500 },
+        { id: 'line-2', budget_id: 'budget-1', kind: 'income', amount: 3000 },
+      ];
+
+      const mockTransactions = [
+        {
+          budget_id: 'budget-1',
+          kind: 'expense',
+          amount: 100,
+          budget_line_id: 'line-1',
+        },
+      ];
+
+      const mockSupabase = {
+        from: (table: string) => ({
+          select: () => ({
+            in: () => {
+              if (table === 'budget_line') {
+                return Promise.resolve({ data: mockBudgetLines, error: null });
+              }
+              return Promise.resolve({ data: mockTransactions, error: null });
+            },
+          }),
+        }),
+      };
+
+      // ACT
+      const result = await repository.fetchBudgetAggregates(
+        ['budget-1'],
+        mockSupabase as any,
+        (amount) => Number(amount) || 0,
+      );
+
+      // ASSERT — should be 500 (envelope covers the 100 transaction), NOT 600
+      const budget1 = result.get('budget-1');
+      expect(budget1?.totalExpenses).toBe(500);
+      expect(budget1?.totalIncome).toBe(3000);
+    });
+
+    it('should use max(line, consumed) when allocated transactions exceed envelope', async () => {
+      // ARRANGE — budget line of 100, allocated transactions totaling 250
+      // Envelope logic: max(100, 250) = 250
+      const mockBudgetLines = [
+        { id: 'line-1', budget_id: 'budget-1', kind: 'expense', amount: 100 },
+        { id: 'line-2', budget_id: 'budget-1', kind: 'income', amount: 5000 },
+      ];
+
+      const mockTransactions = [
+        {
+          budget_id: 'budget-1',
+          kind: 'expense',
+          amount: 150,
+          budget_line_id: 'line-1',
+        },
+        {
+          budget_id: 'budget-1',
+          kind: 'expense',
+          amount: 100,
+          budget_line_id: 'line-1',
+        },
+      ];
+
+      const mockSupabase = {
+        from: (table: string) => ({
+          select: () => ({
+            in: () => {
+              if (table === 'budget_line') {
+                return Promise.resolve({ data: mockBudgetLines, error: null });
+              }
+              return Promise.resolve({ data: mockTransactions, error: null });
+            },
+          }),
+        }),
+      };
+
+      // ACT
+      const result = await repository.fetchBudgetAggregates(
+        ['budget-1'],
+        mockSupabase as any,
+        (amount) => Number(amount) || 0,
+      );
+
+      // ASSERT — max(100, 150+100) = max(100, 250) = 250
+      const budget1 = result.get('budget-1');
+      expect(budget1?.totalExpenses).toBe(250);
+      expect(budget1?.totalIncome).toBe(5000);
+    });
+
+    it('should count free transactions (no budget_line_id) separately', async () => {
+      // ARRANGE — budget line of 500, plus a free transaction of 75
+      const mockBudgetLines = [
+        { id: 'line-1', budget_id: 'budget-1', kind: 'expense', amount: 500 },
+        { id: 'line-2', budget_id: 'budget-1', kind: 'income', amount: 3000 },
+      ];
+
+      const mockTransactions = [
+        {
+          budget_id: 'budget-1',
+          kind: 'expense',
+          amount: 100,
+          budget_line_id: 'line-1',
+        },
+        {
+          budget_id: 'budget-1',
+          kind: 'expense',
+          amount: 75,
+          budget_line_id: null,
+        },
+      ];
+
+      const mockSupabase = {
+        from: (table: string) => ({
+          select: () => ({
+            in: () => {
+              if (table === 'budget_line') {
+                return Promise.resolve({ data: mockBudgetLines, error: null });
+              }
+              return Promise.resolve({ data: mockTransactions, error: null });
+            },
+          }),
+        }),
+      };
+
+      // ACT
+      const result = await repository.fetchBudgetAggregates(
+        ['budget-1'],
+        mockSupabase as any,
+        (amount) => Number(amount) || 0,
+      );
+
+      // ASSERT — max(500, 100) + 75 (free) = 500 + 75 = 575
+      const budget1 = result.get('budget-1');
+      expect(budget1?.totalExpenses).toBe(575);
+      expect(budget1?.totalIncome).toBe(3000);
+    });
+
+    it('should handle savings with envelope logic (savings treated as expenses)', async () => {
+      // ARRANGE — saving line of 300, allocated saving transaction of 200
+      const mockBudgetLines = [
+        { id: 'line-1', budget_id: 'budget-1', kind: 'saving', amount: 300 },
+        { id: 'line-2', budget_id: 'budget-1', kind: 'income', amount: 5000 },
+      ];
+
+      const mockTransactions = [
+        {
+          budget_id: 'budget-1',
+          kind: 'saving',
+          amount: 200,
+          budget_line_id: 'line-1',
+        },
+      ];
+
+      const mockSupabase = {
+        from: (table: string) => ({
+          select: () => ({
+            in: () => {
+              if (table === 'budget_line') {
+                return Promise.resolve({ data: mockBudgetLines, error: null });
+              }
+              return Promise.resolve({ data: mockTransactions, error: null });
+            },
+          }),
+        }),
+      };
+
+      // ACT
+      const result = await repository.fetchBudgetAggregates(
+        ['budget-1'],
+        mockSupabase as any,
+        (amount) => Number(amount) || 0,
+      );
+
+      // ASSERT — max(300, 200) = 300
+      // totalExpenses includes savings per SPECS
+      const budget1 = result.get('budget-1');
+      expect(budget1?.totalExpenses).toBe(300);
+      expect(budget1?.totalIncome).toBe(5000);
+    });
+
+    it('should handle income with envelope logic (income lines + free income transactions)', async () => {
+      // ARRANGE — income line of 5000, plus a free income transaction of 300
+      const mockBudgetLines = [
+        { id: 'line-1', budget_id: 'budget-1', kind: 'income', amount: 5000 },
+        { id: 'line-2', budget_id: 'budget-1', kind: 'expense', amount: 1000 },
+      ];
+
+      const mockTransactions = [
+        {
+          budget_id: 'budget-1',
+          kind: 'income',
+          amount: 300,
+          budget_line_id: null,
+        },
+      ];
+
+      const mockSupabase = {
+        from: (table: string) => ({
+          select: () => ({
+            in: () => {
+              if (table === 'budget_line') {
+                return Promise.resolve({ data: mockBudgetLines, error: null });
+              }
+              return Promise.resolve({ data: mockTransactions, error: null });
+            },
+          }),
+        }),
+      };
+
+      // ACT
+      const result = await repository.fetchBudgetAggregates(
+        ['budget-1'],
+        mockSupabase as any,
+        (amount) => Number(amount) || 0,
+      );
+
+      // ASSERT — income: 5000 (budget line) + 300 (free transaction) = 5300
+      const budget1 = result.get('budget-1');
+      expect(budget1?.totalIncome).toBe(5300);
+      expect(budget1?.totalExpenses).toBe(1000);
     });
   });
 });

--- a/backend-nest/src/modules/budget/budget.repository.spec.ts
+++ b/backend-nest/src/modules/budget/budget.repository.spec.ts
@@ -309,7 +309,7 @@ describe('BudgetRepository', () => {
       expect(budget1?.totalExpenses).toBe(800);
       // Income: 3000 (line) + 500 (free tx) = 3500
       expect(budget1?.totalIncome).toBe(3500);
-      // totalSavings: sum of saving budget lines = 200
+      // totalSavings: max(200, 0) = 200 (envelope, no allocated saving tx)
       expect(budget1?.totalSavings).toBe(200);
 
       const budget2 = result.get('budget-2');
@@ -317,7 +317,8 @@ describe('BudgetRepository', () => {
       // Envelope: max(1000,0)=1000 + 300 (free saving tx) = 1300
       expect(budget2?.totalExpenses).toBe(1300);
       expect(budget2?.totalIncome).toBe(0);
-      expect(budget2?.totalSavings).toBe(0);
+      // totalSavings: 300 (free saving tx, no saving budget lines)
+      expect(budget2?.totalSavings).toBe(300);
     });
 
     it('should return zero aggregates when no budget_lines or transactions exist', async () => {

--- a/backend-nest/src/modules/budget/budget.repository.spec.ts
+++ b/backend-nest/src/modules/budget/budget.repository.spec.ts
@@ -616,5 +616,47 @@ describe('BudgetRepository', () => {
       expect(budget1?.totalIncome).toBe(5300);
       expect(budget1?.totalExpenses).toBe(1000);
     });
+
+    it('should not double-count allocated income transactions', async () => {
+      // ARRANGE
+      const mockBudgetLines = [
+        { id: 'line-1', budget_id: 'budget-1', kind: 'income', amount: 5000 },
+        { id: 'line-2', budget_id: 'budget-1', kind: 'expense', amount: 1000 },
+      ];
+
+      const mockTransactions = [
+        {
+          budget_id: 'budget-1',
+          kind: 'income',
+          amount: 4800,
+          budget_line_id: 'line-1',
+        },
+      ];
+
+      const mockSupabase = {
+        from: (table: string) => ({
+          select: () => ({
+            in: () => {
+              if (table === 'budget_line') {
+                return Promise.resolve({ data: mockBudgetLines, error: null });
+              }
+              return Promise.resolve({ data: mockTransactions, error: null });
+            },
+          }),
+        }),
+      };
+
+      // ACT
+      const result = await repository.fetchBudgetAggregates(
+        ['budget-1'],
+        mockSupabase as any,
+        (amount) => Number(amount) || 0,
+      );
+
+      // ASSERT — income uses envelope: max(5000, 4800) = 5000, NOT 5000 + 4800 = 9800
+      const budget1 = result.get('budget-1');
+      expect(budget1?.totalIncome).toBe(5000);
+      expect(budget1?.totalExpenses).toBe(1000);
+    });
   });
 });

--- a/backend-nest/src/modules/budget/budget.repository.ts
+++ b/backend-nest/src/modules/budget/budget.repository.ts
@@ -434,9 +434,8 @@ export class BudgetRepository {
   ): Map<string, T[]> {
     const map = new Map<string, T[]>();
     for (const item of items) {
-      const list = map.get(item.budget_id) ?? [];
-      list.push(item);
-      map.set(item.budget_id, list);
+      if (!map.has(item.budget_id)) map.set(item.budget_id, []);
+      map.get(item.budget_id)!.push(item);
     }
     return map;
   }

--- a/backend-nest/src/modules/budget/budget.repository.ts
+++ b/backend-nest/src/modules/budget/budget.repository.ts
@@ -4,7 +4,11 @@ import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
 import { type InfoLogger, InjectInfoLogger } from '@common/logger';
 import type { AuthenticatedUser } from '@common/decorators/user.decorator';
 import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.service';
-import type { BudgetUpdate, TransactionKind } from 'pulpe-shared';
+import {
+  type BudgetUpdate,
+  type TransactionKind,
+  BudgetFormulas,
+} from 'pulpe-shared';
 import type { Tables } from '../../types/database.types';
 import type { PostgrestError } from '@supabase/supabase-js';
 
@@ -330,12 +334,14 @@ export class BudgetRepository {
   }
 
   /**
-   * Fetches aggregated totals for multiple budgets in batch
-   * Calculates totalExpenses, totalSavings, totalIncome from budget_lines and transactions
-   * @param budgetIds - Array of budget IDs
-   * @param supabase - Authenticated Supabase client
-   * @param decryptFn - Function to decrypt amount values (default: returns 0)
-   * @returns Map of budget ID to aggregates
+   * Fetches aggregated totals for multiple budgets in batch using envelope logic.
+   *
+   * Envelope rule: for each budget line, use max(line.amount, sum_of_allocated_transactions).
+   * Free transactions (no budget_line_id) are added separately.
+   * This prevents double-counting when transactions are allocated to budget lines.
+   *
+   * totalExpenses includes both expense and saving kinds (per SPECS).
+   * totalSavings is the sum of saving budget line amounts only (for display).
    */
   async fetchBudgetAggregates(
     budgetIds: string[],
@@ -360,20 +366,16 @@ export class BudgetRepository {
       const [budgetLinesResult, transactionsResult] = await Promise.all([
         supabase
           .from('budget_line')
-          .select('budget_id, kind, amount')
+          .select('id, budget_id, kind, amount')
           .in('budget_id', budgetIds),
         supabase
           .from('transaction')
-          .select('budget_id, kind, amount')
+          .select('budget_id, kind, amount, budget_line_id')
           .in('budget_id', budgetIds),
       ]);
 
-      this.accumulateAmounts(
+      this.computeEnvelopeAggregates(
         budgetLinesResult.data ?? [],
-        aggregatesMap,
-        decryptFn,
-      );
-      this.accumulateAmounts(
         transactionsResult.data ?? [],
         aggregatesMap,
         decryptFn,
@@ -388,31 +390,56 @@ export class BudgetRepository {
     return aggregatesMap;
   }
 
-  private accumulateAmounts(
-    items: Array<{
+  private computeEnvelopeAggregates(
+    budgetLines: Array<{
+      id: string;
       budget_id: string;
       kind: TransactionKind;
       amount: string | null;
     }>,
+    transactions: Array<{
+      budget_id: string;
+      kind: TransactionKind;
+      amount: string | null;
+      budget_line_id: string | null;
+    }>,
     aggregatesMap: Map<string, BudgetAggregates>,
     decryptFn: (amount: string | null) => number,
   ): void {
-    for (const item of items) {
-      const aggregates = aggregatesMap.get(item.budget_id);
-      if (!aggregates) continue;
+    const linesByBudget = this.groupByBudgetId(budgetLines);
+    const txsByBudget = this.groupByBudgetId(transactions);
 
-      const value = decryptFn(item.amount);
-      switch (item.kind) {
-        case 'expense':
-          aggregates.totalExpenses += value;
-          break;
-        case 'saving':
-          aggregates.totalSavings += value;
-          break;
-        case 'income':
-          aggregates.totalIncome += value;
-          break;
-      }
+    for (const [budgetId, aggregates] of aggregatesMap) {
+      const lines = (linesByBudget.get(budgetId) ?? []).map((l) => ({
+        id: l.id,
+        kind: l.kind,
+        amount: decryptFn(l.amount),
+      }));
+
+      const txs = (txsByBudget.get(budgetId) ?? []).map((t) => ({
+        kind: t.kind,
+        amount: decryptFn(t.amount),
+        budgetLineId: t.budget_line_id,
+      }));
+
+      aggregates.totalExpenses =
+        BudgetFormulas.calculateTotalExpensesWithEnvelopes(lines, txs);
+      aggregates.totalIncome = BudgetFormulas.calculateTotalIncome(lines, txs);
+      aggregates.totalSavings = lines
+        .filter((l) => l.kind === 'saving')
+        .reduce((sum, l) => sum + l.amount, 0);
     }
+  }
+
+  private groupByBudgetId<T extends { budget_id: string }>(
+    items: T[],
+  ): Map<string, T[]> {
+    const map = new Map<string, T[]>();
+    for (const item of items) {
+      const list = map.get(item.budget_id) ?? [];
+      list.push(item);
+      map.set(item.budget_id, list);
+    }
+    return map;
   }
 }

--- a/backend-nest/src/modules/budget/budget.repository.ts
+++ b/backend-nest/src/modules/budget/budget.repository.ts
@@ -424,7 +424,10 @@ export class BudgetRepository {
 
       aggregates.totalExpenses =
         BudgetFormulas.calculateTotalExpensesWithEnvelopes(lines, txs);
-      aggregates.totalIncome = BudgetFormulas.calculateTotalIncome(lines, txs);
+      aggregates.totalIncome = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+        lines,
+        txs,
+      );
       aggregates.totalSavings = lines
         .filter((l) => l.kind === 'saving')
         .reduce((sum, l) => sum + l.amount, 0);

--- a/backend-nest/src/modules/budget/budget.repository.ts
+++ b/backend-nest/src/modules/budget/budget.repository.ts
@@ -341,7 +341,7 @@ export class BudgetRepository {
    * This prevents double-counting when transactions are allocated to budget lines.
    *
    * totalExpenses includes both expense and saving kinds (per SPECS).
-   * totalSavings is the sum of saving budget line amounts only (for display).
+   * totalSavings uses envelope logic + free saving transactions.
    */
   async fetchBudgetAggregates(
     budgetIds: string[],
@@ -422,15 +422,10 @@ export class BudgetRepository {
         budgetLineId: t.budget_line_id,
       }));
 
-      aggregates.totalExpenses =
-        BudgetFormulas.calculateTotalExpensesWithEnvelopes(lines, txs);
-      aggregates.totalIncome = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
-        lines,
-        txs,
-      );
-      aggregates.totalSavings = lines
-        .filter((l) => l.kind === 'saving')
-        .reduce((sum, l) => sum + l.amount, 0);
+      const metrics = BudgetFormulas.calculateAllMetrics(lines, txs);
+      aggregates.totalExpenses = metrics.totalExpenses;
+      aggregates.totalIncome = metrics.totalIncome;
+      aggregates.totalSavings = metrics.totalSavings;
     }
   }
 

--- a/backend-nest/src/modules/budget/budget.service.spec.ts
+++ b/backend-nest/src/modules/budget/budget.service.spec.ts
@@ -414,7 +414,7 @@ describe('BudgetService', () => {
         ).toBe(1500);
       });
 
-      it('should calculate remaining when requested (income - expenses - savings + rollover)', async () => {
+      it('should calculate remaining when requested (income - expenses + rollover)', async () => {
         const mockUser = createMockAuthenticatedUser();
         const mockBudgets = [
           createValidBudgetEntity({ id: 'budget-1', month: 1, year: 2026 }),
@@ -422,12 +422,13 @@ describe('BudgetService', () => {
 
         mockSupabaseClient.setMockData(mockBudgets).setMockError(null);
 
+        // totalExpenses now includes savings via envelope logic
         mockRepository.fetchBudgetAggregates = () =>
           Promise.resolve(
             new Map([
               [
                 'budget-1',
-                { totalExpenses: 1500, totalSavings: 500, totalIncome: 5000 },
+                { totalExpenses: 2000, totalSavings: 500, totalIncome: 5000 },
               ],
             ]),
           );
@@ -444,7 +445,7 @@ describe('BudgetService', () => {
         );
 
         expect(result.success).toBe(true);
-        // remaining = 5000 - 1500 - 500 + 200 = 3200
+        // remaining = 5000 - 2000 + 200 = 3200 (totalExpenses includes savings)
         expect(result.data[0].remaining).toBe(3200);
       });
 
@@ -481,16 +482,17 @@ describe('BudgetService', () => {
 
         mockSupabaseClient.setMockData(mockBudgets).setMockError(null);
 
+        // totalExpenses includes savings via envelope logic
         mockRepository.fetchBudgetAggregates = () =>
           Promise.resolve(
             new Map([
               [
                 'budget-1',
-                { totalExpenses: 1000, totalSavings: 200, totalIncome: 3000 },
+                { totalExpenses: 1200, totalSavings: 200, totalIncome: 3000 },
               ],
               [
                 'budget-2',
-                { totalExpenses: 500, totalSavings: 100, totalIncome: 2000 },
+                { totalExpenses: 600, totalSavings: 100, totalIncome: 2000 },
               ],
             ]),
           );
@@ -517,12 +519,12 @@ describe('BudgetService', () => {
 
         // First budget: rollover succeeded = 150
         expect(result.data[0].rollover).toBe(150);
-        // remaining = 3000 - 1000 - 200 + 150 = 1950
+        // remaining = 3000 - 1200 + 150 = 1950
         expect(result.data[0].remaining).toBe(1950);
 
         // Second budget: rollover failed, fallback to 0
         expect(result.data[1].rollover).toBe(0);
-        // remaining = 2000 - 500 - 100 + 0 = 1400
+        // remaining = 2000 - 600 + 0 = 1400
         expect(result.data[1].remaining).toBe(1400);
       });
 

--- a/frontend/projects/webapp/src/app/core/analytics/global-error-handler.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/global-error-handler.ts
@@ -20,7 +20,12 @@ export class GlobalErrorHandler implements ErrorHandler {
     this.#logger.error(`[GlobalError] ${errorMessage}`, error);
 
     // HTTP errors already captured by httpErrorInterceptor — don't double-capture
-    if (error instanceof HttpErrorResponse || error instanceof ApiError) {
+    if (error instanceof HttpErrorResponse) {
+      return;
+    }
+
+    // ApiError wrapping an HTTP response is already captured — skip only those
+    if (error instanceof ApiError && error.status > 0) {
       return;
     }
 

--- a/frontend/projects/webapp/src/app/core/analytics/global-error-handler.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/global-error-handler.ts
@@ -17,14 +17,12 @@ export class GlobalErrorHandler implements ErrorHandler {
 
   handleError(error: Error | HttpErrorResponse | unknown): void {
     const errorMessage = this.#extractMessage(error);
+    this.#logger.error(`[GlobalError] ${errorMessage}`, error);
 
-    // HTTP errors already captured by httpErrorInterceptor — log only, don't double-capture
+    // HTTP errors already captured by httpErrorInterceptor — don't double-capture
     if (error instanceof HttpErrorResponse || error instanceof ApiError) {
-      this.#logger.error(`[GlobalError] ${errorMessage}`, error);
       return;
     }
-
-    this.#logger.error(`[GlobalError] ${errorMessage}`, error);
 
     // Only capture JS runtime errors (null refs, type errors, uncaught exceptions)
     this.#postHogService.captureException(error);

--- a/frontend/projects/webapp/src/app/core/analytics/global-error-handler.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/global-error-handler.ts
@@ -2,6 +2,7 @@ import { ErrorHandler, Injectable, inject } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { PostHogService } from './posthog';
 import { Logger } from '../logging/logger';
+import { ApiError } from '../api/api-error';
 
 /**
  * Global error handler following Angular best practices.
@@ -15,17 +16,18 @@ export class GlobalErrorHandler implements ErrorHandler {
   readonly #logger = inject(Logger);
 
   handleError(error: Error | HttpErrorResponse | unknown): void {
-    // Extract meaningful error message for logging
     const errorMessage = this.#extractMessage(error);
-    const isHttpError = error instanceof HttpErrorResponse;
 
-    // Log locally for development
+    // HTTP errors already captured by httpErrorInterceptor — log only, don't double-capture
+    if (error instanceof HttpErrorResponse || error instanceof ApiError) {
+      this.#logger.error(`[GlobalError] ${errorMessage}`, error);
+      return;
+    }
+
     this.#logger.error(`[GlobalError] ${errorMessage}`, error);
 
-    // Send to PostHog (built-in sanitization handles security)
-    this.#postHogService.captureException(error, {
-      isHttpError,
-    });
+    // Only capture JS runtime errors (null refs, type errors, uncaught exceptions)
+    this.#postHogService.captureException(error);
   }
 
   #extractMessage(error: unknown): string {

--- a/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.ts
@@ -34,6 +34,9 @@ export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
   );
 };
 
+/** 401/403 are handled by authInterceptor (token refresh, redirect) — not bugs */
+const AUTH_HANDLED_STATUSES = new Set([401, 403]);
+
 /**
  * Capture HTTP error as exception to PostHog for error tracking
  */
@@ -44,6 +47,10 @@ function captureHttpError(
   logger: Logger,
   applicationConfiguration: ApplicationConfiguration,
 ): void {
+  if (AUTH_HANDLED_STATUSES.has(error.status)) {
+    return;
+  }
+
   try {
     const posthogError = normalizeHttpError(error);
     const context: HttpErrorContext = {

--- a/frontend/projects/webapp/src/app/core/budget/budget-calculator.ts
+++ b/frontend/projects/webapp/src/app/core/budget/budget-calculator.ts
@@ -142,7 +142,7 @@ export class BudgetCalculator {
     transactions: Transaction[],
     rollover = 0,
   ): number {
-    return BudgetFormulas.calculateAllMetricsWithEnvelopes(
+    return BudgetFormulas.calculateAllMetrics(
       budgetLines,
       transactions,
       rollover,

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.spec.ts
@@ -184,10 +184,7 @@ describe('DashboardStore - Business Scenarios', () => {
       const { store } = await setupWithBudgetAndWait(budget, lines, txs);
 
       // Envelope: max(300, 100) = 300, free: 50 → total = 350
-      const expected = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
-        lines,
-        txs,
-      );
+      const expected = BudgetFormulas.calculateTotalExpenses(lines, txs);
       expect(store.totalExpenses()).toBe(expected);
       expect(store.totalExpenses()).toBe(350);
     });

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
@@ -177,30 +177,20 @@ export class DashboardStore {
     return budget?.rollover ?? 0;
   });
 
-  readonly totalIncome = computed<number>(() => {
-    const budgetLines = this.budgetLines();
-    const transactions = this.transactions();
-    return BudgetFormulas.calculateTotalIncome(budgetLines, transactions);
-  });
-
-  readonly totalExpenses = computed<number>(() =>
-    BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+  readonly #metrics = computed(() =>
+    BudgetFormulas.calculateAllMetrics(
       this.budgetLines(),
       this.transactions(),
+      this.rolloverAmount(),
     ),
   );
 
-  readonly totalAvailable = computed<number>(() => {
-    const totalIncome = this.totalIncome();
-    const rollover = this.rolloverAmount();
-    return BudgetFormulas.calculateAvailable(totalIncome, rollover);
-  });
-
-  readonly remaining = computed<number>(() => {
-    const available = this.totalAvailable();
-    const expenses = this.totalExpenses();
-    return BudgetFormulas.calculateRemaining(available, expenses);
-  });
+  readonly totalIncome = computed<number>(() => this.#metrics().totalIncome);
+  readonly totalExpenses = computed<number>(
+    () => this.#metrics().totalExpenses,
+  );
+  readonly totalAvailable = computed<number>(() => this.#metrics().available);
+  readonly remaining = computed<number>(() => this.#metrics().remaining);
 
   readonly uncheckedForecasts = computed<BudgetLine[]>(() =>
     this.budgetLines().filter(
@@ -369,7 +359,7 @@ export class DashboardStore {
         const updatedData = updateData(currentData, responseData);
 
         const rollover = updatedData.budget?.rollover ?? 0;
-        const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+        const metrics = BudgetFormulas.calculateAllMetrics(
           updatedData.budgetLines,
           updatedData.transactions,
           rollover,

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
@@ -251,14 +251,17 @@ describe('WelcomePage', () => {
       );
     });
 
+    it('should track welcome_page_viewed on render', () => {
+      expect(mockPostHogService.captureEvent).toHaveBeenCalledWith(
+        'welcome_page_viewed',
+      );
+    });
+
     it('should not track signup_started when OAuth stops loading', () => {
       mockPostHogService.captureEvent.mockClear();
       component.onGoogleLoadingChange(false);
 
-      expect(mockPostHogService.captureEvent).not.toHaveBeenCalledWith(
-        'signup_started',
-        expect.anything(),
-      );
+      expect(mockPostHogService.captureEvent).not.toHaveBeenCalled();
     });
 
     it('should track signup_started with email method on email click', () => {

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
@@ -252,9 +252,13 @@ describe('WelcomePage', () => {
     });
 
     it('should not track signup_started when OAuth stops loading', () => {
+      mockPostHogService.captureEvent.mockClear();
       component.onGoogleLoadingChange(false);
 
-      expect(mockPostHogService.captureEvent).not.toHaveBeenCalled();
+      expect(mockPostHogService.captureEvent).not.toHaveBeenCalledWith(
+        'signup_started',
+        expect.anything(),
+      );
     });
 
     it('should track signup_started with email method on email click', () => {

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
@@ -1,4 +1,5 @@
 import {
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -210,6 +211,12 @@ export default class WelcomePage {
   readonly #ERROR_MESSAGES = {
     DEMO_INIT_FAILED: 'Le mode démo ne démarre pas — réessaie',
   } as const;
+
+  constructor() {
+    afterNextRender(() => {
+      this.#postHogService.captureEvent('welcome_page_viewed');
+    });
+  }
 
   protected readonly errorMessage = signal('');
   protected readonly isGoogleLoading = signal(false);

--- a/ios/Config/Preview.xcconfig
+++ b/ios/Config/Preview.xcconfig
@@ -4,7 +4,7 @@ API_BASE_URL = https:$(SLASH)$(SLASH)backend-preview-34f4.up.railway.app/api/v1
 SUPABASE_URL = https:$(SLASH)$(SLASH)lrphlfjkzkwyllejanrd.supabase.co
 SUPABASE_ANON_KEY = sb_publishable_6bhOTXKoB7NtR0EeRKg8kA_EdBZeyJb
 APP_ENV = preview
-POSTHOG_API_KEY =
+POSTHOG_API_KEY = phc_TQXZF60iqsU5m3HpGGtTRjGx5vFvggoBt1Gzr4zWLar
 POSTHOG_ENABLED = true
 
 #include? "Preview.secrets.xcconfig"

--- a/ios/Config/Prod.xcconfig
+++ b/ios/Config/Prod.xcconfig
@@ -4,7 +4,7 @@ API_BASE_URL = https:$(SLASH)$(SLASH)api.pulpe.app/api/v1
 SUPABASE_URL = https:$(SLASH)$(SLASH)qhhlloqisgzwcsrbdppn.supabase.co
 SUPABASE_ANON_KEY = sb_publishable_sOPmrqc7yz2nnZRxAOUhwQ_Yr8lfRY2
 APP_ENV = prod
-POSTHOG_API_KEY =
+POSTHOG_API_KEY = phc_TQXZF60iqsU5m3HpGGtTRjGx5vFvggoBt1Gzr4zWLar
 POSTHOG_ENABLED = true
 
 #include? "Prod.secrets.xcconfig"

--- a/ios/Pulpe/Domain/Formulas/BudgetFormulas+Metrics.swift
+++ b/ios/Pulpe/Domain/Formulas/BudgetFormulas+Metrics.swift
@@ -28,8 +28,9 @@ extension BudgetFormulas {
             case .expense:
                 totalExpenses += max(line.amount, consumed(lineTxs) { $0.isOutflow })
             case .saving:
-                totalExpenses += max(line.amount, consumed(lineTxs) { $0.isOutflow })
-                totalSavings += max(line.amount, consumed(lineTxs) { $0 == .saving })
+                let savingsConsumed = consumed(lineTxs) { $0 == .saving }
+                totalExpenses += max(line.amount, savingsConsumed)
+                totalSavings += max(line.amount, savingsConsumed)
             }
         }
 

--- a/ios/Pulpe/Domain/Formulas/BudgetFormulas+Metrics.swift
+++ b/ios/Pulpe/Domain/Formulas/BudgetFormulas+Metrics.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 extension BudgetFormulas {
+    /// Sum amounts of transactions matching a kind predicate
+    private static func consumed(_ txs: [Transaction], where matches: (TransactionKind) -> Bool) -> Decimal {
+        txs.filter { matches($0.kind) }.reduce(.zero) { $0 + $1.amount }
+    }
+
     /// Calculate all metrics at once using envelope logic
     /// Performance: O(n+m) with Dictionary-based indexing
     static func calculateAllMetrics(
@@ -8,57 +13,37 @@ extension BudgetFormulas {
         transactions: [Transaction] = [],
         rollover: Decimal = 0
     ) -> Metrics {
-        let transactionsByLineId = Dictionary(
-            grouping: transactions,
-            by: { $0.budgetLineId ?? "" }
-        )
-
+        let txsByLineId = Dictionary(grouping: transactions, by: { $0.budgetLineId ?? "" })
         var totalIncome: Decimal = 0
         var totalExpenses: Decimal = 0
         var totalSavings: Decimal = 0
 
         for line in budgetLines {
             guard !(line.isRollover ?? false) else { continue }
-
-            let consumed = transactionsByLineId[line.id]?
-                .reduce(Decimal.zero) { $0 + $1.amount } ?? 0
-            let effective = max(line.amount, consumed)
+            let lineTxs = txsByLineId[line.id] ?? []
 
             switch line.kind {
             case .income:
-                totalIncome += effective
+                totalIncome += max(line.amount, consumed(lineTxs) { $0 == .income })
             case .expense:
-                totalExpenses += effective
+                totalExpenses += max(line.amount, consumed(lineTxs) { $0.isOutflow })
             case .saving:
-                totalSavings += effective
-                totalExpenses += effective
+                totalExpenses += max(line.amount, consumed(lineTxs) { $0.isOutflow })
+                totalSavings += max(line.amount, consumed(lineTxs) { $0 == .saving })
             }
         }
 
-        if let freeTransactions = transactionsByLineId[""] {
-            for tx in freeTransactions {
-                switch tx.kind {
-                case .income:
-                    totalIncome += tx.amount
-                case .expense:
-                    totalExpenses += tx.amount
-                case .saving:
-                    totalSavings += tx.amount
-                    totalExpenses += tx.amount
-                }
-            }
+        for tx in txsByLineId[""] ?? [] {
+            if tx.kind == .income { totalIncome += tx.amount }
+            if tx.kind.isOutflow { totalExpenses += tx.amount }
+            if tx.kind == .saving { totalSavings += tx.amount }
         }
 
         let available = totalIncome + rollover
         let endingBalance = available - totalExpenses
-
         return Metrics(
-            totalIncome: totalIncome,
-            totalExpenses: totalExpenses,
-            totalSavings: totalSavings,
-            available: available,
-            endingBalance: endingBalance,
-            remaining: endingBalance,
+            totalIncome: totalIncome, totalExpenses: totalExpenses, totalSavings: totalSavings,
+            available: available, endingBalance: endingBalance, remaining: endingBalance,
             rollover: rollover
         )
     }

--- a/ios/Pulpe/Domain/Formulas/BudgetFormulas+Metrics.swift
+++ b/ios/Pulpe/Domain/Formulas/BudgetFormulas+Metrics.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+extension BudgetFormulas {
+    /// Calculate all metrics at once using envelope logic
+    /// Performance: O(n+m) with Dictionary-based indexing
+    static func calculateAllMetrics(
+        budgetLines: [BudgetLine],
+        transactions: [Transaction] = [],
+        rollover: Decimal = 0
+    ) -> Metrics {
+        let transactionsByLineId = Dictionary(
+            grouping: transactions,
+            by: { $0.budgetLineId ?? "" }
+        )
+
+        var totalIncome: Decimal = 0
+        var totalExpenses: Decimal = 0
+        var totalSavings: Decimal = 0
+
+        for line in budgetLines {
+            guard !(line.isRollover ?? false) else { continue }
+
+            let consumed = transactionsByLineId[line.id]?
+                .reduce(Decimal.zero) { $0 + $1.amount } ?? 0
+            let effective = max(line.amount, consumed)
+
+            switch line.kind {
+            case .income:
+                totalIncome += effective
+            case .expense:
+                totalExpenses += effective
+            case .saving:
+                totalSavings += effective
+                totalExpenses += effective
+            }
+        }
+
+        if let freeTransactions = transactionsByLineId[""] {
+            for tx in freeTransactions {
+                switch tx.kind {
+                case .income:
+                    totalIncome += tx.amount
+                case .expense:
+                    totalExpenses += tx.amount
+                case .saving:
+                    totalSavings += tx.amount
+                    totalExpenses += tx.amount
+                }
+            }
+        }
+
+        let available = totalIncome + rollover
+        let endingBalance = available - totalExpenses
+
+        return Metrics(
+            totalIncome: totalIncome,
+            totalExpenses: totalExpenses,
+            totalSavings: totalSavings,
+            available: available,
+            endingBalance: endingBalance,
+            remaining: endingBalance,
+            rollover: rollover
+        )
+    }
+
+    /// Calculate realized metrics
+    static func calculateRealizedMetrics(
+        budgetLines: [BudgetLine],
+        transactions: [Transaction] = []
+    ) -> RealizedMetrics {
+        let realizedIncome = calculateRealizedIncome(budgetLines: budgetLines, transactions: transactions)
+        let realizedExpenses = calculateRealizedExpenses(budgetLines: budgetLines, transactions: transactions)
+        let realizedBalance = realizedIncome - realizedExpenses
+
+        let checkedCount = budgetLines.filter { $0.isChecked }.count + transactions.filter { $0.isChecked }.count
+        let totalCount = budgetLines.count + transactions.count
+
+        let checkedSavingsAmount = budgetLines
+            .filter { $0.isChecked && $0.kind == .saving }
+            .reduce(Decimal.zero) { $0 + $1.amount }
+            + transactions
+            .filter { $0.isChecked && $0.kind == .saving }
+            .reduce(Decimal.zero) { $0 + $1.amount }
+
+        return RealizedMetrics(
+            realizedIncome: realizedIncome,
+            realizedExpenses: realizedExpenses,
+            realizedBalance: realizedBalance,
+            checkedItemsCount: checkedCount,
+            totalItemsCount: totalCount,
+            checkedSavingsAmount: checkedSavingsAmount
+        )
+    }
+}

--- a/ios/Pulpe/Domain/Formulas/BudgetFormulas.swift
+++ b/ios/Pulpe/Domain/Formulas/BudgetFormulas.swift
@@ -60,60 +60,90 @@ enum BudgetFormulas {
 
     // MARK: - Income Calculations
 
-    /// Calculate total income from budget lines and transactions
-    /// Formula: Σ(items WHERE kind = 'income')
+    /// Calculate total income using envelope logic
+    /// Allocated transactions are covered by their envelope: max(line.amount, consumed)
+    /// Free transactions (no budgetLineId) are added separately
     static func calculateTotalIncome(
         budgetLines: [BudgetLine],
         transactions: [Transaction] = []
     ) -> Decimal {
-        let budgetIncome = budgetLines
-            .filter { $0.kind == .income && !($0.isRollover ?? false) }
-            .reduce(Decimal.zero) { $0 + $1.amount }
+        let transactionsByLineId = Dictionary(
+            grouping: transactions.filter { $0.kind == .income },
+            by: { $0.budgetLineId ?? "" }
+        )
 
-        let transactionIncome = transactions
-            .filter { $0.kind == .income }
-            .reduce(Decimal.zero) { $0 + $1.amount }
+        var total: Decimal = 0
 
-        return budgetIncome + transactionIncome
+        for line in budgetLines {
+            guard line.kind == .income, !(line.isRollover ?? false) else { continue }
+            let consumed = transactionsByLineId[line.id]?
+                .reduce(Decimal.zero) { $0 + $1.amount } ?? 0
+            total += max(line.amount, consumed)
+        }
+
+        let freeTransactions = transactionsByLineId[""]?
+            .reduce(Decimal.zero) { $0 + $1.amount } ?? 0
+
+        return total + freeTransactions
     }
 
     // MARK: - Expense Calculations
 
-    /// Calculate total expenses (expenses + savings) from budget lines and transactions
-    /// Formula: Σ(items WHERE kind IN ('expense', 'saving'))
+    /// Calculate total expenses (expenses + savings) using envelope logic
+    /// Allocated transactions are covered by their envelope: max(line.amount, consumed)
+    /// Free transactions (no budgetLineId) are added separately
     /// Note: Savings are treated as expenses per SPECS
     static func calculateTotalExpenses(
         budgetLines: [BudgetLine],
         transactions: [Transaction] = []
     ) -> Decimal {
-        let budgetExpenses = budgetLines
-            .filter { $0.kind.isOutflow && !($0.isRollover ?? false) }
-            .reduce(Decimal.zero) { $0 + $1.amount }
+        let transactionsByLineId = Dictionary(
+            grouping: transactions.filter { $0.kind.isOutflow },
+            by: { $0.budgetLineId ?? "" }
+        )
 
-        let transactionExpenses = transactions
-            .filter { $0.kind.isOutflow }
-            .reduce(Decimal.zero) { $0 + $1.amount }
+        var total: Decimal = 0
 
-        return budgetExpenses + transactionExpenses
+        for line in budgetLines {
+            guard line.kind.isOutflow, !(line.isRollover ?? false) else { continue }
+            let consumed = transactionsByLineId[line.id]?
+                .reduce(Decimal.zero) { $0 + $1.amount } ?? 0
+            total += max(line.amount, consumed)
+        }
+
+        let freeTransactions = transactionsByLineId[""]?
+            .reduce(Decimal.zero) { $0 + $1.amount } ?? 0
+
+        return total + freeTransactions
     }
 
     // MARK: - Savings Calculations
 
-    /// Calculate total savings from budget lines and transactions
-    /// Formula: Σ(items WHERE kind = 'saving')
+    /// Calculate total savings using envelope logic
+    /// Allocated transactions are covered by their envelope: max(line.amount, consumed)
+    /// Free transactions (no budgetLineId) are added separately
     static func calculateTotalSavings(
         budgetLines: [BudgetLine],
         transactions: [Transaction] = []
     ) -> Decimal {
-        let budgetSavings = budgetLines
-            .filter { $0.kind == .saving && !($0.isRollover ?? false) }
-            .reduce(Decimal.zero) { $0 + $1.amount }
+        let transactionsByLineId = Dictionary(
+            grouping: transactions.filter { $0.kind == .saving },
+            by: { $0.budgetLineId ?? "" }
+        )
 
-        let transactionSavings = transactions
-            .filter { $0.kind == .saving }
-            .reduce(Decimal.zero) { $0 + $1.amount }
+        var total: Decimal = 0
 
-        return budgetSavings + transactionSavings
+        for line in budgetLines {
+            guard line.kind == .saving, !(line.isRollover ?? false) else { continue }
+            let consumed = transactionsByLineId[line.id]?
+                .reduce(Decimal.zero) { $0 + $1.amount } ?? 0
+            total += max(line.amount, consumed)
+        }
+
+        let freeTransactions = transactionsByLineId[""]?
+            .reduce(Decimal.zero) { $0 + $1.amount } ?? 0
+
+        return total + freeTransactions
     }
 
     // MARK: - Realized Calculations (checked items only)
@@ -202,96 +232,6 @@ enum BudgetFormulas {
     /// Formula: remaining = available - totalExpenses
     static func calculateRemaining(available: Decimal, totalExpenses: Decimal) -> Decimal {
         calculateEndingBalance(available: available, totalExpenses: totalExpenses)
-    }
-
-    // MARK: - All Metrics
-
-    /// Calculate all metrics at once (single-pass optimization)
-    /// Performance: O(n+m) with 2 iterations instead of 10
-    static func calculateAllMetrics(
-        budgetLines: [BudgetLine],
-        transactions: [Transaction] = [],
-        rollover: Decimal = 0
-    ) -> Metrics {
-        // Single pass over budget lines
-        var budgetIncome: Decimal = 0
-        var budgetExpenses: Decimal = 0
-        var budgetSavings: Decimal = 0
-
-        for line in budgetLines {
-            guard !(line.isRollover ?? false) else { continue }
-            switch line.kind {
-            case .income:
-                budgetIncome += line.amount
-            case .expense:
-                budgetExpenses += line.amount
-            case .saving:
-                budgetSavings += line.amount
-                budgetExpenses += line.amount // Savings count as expenses per SPECS
-            }
-        }
-
-        // Single pass over transactions
-        var transactionIncome: Decimal = 0
-        var transactionExpenses: Decimal = 0
-        var transactionSavings: Decimal = 0
-
-        for tx in transactions {
-            switch tx.kind {
-            case .income:
-                transactionIncome += tx.amount
-            case .expense:
-                transactionExpenses += tx.amount
-            case .saving:
-                transactionSavings += tx.amount
-                transactionExpenses += tx.amount // Savings count as expenses per SPECS
-            }
-        }
-
-        let totalIncome = budgetIncome + transactionIncome
-        let totalExpenses = budgetExpenses + transactionExpenses
-        let totalSavings = budgetSavings + transactionSavings
-        let available = totalIncome + rollover
-        let endingBalance = available - totalExpenses
-
-        return Metrics(
-            totalIncome: totalIncome,
-            totalExpenses: totalExpenses,
-            totalSavings: totalSavings,
-            available: available,
-            endingBalance: endingBalance,
-            remaining: endingBalance, // Same as ending balance per SPECS
-            rollover: rollover
-        )
-    }
-
-    /// Calculate realized metrics
-    static func calculateRealizedMetrics(
-        budgetLines: [BudgetLine],
-        transactions: [Transaction] = []
-    ) -> RealizedMetrics {
-        let realizedIncome = calculateRealizedIncome(budgetLines: budgetLines, transactions: transactions)
-        let realizedExpenses = calculateRealizedExpenses(budgetLines: budgetLines, transactions: transactions)
-        let realizedBalance = realizedIncome - realizedExpenses
-
-        let checkedCount = budgetLines.filter { $0.isChecked }.count + transactions.filter { $0.isChecked }.count
-        let totalCount = budgetLines.count + transactions.count
-
-        let checkedSavingsAmount = budgetLines
-            .filter { $0.isChecked && $0.kind == .saving }
-            .reduce(Decimal.zero) { $0 + $1.amount }
-            + transactions
-            .filter { $0.isChecked && $0.kind == .saving }
-            .reduce(Decimal.zero) { $0 + $1.amount }
-
-        return RealizedMetrics(
-            realizedIncome: realizedIncome,
-            realizedExpenses: realizedExpenses,
-            realizedBalance: realizedBalance,
-            checkedItemsCount: checkedCount,
-            totalItemsCount: totalCount,
-            checkedSavingsAmount: checkedSavingsAmount
-        )
     }
 
     // MARK: - Consumption Tracking

--- a/ios/PulpeTests/Domain/Formulas/BudgetFormulasEnvelopeTests.swift
+++ b/ios/PulpeTests/Domain/Formulas/BudgetFormulasEnvelopeTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Envelope-aware expense calculation tests (allocated vs free transactions)
+struct BudgetFormulasEnvelopeTests {
+    // MARK: - Expense Envelopes
+
+    @Test func calculateTotalExpenses_withAllocatedTransaction_doesNotDoubleCount() {
+        let lines = [
+            TestDataFactory.createBudgetLine(id: "1", amount: 500, kind: .expense)
+        ]
+        let transactions = [
+            TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "1", amount: 200, kind: .expense)
+        ]
+        let result = BudgetFormulas.calculateTotalExpenses(budgetLines: lines, transactions: transactions)
+        #expect(result == 500) // Not 700 — transaction covered by envelope
+    }
+
+    @Test func calculateTotalExpenses_withAllocatedTransactionExceedingEnvelope_usesMax() {
+        let lines = [
+            TestDataFactory.createBudgetLine(id: "1", amount: 100, kind: .expense)
+        ]
+        let transactions = [
+            TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "1", amount: 188, kind: .expense)
+        ]
+        let result = BudgetFormulas.calculateTotalExpenses(budgetLines: lines, transactions: transactions)
+        #expect(result == 188) // Overage: transaction exceeds envelope
+    }
+
+    @Test func calculateTotalExpenses_withFreeAndAllocatedTransactions_onlyCountsFreeOnes() {
+        let lines = [
+            TestDataFactory.createBudgetLine(id: "1", amount: 500, kind: .expense)
+        ]
+        let transactions = [
+            TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "1", amount: 200, kind: .expense),
+            TestDataFactory.createTransaction(id: "tx-2", amount: 50, kind: .expense)
+        ]
+        let result = BudgetFormulas.calculateTotalExpenses(budgetLines: lines, transactions: transactions)
+        #expect(result == 550) // 500 envelope + 50 free
+    }
+
+    @Test func calculateTotalExpenses_withMultipleEnvelopes_handlesIndependently() {
+        let lines = [
+            TestDataFactory.createBudgetLine(id: "1", amount: 500, kind: .expense),
+            TestDataFactory.createBudgetLine(id: "2", amount: 200, kind: .expense)
+        ]
+        let transactions = [
+            TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "1", amount: 400, kind: .expense),
+            TestDataFactory.createTransaction(id: "tx-2", budgetLineId: "2", amount: 350, kind: .expense)
+        ]
+        let result = BudgetFormulas.calculateTotalExpenses(budgetLines: lines, transactions: transactions)
+        #expect(result == 850) // 500 (no overage) + 350 (overage)
+    }
+
+    // MARK: - Income & Savings Envelopes
+
+    @Test func calculateTotalIncome_withAllocatedIncomeTransaction_doesNotDoubleCount() {
+        let lines = [
+            TestDataFactory.createBudgetLine(id: "1", amount: 3000, kind: .income)
+        ]
+        let transactions = [
+            TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "1", amount: 500, kind: .income)
+        ]
+        let result = BudgetFormulas.calculateTotalIncome(budgetLines: lines, transactions: transactions)
+        #expect(result == 3000) // Not 3500 — transaction covered by envelope
+    }
+
+    @Test func calculateTotalSavings_withAllocatedSavingTransaction_doesNotDoubleCount() {
+        let lines = [
+            TestDataFactory.createBudgetLine(id: "1", amount: 400, kind: .saving)
+        ]
+        let transactions = [
+            TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "1", amount: 150, kind: .saving)
+        ]
+        let result = BudgetFormulas.calculateTotalSavings(budgetLines: lines, transactions: transactions)
+        #expect(result == 400) // Not 550 — transaction covered by envelope
+    }
+
+    // MARK: - Metrics with Envelopes
+
+    @Test func calculateAllMetrics_withAllocatedTransactions_usesEnvelopeLogic() {
+        let lines = [
+            TestDataFactory.createBudgetLine(id: "1", amount: 3000, kind: .income),
+            TestDataFactory.createBudgetLine(id: "2", amount: 800, kind: .expense)
+        ]
+        let transactions = [
+            TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "2", amount: 600, kind: .expense),
+            TestDataFactory.createTransaction(id: "tx-2", amount: 50, kind: .expense)
+        ]
+        let metrics = BudgetFormulas.calculateAllMetrics(budgetLines: lines, transactions: transactions)
+        #expect(metrics.totalExpenses == 850) // 800 envelope + 50 free, not 1450
+        #expect(metrics.totalIncome == 3000)
+    }
+}

--- a/landing/components/sections/FinalCTA.tsx
+++ b/landing/components/sections/FinalCTA.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Button, Container, FadeIn, GrainOverlay } from '@/components/ui'
-import { ANGULAR_APP_URL } from '@/lib/config'
+import { angularUrl } from '@/lib/config'
 import { trackCTAClick } from '@/lib/posthog'
 
 export function FinalCTA() {
@@ -28,7 +28,7 @@ export function FinalCTA() {
             <p className="text-lg text-white/80 mb-10 max-w-xl mx-auto">
               Gratuit, open source, et respectueux de ta vie privée.
             </p>
-            <Button href={`${ANGULAR_APP_URL}/signup`} variant="inverse" onClick={() => trackCTAClick('commencer_gratuitement', 'final_cta', '/signup')}>
+            <Button href={angularUrl('/signup', 'final_cta_commencer')} variant="inverse" onClick={() => trackCTAClick('commencer_gratuitement', 'final_cta', '/signup')}>
               Commencer gratuitement
             </Button>
           </FadeIn>

--- a/landing/components/sections/Header.tsx
+++ b/landing/components/sections/Header.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, type CSSProperties } from 'react'
 import { Menu, X } from 'lucide-react'
 import { Button } from '@/components/ui'
-import { ANGULAR_APP_URL } from '@/lib/config'
+import { angularUrl } from '@/lib/config'
 import { trackCTAClick } from '@/lib/posthog'
 
 const navLinks = [
@@ -156,7 +156,7 @@ export function Header() {
           </div>
 
           <div className="relative z-10 flex items-center gap-2">
-            <Button href={`${ANGULAR_APP_URL}/welcome`} size="sm" className="rounded-full shadow-lg shadow-primary/20 hover:shadow-primary/30 transition-shadow" onClick={() => trackCTAClick('essayer', 'header', '/welcome')}>
+            <Button href={angularUrl('/welcome', 'header_essayer')} size="sm" className="rounded-full shadow-lg shadow-primary/20 hover:shadow-primary/30 transition-shadow" onClick={() => trackCTAClick('essayer', 'header', '/welcome')}>
               Essayer
             </Button>
 

--- a/landing/components/sections/Hero.tsx
+++ b/landing/components/sections/Hero.tsx
@@ -8,7 +8,7 @@ import {
   HeroScreenshot,
   TypeWriter,
 } from "@/components/ui";
-import { ANGULAR_APP_URL } from "@/lib/config";
+import { angularUrl } from "@/lib/config";
 import { trackCTAClick } from "@/lib/posthog";
 import {
   Check,
@@ -205,7 +205,7 @@ export function Hero() {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 sm:items-start items-center justify-center lg:justify-start">
               <div className="flex flex-col items-center gap-2">
-                <Button href={`${ANGULAR_APP_URL}/signup`} glow onClick={() => trackCTAClick('commencer', 'hero', '/signup')}>
+                <Button href={angularUrl('/signup', 'hero_commencer')} glow onClick={() => trackCTAClick('commencer', 'hero', '/signup')}>
                   Commencer
                 </Button>
                 <span className="text-xs italic text-text-secondary">

--- a/landing/components/sections/HowItWorks.tsx
+++ b/landing/components/sections/HowItWorks.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Section, Button, FadeIn } from '@/components/ui'
-import { ANGULAR_APP_URL } from '@/lib/config'
+import { angularUrl } from '@/lib/config'
 import { trackCTAClick } from '@/lib/posthog'
 import { Check } from 'lucide-react'
 
@@ -83,7 +83,7 @@ export function HowItWorks() {
 
       <FadeIn variant="blur" delay={0.4}>
         <div className="text-center">
-          <Button href={`${ANGULAR_APP_URL}/signup`} onClick={() => trackCTAClick('creer_mon_budget', 'how_it_works', '/signup')}>Créer mon budget</Button>
+          <Button href={angularUrl('/signup', 'how_it_works_creer')} onClick={() => trackCTAClick('creer_mon_budget', 'how_it_works', '/signup')}>Créer mon budget</Button>
         </div>
       </FadeIn>
     </Section>

--- a/landing/components/sections/Platforms.tsx
+++ b/landing/components/sections/Platforms.tsx
@@ -2,7 +2,7 @@
 
 import { Globe, Smartphone, Apple } from 'lucide-react'
 import { Section, Badge, Button, FadeIn, Card, ShineBorder } from '@/components/ui'
-import { ANGULAR_APP_URL } from '@/lib/config'
+import { angularUrl } from '@/lib/config'
 import { trackCTAClick } from '@/lib/posthog'
 
 const IOS_APP_URL = '#' // TODO: Remplacer par le lien App Store
@@ -30,7 +30,7 @@ export function Platforms() {
             <p className="text-text-secondary mb-6 flex-1">
               Utilise Pulpe directement dans ton navigateur, sur ordinateur ou téléphone. Aucune installation requise.
             </p>
-            <Button href={`${ANGULAR_APP_URL}/welcome`} variant="secondary" className="w-full" onClick={() => trackCTAClick('ouvrir_navigateur', 'platforms', '/welcome')}>
+            <Button href={angularUrl('/welcome', 'platforms_ouvrir')} variant="secondary" className="w-full" onClick={() => trackCTAClick('ouvrir_navigateur', 'platforms', '/welcome')}>
               Ouvrir dans le navigateur
             </Button>
           </Card>

--- a/landing/lib/config.ts
+++ b/landing/lib/config.ts
@@ -1,1 +1,5 @@
 export const ANGULAR_APP_URL = process.env.NEXT_PUBLIC_ANGULAR_APP_URL || ''
+
+export function angularUrl(path: string, utmContent: string): string {
+  return `${ANGULAR_APP_URL}${path}?utm_source=landing&utm_medium=cta&utm_content=${encodeURIComponent(utmContent)}`;
+}

--- a/landing/lib/config.ts
+++ b/landing/lib/config.ts
@@ -1,5 +1,6 @@
 export const ANGULAR_APP_URL = process.env.NEXT_PUBLIC_ANGULAR_APP_URL || ''
 
 export function angularUrl(path: string, utmContent: string): string {
-  return `${ANGULAR_APP_URL}${path}?utm_source=landing&utm_medium=cta&utm_content=${encodeURIComponent(utmContent)}`;
+  const separator = path.includes('?') ? '&' : '?';
+  return `${ANGULAR_APP_URL}${path}${separator}utm_source=landing&utm_medium=cta&utm_content=${encodeURIComponent(utmContent)}`;
 }

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -36,6 +36,13 @@ Progress = (Expenses ÷ Available) × 100
 Ending Balance = Remaining (stored, becomes next month's rollover)
 ```
 
+### Envelope Logic
+
+All kinds (income, expense, saving) use the same envelope rule:
+
+- **Allocated transactions** (`budget_line_id` set) are covered by their envelope (budget line). Effective amount = `max(line.amount, consumed)`. This prevents double-counting when transactions are allocated to a line.
+- **Free transactions** (`budget_line_id` null) impact the budget directly, added on top of envelope totals.
+
 ### Rollover Chain
 
 ```

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -36,12 +36,14 @@ Progress = (Expenses ÷ Available) × 100
 Ending Balance = Remaining (stored, becomes next month's rollover)
 ```
 
-### Envelope Logic
+### Envelope Logic (SSOT: `shared/BudgetFormulas`)
 
-All kinds (income, expense, saving) use the same envelope rule:
+All calculations use a single set of formulas with envelope logic and kind filtering. There is only one version of each formula — no "with/without envelope" variants.
 
 - **Allocated transactions** (`budget_line_id` set) are covered by their envelope (budget line). Effective amount = `max(line.amount, consumed)`. This prevents double-counting when transactions are allocated to a line.
+- **Kind filter**: When computing `consumed` for a line, only transactions matching the line's kind category count (income transactions for income lines, expense/saving transactions for expense/saving lines). This prevents a misallocated transaction from inflating the wrong total.
 - **Free transactions** (`budget_line_id` null) impact the budget directly, added on top of envelope totals.
+- **totalSavings**: Uses envelope logic (`max(line.amount, consumed)`) for saving lines, plus free saving transactions. This provides a complete savings picture including ad-hoc savings.
 
 ### Rollover Chain
 

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -296,12 +296,18 @@ Ending Balance = Remaining (becomes next month's rollover)
 
 ### Envelope Pattern (BudgetFormulas)
 
-`calculateAllMetricsWithEnvelopes` is the primary entry point for budget metric calculations. It delegates to:
+`calculateAllMetrics` is the single entry point for budget metric calculations. It delegates to:
 
-- `calculateTotalIncomeWithEnvelopes` — income with envelope logic
-- `calculateTotalExpensesWithEnvelopes` — expenses/savings with envelope logic
+- `calculateTotalIncome` — income with envelope logic + kind filter
+- `calculateTotalExpenses` — expenses/savings with envelope logic + kind filter
+- `calculateTotalSavings` — savings with envelope logic + free saving transactions
 
-Both use the same rule: for each budget line, `effective = max(line.amount, consumed)`. Free transactions (no `budgetLineId`) are added separately. This ensures allocated transactions are never double-counted across all kinds (income, expense, saving).
+All use the same rule: for each budget line, `effective = max(line.amount, consumed)` where consumed only counts transactions matching the line's kind category (income vs outflow). Free transactions (no `budgetLineId`) are added separately. This ensures:
+1. Allocated transactions are never double-counted
+2. A misallocated transaction (e.g., income tx on an expense line) doesn't inflate the wrong total
+3. `totalSavings` includes both envelope-covered savings and free saving transactions
+
+Backend, frontend, and iOS all delegate to this shared logic (iOS has a Swift port with identical semantics).
 
 ---
 

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -294,6 +294,15 @@ Remaining = Available - Expenses
 Ending Balance = Remaining (becomes next month's rollover)
 ```
 
+### Envelope Pattern (BudgetFormulas)
+
+`calculateAllMetricsWithEnvelopes` is the primary entry point for budget metric calculations. It delegates to:
+
+- `calculateTotalIncomeWithEnvelopes` — income with envelope logic
+- `calculateTotalExpensesWithEnvelopes` — expenses/savings with envelope logic
+
+Both use the same rule: for each budget line, `effective = max(line.amount, consumed)`. Free transactions (no `budgetLineId`) are added separately. This ensures allocated transactions are never double-counted across all kinds (income, expense, saving).
+
 ---
 
 ## Shared Package (pulpe-shared)

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -78,7 +78,8 @@ export const budgetSchema = z.object({
   // Report du mois précédent selon formule SPECS rollover_M = ending_balance_M-1
   rollover: z.number().optional(),
   // remaining : CALCULÉ par le backend pour la liste des budgets
-  // Formule: remaining = (totalIncome + rollover) - totalExpenses - totalSavings
+  // Formule: remaining = (totalIncome + rollover) - totalExpenses
+  // totalExpenses inclut les savings via la logique d'enveloppe
   // Correspond au "Disponible CHF" de la barre de progression
   remaining: z.number().optional(),
   // previousBudgetId : Budget source du rollover pour traçabilité

--- a/shared/src/calculators/budget-formulas.spec.ts
+++ b/shared/src/calculators/budget-formulas.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { BudgetFormulas } from './budget-formulas.js';
+import { BudgetFormulas, isOutflowKind } from './budget-formulas.js';
 import type { TransactionKind } from '../types.js';
 
 /**
@@ -19,7 +19,7 @@ function createFinancialItem(kind: TransactionKind, amount: number) {
 let idCounter = 0;
 
 /**
- * Helper pour créer des items financiers avec id (pour calculateAllMetricsWithEnvelopes)
+ * Helper pour créer des items financiers avec id (pour les calculs avec logique d'enveloppe)
  */
 function createFinancialItemWithId(kind: TransactionKind, amount: number) {
   return { id: `item-${++idCounter}`, kind, amount };
@@ -44,40 +44,37 @@ const complexTestDataWithIds = {
   rollover: 250, // Report positif
 };
 
-/**
- * Dataset de test complexe simulant un mois réel (legacy - sans ids)
- */
-const complexTestData = {
-  budgetLines: [
-    createFinancialItem('income', 5000), // Salaire
-    createFinancialItem('expense', 1500), // Loyer
-    createFinancialItem('expense', 800), // Courses
-    createFinancialItem('saving', 500), // Épargne planifiée
-  ],
-  transactions: [
-    createFinancialItem('expense', 200), // Restaurant
-    createFinancialItem('expense', 150), // Essence
-    createFinancialItem('income', 300), // Freelance
-    createFinancialItem('saving', 100), // Épargne supplémentaire
-  ],
-  rollover: 250, // Report positif
-};
+describe('isOutflowKind', () => {
+  it('should return true for expense', () => {
+    expect(isOutflowKind('expense')).toBe(true);
+  });
+
+  it('should return true for saving', () => {
+    expect(isOutflowKind('saving')).toBe(true);
+  });
+
+  it('should return false for income', () => {
+    expect(isOutflowKind('income')).toBe(false);
+  });
+});
 
 describe('BudgetFormulas', () => {
   describe('calculateTotalIncome', () => {
     it('should calculate income from budget lines only', () => {
       const budgetLines = [
-        createFinancialItem('income', 5000),
-        createFinancialItem('income', 1000),
-        createFinancialItem('expense', 500), // Should be ignored
+        createFinancialItemWithId('income', 5000),
+        createFinancialItemWithId('income', 1000),
+        createFinancialItemWithId('expense', 500), // Should be ignored
       ];
 
       expect(BudgetFormulas.calculateTotalIncome(budgetLines, [])).toBe(6000);
     });
 
     it('should calculate income from budget lines and transactions', () => {
-      const budgetLines = [createFinancialItem('income', 5000)];
-      const transactions = [createFinancialItem('income', 300)];
+      const budgetLines = [createFinancialItemWithId('income', 5000)];
+      const transactions = [
+        { ...createFinancialItem('income', 300), budgetLineId: null },
+      ];
 
       expect(
         BudgetFormulas.calculateTotalIncome(budgetLines, transactions),
@@ -91,10 +88,12 @@ describe('BudgetFormulas', () => {
 
     it('should ignore non-income items', () => {
       const budgetLines = [
-        createFinancialItem('expense', 1000),
-        createFinancialItem('saving', 500),
+        createFinancialItemWithId('expense', 1000),
+        createFinancialItemWithId('saving', 500),
       ];
-      const transactions = [createFinancialItem('expense', 200)];
+      const transactions = [
+        { ...createFinancialItem('expense', 200), budgetLineId: null },
+      ];
 
       expect(
         BudgetFormulas.calculateTotalIncome(budgetLines, transactions),
@@ -105,9 +104,9 @@ describe('BudgetFormulas', () => {
   describe('calculateTotalExpenses', () => {
     it('should include both expenses and savings according to SPECS', () => {
       const budgetLines = [
-        createFinancialItem('expense', 1000),
-        createFinancialItem('saving', 500), // Traité comme expense selon SPECS
-        createFinancialItem('income', 5000), // Should be ignored
+        createFinancialItemWithId('expense', 1000),
+        createFinancialItemWithId('saving', 500), // Traité comme expense selon SPECS
+        createFinancialItemWithId('income', 5000), // Should be ignored
       ];
 
       expect(BudgetFormulas.calculateTotalExpenses(budgetLines, [])).toBe(1500);
@@ -115,12 +114,12 @@ describe('BudgetFormulas', () => {
 
     it('should combine budget lines and transactions expenses', () => {
       const budgetLines = [
-        createFinancialItem('expense', 1000),
-        createFinancialItem('saving', 500),
+        createFinancialItemWithId('expense', 1000),
+        createFinancialItemWithId('saving', 500),
       ];
       const transactions = [
-        createFinancialItem('expense', 200),
-        createFinancialItem('saving', 100),
+        { ...createFinancialItem('expense', 200), budgetLineId: null },
+        { ...createFinancialItem('saving', 100), budgetLineId: null },
       ];
 
       expect(
@@ -134,8 +133,10 @@ describe('BudgetFormulas', () => {
     });
 
     it('should ignore income items', () => {
-      const budgetLines = [createFinancialItem('income', 5000)];
-      const transactions = [createFinancialItem('income', 300)];
+      const budgetLines = [createFinancialItemWithId('income', 5000)];
+      const transactions = [
+        { ...createFinancialItem('income', 300), budgetLineId: null },
+      ];
 
       expect(
         BudgetFormulas.calculateTotalExpenses(budgetLines, transactions),
@@ -877,7 +878,7 @@ describe('BudgetFormulas', () => {
   describe('validateMetricsCoherence', () => {
     it('should validate coherent metrics', () => {
       const { budgetLines, transactions, rollover } = complexTestDataWithIds;
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         budgetLines,
         transactions,
         rollover,
@@ -891,6 +892,7 @@ describe('BudgetFormulas', () => {
       const badMetrics = {
         totalIncome: 5000,
         totalExpenses: 3000,
+        totalSavings: 0,
         available: 4000, // Incorrecte: devrait être 5000 + rollover
         endingBalance: 2000,
         remaining: 2000,
@@ -904,6 +906,7 @@ describe('BudgetFormulas', () => {
       const badMetrics = {
         totalIncome: -1000, // Invalide
         totalExpenses: 3000,
+        totalSavings: 0,
         available: 4000,
         endingBalance: 2000,
         remaining: 2000,
@@ -922,11 +925,7 @@ describe('BudgetFormulas', () => {
         createFinancialItemWithId('expense', 4500),
       ];
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
-        budgetLines,
-        [],
-        0,
-      );
+      const metrics = BudgetFormulas.calculateAllMetrics(budgetLines, [], 0);
 
       expect(metrics.totalIncome).toBe(5000);
       expect(metrics.totalExpenses).toBe(4500);
@@ -943,7 +942,7 @@ describe('BudgetFormulas', () => {
       ];
       const rollover = 500; // Depuis janvier
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         budgetLines,
         [],
         rollover,
@@ -964,11 +963,7 @@ describe('BudgetFormulas', () => {
         createFinancialItemWithId('saving', 1000), // Doit être traité comme expense
       ];
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
-        budgetLines,
-        [],
-        0,
-      );
+      const metrics = BudgetFormulas.calculateAllMetrics(budgetLines, [], 0);
 
       expect(metrics.totalExpenses).toBe(4000); // 3000 + 1000 (saving inclus)
       expect(metrics.endingBalance).toBe(1000); // 5000 - 4000
@@ -982,7 +977,7 @@ describe('BudgetFormulas', () => {
       ];
       const rollover = 900; // Depuis février
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         budgetLines,
         [],
         rollover,
@@ -1003,7 +998,7 @@ describe('BudgetFormulas', () => {
       ];
       const rollover = 800; // Depuis mars
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         budgetLines,
         [],
         rollover,
@@ -1055,7 +1050,7 @@ describe('BudgetFormulas', () => {
           createFinancialItemWithId('expense', month.expenses),
         ];
 
-        const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+        const metrics = BudgetFormulas.calculateAllMetrics(
           budgetLines,
           [],
           month.rollover,
@@ -1084,7 +1079,7 @@ describe('BudgetFormulas', () => {
       }));
 
       const start = performance.now();
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         largeBudgetLines,
         largeTransactions,
         0,
@@ -1101,7 +1096,7 @@ describe('BudgetFormulas', () => {
     });
   });
 
-  describe('calculateTotalExpensesWithEnvelopes', () => {
+  describe('calculateTotalExpenses', () => {
     function createBudgetLine(
       id: string,
       kind: TransactionKind,
@@ -1124,7 +1119,7 @@ describe('BudgetFormulas', () => {
           const budgetLines = [createBudgetLine('line-1', 'expense', 500)];
           const transactions = [createTransaction('expense', 100, 'line-1')];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1134,22 +1129,15 @@ describe('BudgetFormulas', () => {
         });
 
         it('should not double-count the transaction amount', () => {
-          // Without envelope logic: 500 (line) + 100 (tx) = 600 (WRONG)
           // With envelope logic: max(500, 100) = 500 (CORRECT)
           const budgetLines = [createBudgetLine('line-1', 'expense', 500)];
           const transactions = [createTransaction('expense', 100, 'line-1')];
 
-          const naiveResult = BudgetFormulas.calculateTotalExpenses(
+          const envelopeResult = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
-          const envelopeResult =
-            BudgetFormulas.calculateTotalExpensesWithEnvelopes(
-              budgetLines,
-              transactions,
-            );
 
-          expect(naiveResult).toBe(600); // Naive double-counts
           expect(envelopeResult).toBe(500); // Envelope-aware is correct
         });
       });
@@ -1159,7 +1147,7 @@ describe('BudgetFormulas', () => {
           const budgetLines = [createBudgetLine('line-1', 'expense', 100)];
           const transactions = [createTransaction('expense', 150, 'line-1')];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1172,7 +1160,7 @@ describe('BudgetFormulas', () => {
           const budgetLines = [createBudgetLine('line-1', 'expense', 100)];
           const transactions = [createTransaction('expense', 188, 'line-1')];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1187,7 +1175,7 @@ describe('BudgetFormulas', () => {
           const budgetLines: ReturnType<typeof createBudgetLine>[] = [];
           const transactions = [createTransaction('expense', 50, null)];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1202,7 +1190,7 @@ describe('BudgetFormulas', () => {
             createTransaction('expense', 75, null), // Free transaction
           ];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1222,7 +1210,7 @@ describe('BudgetFormulas', () => {
             createTransaction('expense', 150, 'line-1'),
           ];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1238,7 +1226,7 @@ describe('BudgetFormulas', () => {
             createTransaction('expense', 250, 'line-1'),
           ];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1260,7 +1248,7 @@ describe('BudgetFormulas', () => {
             createTransaction('expense', 50, null), // Free transaction
           ];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1278,7 +1266,7 @@ describe('BudgetFormulas', () => {
           const budgetLines = [createBudgetLine('line-1', 'saving', 500)];
           const transactions = [createTransaction('saving', 100, 'line-1')];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1295,20 +1283,34 @@ describe('BudgetFormulas', () => {
             createTransaction('income', 300, null), // Free income - should be ignored
           ];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
 
           expect(result).toBe(500);
         });
+
+        it('should not inflate consumed when an income tx is allocated to an expense line', () => {
+          const budgetLines = [createBudgetLine('line-1', 'expense', 500)];
+          const transactions = [
+            createTransaction('expense', 200, 'line-1'),
+            createTransaction('income', 300, 'line-1'), // income allocated to expense line — should NOT count toward consumed
+          ];
+
+          const result = BudgetFormulas.calculateTotalExpenses(
+            budgetLines,
+            transactions,
+          );
+
+          // Only expense tx counts toward consumed: max(500, 200) = 500
+          expect(result).toBe(500);
+        });
       });
 
       describe('edge cases', () => {
         it('should return 0 for empty arrays', () => {
-          expect(
-            BudgetFormulas.calculateTotalExpensesWithEnvelopes([], []),
-          ).toBe(0);
+          expect(BudgetFormulas.calculateTotalExpenses([], [])).toBe(0);
         });
 
         it('should handle budget lines with no transactions', () => {
@@ -1317,10 +1319,7 @@ describe('BudgetFormulas', () => {
             createBudgetLine('line-2', 'expense', 300),
           ];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
-            budgetLines,
-            [],
-          );
+          const result = BudgetFormulas.calculateTotalExpenses(budgetLines, []);
 
           expect(result).toBe(800);
         });
@@ -1334,10 +1333,7 @@ describe('BudgetFormulas', () => {
             },
           ];
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
-            budgetLines,
-            [],
-          );
+          const result = BudgetFormulas.calculateTotalExpenses(budgetLines, []);
 
           expect(result).toBe(600);
         });
@@ -1346,7 +1342,7 @@ describe('BudgetFormulas', () => {
           const budgetLines = [createBudgetLine('line-1', 'expense', 500)];
           const transactions = [{ kind: 'expense' as const, amount: 50 }]; // No budgetLineId field
 
-          const result = BudgetFormulas.calculateTotalExpensesWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalExpenses(
             budgetLines,
             transactions,
           );
@@ -1358,7 +1354,7 @@ describe('BudgetFormulas', () => {
     });
   });
 
-  describe('calculateTotalIncomeWithEnvelopes', () => {
+  describe('calculateTotalIncome', () => {
     function createBudgetLine(
       id: string,
       kind: TransactionKind,
@@ -1381,7 +1377,7 @@ describe('BudgetFormulas', () => {
           const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
           const transactions = [createTransaction('income', 4800, 'line-1')];
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalIncome(
             budgetLines,
             transactions,
           );
@@ -1396,7 +1392,7 @@ describe('BudgetFormulas', () => {
           const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
           const transactions = [createTransaction('income', 5200, 'line-1')];
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalIncome(
             budgetLines,
             transactions,
           );
@@ -1413,7 +1409,7 @@ describe('BudgetFormulas', () => {
             createTransaction('income', 300, null), // Free income
           ];
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalIncome(
             budgetLines,
             transactions,
           );
@@ -1433,7 +1429,7 @@ describe('BudgetFormulas', () => {
             createTransaction('income', 300, null), // Free income
           ];
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalIncome(
             budgetLines,
             transactions,
           );
@@ -1456,7 +1452,7 @@ describe('BudgetFormulas', () => {
             createTransaction('income', 3500, 'line-2'),
           ];
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalIncome(
             budgetLines,
             transactions,
           );
@@ -1476,7 +1472,7 @@ describe('BudgetFormulas', () => {
           ];
           const transactions: ReturnType<typeof createTransaction>[] = [];
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalIncome(
             budgetLines,
             transactions,
           );
@@ -1492,20 +1488,34 @@ describe('BudgetFormulas', () => {
             createTransaction('expense', 200, null), // Free expense - should be ignored
           ];
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalIncome(
             budgetLines,
             transactions,
           );
 
           expect(result).toBe(5000);
         });
+
+        it('should not inflate consumed when an expense tx is allocated to an income line', () => {
+          const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
+          const transactions = [
+            createTransaction('income', 4800, 'line-1'),
+            createTransaction('expense', 300, 'line-1'), // expense allocated to income line — should NOT count toward consumed
+          ];
+
+          const result = BudgetFormulas.calculateTotalIncome(
+            budgetLines,
+            transactions,
+          );
+
+          // Only income tx counts toward consumed: max(5000, 4800) = 5000
+          expect(result).toBe(5000);
+        });
       });
 
       describe('edge cases', () => {
         it('should return 0 for empty arrays', () => {
-          expect(BudgetFormulas.calculateTotalIncomeWithEnvelopes([], [])).toBe(
-            0,
-          );
+          expect(BudgetFormulas.calculateTotalIncome([], [])).toBe(0);
         });
 
         it('should handle budget lines with no transactions', () => {
@@ -1514,10 +1524,7 @@ describe('BudgetFormulas', () => {
             createBudgetLine('line-2', 'income', 3000),
           ];
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
-            budgetLines,
-            [],
-          );
+          const result = BudgetFormulas.calculateTotalIncome(budgetLines, []);
 
           expect(result).toBe(8000);
         });
@@ -1526,7 +1533,7 @@ describe('BudgetFormulas', () => {
           const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
           const transactions = [{ kind: 'income' as const, amount: 300 }]; // No budgetLineId field
 
-          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+          const result = BudgetFormulas.calculateTotalIncome(
             budgetLines,
             transactions,
           );
@@ -1538,7 +1545,104 @@ describe('BudgetFormulas', () => {
     });
   });
 
-  describe('calculateAllMetricsWithEnvelopes', () => {
+  describe('calculateTotalSavings', () => {
+    function createBudgetLine(
+      id: string,
+      kind: TransactionKind,
+      amount: number,
+    ) {
+      return { id, kind, amount };
+    }
+
+    function createTransaction(
+      kind: TransactionKind,
+      amount: number,
+      budgetLineId?: string | null,
+    ) {
+      return { kind, amount, budgetLineId };
+    }
+
+    it('should return sum of saving budget line amounts only', () => {
+      const budgetLines = [
+        createBudgetLine('line-1', 'saving', 500),
+        createBudgetLine('line-2', 'saving', 300),
+        createBudgetLine('line-3', 'expense', 1000), // should be ignored
+      ];
+
+      const result = BudgetFormulas.calculateTotalSavings(budgetLines, []);
+
+      expect(result).toBe(800);
+    });
+
+    it('should add free saving transactions directly', () => {
+      const budgetLines: ReturnType<typeof createBudgetLine>[] = [];
+      const transactions = [
+        createTransaction('saving', 100, null),
+        createTransaction('saving', 50, null),
+        createTransaction('expense', 200, null), // should be ignored
+      ];
+
+      const result = BudgetFormulas.calculateTotalSavings(
+        budgetLines,
+        transactions,
+      );
+
+      expect(result).toBe(150);
+    });
+
+    it('should use envelope logic: max(line.amount, consumed) for allocated saving transactions', () => {
+      const budgetLines = [createBudgetLine('line-1', 'saving', 500)];
+      const transactions = [
+        createTransaction('saving', 200, 'line-1'),
+        createTransaction('saving', 150, 'line-1'),
+      ];
+
+      const result = BudgetFormulas.calculateTotalSavings(
+        budgetLines,
+        transactions,
+      );
+
+      // Envelope: 500, consumed: 200 + 150 = 350 -> max(500, 350) = 500
+      expect(result).toBe(500);
+    });
+
+    it('should use consumed when it exceeds envelope', () => {
+      const budgetLines = [createBudgetLine('line-1', 'saving', 200)];
+      const transactions = [createTransaction('saving', 350, 'line-1')];
+
+      const result = BudgetFormulas.calculateTotalSavings(
+        budgetLines,
+        transactions,
+      );
+
+      // Envelope: 200, consumed: 350 -> max(200, 350) = 350
+      expect(result).toBe(350);
+    });
+
+    it('should ignore expense and income items', () => {
+      const budgetLines = [
+        createBudgetLine('line-1', 'income', 5000),
+        createBudgetLine('line-2', 'expense', 1000),
+      ];
+      const transactions = [
+        createTransaction('income', 300, null),
+        createTransaction('expense', 200, null),
+      ];
+
+      const result = BudgetFormulas.calculateTotalSavings(
+        budgetLines,
+        transactions,
+      );
+
+      expect(result).toBe(0);
+    });
+
+    it('should handle empty arrays', () => {
+      expect(BudgetFormulas.calculateTotalSavings([], [])).toBe(0);
+    });
+  });
+
+  describe('calculateAllMetrics', () => {
     function createBudgetLine(
       id: string,
       kind: TransactionKind,
@@ -1563,7 +1667,7 @@ describe('BudgetFormulas', () => {
       const transactions = [createTransaction('expense', 100, 'expense-1')];
       const rollover = 200;
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         budgetLines,
         transactions,
         rollover,
@@ -1571,6 +1675,7 @@ describe('BudgetFormulas', () => {
 
       expect(metrics.totalIncome).toBe(5000);
       expect(metrics.totalExpenses).toBe(500); // envelope-aware: max(500, 100) = 500
+      expect(metrics.totalSavings).toBe(0);
       expect(metrics.available).toBe(5200); // 5000 + 200
       expect(metrics.endingBalance).toBe(4700); // 5200 - 500
       expect(metrics.remaining).toBe(4700);
@@ -1584,7 +1689,7 @@ describe('BudgetFormulas', () => {
       ];
       const transactions = [createTransaction('expense', 300, 'expense-1')];
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         budgetLines,
         transactions,
         0,
@@ -1604,7 +1709,7 @@ describe('BudgetFormulas', () => {
         createTransaction('expense', 50, null), // free transaction
       ];
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         budgetLines,
         transactions,
         0,
@@ -1629,7 +1734,7 @@ describe('BudgetFormulas', () => {
       ];
       const rollover = 250;
 
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
+      const metrics = BudgetFormulas.calculateAllMetrics(
         budgetLines,
         transactions,
         rollover,
@@ -1641,18 +1746,33 @@ describe('BudgetFormulas', () => {
         metrics.available - metrics.totalExpenses,
       );
       expect(metrics.remaining).toBe(metrics.endingBalance);
+      expect(metrics.totalSavings).toBeGreaterThanOrEqual(0);
       expect(BudgetFormulas.validateMetricsCoherence(metrics)).toBe(true);
     });
 
-    it('should handle empty data', () => {
-      const metrics = BudgetFormulas.calculateAllMetricsWithEnvelopes(
-        [],
-        [],
+    it('should include totalSavings in returned metrics', () => {
+      const budgetLines = [
+        createBudgetLine('income-1', 'income', 5000),
+        createBudgetLine('saving-1', 'saving', 400),
+      ];
+      const transactions = [createTransaction('saving', 100, null)];
+
+      const metrics = BudgetFormulas.calculateAllMetrics(
+        budgetLines,
+        transactions,
         0,
       );
 
+      // saving line: max(400, 0) = 400; free saving tx: 100 → totalSavings = 500
+      expect(metrics.totalSavings).toBe(500);
+    });
+
+    it('should handle empty data', () => {
+      const metrics = BudgetFormulas.calculateAllMetrics([], [], 0);
+
       expect(metrics.totalIncome).toBe(0);
       expect(metrics.totalExpenses).toBe(0);
+      expect(metrics.totalSavings).toBe(0);
       expect(metrics.available).toBe(0);
       expect(metrics.endingBalance).toBe(0);
       expect(metrics.remaining).toBe(0);

--- a/shared/src/calculators/budget-formulas.spec.ts
+++ b/shared/src/calculators/budget-formulas.spec.ts
@@ -1358,6 +1358,186 @@ describe('BudgetFormulas', () => {
     });
   });
 
+  describe('calculateTotalIncomeWithEnvelopes', () => {
+    function createBudgetLine(
+      id: string,
+      kind: TransactionKind,
+      amount: number,
+    ) {
+      return { id, kind, amount };
+    }
+
+    function createTransaction(
+      kind: TransactionKind,
+      amount: number,
+      budgetLineId?: string | null,
+    ) {
+      return { kind, amount, budgetLineId };
+    }
+
+    describe('Envelope allocation business rules', () => {
+      describe('when income transaction is allocated within its envelope', () => {
+        it('should only count the envelope amount (no double-counting)', () => {
+          const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
+          const transactions = [createTransaction('income', 4800, 'line-1')];
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            transactions,
+          );
+
+          // Envelope is 5000, consumed is 4800 -> max(5000, 4800) = 5000
+          expect(result).toBe(5000);
+        });
+      });
+
+      describe('when income transaction exceeds its envelope', () => {
+        it('should count the actual consumed amount (overage)', () => {
+          const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
+          const transactions = [createTransaction('income', 5200, 'line-1')];
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            transactions,
+          );
+
+          // Envelope is 5000, consumed is 5200 -> max(5000, 5200) = 5200
+          expect(result).toBe(5200);
+        });
+      });
+
+      describe('when income transaction has no envelope allocation (free)', () => {
+        it('should count the full transaction amount directly', () => {
+          const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
+          const transactions = [
+            createTransaction('income', 300, null), // Free income
+          ];
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            transactions,
+          );
+
+          // Envelope: max(5000, 0) = 5000
+          // Free: 300
+          // Total: 5000 + 300 = 5300
+          expect(result).toBe(5300);
+        });
+      });
+
+      describe('with mixed allocated and free income transactions', () => {
+        it('should apply envelope rules to allocated and direct impact for free', () => {
+          const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
+          const transactions = [
+            createTransaction('income', 4800, 'line-1'), // Allocated within envelope
+            createTransaction('income', 300, null), // Free income
+          ];
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            transactions,
+          );
+
+          // Envelope: max(5000, 4800) = 5000
+          // Free: 300
+          // Total: 5000 + 300 = 5300
+          expect(result).toBe(5300);
+        });
+      });
+
+      describe('with multiple income lines and their transactions', () => {
+        it('should apply envelope logic per line independently', () => {
+          const budgetLines = [
+            createBudgetLine('line-1', 'income', 5000),
+            createBudgetLine('line-2', 'income', 3000),
+          ];
+          const transactions = [
+            createTransaction('income', 4800, 'line-1'),
+            createTransaction('income', 3500, 'line-2'),
+          ];
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            transactions,
+          );
+
+          // line-1: max(5000, 4800) = 5000
+          // line-2: max(3000, 3500) = 3500
+          // Total: 5000 + 3500 = 8500
+          expect(result).toBe(8500);
+        });
+      });
+
+      describe('with non-income items', () => {
+        it('should ignore expense and saving budget lines', () => {
+          const budgetLines = [
+            createBudgetLine('line-1', 'income', 5000),
+            createBudgetLine('line-2', 'expense', 1000),
+          ];
+          const transactions: ReturnType<typeof createTransaction>[] = [];
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            transactions,
+          );
+
+          // Only income line counts: 5000
+          expect(result).toBe(5000);
+        });
+
+        it('should not count free expense transactions', () => {
+          const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
+          const transactions = [
+            createTransaction('income', 4800, 'line-1'),
+            createTransaction('expense', 200, null), // Free expense - should be ignored
+          ];
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            transactions,
+          );
+
+          expect(result).toBe(5000);
+        });
+      });
+
+      describe('edge cases', () => {
+        it('should return 0 for empty arrays', () => {
+          expect(BudgetFormulas.calculateTotalIncomeWithEnvelopes([], [])).toBe(
+            0,
+          );
+        });
+
+        it('should handle budget lines with no transactions', () => {
+          const budgetLines = [
+            createBudgetLine('line-1', 'income', 5000),
+            createBudgetLine('line-2', 'income', 3000),
+          ];
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            [],
+          );
+
+          expect(result).toBe(8000);
+        });
+
+        it('should handle transactions without budgetLineId field', () => {
+          const budgetLines = [createBudgetLine('line-1', 'income', 5000)];
+          const transactions = [{ kind: 'income' as const, amount: 300 }]; // No budgetLineId field
+
+          const result = BudgetFormulas.calculateTotalIncomeWithEnvelopes(
+            budgetLines,
+            transactions,
+          );
+
+          // Budget line: 5000, free transaction: 300 -> 5300
+          expect(result).toBe(5300);
+        });
+      });
+    });
+  });
+
   describe('calculateAllMetricsWithEnvelopes', () => {
     function createBudgetLine(
       id: string,

--- a/shared/src/calculators/budget-formulas.ts
+++ b/shared/src/calculators/budget-formulas.ts
@@ -60,28 +60,35 @@ export function isOutflowKind(kind: TransactionKind): boolean {
  * Toutes les méthodes sont statiques et pures (pas d'effets de bord)
  */
 export class BudgetFormulas {
-  /**
-   * Envelope-aware total for a given kind filter.
-   * For each matching line: effective = max(line.amount, consumed_matching_txs).
-   * Free transactions (no budgetLineId) matching the filter are added directly.
-   */
+  static #indexByLineId(
+    transactions: TransactionWithBudgetLineId[],
+  ): Map<string, TransactionWithBudgetLineId[]> {
+    const map = new Map<string, TransactionWithBudgetLineId[]>();
+    for (const tx of transactions) {
+      const key = tx.budgetLineId ?? '';
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(tx);
+    }
+    return map;
+  }
+
   static #calculateEnvelopeTotal(
     budgetLines: FinancialItemWithId[],
-    transactions: TransactionWithBudgetLineId[],
+    txsByLineId: Map<string, TransactionWithBudgetLineId[]>,
     kindFilter: (kind: TransactionKind) => boolean,
   ): number {
     let total = 0;
 
     for (const line of budgetLines) {
       if (!kindFilter(line.kind)) continue;
-      const consumed = transactions
-        .filter((tx) => tx.budgetLineId === line.id && kindFilter(tx.kind))
+      const consumed = (txsByLineId.get(line.id) ?? [])
+        .filter((tx) => kindFilter(tx.kind))
         .reduce((sum, tx) => sum + tx.amount, 0);
       total += Math.max(line.amount, consumed);
     }
 
-    for (const tx of transactions) {
-      if (!tx.budgetLineId && kindFilter(tx.kind)) {
+    for (const tx of txsByLineId.get('') ?? []) {
+      if (kindFilter(tx.kind)) {
         total += tx.amount;
       }
     }
@@ -96,7 +103,7 @@ export class BudgetFormulas {
   ): number {
     return this.#calculateEnvelopeTotal(
       budgetLines,
-      transactions,
+      this.#indexByLineId(transactions),
       (kind) => kind === 'income',
     );
   }
@@ -108,7 +115,7 @@ export class BudgetFormulas {
   ): number {
     return this.#calculateEnvelopeTotal(
       budgetLines,
-      transactions,
+      this.#indexByLineId(transactions),
       isOutflowKind,
     );
   }
@@ -120,7 +127,7 @@ export class BudgetFormulas {
   ): number {
     return this.#calculateEnvelopeTotal(
       budgetLines,
-      transactions,
+      this.#indexByLineId(transactions),
       (kind) => kind === 'saving',
     );
   }
@@ -164,18 +171,14 @@ export class BudgetFormulas {
     budgetLines: FinancialItemWithId[],
     transactions: TransactionWithBudgetLineId[] = [],
   ): number {
+    const txsByLineId = this.#indexByLineId(transactions);
     let total = 0;
 
-    budgetLines.forEach((line) => {
-      if (!isOutflowKind(line.kind)) return;
+    for (const line of budgetLines) {
+      if (!isOutflowKind(line.kind)) continue;
 
-      const consumed = transactions
-        .filter(
-          (tx) =>
-            tx.budgetLineId === line.id &&
-            tx.checkedAt != null &&
-            isOutflowKind(tx.kind),
-        )
+      const consumed = (txsByLineId.get(line.id) ?? [])
+        .filter((tx) => tx.checkedAt != null && isOutflowKind(tx.kind))
         .reduce((sum, tx) => sum + tx.amount, 0);
 
       if (line.checkedAt != null) {
@@ -183,14 +186,13 @@ export class BudgetFormulas {
       } else {
         total += consumed;
       }
-    });
+    }
 
-    // Ajouter les transactions libres (sans budgetLineId) qui sont pointées
-    transactions.forEach((tx) => {
-      if (!tx.budgetLineId && tx.checkedAt != null && isOutflowKind(tx.kind)) {
+    for (const tx of txsByLineId.get('') ?? []) {
+      if (tx.checkedAt != null && isOutflowKind(tx.kind)) {
         total += tx.amount;
       }
-    });
+    }
 
     return total;
   }
@@ -276,12 +278,22 @@ export class BudgetFormulas {
     transactions: TransactionWithBudgetLineId[] = [],
     rollover: number = 0,
   ) {
-    const totalIncome = this.calculateTotalIncome(budgetLines, transactions);
-    const totalExpenses = this.calculateTotalExpenses(
+    const txsByLineId = this.#indexByLineId(transactions);
+    const totalIncome = this.#calculateEnvelopeTotal(
       budgetLines,
-      transactions,
+      txsByLineId,
+      (kind) => kind === 'income',
     );
-    const totalSavings = this.calculateTotalSavings(budgetLines, transactions);
+    const totalExpenses = this.#calculateEnvelopeTotal(
+      budgetLines,
+      txsByLineId,
+      isOutflowKind,
+    );
+    const totalSavings = this.#calculateEnvelopeTotal(
+      budgetLines,
+      txsByLineId,
+      (kind) => kind === 'saving',
+    );
     const available = this.calculateAvailable(totalIncome, rollover);
     const endingBalance = this.calculateEndingBalance(available, totalExpenses);
     const remaining = endingBalance;

--- a/shared/src/calculators/budget-formulas.ts
+++ b/shared/src/calculators/budget-formulas.ts
@@ -4,11 +4,11 @@
  * Implémentation des formules SPECS.md section 3 "Modèle de Calcul"
  * Fonctions pures, testables, réutilisables côté frontend ET backend
  *
- * Formules SPECS:
+ * Formules SPECS (avec logique d'enveloppe):
+ * - Pour chaque ligne: effective = max(line.amount, consumed_matching_txs)
  * - available_M = income_M + rollover_M
- * - expenses_M = Σ(budget_lines WHERE type IN ('expense', 'saving')) + Σ(transactions WHERE type IN ('expense', 'saving'))
  * - ending_balance_M = available_M - expenses_M
- * - remaining_M = available_M - expenses_M
+ * - remaining_M = ending_balance_M
  *
  * NOTE: L'import utilise l'extension .js (pas .ts) - exigence ESM Node.js
  * Voir shared/README.md section "Résolution des Modules ESM"
@@ -48,134 +48,81 @@ interface TransactionWithBudgetLineId extends FinancialItem {
 }
 
 /**
+ * Returns true for outflow kinds (expense, saving).
+ * Mirrors iOS `TransactionKind.isOutflow`.
+ */
+export function isOutflowKind(kind: TransactionKind): boolean {
+  return kind === 'expense' || kind === 'saving';
+}
+
+/**
  * Classe contenant toutes les formules métier selon SPECS
  * Toutes les méthodes sont statiques et pures (pas d'effets de bord)
  */
 export class BudgetFormulas {
   /**
-   * Calcule le revenu total depuis les budget lines et transactions
-   * Formule: Σ(items WHERE kind = 'income')
-   *
-   * @param budgetLines - Lignes budgétaires planifiées
-   * @param transactions - Transactions réelles
-   * @returns Montant total des revenus
+   * Envelope-aware total for a given kind filter.
+   * For each matching line: effective = max(line.amount, consumed_matching_txs).
+   * Free transactions (no budgetLineId) matching the filter are added directly.
    */
+  static #calculateEnvelopeTotal(
+    budgetLines: FinancialItemWithId[],
+    transactions: TransactionWithBudgetLineId[],
+    kindFilter: (kind: TransactionKind) => boolean,
+  ): number {
+    let total = 0;
+
+    for (const line of budgetLines) {
+      if (!kindFilter(line.kind)) continue;
+      const consumed = transactions
+        .filter((tx) => tx.budgetLineId === line.id && kindFilter(tx.kind))
+        .reduce((sum, tx) => sum + tx.amount, 0);
+      total += Math.max(line.amount, consumed);
+    }
+
+    for (const tx of transactions) {
+      if (!tx.budgetLineId && kindFilter(tx.kind)) {
+        total += tx.amount;
+      }
+    }
+
+    return total;
+  }
+
+  /** Total income with envelope logic + kind filter. */
   static calculateTotalIncome(
-    budgetLines: FinancialItem[],
-    transactions: FinancialItem[] = [],
-  ): number {
-    const budgetIncome = budgetLines
-      .filter((line) => line.kind === 'income')
-      .reduce((sum, line) => sum + line.amount, 0);
-
-    const transactionIncome = transactions
-      .filter((t) => t.kind === 'income')
-      .reduce((sum, t) => sum + t.amount, 0);
-
-    return budgetIncome + transactionIncome;
-  }
-
-  /**
-   * Calcule le revenu total avec logique d'enveloppe
-   *
-   * Business Rule:
-   * - Allocated income transactions are "covered" by their envelope (budget line)
-   * - Only the OVERAGE (consumed > envelope.amount) impacts the budget
-   * - Free income transactions (no budgetLineId) impact the budget directly
-   *
-   * @param budgetLines - Budget lines with `id` field
-   * @param transactions - Transactions with optional `budgetLineId` field
-   * @returns Total income accounting for envelope coverage
-   */
-  static calculateTotalIncomeWithEnvelopes(
     budgetLines: FinancialItemWithId[],
     transactions: TransactionWithBudgetLineId[] = [],
   ): number {
-    let total = 0;
-
-    budgetLines.forEach((line) => {
-      if (line.kind === 'income') {
-        const consumed = transactions
-          .filter((tx) => tx.budgetLineId === line.id)
-          .reduce((sum, tx) => sum + tx.amount, 0);
-
-        total += Math.max(line.amount, consumed);
-      }
-    });
-
-    transactions.forEach((tx) => {
-      if (!tx.budgetLineId && tx.kind === 'income') {
-        total += tx.amount;
-      }
-    });
-
-    return total;
+    return this.#calculateEnvelopeTotal(
+      budgetLines,
+      transactions,
+      (kind) => kind === 'income',
+    );
   }
 
-  /**
-   * Calcule les dépenses totales (expenses + savings) depuis les budget lines et transactions
-   * Formule SPECS: expenses_M = Σ(budget_lines WHERE type IN ('expense', 'saving')) + Σ(transactions WHERE type IN ('expense', 'saving'))
-   *
-   * Note SPECS: "Le saving est volontairement traité comme une expense dans les calculs"
-   *
-   * @param budgetLines - Lignes budgétaires planifiées
-   * @param transactions - Transactions réelles
-   * @returns Montant total des dépenses + épargnes
-   */
+  /** Total expenses (expense + saving) with envelope logic + kind filter. */
   static calculateTotalExpenses(
-    budgetLines: FinancialItem[],
-    transactions: FinancialItem[] = [],
-  ): number {
-    const budgetExpenses = budgetLines
-      .filter((line) => line.kind === 'expense' || line.kind === 'saving')
-      .reduce((sum, line) => sum + line.amount, 0);
-
-    const transactionExpenses = transactions
-      .filter((t) => t.kind === 'expense' || t.kind === 'saving')
-      .reduce((sum, t) => sum + t.amount, 0);
-
-    return budgetExpenses + transactionExpenses;
-  }
-
-  /**
-   * Calcule les dépenses totales avec logique d'enveloppe
-   *
-   * Business Rule:
-   * - Allocated transactions are "covered" by their envelope (budget line)
-   * - Only the OVERAGE (consumed > envelope.amount) impacts the budget
-   * - Free transactions (no budgetLineId) impact the budget directly
-   *
-   * @param budgetLines - Budget lines with `id` field
-   * @param transactions - Transactions with optional `budgetLineId` field
-   * @returns Total expenses accounting for envelope coverage
-   */
-  static calculateTotalExpensesWithEnvelopes(
     budgetLines: FinancialItemWithId[],
     transactions: TransactionWithBudgetLineId[] = [],
   ): number {
-    let total = 0;
+    return this.#calculateEnvelopeTotal(
+      budgetLines,
+      transactions,
+      isOutflowKind,
+    );
+  }
 
-    // For each expense/saving budget line, use max(envelope, consumed)
-    budgetLines.forEach((line) => {
-      if (line.kind === 'expense' || line.kind === 'saving') {
-        // Calculate consumed amount for this envelope
-        const consumed = transactions
-          .filter((tx) => tx.budgetLineId === line.id)
-          .reduce((sum, tx) => sum + tx.amount, 0);
-
-        const effectiveAmount = Math.max(line.amount, consumed);
-        total += effectiveAmount;
-      }
-    });
-
-    // Add free transactions (those without budgetLineId)
-    transactions.forEach((tx) => {
-      if (!tx.budgetLineId && (tx.kind === 'expense' || tx.kind === 'saving')) {
-        total += tx.amount;
-      }
-    });
-
-    return total;
+  /** Total savings with envelope logic + kind filter. */
+  static calculateTotalSavings(
+    budgetLines: FinancialItemWithId[],
+    transactions: TransactionWithBudgetLineId[] = [],
+  ): number {
+    return this.#calculateEnvelopeTotal(
+      budgetLines,
+      transactions,
+      (kind) => kind === 'saving',
+    );
   }
 
   /**
@@ -220,14 +167,14 @@ export class BudgetFormulas {
     let total = 0;
 
     budgetLines.forEach((line) => {
-      if (line.kind !== 'expense' && line.kind !== 'saving') return;
+      if (!isOutflowKind(line.kind)) return;
 
       const consumed = transactions
         .filter(
           (tx) =>
             tx.budgetLineId === line.id &&
             tx.checkedAt != null &&
-            (tx.kind === 'expense' || tx.kind === 'saving'),
+            isOutflowKind(tx.kind),
         )
         .reduce((sum, tx) => sum + tx.amount, 0);
 
@@ -240,11 +187,7 @@ export class BudgetFormulas {
 
     // Ajouter les transactions libres (sans budgetLineId) qui sont pointées
     transactions.forEach((tx) => {
-      if (
-        !tx.budgetLineId &&
-        tx.checkedAt != null &&
-        (tx.kind === 'expense' || tx.kind === 'saving')
-      ) {
+      if (!tx.budgetLineId && tx.checkedAt != null && isOutflowKind(tx.kind)) {
         total += tx.amount;
       }
     });
@@ -328,19 +271,17 @@ export class BudgetFormulas {
    * @param rollover - Report du mois précédent
    * @returns Toutes les métriques calculées avec logique d'enveloppe
    */
-  static calculateAllMetricsWithEnvelopes(
+  static calculateAllMetrics(
     budgetLines: FinancialItemWithId[],
     transactions: TransactionWithBudgetLineId[] = [],
     rollover: number = 0,
   ) {
-    const totalIncome = this.calculateTotalIncomeWithEnvelopes(
+    const totalIncome = this.calculateTotalIncome(budgetLines, transactions);
+    const totalExpenses = this.calculateTotalExpenses(
       budgetLines,
       transactions,
     );
-    const totalExpenses = this.calculateTotalExpensesWithEnvelopes(
-      budgetLines,
-      transactions,
-    );
+    const totalSavings = this.calculateTotalSavings(budgetLines, transactions);
     const available = this.calculateAvailable(totalIncome, rollover);
     const endingBalance = this.calculateEndingBalance(available, totalExpenses);
     const remaining = endingBalance;
@@ -348,6 +289,7 @@ export class BudgetFormulas {
     return {
       totalIncome,
       totalExpenses,
+      totalSavings,
       available,
       endingBalance,
       remaining,
@@ -355,13 +297,6 @@ export class BudgetFormulas {
     };
   }
 
-  /**
-   * Valide la cohérence des calculs selon les règles métier
-   * Utile pour les tests et la validation
-   *
-   * @param metrics - Métriques calculées
-   * @returns True si cohérent, false sinon
-   */
   /**
    * Calcule le rollover pour un budget donné (port TypeScript de get_budget_with_rollover SQL).
    *
@@ -456,7 +391,7 @@ export class BudgetFormulas {
   }
 
   static validateMetricsCoherence(
-    metrics: ReturnType<typeof BudgetFormulas.calculateAllMetricsWithEnvelopes>,
+    metrics: ReturnType<typeof BudgetFormulas.calculateAllMetrics>,
   ): boolean {
     // Tolérance epsilon pour les comparaisons de nombres décimaux
     const EPSILON = 0.01;

--- a/shared/src/calculators/budget-formulas.ts
+++ b/shared/src/calculators/budget-formulas.ts
@@ -76,6 +76,43 @@ export class BudgetFormulas {
   }
 
   /**
+   * Calcule le revenu total avec logique d'enveloppe
+   *
+   * Business Rule:
+   * - Allocated income transactions are "covered" by their envelope (budget line)
+   * - Only the OVERAGE (consumed > envelope.amount) impacts the budget
+   * - Free income transactions (no budgetLineId) impact the budget directly
+   *
+   * @param budgetLines - Budget lines with `id` field
+   * @param transactions - Transactions with optional `budgetLineId` field
+   * @returns Total income accounting for envelope coverage
+   */
+  static calculateTotalIncomeWithEnvelopes(
+    budgetLines: FinancialItemWithId[],
+    transactions: TransactionWithBudgetLineId[] = [],
+  ): number {
+    let total = 0;
+
+    budgetLines.forEach((line) => {
+      if (line.kind === 'income') {
+        const consumed = transactions
+          .filter((tx) => tx.budgetLineId === line.id)
+          .reduce((sum, tx) => sum + tx.amount, 0);
+
+        total += Math.max(line.amount, consumed);
+      }
+    });
+
+    transactions.forEach((tx) => {
+      if (!tx.budgetLineId && tx.kind === 'income') {
+        total += tx.amount;
+      }
+    });
+
+    return total;
+  }
+
+  /**
    * Calcule les dépenses totales (expenses + savings) depuis les budget lines et transactions
    * Formule SPECS: expenses_M = Σ(budget_lines WHERE type IN ('expense', 'saving')) + Σ(transactions WHERE type IN ('expense', 'saving'))
    *
@@ -296,7 +333,10 @@ export class BudgetFormulas {
     transactions: TransactionWithBudgetLineId[] = [],
     rollover: number = 0,
   ) {
-    const totalIncome = this.calculateTotalIncome(budgetLines, transactions);
+    const totalIncome = this.calculateTotalIncomeWithEnvelopes(
+      budgetLines,
+      transactions,
+    );
     const totalExpenses = this.calculateTotalExpensesWithEnvelopes(
       budgetLines,
       transactions,

--- a/shared/src/calculators/index.ts
+++ b/shared/src/calculators/index.ts
@@ -9,7 +9,7 @@
  * Voir shared/README.md section "Résolution des Modules ESM" pour plus de détails.
  */
 
-export { BudgetFormulas } from './budget-formulas.js';
+export { BudgetFormulas, isOutflowKind } from './budget-formulas.js';
 export {
   getBudgetPeriodForDate,
   isInCurrentBudgetPeriod,

--- a/shared/src/calculators/index.ts
+++ b/shared/src/calculators/index.ts
@@ -9,7 +9,7 @@
  * Voir shared/README.md section "Résolution des Modules ESM" pour plus de détails.
  */
 
-export { BudgetFormulas, isOutflowKind } from './budget-formulas.js';
+export { BudgetFormulas } from './budget-formulas.js';
 export {
   getBudgetPeriodForDate,
   isInCurrentBudgetPeriod,


### PR DESCRIPTION
## Summary

• Implement envelope logic in backend budget aggregation to prevent transaction double-counting
• Implement corresponding iOS BudgetFormulas to align with backend calculations
• Fix remaining balance formula with proper envelope accounting
• Add PostHog API keys to iOS build configs
• Add analytics tracking for welcome page

## Changes

**Backend (NestJS)**
- Update budget aggregation with envelope logic
- Fix remaining balance formula
- Add comprehensive tests for envelope calculations

**iOS (SwiftUI)**
- Refactor BudgetFormulas to use envelope logic
- Add metrics calculations (actual/forecast/envelope amounts)
- Add test suite for envelope logic

**Frontend & Landing**
- Add welcome page analytics tracking
- Centralize landing CTA URLs in config

## Type

fix, feat