### PR TITLE
feat(encryption): add change-pin endpoint with re-encryption

### DIFF
--- a/.claude/rules/00-architecture/nestjs-api-contracts.md
+++ b/.claude/rules/00-architecture/nestjs-api-contracts.md
@@ -1,0 +1,71 @@
+---
+description: Mandatory Zod-based API contracts for all NestJS endpoints
+paths: "backend-nest/src/modules/**/*.controller.ts"
+---
+
+# API Contracts — Zod DTOs (Mandatory)
+
+## Rule
+
+**Every** controller endpoint **MUST** use Zod-based DTOs for request bodies and response types. Inline `body: { ... }` type annotations are **forbidden**.
+
+## How It Works
+
+```
+shared/schemas.ts → createZodDto (nestjs-zod) → Controller @Body() dto
+```
+
+1. **Define schemas** in `shared/schemas.ts` (single source of truth)
+2. **Export** from `shared/index.ts` (schema + inferred type)
+3. **Create DTO class** in `backend-nest/src/modules/[domain]/dto/[domain]-swagger.dto.ts`
+4. **Use DTO** in controller with `@Body() dto: MyRequestDto`
+5. **Add response type** to `@ApiResponse({ type: MyResponseDto })`
+
+## Schema Naming Convention
+
+```typescript
+// Request: [domain][Action]RequestSchema
+export const encryptionChangePinRequestSchema = z.object({ ... });
+export type EncryptionChangePinRequest = z.infer<typeof encryptionChangePinRequestSchema>;
+
+// Response: [domain][Action]ResponseSchema
+export const encryptionChangePinResponseSchema = z.object({ ... });
+export type EncryptionChangePinResponse = z.infer<typeof encryptionChangePinResponseSchema>;
+```
+
+## DTO Naming Convention
+
+```typescript
+// Request DTO: [Domain][Action]RequestDto
+export class EncryptionChangePinRequestDto extends createZodDto(encryptionChangePinRequestSchema) {}
+
+// Response DTO: [Domain][Action]ResponseDto
+export class EncryptionChangePinResponseDto extends createZodDto(encryptionChangePinResponseSchema) {}
+```
+
+## Controller Usage
+
+```typescript
+// CORRECT — Zod DTO with Swagger type
+@ApiResponse({ status: 200, type: ChangePinResponseDto })
+async changePin(@Body() body: ChangePinRequestDto): Promise<ChangePinResponse> { ... }
+
+// WRONG — inline type, no validation, no Swagger schema
+async changePin(@Body() body: { oldKey: string; newKey: string }): Promise<{ success: boolean }> { ... }
+```
+
+## Checklist for New Endpoints
+
+- [ ] Schema defined in `shared/schemas.ts`
+- [ ] Schema + type exported from `shared/index.ts`
+- [ ] `shared` rebuilt (`pnpm build:shared`)
+- [ ] DTO class in `modules/[domain]/dto/[domain]-swagger.dto.ts`
+- [ ] Controller uses DTO class for `@Body()`
+- [ ] `@ApiResponse` includes `type: ResponseDto`
+
+## Why
+
+- `ZodValidationPipe` (global) auto-validates request bodies
+- Swagger docs auto-generated from Zod schemas
+- Frontend and backend share the same contract via `pulpe-shared`
+- Type safety end-to-end: schema → DTO → controller → service

--- a/.claude/rules/00-architecture/nestjs-architecture.md
+++ b/.claude/rules/00-architecture/nestjs-architecture.md
@@ -84,6 +84,30 @@ export class BudgetService {
 }
 ```
 
+## Module Pattern
+
+**MANDATORY:** Every class that uses `@InjectInfoLogger` MUST have a corresponding `createInfoLoggerProvider` in its module's `providers` array. Forgetting this causes a NestJS DI error at runtime.
+
+```typescript
+import { createInfoLoggerProvider } from '@common/logger';
+
+@Module({
+  controllers: [BudgetController],
+  providers: [
+    BudgetService,
+    BudgetRepository,
+    BudgetMapper,
+    createInfoLoggerProvider(BudgetService.name),      // required — service uses @InjectInfoLogger
+    createInfoLoggerProvider(BudgetController.name),   // required — controller uses @InjectInfoLogger
+  ],
+})
+export class BudgetModule {}
+```
+
+**Checklist when creating or modifying a module:**
+- [ ] Each `Service` using `@InjectInfoLogger` → `createInfoLoggerProvider(Service.name)` in providers
+- [ ] Each `Controller` using `@InjectInfoLogger` → `createInfoLoggerProvider(Controller.name)` in providers
+
 ## Dependency Flow
 
 ```

--- a/.claude/rules/05-workflows-and-processes/error-handling-backend.md
+++ b/.claude/rules/05-workflows-and-processes/error-handling-backend.md
@@ -92,11 +92,18 @@ export class MyService {
 
 ### Module Setup
 
+**MANDATORY:** Every class using `@InjectInfoLogger` — service or controller — needs a `createInfoLoggerProvider` entry. Missing one causes a NestJS DI error at runtime.
+
 ```typescript
 import { createInfoLoggerProvider } from '@common/logger';
 
 @Module({
-  providers: [MyService, createInfoLoggerProvider(MyService.name)],
+  controllers: [MyController],
+  providers: [
+    MyService,
+    createInfoLoggerProvider(MyService.name),      // required — service uses @InjectInfoLogger
+    createInfoLoggerProvider(MyController.name),   // required — controller uses @InjectInfoLogger
+  ],
 })
 export class MyModule {}
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 # Éviter les runs multiples pour la même ref
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-v2
   cancel-in-progress: true
 
 # Sécurité : permissions minimales

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, preview] # Seulement sur les branches principales
   pull_request:
     branches: [main, preview] # Tests sur toutes les PRs vers ces branches
+  workflow_dispatch: # Manual trigger
 
 # Éviter les runs multiples pour la même ref
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,10 @@ on:
     branches: [main, preview] # Seulement sur les branches principales
   pull_request:
     branches: [main, preview] # Tests sur toutes les PRs vers ces branches
-  workflow_dispatch: # Manual trigger
 
 # Éviter les runs multiples pour la même ref
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-v2
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 # Sécurité : permissions minimales

--- a/backend-nest/src/common/constants/error-definitions.ts
+++ b/backend-nest/src/common/constants/error-definitions.ts
@@ -92,6 +92,11 @@ export const ERROR_DEFINITIONS = {
     message: () => 'Client key verification failed',
     httpStatus: HttpStatus.BAD_REQUEST,
   },
+  ENCRYPTION_SAME_KEY: {
+    code: 'ERR_ENCRYPTION_SAME_KEY',
+    message: () => 'New client key must be different from the old one',
+    httpStatus: HttpStatus.BAD_REQUEST,
+  },
   ENCRYPTION_REKEY_PARTIAL_FAILURE: {
     code: 'ERR_ENCRYPTION_REKEY_PARTIAL_FAILURE',
     message: () =>

--- a/backend-nest/src/modules/encryption/dto/encryption-swagger.dto.ts
+++ b/backend-nest/src/modules/encryption/dto/encryption-swagger.dto.ts
@@ -1,0 +1,39 @@
+import { createZodDto } from 'nestjs-zod';
+import {
+  encryptionValidateKeyRequestSchema,
+  encryptionRecoverRequestSchema,
+  encryptionChangePinRequestSchema,
+  encryptionVaultStatusResponseSchema,
+  encryptionSaltResponseSchema,
+  encryptionSetupRecoveryResponseSchema,
+  encryptionRecoverResponseSchema,
+  encryptionChangePinResponseSchema,
+} from 'pulpe-shared';
+
+// Request DTOs
+export class EncryptionValidateKeyRequestDto extends createZodDto(
+  encryptionValidateKeyRequestSchema,
+) {}
+export class EncryptionRecoverRequestDto extends createZodDto(
+  encryptionRecoverRequestSchema,
+) {}
+export class EncryptionChangePinRequestDto extends createZodDto(
+  encryptionChangePinRequestSchema,
+) {}
+
+// Response DTOs
+export class EncryptionVaultStatusResponseDto extends createZodDto(
+  encryptionVaultStatusResponseSchema,
+) {}
+export class EncryptionSaltResponseDto extends createZodDto(
+  encryptionSaltResponseSchema,
+) {}
+export class EncryptionSetupRecoveryResponseDto extends createZodDto(
+  encryptionSetupRecoveryResponseSchema,
+) {}
+export class EncryptionRecoverResponseDto extends createZodDto(
+  encryptionRecoverResponseSchema,
+) {}
+export class EncryptionChangePinResponseDto extends createZodDto(
+  encryptionChangePinResponseSchema,
+) {}

--- a/backend-nest/src/modules/encryption/encryption-key.repository.ts
+++ b/backend-nest/src/modules/encryption/encryption-key.repository.ts
@@ -119,23 +119,6 @@ export class EncryptionKeyRepository {
     }
   }
 
-  async hasVaultCode(userId: string): Promise<boolean> {
-    const supabase = this.#supabaseService.getServiceRoleClient();
-    const { data, error } = await supabase
-      .from('user_encryption_key')
-      .select('key_check, wrapped_dek')
-      .eq('user_id', userId)
-      .single();
-
-    if (error) {
-      if (error.code === 'PGRST116') return false;
-      throw new Error(
-        `Failed to check vault code for user ${userId}: ${error.message}`,
-      );
-    }
-    return data?.key_check != null && data?.wrapped_dek != null;
-  }
-
   async getVaultStatus(userId: string): Promise<VaultStatusRow> {
     const supabase = this.#supabaseService.getServiceRoleClient();
     const { data, error } = await supabase

--- a/backend-nest/src/modules/encryption/encryption-key.repository.ts
+++ b/backend-nest/src/modules/encryption/encryption-key.repository.ts
@@ -167,20 +167,6 @@ export class EncryptionKeyRepository {
     };
   }
 
-  async updateKeyCheck(userId: string, keyCheck: string): Promise<void> {
-    const supabase = this.#supabaseService.getServiceRoleClient();
-    const { error } = await supabase
-      .from('user_encryption_key')
-      .update({ key_check: keyCheck })
-      .eq('user_id', userId);
-
-    if (error) {
-      throw new Error(
-        `Failed to update key_check for user ${userId}: ${error.message}`,
-      );
-    }
-  }
-
   async updateKeyCheckIfNull(userId: string, keyCheck: string): Promise<void> {
     const supabase = this.#supabaseService.getServiceRoleClient();
     const { error } = await supabase

--- a/backend-nest/src/modules/encryption/encryption-key.repository.ts
+++ b/backend-nest/src/modules/encryption/encryption-key.repository.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { SupabaseService } from '@modules/supabase/supabase.service';
 
 interface UserEncryptionKeyRow {
@@ -20,7 +20,6 @@ export interface VaultStatusRow {
 
 @Injectable()
 export class EncryptionKeyRepository {
-  readonly #logger = new Logger(EncryptionKeyRepository.name);
   readonly #supabaseService: SupabaseService;
 
   constructor(supabaseService: SupabaseService) {

--- a/backend-nest/src/modules/encryption/encryption.controller.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.spec.ts
@@ -752,37 +752,6 @@ describe('EncryptionController', () => {
       logSpy.mockRestore();
     });
 
-    it('should log warning on non-BusinessException failure', async () => {
-      const user = createMockUser();
-      const mockSupabase = {};
-      const body = {
-        oldClientKey: 'ab'.repeat(32),
-        newClientKey: 'cd'.repeat(32),
-      };
-      const warnSpy = spyOn(Logger.prototype, 'warn');
-
-      const { controller } = setupController({
-        changePinRekey: mock(() => Promise.reject(new Error('RPC failed'))),
-      });
-
-      try {
-        await controller.changePin(user, mockSupabase as any, body);
-      } catch {
-        // Expected to throw
-      }
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        {
-          userId: user.id,
-          operation: 'pin_change.failed',
-          error: 'RPC failed',
-        },
-        'PIN change failed',
-      );
-
-      warnSpy.mockRestore();
-    });
-
     it('should call changePinRekey with correct arguments', async () => {
       const user = createMockUser();
       const mockSupabase = { test: 'supabase' };

--- a/backend-nest/src/modules/encryption/encryption.controller.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.spec.ts
@@ -441,7 +441,7 @@ describe('EncryptionController', () => {
       }
     });
 
-    it('should call recoverWithKey with correct callback', async () => {
+    it('should call recoverWithKey with supabase client', async () => {
       const user = createMockUser();
       const mockSupabase = { test: 'supabase' };
       const body = {
@@ -449,22 +449,15 @@ describe('EncryptionController', () => {
         newClientKey: 'ab'.repeat(32),
       };
 
-      let callbackCalled = false;
-      const { controller, mockEncryptionService } = setupController({
-        recoverWithKey: mock(
-          async (_userId, _recoveryKey, _newKey, callback) => {
-            callbackCalled = true;
-            await callback(randomBytes(32), randomBytes(32));
-          },
-        ),
-      });
+      const { controller, mockEncryptionService } = setupController();
 
       await controller.recover(user, mockSupabase as any, body);
 
-      expect(callbackCalled).toBe(true);
-      expect(mockEncryptionService.reEncryptAllUserData.mock.calls.length).toBe(
-        1,
-      );
+      expect(mockEncryptionService.recoverWithKey).toHaveBeenCalledTimes(1);
+      const args = mockEncryptionService.recoverWithKey.mock.calls[0];
+      expect(args[0]).toBe(user.id);
+      expect(args[1]).toBe(body.recoveryKey);
+      expect(args[3]).toBe(mockSupabase);
     });
 
     it('should delegate key_check to encryption service (atomic RPC)', async () => {

--- a/backend-nest/src/modules/encryption/encryption.controller.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.spec.ts
@@ -17,6 +17,7 @@ const createMockEncryptionService = (overrides?: {
   regenerateRecoveryKey?: ReturnType<typeof mock>;
   recoverWithKey?: ReturnType<typeof mock>;
   reEncryptAllUserData?: ReturnType<typeof mock>;
+  changePinRekey?: ReturnType<typeof mock>;
 }) => ({
   getVaultStatus:
     overrides?.getVaultStatus ??
@@ -45,6 +46,14 @@ const createMockEncryptionService = (overrides?: {
   recoverWithKey: overrides?.recoverWithKey ?? mock(() => Promise.resolve()),
   reEncryptAllUserData:
     overrides?.reEncryptAllUserData ?? mock(() => Promise.resolve()),
+  changePinRekey:
+    overrides?.changePinRekey ??
+    mock(() =>
+      Promise.resolve({
+        keyCheck: 'mock-key-check',
+        recoveryKey: null,
+      }),
+    ),
 });
 
 const createMockUser = (): AuthenticatedUser => ({
@@ -548,6 +557,258 @@ describe('EncryptionController', () => {
         expect(error).toBe(originalError);
         expect(error.message).toBe('DB connection lost');
       }
+    });
+  });
+
+  describe('changePin', () => {
+    it('should return result without recovery key (user had none)', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: 'cd'.repeat(32),
+      };
+      const expected = {
+        keyCheck: 'new-key-check',
+        recoveryKey: null,
+      };
+
+      const { controller } = setupController({
+        changePinRekey: mock(() => Promise.resolve(expected)),
+      });
+
+      const result = await controller.changePin(
+        user,
+        mockSupabase as any,
+        body,
+      );
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should return new recovery key when user had one', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: 'cd'.repeat(32),
+      };
+      const expected = {
+        keyCheck: 'new-key-check',
+        recoveryKey: 'ABCD-EFGH-IJKL-MNOP',
+      };
+
+      const { controller } = setupController({
+        changePinRekey: mock(() => Promise.resolve(expected)),
+      });
+
+      const result = await controller.changePin(
+        user,
+        mockSupabase as any,
+        body,
+      );
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should throw BusinessException when old PIN is incorrect', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: 'cd'.repeat(32),
+      };
+
+      const { controller } = setupController({
+        changePinRekey: mock(() =>
+          Promise.reject(
+            new BusinessException(
+              ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
+            ),
+          ),
+        ),
+      });
+
+      try {
+        await controller.changePin(user, mockSupabase as any, body);
+        expect.unreachable('Should have thrown BusinessException');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect(error.code).toBe(
+          ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED.code,
+        );
+      }
+    });
+
+    it('should throw BusinessException for invalid oldClientKey format', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'not-valid-hex',
+        newClientKey: 'cd'.repeat(32),
+      };
+
+      const { controller } = setupController();
+
+      try {
+        await controller.changePin(user, mockSupabase as any, body);
+        expect.unreachable('Should have thrown BusinessException');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect(error.code).toBe(ERROR_DEFINITIONS.AUTH_CLIENT_KEY_INVALID.code);
+      }
+    });
+
+    it('should throw BusinessException for invalid newClientKey format', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: 'not-valid-hex',
+      };
+
+      const { controller } = setupController();
+
+      try {
+        await controller.changePin(user, mockSupabase as any, body);
+        expect.unreachable('Should have thrown BusinessException');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect(error.code).toBe(ERROR_DEFINITIONS.AUTH_CLIENT_KEY_INVALID.code);
+      }
+    });
+
+    it('should throw BusinessException for all-zero oldClientKey', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: '00'.repeat(32),
+        newClientKey: 'cd'.repeat(32),
+      };
+
+      const { controller } = setupController();
+
+      try {
+        await controller.changePin(user, mockSupabase as any, body);
+        expect.unreachable('Should have thrown BusinessException');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect(error.code).toBe(ERROR_DEFINITIONS.AUTH_CLIENT_KEY_INVALID.code);
+      }
+    });
+
+    it('should re-throw non-BusinessException errors', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: 'cd'.repeat(32),
+      };
+
+      const originalError = new Error('DB connection lost');
+      const { controller } = setupController({
+        changePinRekey: mock(() => Promise.reject(originalError)),
+      });
+
+      try {
+        await controller.changePin(user, mockSupabase as any, body);
+        expect.unreachable('Should have thrown original error');
+      } catch (error: any) {
+        expect(error).not.toBeInstanceOf(BusinessException);
+        expect(error).toBe(originalError);
+        expect(error.message).toBe('DB connection lost');
+      }
+    });
+
+    it('should log audit event on successful PIN change', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: 'cd'.repeat(32),
+      };
+      const logSpy = spyOn(Logger.prototype, 'log');
+
+      const { controller } = setupController({
+        changePinRekey: mock(() =>
+          Promise.resolve({
+            keyCheck: 'kc',
+            recoveryKey: 'ABCD-EFGH-IJKL',
+          }),
+        ),
+      });
+
+      await controller.changePin(user, mockSupabase as any, body);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        {
+          userId: user.id,
+          operation: 'pin_change.complete',
+          recoveryKeyRegenerated: true,
+        },
+        'PIN changed and data re-encrypted',
+      );
+
+      logSpy.mockRestore();
+    });
+
+    it('should log warning on non-BusinessException failure', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: 'cd'.repeat(32),
+      };
+      const warnSpy = spyOn(Logger.prototype, 'warn');
+
+      const { controller } = setupController({
+        changePinRekey: mock(() => Promise.reject(new Error('RPC failed'))),
+      });
+
+      try {
+        await controller.changePin(user, mockSupabase as any, body);
+      } catch {
+        // Expected to throw
+      }
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        {
+          userId: user.id,
+          operation: 'pin_change.failed',
+          error: 'RPC failed',
+        },
+        'PIN change failed',
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('should call changePinRekey with correct arguments', async () => {
+      const user = createMockUser();
+      const mockSupabase = { test: 'supabase' };
+      const oldKeyHex = 'ab'.repeat(32);
+      const newKeyHex = 'cd'.repeat(32);
+      const body = { oldClientKey: oldKeyHex, newClientKey: newKeyHex };
+
+      const callArguments: any[] = [];
+      const { controller } = setupController({
+        changePinRekey: mock(async (...args) => {
+          callArguments.push(
+            args[0],
+            Buffer.from(args[1]),
+            Buffer.from(args[2]),
+            args[3],
+          );
+          return { keyCheck: 'kc', recoveryKey: null };
+        }),
+      });
+
+      await controller.changePin(user, mockSupabase as any, body);
+
+      expect(callArguments[0]).toBe(user.id);
+      expect(callArguments[1]).toEqual(Buffer.from(oldKeyHex, 'hex'));
+      expect(callArguments[2]).toEqual(Buffer.from(newKeyHex, 'hex'));
+      expect(callArguments[3]).toBe(mockSupabase);
     });
   });
 });

--- a/backend-nest/src/modules/encryption/encryption.controller.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.spec.ts
@@ -697,6 +697,50 @@ describe('EncryptionController', () => {
       }
     });
 
+    it('should throw BusinessException for all-zero newClientKey', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: '00'.repeat(32),
+      };
+
+      const { controller } = setupController();
+
+      try {
+        await controller.changePin(user, mockSupabase as any, body);
+        expect.unreachable('Should have thrown BusinessException');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect(error.code).toBe(ERROR_DEFINITIONS.AUTH_CLIENT_KEY_INVALID.code);
+      }
+    });
+
+    it('should propagate ENCRYPTION_SAME_KEY from service', async () => {
+      const user = createMockUser();
+      const mockSupabase = {};
+      const body = {
+        oldClientKey: 'ab'.repeat(32),
+        newClientKey: 'cd'.repeat(32),
+      };
+
+      const { controller } = setupController({
+        changePinRekey: mock(() =>
+          Promise.reject(
+            new BusinessException(ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY),
+          ),
+        ),
+      });
+
+      try {
+        await controller.changePin(user, mockSupabase as any, body);
+        expect.unreachable('Should have thrown BusinessException');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect(error.code).toBe(ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY.code);
+      }
+    });
+
     it('should re-throw non-BusinessException errors', async () => {
       const user = createMockUser();
       const mockSupabase = {};

--- a/backend-nest/src/modules/encryption/encryption.controller.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.spec.ts
@@ -11,7 +11,6 @@ const createMockEncryptionService = (overrides?: {
   getUserSalt?: ReturnType<typeof mock>;
   getUserDEK?: ReturnType<typeof mock>;
   generateKeyCheck?: ReturnType<typeof mock>;
-  storeKeyCheck?: ReturnType<typeof mock>;
   verifyAndEnsureKeyCheck?: ReturnType<typeof mock>;
   createRecoveryKey?: ReturnType<typeof mock>;
   regenerateRecoveryKey?: ReturnType<typeof mock>;
@@ -34,7 +33,6 @@ const createMockEncryptionService = (overrides?: {
   getUserDEK:
     overrides?.getUserDEK ?? mock(() => Promise.resolve(randomBytes(32))),
   generateKeyCheck: overrides?.generateKeyCheck ?? mock(() => 'mock-key-check'),
-  storeKeyCheck: overrides?.storeKeyCheck ?? mock(() => Promise.resolve()),
   verifyAndEnsureKeyCheck:
     overrides?.verifyAndEnsureKeyCheck ?? mock(() => Promise.resolve(true)),
   createRecoveryKey:
@@ -478,12 +476,10 @@ describe('EncryptionController', () => {
 
       const getUserDEK = mock(() => Promise.resolve(randomBytes(32)));
       const generateKeyCheck = mock(() => 'should-not-be-called');
-      const storeKeyCheck = mock(() => Promise.resolve());
 
       const { controller, mockEncryptionService } = setupController({
         getUserDEK,
         generateKeyCheck,
-        storeKeyCheck,
       });
 
       await controller.recover(user, mockSupabase as any, body);
@@ -493,7 +489,6 @@ describe('EncryptionController', () => {
       );
       expect(getUserDEK).not.toHaveBeenCalled();
       expect(generateKeyCheck).not.toHaveBeenCalled();
-      expect(storeKeyCheck).not.toHaveBeenCalled();
     });
 
     it('should log audit event with recovery.complete operation', async () => {

--- a/backend-nest/src/modules/encryption/encryption.controller.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.spec.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, mock, spyOn } from 'bun:test';
-import { Logger } from '@nestjs/common';
+import { describe, it, expect, mock } from 'bun:test';
 import { randomBytes } from 'node:crypto';
 import { EncryptionController } from './encryption.controller';
 import { BusinessException } from '@common/exceptions/business.exception';
@@ -61,13 +60,24 @@ const createMockUser = (): AuthenticatedUser => ({
   clientKey: Buffer.alloc(32, 0xab),
 });
 
+const createMockLogger = () => ({
+  info: mock(() => {}),
+  warn: mock(() => {}),
+  debug: mock(() => {}),
+  trace: mock(() => {}),
+});
+
 function setupController(
   encryptionOverrides?: Parameters<typeof createMockEncryptionService>[0],
 ) {
   const mockEncryptionService =
     createMockEncryptionService(encryptionOverrides);
-  const controller = new EncryptionController(mockEncryptionService as any);
-  return { controller, mockEncryptionService };
+  const mockLogger = createMockLogger();
+  const controller = new EncryptionController(
+    mockLogger as any,
+    mockEncryptionService as any,
+  );
+  return { controller, mockEncryptionService, mockLogger };
 }
 
 describe('EncryptionController', () => {
@@ -188,9 +198,8 @@ describe('EncryptionController', () => {
     it('should log warning on failed validation', async () => {
       const user = createMockUser();
       const body = { clientKey: 'ab'.repeat(32) };
-      const warnSpy = spyOn(Logger.prototype, 'warn');
 
-      const { controller } = setupController({
+      const { controller, mockLogger } = setupController({
         verifyAndEnsureKeyCheck: mock(() => Promise.resolve(false)),
       });
 
@@ -200,12 +209,10 @@ describe('EncryptionController', () => {
         // Expected to throw
       }
 
-      expect(warnSpy).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         { userId: user.id, operation: 'validate_key.failed' },
         'Client key verification failed',
       );
-
-      warnSpy.mockRestore();
     });
 
     it('should throw BusinessException for all-zero client key', async () => {
@@ -259,18 +266,15 @@ describe('EncryptionController', () => {
 
     it('should log audit event with recovery_key.create operation', async () => {
       const user = createMockUser();
-      const logSpy = spyOn(Logger.prototype, 'log');
 
-      const { controller } = setupController();
+      const { controller, mockLogger } = setupController();
 
       await controller.setupRecovery(user);
 
-      expect(logSpy).toHaveBeenCalledWith(
+      expect(mockLogger.info).toHaveBeenCalledWith(
         { userId: user.id, operation: 'recovery_key.create' },
         'Recovery key created',
       );
-
-      logSpy.mockRestore();
     });
 
     it('should use user.clientKey from AuthenticatedUser', async () => {
@@ -326,18 +330,15 @@ describe('EncryptionController', () => {
 
     it('should log audit event with recovery_key.regenerate operation', async () => {
       const user = createMockUser();
-      const logSpy = spyOn(Logger.prototype, 'log');
 
-      const { controller } = setupController();
+      const { controller, mockLogger } = setupController();
 
       await controller.regenerateRecovery(user);
 
-      expect(logSpy).toHaveBeenCalledWith(
+      expect(mockLogger.info).toHaveBeenCalledWith(
         { userId: user.id, operation: 'recovery_key.regenerate' },
         'Recovery key regenerated',
       );
-
-      logSpy.mockRestore();
     });
   });
 
@@ -498,18 +499,15 @@ describe('EncryptionController', () => {
         recoveryKey: 'XXXX-YYYY-ZZZZ-1234',
         newClientKey: 'ab'.repeat(32),
       };
-      const logSpy = spyOn(Logger.prototype, 'log');
 
-      const { controller } = setupController();
+      const { controller, mockLogger } = setupController();
 
       await controller.recover(user, mockSupabase as any, body);
 
-      expect(logSpy).toHaveBeenCalledWith(
+      expect(mockLogger.info).toHaveBeenCalledWith(
         { userId: user.id, operation: 'recovery.complete' },
         'Account recovered with recovery key',
       );
-
-      logSpy.mockRestore();
     });
 
     it('should throw BusinessException for all-zero newClientKey', async () => {
@@ -766,9 +764,8 @@ describe('EncryptionController', () => {
         oldClientKey: 'ab'.repeat(32),
         newClientKey: 'cd'.repeat(32),
       };
-      const logSpy = spyOn(Logger.prototype, 'log');
 
-      const { controller } = setupController({
+      const { controller, mockLogger } = setupController({
         changePinRekey: mock(() =>
           Promise.resolve({
             keyCheck: 'kc',
@@ -779,7 +776,7 @@ describe('EncryptionController', () => {
 
       await controller.changePin(user, mockSupabase as any, body);
 
-      expect(logSpy).toHaveBeenCalledWith(
+      expect(mockLogger.info).toHaveBeenCalledWith(
         {
           userId: user.id,
           operation: 'pin_change.complete',
@@ -787,8 +784,6 @@ describe('EncryptionController', () => {
         },
         'PIN changed and data re-encrypted',
       );
-
-      logSpy.mockRestore();
     });
 
     it('should call changePinRekey with correct arguments', async () => {

--- a/backend-nest/src/modules/encryption/encryption.controller.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.ts
@@ -304,15 +304,6 @@ export class EncryptionController {
   }
 
   #handleRecoveryError(userId: string, error: unknown): never {
-    this.logger.warn(
-      {
-        userId,
-        operation: 'recovery.failed',
-        error: error instanceof Error ? error.message : String(error),
-      },
-      'Recovery attempt failed',
-    );
-
     if (error instanceof Error) {
       const isRecoveryKeyError =
         error.message.includes('No recovery key configured') ||
@@ -322,7 +313,12 @@ export class EncryptionController {
         error.message.includes('Unwrapped DEK has invalid length');
 
       if (isRecoveryKeyError) {
-        throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+        throw new BusinessException(
+          ERROR_DEFINITIONS.RECOVERY_KEY_INVALID,
+          undefined,
+          { userId, operation: 'recovery.failed' },
+          { cause: error },
+        );
       }
     }
     throw error;

--- a/backend-nest/src/modules/encryption/encryption.controller.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.ts
@@ -30,6 +30,16 @@ import { ErrorResponseDto } from '@common/dto/response.dto';
 import { BusinessException } from '@common/exceptions/business.exception';
 import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
 import { EncryptionService } from './encryption.service';
+import {
+  EncryptionValidateKeyRequestDto,
+  EncryptionRecoverRequestDto,
+  EncryptionChangePinRequestDto,
+  EncryptionVaultStatusResponseDto,
+  EncryptionSaltResponseDto,
+  EncryptionSetupRecoveryResponseDto,
+  EncryptionRecoverResponseDto,
+  EncryptionChangePinResponseDto,
+} from './dto/encryption-swagger.dto';
 
 const CLIENT_KEY_LENGTH = 32;
 const HEX_KEY_REGEX = /^[0-9a-f]{64}$/i;
@@ -57,6 +67,7 @@ export class EncryptionController {
   @ApiResponse({
     status: 200,
     description: 'Vault code configuration status',
+    type: EncryptionVaultStatusResponseDto,
   })
   async getVaultStatus(@User() user: AuthenticatedUser): Promise<{
     pinCodeConfigured: boolean;
@@ -72,6 +83,7 @@ export class EncryptionController {
   @ApiResponse({
     status: 200,
     description: 'Salt, KDF iterations, and recovery key status',
+    type: EncryptionSaltResponseDto,
   })
   async getSalt(
     @User() user: AuthenticatedUser,
@@ -94,7 +106,7 @@ export class EncryptionController {
   })
   async validateKey(
     @User() user: AuthenticatedUser,
-    @Body() body: { clientKey: string },
+    @Body() body: EncryptionValidateKeyRequestDto,
   ): Promise<void> {
     const keyBuffer = this.#validateClientKeyHex(body.clientKey);
     try {
@@ -128,6 +140,7 @@ export class EncryptionController {
     status: 201,
     description:
       'Recovery key generated (shown once, never stored server-side)',
+    type: EncryptionSetupRecoveryResponseDto,
   })
   async setupRecovery(
     @User() user: AuthenticatedUser,
@@ -156,6 +169,7 @@ export class EncryptionController {
     status: 201,
     description:
       'Recovery key regenerated (shown once, never stored server-side)',
+    type: EncryptionSetupRecoveryResponseDto,
   })
   async regenerateRecovery(
     @User() user: AuthenticatedUser,
@@ -184,6 +198,7 @@ export class EncryptionController {
   @ApiResponse({
     status: 200,
     description: 'Account recovered and data re-encrypted',
+    type: EncryptionRecoverResponseDto,
   })
   @ApiBadRequestResponse({
     description: 'Invalid recovery key or new client key',
@@ -192,7 +207,7 @@ export class EncryptionController {
   async recover(
     @User() user: AuthenticatedUser,
     @SupabaseClient() supabase: AuthenticatedSupabaseClient,
-    @Body() body: { recoveryKey: string; newClientKey: string },
+    @Body() body: EncryptionRecoverRequestDto,
   ): Promise<{ success: boolean }> {
     if (!body.recoveryKey?.trim()) {
       throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
@@ -226,6 +241,63 @@ export class EncryptionController {
     );
 
     return { success: true };
+  }
+
+  @SkipClientKey()
+  @Post('change-pin')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 5, ttl: 3600000 } })
+  @ApiOperation({ summary: 'Change PIN code and re-encrypt all user data' })
+  @ApiResponse({
+    status: 200,
+    description: 'PIN changed and data re-encrypted',
+    type: EncryptionChangePinResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid client key or old PIN verification failed',
+    type: ErrorResponseDto,
+  })
+  async changePin(
+    @User() user: AuthenticatedUser,
+    @SupabaseClient() supabase: AuthenticatedSupabaseClient,
+    @Body() body: EncryptionChangePinRequestDto,
+  ): Promise<{ keyCheck: string; recoveryKey: string | null }> {
+    const oldKeyBuffer = this.#validateClientKeyHex(body.oldClientKey);
+    const newKeyBuffer = this.#validateClientKeyHex(body.newClientKey);
+
+    try {
+      const result = await this.encryptionService.changePinRekey(
+        user.id,
+        oldKeyBuffer,
+        newKeyBuffer,
+        supabase,
+      );
+
+      this.#logger.log(
+        {
+          userId: user.id,
+          operation: 'pin_change.complete',
+          recoveryKeyRegenerated: result.recoveryKey !== null,
+        },
+        'PIN changed and data re-encrypted',
+      );
+
+      return result;
+    } catch (error) {
+      if (error instanceof BusinessException) throw error;
+      this.#logger.warn(
+        {
+          userId: user.id,
+          operation: 'pin_change.failed',
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'PIN change failed',
+      );
+      throw error;
+    } finally {
+      oldKeyBuffer.fill(0);
+      newKeyBuffer.fill(0);
+    }
   }
 
   #validateClientKeyHex(hex: string): Buffer {

--- a/backend-nest/src/modules/encryption/encryption.controller.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.ts
@@ -223,14 +223,7 @@ export class EncryptionController {
         user.id,
         body.recoveryKey,
         newKeyBuffer,
-        async (oldDek, newDek) => {
-          await this.encryptionService.reEncryptAllUserData(
-            user.id,
-            oldDek,
-            newDek,
-            supabase,
-          );
-        },
+        supabase,
       );
     } catch (error) {
       this.#handleRecoveryError(user.id, error);

--- a/backend-nest/src/modules/encryption/encryption.controller.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.ts
@@ -25,6 +25,7 @@ import {
   SupabaseClient,
   type AuthenticatedUser,
 } from '@common/decorators/user.decorator';
+import type { EncryptionChangePinResponse } from 'pulpe-shared';
 import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.service';
 import { ErrorResponseDto } from '@common/dto/response.dto';
 import { BusinessException } from '@common/exceptions/business.exception';
@@ -261,11 +262,13 @@ export class EncryptionController {
     @User() user: AuthenticatedUser,
     @SupabaseClient() supabase: AuthenticatedSupabaseClient,
     @Body() body: EncryptionChangePinRequestDto,
-  ): Promise<{ keyCheck: string; recoveryKey: string | null }> {
-    const oldKeyBuffer = this.#validateClientKeyHex(body.oldClientKey);
-    const newKeyBuffer = this.#validateClientKeyHex(body.newClientKey);
+  ): Promise<EncryptionChangePinResponse> {
+    let oldKeyBuffer: Buffer | undefined;
+    let newKeyBuffer: Buffer | undefined;
 
     try {
+      oldKeyBuffer = this.#validateClientKeyHex(body.oldClientKey);
+      newKeyBuffer = this.#validateClientKeyHex(body.newClientKey);
       const result = await this.encryptionService.changePinRekey(
         user.id,
         oldKeyBuffer,
@@ -284,8 +287,8 @@ export class EncryptionController {
 
       return result;
     } finally {
-      oldKeyBuffer.fill(0);
-      newKeyBuffer.fill(0);
+      oldKeyBuffer?.fill(0);
+      newKeyBuffer?.fill(0);
     }
   }
 

--- a/backend-nest/src/modules/encryption/encryption.controller.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.ts
@@ -4,7 +4,6 @@ import {
   Post,
   Body,
   UseGuards,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -30,6 +29,7 @@ import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.ser
 import { ErrorResponseDto } from '@common/dto/response.dto';
 import { BusinessException } from '@common/exceptions/business.exception';
 import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
+import { type InfoLogger, InjectInfoLogger } from '@common/logger';
 import { EncryptionService } from './encryption.service';
 import {
   EncryptionValidateKeyRequestDto,
@@ -58,9 +58,11 @@ const HEX_KEY_REGEX = /^[0-9a-f]{64}$/i;
   type: ErrorResponseDto,
 })
 export class EncryptionController {
-  readonly #logger = new Logger(EncryptionController.name);
-
-  constructor(private readonly encryptionService: EncryptionService) {}
+  constructor(
+    @InjectInfoLogger(EncryptionController.name)
+    private readonly logger: InfoLogger,
+    private readonly encryptionService: EncryptionService,
+  ) {}
 
   @SkipClientKey()
   @Get('vault-status')
@@ -117,7 +119,7 @@ export class EncryptionController {
       );
 
       if (!isValid) {
-        this.#logger.warn(
+        this.logger.warn(
           { userId: user.id, operation: 'validate_key.failed' },
           'Client key verification failed',
         );
@@ -151,7 +153,7 @@ export class EncryptionController {
       user.clientKey,
     );
 
-    this.#logger.log(
+    this.logger.info(
       { userId: user.id, operation: 'recovery_key.create' },
       'Recovery key created',
     );
@@ -180,7 +182,7 @@ export class EncryptionController {
       user.clientKey,
     );
 
-    this.#logger.log(
+    this.logger.info(
       { userId: user.id, operation: 'recovery_key.regenerate' },
       'Recovery key regenerated',
     );
@@ -236,7 +238,7 @@ export class EncryptionController {
       newKeyBuffer.fill(0);
     }
 
-    this.#logger.log(
+    this.logger.info(
       { userId: user.id, operation: 'recovery.complete' },
       'Account recovered with recovery key',
     );
@@ -276,7 +278,7 @@ export class EncryptionController {
         supabase,
       );
 
-      this.#logger.log(
+      this.logger.info(
         {
           userId: user.id,
           operation: 'pin_change.complete',
@@ -309,7 +311,7 @@ export class EncryptionController {
   }
 
   #handleRecoveryError(userId: string, error: unknown): never {
-    this.#logger.warn(
+    this.logger.warn(
       {
         userId,
         operation: 'recovery.failed',

--- a/backend-nest/src/modules/encryption/encryption.controller.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.ts
@@ -283,17 +283,6 @@ export class EncryptionController {
       );
 
       return result;
-    } catch (error) {
-      if (error instanceof BusinessException) throw error;
-      this.#logger.warn(
-        {
-          userId: user.id,
-          operation: 'pin_change.failed',
-          error: error instanceof Error ? error.message : String(error),
-        },
-        'PIN change failed',
-      );
-      throw error;
     } finally {
       oldKeyBuffer.fill(0);
       newKeyBuffer.fill(0);

--- a/backend-nest/src/modules/encryption/encryption.e2e.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.e2e.spec.ts
@@ -373,6 +373,54 @@ describe('Encryption E2E (local Supabase)', () => {
     expect(res.body.pinCodeConfigured).toBe(true);
   });
 
+  it('change-pin with recovery key: setup → change-pin → verify new recovery key works', async () => {
+    if (!hasSupabase) return;
+
+    // Current active key is NEW_CLIENT_KEY_HEX from earlier tests
+
+    // 1. Setup recovery key
+    const setupRes = await request(app.getHttpServer())
+      .post('/api/v1/encryption/setup-recovery')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('X-Client-Key', NEW_CLIENT_KEY_HEX)
+      .expect(201);
+
+    expect(setupRes.body.recoveryKey).toBeTruthy();
+
+    // 2. Change PIN — should return a new recovery key since one was configured
+    const THIRD_CLIENT_KEY_HEX = 'dd'.repeat(32);
+    const changePinRes = await request(app.getHttpServer())
+      .post('/api/v1/encryption/change-pin')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        oldClientKey: NEW_CLIENT_KEY_HEX,
+        newClientKey: THIRD_CLIENT_KEY_HEX,
+      })
+      .expect(200);
+
+    expect(changePinRes.body.keyCheck).toBeTruthy();
+    expect(changePinRes.body.recoveryKey).not.toBeNull();
+    expect(changePinRes.body.recoveryKey).toMatch(
+      /^[A-Z2-7]{4}(-[A-Z2-7]{4})+$/,
+    );
+
+    // 3. New key works
+    await request(app.getHttpServer())
+      .post('/api/v1/encryption/validate-key')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ clientKey: THIRD_CLIENT_KEY_HEX })
+      .expect(204);
+
+    // 4. Old key fails
+    const oldKeyRes = await request(app.getHttpServer())
+      .post('/api/v1/encryption/validate-key')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ clientKey: NEW_CLIENT_KEY_HEX })
+      .expect(400);
+
+    expect(oldKeyRes.body.code).toBe('ERR_ENCRYPTION_KEY_CHECK_FAILED');
+  }, 30_000);
+
   it('Zod validation rejects malformed body in real app', async () => {
     if (!hasSupabase) return;
 

--- a/backend-nest/src/modules/encryption/encryption.e2e.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.e2e.spec.ts
@@ -1,0 +1,387 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { execSync } from 'node:child_process';
+import { delimiter, resolve } from 'node:path';
+import { type INestApplication, VersioningType } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import request from 'supertest';
+import type { Database } from '../../types/database.types';
+import { AppModule } from '../../app.module';
+import { UserThrottlerGuard } from '@common/guards/user-throttler.guard';
+
+const BACKEND_ROOT = resolve(__dirname, '../../..');
+
+const TEST_PASSWORD = 'test-password-e2e-123';
+const OLD_CLIENT_KEY_HEX = 'aa'.repeat(32);
+const NEW_CLIENT_KEY_HEX = 'bb'.repeat(32);
+
+type SupabaseEnv = {
+  apiUrl: string;
+  anonKey: string;
+  serviceRoleKey: string;
+};
+
+const LOCAL_SUPABASE_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+
+function stripNodeModulesBin(
+  pathValue: string | undefined,
+): string | undefined {
+  if (!pathValue) return pathValue;
+  return pathValue
+    .split(delimiter)
+    .filter((segment) => !segment.includes('node_modules/.bin'))
+    .join(delimiter);
+}
+
+function resolveSupabaseCliPath(): string {
+  if (process.env.SUPABASE_CLI_PATH) {
+    return process.env.SUPABASE_CLI_PATH;
+  }
+
+  const env = { ...process.env, PATH: stripNodeModulesBin(process.env.PATH) };
+
+  try {
+    const resolved = execSync('command -v supabase', {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+      .toString()
+      .trim();
+    return resolved || 'supabase';
+  } catch {
+    return 'supabase';
+  }
+}
+
+function runSupabase(command: string): string {
+  const env = { ...process.env };
+  delete env.SUPABASE_ACCESS_TOKEN;
+  delete env.SUPABASE_PROJECT_REF;
+  delete env.SUPABASE_PROJECT_ID;
+
+  env.PATH = stripNodeModulesBin(env.PATH);
+  const cliPath = resolveSupabaseCliPath();
+  const cli = cliPath.includes(' ')
+    ? `"${cliPath.replace(/"/g, '\\"')}"`
+    : cliPath;
+
+  return execSync(`${cli} --workdir "${BACKEND_ROOT}" ${command}`, {
+    cwd: BACKEND_ROOT,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).toString();
+}
+
+function parseSupabaseStatus(raw: string): SupabaseEnv {
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('Supabase status output missing JSON payload');
+  }
+  const status = JSON.parse(raw.slice(start, end + 1)) as Record<
+    string,
+    string
+  >;
+
+  const apiUrl =
+    status.api_url ?? status.API_URL ?? status.apiUrl ?? status.ApiUrl;
+  const anonKey =
+    status.anon_key ?? status.ANON_KEY ?? status.anonKey ?? status.AnonKey;
+  const serviceRoleKey =
+    status.service_role_key ??
+    status.SERVICE_ROLE_KEY ??
+    status.serviceRoleKey ??
+    status.ServiceRoleKey;
+
+  if (!apiUrl || !anonKey || !serviceRoleKey) {
+    throw new Error(
+      `Supabase status missing keys. Got: ${Object.keys(status).join(', ')}`,
+    );
+  }
+
+  return { apiUrl, anonKey, serviceRoleKey };
+}
+
+function tryGetSupabaseEnv(): SupabaseEnv | null {
+  try {
+    const raw = runSupabase('status --output json');
+    return parseSupabaseStatus(raw);
+  } catch {
+    return null;
+  }
+}
+
+function isLocalSupabaseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return LOCAL_SUPABASE_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function getJwtAlg(token: string): string | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const header = JSON.parse(Buffer.from(parts[0], 'base64url').toString());
+    return typeof header.alg === 'string' ? header.alg : null;
+  } catch {
+    return null;
+  }
+}
+
+function getSupabaseEnvFromProcess(): SupabaseEnv | null {
+  const apiUrl = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!apiUrl || !anonKey || !serviceRoleKey) return null;
+  if (!isLocalSupabaseUrl(apiUrl)) return null;
+  const alg = getJwtAlg(serviceRoleKey);
+  if (!alg || alg !== 'ES256') return null;
+
+  return { apiUrl, anonKey, serviceRoleKey };
+}
+
+async function isSupabaseApiReachable(apiUrl: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1500);
+  try {
+    const response = await fetch(new URL('/auth/v1/health', apiUrl), {
+      signal: controller.signal,
+    });
+    return response.status < 500;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function ensureSupabaseAvailable(): Promise<SupabaseEnv> {
+  const envFromProcess = getSupabaseEnvFromProcess();
+  if (envFromProcess && (await isSupabaseApiReachable(envFromProcess.apiUrl))) {
+    return envFromProcess;
+  }
+
+  const statusEnv = tryGetSupabaseEnv();
+  if (
+    statusEnv &&
+    isLocalSupabaseUrl(statusEnv.apiUrl) &&
+    (await isSupabaseApiReachable(statusEnv.apiUrl))
+  ) {
+    return statusEnv;
+  }
+
+  throw new Error(
+    'Supabase local is not reachable. Start it with `supabase start` from backend-nest.',
+  );
+}
+
+class NoopThrottlerGuard {
+  canActivate(): boolean {
+    return true;
+  }
+}
+
+describe('Encryption E2E (local Supabase)', () => {
+  let hasSupabase = false;
+  let adminClient: SupabaseClient<Database>;
+  let app: INestApplication;
+  let testUserId: string;
+  let testUserEmail: string;
+  let accessToken: string;
+
+  beforeAll(async () => {
+    const env = await ensureSupabaseAvailable().catch((error) => {
+      if (process.env.CI === 'true') throw error;
+      return null;
+    });
+    if (!env) return;
+
+    // Force-override env vars before AppModule creation.
+    // Bun auto-loads .env.local which may have non-JWT service role keys.
+    // ConfigModule reads process.env at module init time.
+    process.env.SUPABASE_URL = env.apiUrl;
+    process.env.SUPABASE_ANON_KEY = env.anonKey;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = env.serviceRoleKey;
+    process.env.ENCRYPTION_MASTER_KEY =
+      process.env.ENCRYPTION_MASTER_KEY ?? '11'.repeat(32);
+    process.env.TURNSTILE_SECRET_KEY =
+      process.env.TURNSTILE_SECRET_KEY ?? 'test-turnstile-key';
+    process.env.NODE_ENV = 'test';
+
+    adminClient = createClient<Database>(env.apiUrl, env.serviceRoleKey);
+
+    // Create test user
+    testUserEmail = `encryption-e2e-${Date.now()}@test.local`;
+    const { data, error } = await adminClient.auth.admin.createUser({
+      email: testUserEmail,
+      password: TEST_PASSWORD,
+      email_confirm: true,
+    });
+    if (error || !data?.user) {
+      throw new Error(
+        `Failed to create test user: ${error?.message ?? 'unknown'}`,
+      );
+    }
+    testUserId = data.user.id;
+
+    // Sign in to get JWT
+    const authClient = createClient<Database>(env.apiUrl, env.anonKey);
+    const { data: signInData, error: signInError } =
+      await authClient.auth.signInWithPassword({
+        email: testUserEmail,
+        password: TEST_PASSWORD,
+      });
+    if (signInError || !signInData?.session?.access_token) {
+      throw new Error(
+        `Failed to sign in: ${signInError?.message ?? 'no session'}`,
+      );
+    }
+    accessToken = signInData.session.access_token;
+
+    // Build the full app with throttler bypassed.
+    // Override ConfigService to use CLI values, since Bun auto-loads
+    // .env.local which may contain non-JWT Supabase keys.
+    const testConfigValues: Record<string, string> = {
+      SUPABASE_URL: env.apiUrl,
+      SUPABASE_ANON_KEY: env.anonKey,
+      SUPABASE_SERVICE_ROLE_KEY: env.serviceRoleKey,
+      ENCRYPTION_MASTER_KEY: process.env.ENCRYPTION_MASTER_KEY!,
+      TURNSTILE_SECRET_KEY: process.env.TURNSTILE_SECRET_KEY!,
+      NODE_ENV: 'test',
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(UserThrottlerGuard)
+      .useClass(NoopThrottlerGuard)
+      .overrideProvider(ConfigService)
+      .useValue({
+        get: <T>(key: string, defaultValue?: T): T =>
+          (testConfigValues[key] ?? process.env[key] ?? defaultValue) as T,
+        getOrThrow: <T>(key: string): T => {
+          const value = testConfigValues[key] ?? process.env[key];
+          if (value === undefined) throw new Error(`Missing config: ${key}`);
+          return value as T;
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.enableVersioning({ type: VersioningType.URI });
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    hasSupabase = true;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    if (hasSupabase && testUserId) {
+      await adminClient
+        .from('user_encryption_key')
+        .delete()
+        .eq('user_id', testUserId);
+      await adminClient.auth.admin.deleteUser(testUserId);
+    }
+  });
+
+  it('full change-pin flow: salt → validate-key → change-pin → validate-key with new key', async () => {
+    if (!hasSupabase) return;
+
+    // 1. Get salt
+    const saltRes = await request(app.getHttpServer())
+      .get('/api/v1/encryption/salt')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(saltRes.body.salt).toBeTruthy();
+    expect(saltRes.body.kdfIterations).toBe(600000);
+
+    // 2. Validate old key (establishes DEK + key_check)
+    await request(app.getHttpServer())
+      .post('/api/v1/encryption/validate-key')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ clientKey: OLD_CLIENT_KEY_HEX })
+      .expect(204);
+
+    // 3. Change PIN
+    const changePinRes = await request(app.getHttpServer())
+      .post('/api/v1/encryption/change-pin')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        oldClientKey: OLD_CLIENT_KEY_HEX,
+        newClientKey: NEW_CLIENT_KEY_HEX,
+      })
+      .expect(200);
+
+    expect(changePinRes.body.keyCheck).toBeTruthy();
+    expect(changePinRes.body.recoveryKey).toBeNull();
+
+    // 4. Validate new key succeeds
+    await request(app.getHttpServer())
+      .post('/api/v1/encryption/validate-key')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ clientKey: NEW_CLIENT_KEY_HEX })
+      .expect(204);
+
+    // 5. Verify old key now fails
+    const oldKeyRes = await request(app.getHttpServer())
+      .post('/api/v1/encryption/validate-key')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ clientKey: OLD_CLIENT_KEY_HEX })
+      .expect(400);
+
+    expect(oldKeyRes.body.code).toBe('ERR_ENCRYPTION_KEY_CHECK_FAILED');
+  }, 30_000);
+
+  it('returns 400 when change-pin with wrong old key', async () => {
+    if (!hasSupabase) return;
+
+    // The previous test left the user with NEW_CLIENT_KEY_HEX as the active key
+    const wrongOldKey = 'ee'.repeat(32);
+
+    const res = await request(app.getHttpServer())
+      .post('/api/v1/encryption/change-pin')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        oldClientKey: wrongOldKey,
+        newClientKey: 'ff'.repeat(32),
+      })
+      .expect(400);
+
+    expect(res.body.code).toBe('ERR_ENCRYPTION_KEY_CHECK_FAILED');
+  });
+
+  it('vault-status reflects configured state', async () => {
+    if (!hasSupabase) return;
+
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/encryption/vault-status')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(typeof res.body.pinCodeConfigured).toBe('boolean');
+    expect(typeof res.body.recoveryKeyConfigured).toBe('boolean');
+    expect(typeof res.body.vaultCodeConfigured).toBe('boolean');
+    // After previous tests, pin should be configured
+    expect(res.body.pinCodeConfigured).toBe(true);
+  });
+
+  it('Zod validation rejects malformed body in real app', async () => {
+    if (!hasSupabase) return;
+
+    const res = await request(app.getHttpServer())
+      .post('/api/v1/encryption/change-pin')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ wrongField: 'value' })
+      .expect(400);
+
+    expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+  });
+});

--- a/backend-nest/src/modules/encryption/encryption.http.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.http.spec.ts
@@ -69,7 +69,6 @@ function createMockEncryptionService() {
     ensureUserDEK: mock(() => Promise.resolve(Buffer.alloc(32))),
     getUserDEK: mock(() => Promise.resolve(Buffer.alloc(32))),
     generateKeyCheck: mock(() => 'mock-key-check'),
-    storeKeyCheck: mock(() => Promise.resolve()),
   };
 }
 

--- a/backend-nest/src/modules/encryption/encryption.http.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.http.spec.ts
@@ -1,0 +1,407 @@
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
+import {
+  type INestApplication,
+  VersioningType,
+  type CanActivate,
+  type ExecutionContext,
+} from '@nestjs/common';
+import { APP_FILTER, APP_PIPE, Reflector } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { ZodValidationPipe } from 'nestjs-zod';
+import { PinoLogger } from 'nestjs-pino';
+import { EncryptionController } from './encryption.controller';
+import { EncryptionService } from './encryption.service';
+import { GlobalExceptionFilter } from '@common/filters/global-exception.filter';
+import { AuthGuard } from '@common/guards/auth.guard';
+import { BusinessException } from '@common/exceptions/business.exception';
+import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
+
+const VALID_HEX_KEY = 'ab'.repeat(32);
+const VALID_HEX_KEY_ALT = 'cd'.repeat(32);
+const MOCK_USER_ID = 'user-http-test';
+
+class MockAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    req.user = {
+      id: MOCK_USER_ID,
+      email: 'http-test@test.local',
+      accessToken: 'mock-token',
+      clientKey: Buffer.alloc(32, 0xab),
+    };
+    req.supabase = {};
+    return true;
+  }
+}
+
+function createMockEncryptionService() {
+  return {
+    getVaultStatus: mock(() =>
+      Promise.resolve({
+        pinCodeConfigured: true,
+        recoveryKeyConfigured: false,
+        vaultCodeConfigured: true,
+      }),
+    ),
+    getUserSalt: mock(() =>
+      Promise.resolve({
+        salt: 'aabb00ff',
+        kdfIterations: 600000,
+        hasRecoveryKey: false,
+      }),
+    ),
+    verifyAndEnsureKeyCheck: mock(() => Promise.resolve(true)),
+    changePinRekey: mock(() =>
+      Promise.resolve({
+        keyCheck: 'mock-key-check',
+        recoveryKey: null as string | null,
+      }),
+    ),
+    recoverWithKey: mock(() => Promise.resolve()),
+    reEncryptAllUserData: mock(() => Promise.resolve()),
+    createRecoveryKey: mock(() =>
+      Promise.resolve({ formatted: 'XXXX-YYYY-ZZZZ-1234' }),
+    ),
+    regenerateRecoveryKey: mock(() =>
+      Promise.resolve({ formatted: 'AAAA-BBBB-CCCC-5678' }),
+    ),
+    ensureUserDEK: mock(() => Promise.resolve(Buffer.alloc(32))),
+    getUserDEK: mock(() => Promise.resolve(Buffer.alloc(32))),
+    generateKeyCheck: mock(() => 'mock-key-check'),
+    storeKeyCheck: mock(() => Promise.resolve()),
+  };
+}
+
+function createMockPinoLogger(): Partial<PinoLogger> {
+  const noop = () => {};
+  return {
+    info: noop,
+    error: noop,
+    warn: noop,
+    debug: noop,
+    trace: noop,
+    fatal: noop,
+    setContext: noop,
+  } as unknown as Partial<PinoLogger>;
+}
+
+let app: INestApplication;
+let mockService: ReturnType<typeof createMockEncryptionService>;
+
+beforeAll(async () => {
+  mockService = createMockEncryptionService();
+  const mockLogger = createMockPinoLogger();
+
+  const moduleRef = await Test.createTestingModule({
+    controllers: [EncryptionController],
+    providers: [
+      { provide: EncryptionService, useValue: mockService },
+      { provide: APP_PIPE, useClass: ZodValidationPipe },
+      {
+        provide: APP_FILTER,
+        useFactory: () => new GlobalExceptionFilter(mockLogger as PinoLogger),
+      },
+      Reflector,
+    ],
+  })
+    .overrideGuard(AuthGuard)
+    .useClass(MockAuthGuard)
+    .compile();
+
+  app = moduleRef.createNestApplication();
+  app.enableVersioning({ type: VersioningType.URI });
+  app.setGlobalPrefix('api');
+  await app.init();
+});
+
+afterAll(async () => {
+  await app?.close();
+});
+
+describe('Encryption HTTP pipeline', () => {
+  // ──────────────────────────────────────────────
+  // POST /api/v1/encryption/validate-key
+  // ──────────────────────────────────────────────
+  describe('POST /api/v1/encryption/validate-key', () => {
+    it('returns 204 with valid clientKey', async () => {
+      await request(app.getHttpServer())
+        .post('/api/v1/encryption/validate-key')
+        .send({ clientKey: VALID_HEX_KEY })
+        .expect(204);
+    });
+
+    it('returns 400 Zod error when clientKey is missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/validate-key')
+        .send({})
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+
+    it('returns 400 Zod error when clientKey is wrong type', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/validate-key')
+        .send({ clientKey: 123 })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+
+    it('returns 400 ERR_AUTH_CLIENT_KEY_INVALID for invalid hex', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/validate-key')
+        .send({ clientKey: 'not-valid-hex' })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_AUTH_CLIENT_KEY_INVALID');
+    });
+
+    it('returns 400 ERR_AUTH_CLIENT_KEY_INVALID for all-zero key', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/validate-key')
+        .send({ clientKey: '00'.repeat(32) })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_AUTH_CLIENT_KEY_INVALID');
+    });
+
+    it('returns 400 ERR_ENCRYPTION_KEY_CHECK_FAILED when service returns false', async () => {
+      mockService.verifyAndEnsureKeyCheck.mockImplementationOnce(() =>
+        Promise.resolve(false),
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/validate-key')
+        .send({ clientKey: VALID_HEX_KEY })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ENCRYPTION_KEY_CHECK_FAILED');
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // POST /api/v1/encryption/change-pin
+  // ──────────────────────────────────────────────
+  describe('POST /api/v1/encryption/change-pin', () => {
+    it('returns 200 with keyCheck and null recoveryKey', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ oldClientKey: VALID_HEX_KEY, newClientKey: VALID_HEX_KEY_ALT })
+        .expect(200);
+
+      expect(res.body).toEqual({
+        keyCheck: 'mock-key-check',
+        recoveryKey: null,
+      });
+    });
+
+    it('returns 200 with recoveryKey when service returns one', async () => {
+      mockService.changePinRekey.mockImplementationOnce(() =>
+        Promise.resolve({
+          keyCheck: 'new-kc',
+          recoveryKey: 'ABCD-EFGH-IJKL-MNOP',
+        }),
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ oldClientKey: VALID_HEX_KEY, newClientKey: VALID_HEX_KEY_ALT })
+        .expect(200);
+
+      expect(res.body.recoveryKey).toBe('ABCD-EFGH-IJKL-MNOP');
+    });
+
+    it('returns 400 Zod error when oldClientKey is missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ newClientKey: VALID_HEX_KEY_ALT })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+
+    it('returns 400 Zod error when newClientKey is missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ oldClientKey: VALID_HEX_KEY })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+
+    it('returns 400 Zod error on empty body', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({})
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+
+    it('returns 400 ERR_ENCRYPTION_SAME_KEY when service throws', async () => {
+      mockService.changePinRekey.mockImplementationOnce(() =>
+        Promise.reject(
+          new BusinessException(ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY),
+        ),
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ oldClientKey: VALID_HEX_KEY, newClientKey: VALID_HEX_KEY_ALT })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ENCRYPTION_SAME_KEY');
+    });
+
+    it('returns 400 ERR_ENCRYPTION_KEY_CHECK_FAILED when old key is wrong', async () => {
+      mockService.changePinRekey.mockImplementationOnce(() =>
+        Promise.reject(
+          new BusinessException(ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED),
+        ),
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ oldClientKey: VALID_HEX_KEY, newClientKey: VALID_HEX_KEY_ALT })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ENCRYPTION_KEY_CHECK_FAILED');
+    });
+
+    it('returns 400 ERR_AUTH_CLIENT_KEY_INVALID for invalid hex oldClientKey', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ oldClientKey: 'not-hex', newClientKey: VALID_HEX_KEY_ALT })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_AUTH_CLIENT_KEY_INVALID');
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // POST /api/v1/encryption/recover
+  // ──────────────────────────────────────────────
+  describe('POST /api/v1/encryption/recover', () => {
+    it('returns 200 { success: true } on valid recovery', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/recover')
+        .send({
+          recoveryKey: 'XXXX-YYYY-ZZZZ-1234',
+          newClientKey: VALID_HEX_KEY,
+        })
+        .expect(200);
+
+      expect(res.body).toEqual({ success: true });
+    });
+
+    it('returns 400 Zod error when recoveryKey is missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/recover')
+        .send({ newClientKey: VALID_HEX_KEY })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+
+    it('returns 400 ERR_RECOVERY_KEY_INVALID for empty recoveryKey string', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/recover')
+        .send({ recoveryKey: '', newClientKey: VALID_HEX_KEY })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_RECOVERY_KEY_INVALID');
+    });
+
+    it('returns 400 ERR_RECOVERY_KEY_INVALID for whitespace-only recoveryKey', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/recover')
+        .send({ recoveryKey: '   ', newClientKey: VALID_HEX_KEY })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_RECOVERY_KEY_INVALID');
+    });
+
+    it('returns 400 ERR_AUTH_CLIENT_KEY_INVALID for invalid hex newClientKey', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/recover')
+        .send({ recoveryKey: 'XXXX-YYYY-ZZZZ', newClientKey: 'not-valid-hex' })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_AUTH_CLIENT_KEY_INVALID');
+    });
+
+    it('returns 400 Zod error when newClientKey is missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/recover')
+        .send({ recoveryKey: 'XXXX-YYYY-ZZZZ-1234' })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // GET /api/v1/encryption/vault-status
+  // ──────────────────────────────────────────────
+  describe('GET /api/v1/encryption/vault-status', () => {
+    it('returns 200 with three boolean flags', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/encryption/vault-status')
+        .expect(200);
+
+      expect(res.body).toEqual({
+        pinCodeConfigured: true,
+        recoveryKeyConfigured: false,
+        vaultCodeConfigured: true,
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // GET /api/v1/encryption/salt
+  // ──────────────────────────────────────────────
+  describe('GET /api/v1/encryption/salt', () => {
+    it('returns 200 with salt, kdfIterations, and hasRecoveryKey', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/encryption/salt')
+        .expect(200);
+
+      expect(res.body).toEqual({
+        salt: 'aabb00ff',
+        kdfIterations: 600000,
+        hasRecoveryKey: false,
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // Error response shape
+  // ──────────────────────────────────────────────
+  describe('Error response shape', () => {
+    it('includes standard error envelope fields', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/validate-key')
+        .send({ clientKey: 'bad-hex' })
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.statusCode).toBe(400);
+      expect(res.body.code).toBe('ERR_AUTH_CLIENT_KEY_INVALID');
+      expect(res.body.path).toBe('/api/v1/encryption/validate-key');
+      expect(res.body.method).toBe('POST');
+      expect(typeof res.body.timestamp).toBe('string');
+    });
+
+    it('Zod errors include validation details in message', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ oldClientKey: 123, newClientKey: true })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+      expect(res.body.error).toBe('ZodValidationException');
+    });
+  });
+});

--- a/backend-nest/src/modules/encryption/encryption.http.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.http.spec.ts
@@ -16,6 +16,7 @@ import { GlobalExceptionFilter } from '@common/filters/global-exception.filter';
 import { AuthGuard } from '@common/guards/auth.guard';
 import { BusinessException } from '@common/exceptions/business.exception';
 import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
+import { createInfoLoggerProvider } from '@common/logger';
 
 const VALID_HEX_KEY = 'ab'.repeat(32);
 const VALID_HEX_KEY_ALT = 'cd'.repeat(32);
@@ -101,6 +102,8 @@ beforeAll(async () => {
         provide: APP_FILTER,
         useFactory: () => new GlobalExceptionFilter(mockLogger as PinoLogger),
       },
+      { provide: PinoLogger, useValue: mockLogger },
+      createInfoLoggerProvider(EncryptionController.name),
       Reflector,
     ],
   })

--- a/backend-nest/src/modules/encryption/encryption.http.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.http.spec.ts
@@ -148,13 +148,13 @@ describe('Encryption HTTP pipeline', () => {
       expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
     });
 
-    it('returns 400 ERR_AUTH_CLIENT_KEY_INVALID for invalid hex', async () => {
+    it('returns 400 Zod error for invalid hex', async () => {
       const res = await request(app.getHttpServer())
         .post('/api/v1/encryption/validate-key')
         .send({ clientKey: 'not-valid-hex' })
         .expect(400);
 
-      expect(res.body.code).toBe('ERR_AUTH_CLIENT_KEY_INVALID');
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
     });
 
     it('returns 400 ERR_AUTH_CLIENT_KEY_INVALID for all-zero key', async () => {
@@ -269,13 +269,13 @@ describe('Encryption HTTP pipeline', () => {
       expect(res.body.code).toBe('ERR_ENCRYPTION_KEY_CHECK_FAILED');
     });
 
-    it('returns 400 ERR_AUTH_CLIENT_KEY_INVALID for invalid hex oldClientKey', async () => {
+    it('returns 400 Zod error for invalid hex oldClientKey', async () => {
       const res = await request(app.getHttpServer())
         .post('/api/v1/encryption/change-pin')
         .send({ oldClientKey: 'not-hex', newClientKey: VALID_HEX_KEY_ALT })
         .expect(400);
 
-      expect(res.body.code).toBe('ERR_AUTH_CLIENT_KEY_INVALID');
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
     });
   });
 
@@ -322,13 +322,13 @@ describe('Encryption HTTP pipeline', () => {
       expect(res.body.code).toBe('ERR_RECOVERY_KEY_INVALID');
     });
 
-    it('returns 400 ERR_AUTH_CLIENT_KEY_INVALID for invalid hex newClientKey', async () => {
+    it('returns 400 Zod error for invalid hex newClientKey', async () => {
       const res = await request(app.getHttpServer())
         .post('/api/v1/encryption/recover')
         .send({ recoveryKey: 'XXXX-YYYY-ZZZZ', newClientKey: 'not-valid-hex' })
         .expect(400);
 
-      expect(res.body.code).toBe('ERR_AUTH_CLIENT_KEY_INVALID');
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
     });
 
     it('returns 400 Zod error when newClientKey is missing', async () => {
@@ -380,9 +380,10 @@ describe('Encryption HTTP pipeline', () => {
   // ──────────────────────────────────────────────
   describe('Error response shape', () => {
     it('includes standard error envelope fields', async () => {
+      // Use all-zero key (valid hex, passes Zod, caught by controller buffer check)
       const res = await request(app.getHttpServer())
         .post('/api/v1/encryption/validate-key')
-        .send({ clientKey: 'bad-hex' })
+        .send({ clientKey: '00'.repeat(32) })
         .expect(400);
 
       expect(res.body.success).toBe(false);

--- a/backend-nest/src/modules/encryption/encryption.http.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.http.spec.ts
@@ -280,6 +280,15 @@ describe('Encryption HTTP pipeline', () => {
 
       expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
     });
+
+    it('returns 400 Zod error for invalid hex newClientKey', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/change-pin')
+        .send({ oldClientKey: VALID_HEX_KEY, newClientKey: 'not-hex' })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
   });
 
   // ──────────────────────────────────────────────

--- a/backend-nest/src/modules/encryption/encryption.integration.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.integration.spec.ts
@@ -697,14 +697,7 @@ describe('Encryption integration (local Supabase)', () => {
         userId,
         recoveryKey,
         recoveredClientKey,
-        async (oldRecoveredDek, newRecoveredDek) => {
-          await encryptionService.reEncryptAllUserData(
-            userId,
-            oldRecoveredDek,
-            newRecoveredDek,
-            adminClient,
-          );
-        },
+        adminClient,
       );
 
       const afterRecoverState = await getUserEncryptionKeyState(
@@ -803,21 +796,12 @@ describe('Encryption integration (local Supabase)', () => {
         .eq('id', budgetLineId)
         .single();
 
-      let callbackCalled = false;
       try {
         await encryptionService.recoverWithKey(
           userId,
           invalidRecoveryKey,
           newClientKey,
-          async (oldRecoveredDek, newRecoveredDek) => {
-            callbackCalled = true;
-            await encryptionService.reEncryptAllUserData(
-              userId,
-              oldRecoveredDek,
-              newRecoveredDek,
-              adminClient,
-            );
-          },
+          adminClient,
         );
         expect.unreachable('recoverWithKey should reject invalid recovery key');
       } catch {
@@ -834,7 +818,6 @@ describe('Encryption integration (local Supabase)', () => {
         .eq('id', budgetLineId)
         .single();
 
-      expect(callbackCalled).toBe(false);
       expect(keyStateAfter.salt).toBe(keyStateBefore.salt);
       expect(keyStateAfter.wrapped_dek).toBe(keyStateBefore.wrapped_dek);
       expect(keyStateAfter.key_check).toBe(keyStateBefore.key_check);

--- a/backend-nest/src/modules/encryption/encryption.integration.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.integration.spec.ts
@@ -449,10 +449,14 @@ describe('Encryption integration (local Supabase)', () => {
         })
         .eq('id', budgetId);
 
-      await encryptionService.rekeyUserData(
+      const newDek = await encryptionService.ensureUserDEK(
         userId,
-        oldClientKey,
         newClientKey,
+      );
+      await encryptionService.reEncryptAllUserData(
+        userId,
+        oldDek,
+        newDek,
         adminClient,
       );
 
@@ -487,8 +491,6 @@ describe('Encryption integration (local Supabase)', () => {
       expect(templateLine?.amount).toBeTruthy();
       expect(savingsGoal?.target_amount).toBeTruthy();
       expect(monthlyBudget?.ending_balance).toBeTruthy();
-
-      const newDek = await encryptionService.getUserDEK(userId, newClientKey);
 
       expect(encryptionService.decryptAmount(budgetLine!.amount!, newDek)).toBe(
         150,
@@ -583,11 +585,15 @@ describe('Encryption integration (local Supabase)', () => {
         .eq('id', transactionId)
         .single();
 
+      const newDek = await encryptionService.ensureUserDEK(
+        userId,
+        newClientKey,
+      );
       await expect(
-        encryptionService.rekeyUserData(
+        encryptionService.reEncryptAllUserData(
           userId,
-          oldClientKey,
-          newClientKey,
+          oldDek,
+          newDek,
           adminClient,
         ),
       ).rejects.toThrow();
@@ -907,10 +913,14 @@ describe('Encryption integration (local Supabase)', () => {
       }
 
       // Rekey via authenticated client (same path as production)
-      await encryptionService.rekeyUserData(
+      const newDek = await encryptionService.ensureUserDEK(
         userId,
-        oldClientKey,
         newClientKey,
+      );
+      await encryptionService.reEncryptAllUserData(
+        userId,
+        oldDek,
+        newDek,
         authClient as unknown as SupabaseClient<Database>,
       );
 
@@ -919,7 +929,6 @@ describe('Encryption integration (local Supabase)', () => {
       expect(keyState.key_check).toBeTruthy();
 
       // Verify key_check validates against new DEK (not old DEK)
-      const newDek = await encryptionService.getUserDEK(userId, newClientKey);
       expect(
         encryptionService.validateKeyCheck(keyState.key_check!, newDek),
       ).toBe(true);

--- a/backend-nest/src/modules/encryption/encryption.integration.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.integration.spec.ts
@@ -346,7 +346,17 @@ describe('Encryption integration (local Supabase)', () => {
     }
 
     hasSupabase = true;
-    encryptionService = new EncryptionService(configService, repository);
+    const mockLogger = {
+      info: () => {},
+      warn: () => {},
+      debug: () => {},
+      trace: () => {},
+    };
+    encryptionService = new EncryptionService(
+      mockLogger as any,
+      configService,
+      repository,
+    );
   });
 
   afterAll(() => {

--- a/backend-nest/src/modules/encryption/encryption.module.ts
+++ b/backend-nest/src/modules/encryption/encryption.module.ts
@@ -1,4 +1,5 @@
 import { Global, Module } from '@nestjs/common';
+import { createInfoLoggerProvider } from '@common/logger';
 import { EncryptionService } from './encryption.service';
 import { EncryptionKeyRepository } from './encryption-key.repository';
 import { EncryptionController } from './encryption.controller';
@@ -6,7 +7,12 @@ import { EncryptionController } from './encryption.controller';
 @Global()
 @Module({
   controllers: [EncryptionController],
-  providers: [EncryptionService, EncryptionKeyRepository],
+  providers: [
+    EncryptionService,
+    EncryptionKeyRepository,
+    createInfoLoggerProvider(EncryptionService.name),
+    createInfoLoggerProvider(EncryptionController.name),
+  ],
   exports: [EncryptionService],
 })
 export class EncryptionModule {}

--- a/backend-nest/src/modules/encryption/encryption.rate-limit.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.rate-limit.spec.ts
@@ -106,4 +106,18 @@ describe('EncryptionController Rate Limiting', () => {
       expect(error).toBeInstanceOf(ThrottlerException);
     }
   });
+
+  it('throttles changePin after 5 attempts per hour', async () => {
+    const guard = await createGuard();
+    const handler = EncryptionController.prototype.changePin;
+
+    await runAttempts(guard, handler, 5);
+
+    try {
+      await guard.canActivate(createContext(handler) as any);
+      expect.unreachable('Expected throttling exception after 5 attempts');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ThrottlerException);
+    }
+  });
 });

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -2129,7 +2129,7 @@ describe('EncryptionService', () => {
       reEncryptSpy.mockRestore();
     });
 
-    it('should generate key_check when row exists but key_check is null', async () => {
+    it('should throw ENCRYPTION_KEY_CHECK_FAILED when key_check is null (not initialized)', async () => {
       const findByUserId = mock(() =>
         Promise.resolve({
           salt: existingSalt,
@@ -2138,35 +2138,28 @@ describe('EncryptionService', () => {
           key_check: null,
         }),
       );
-      const updateKeyCheckIfNull = mock(() => Promise.resolve());
 
-      const repo = createMockRepository({
-        findByUserId,
-        updateKeyCheckIfNull,
-      });
+      const repo = createMockRepository({ findByUserId });
       service = new EncryptionService(
         createMockLogger() as any,
         mockConfigService as any,
         repo as any,
       );
 
-      const reEncryptSpy = spyOn(
-        service,
-        'reEncryptAllUserData',
-      ).mockResolvedValue('mock-key-check');
-
-      const result = await service.changePinRekey(
-        TEST_USER_ID,
-        oldClientKey,
-        newClientKey,
-        mockSupabase,
-      );
-
-      expect(updateKeyCheckIfNull).toHaveBeenCalledTimes(1);
-      expect(result.keyCheck).toBe('mock-key-check');
-      expect(reEncryptSpy).toHaveBeenCalledTimes(1);
-
-      reEncryptSpy.mockRestore();
+      try {
+        await service.changePinRekey(
+          TEST_USER_ID,
+          oldClientKey,
+          newClientKey,
+          mockSupabase,
+        );
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect((error as BusinessException).code).toBe(
+          ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED.code,
+        );
+      }
     });
 
     it('should nullify wrapped_dek and throw REKEY_PARTIAL_FAILURE when recovery re-wrap fails', async () => {

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -2227,7 +2227,7 @@ describe('EncryptionService', () => {
       wrapSpy.mockRestore();
     });
 
-    it('should throw ENCRYPTION_REKEY_PARTIAL_FAILURE when user has no encryption key', async () => {
+    it('should throw ENCRYPTION_KEY_CHECK_FAILED when user has no encryption key', async () => {
       const findByUserId = mock(() => Promise.resolve(null));
 
       const repo = createMockRepository({ findByUserId });
@@ -2248,7 +2248,7 @@ describe('EncryptionService', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(BusinessException);
         expect((error as BusinessException).code).toBe(
-          ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE.code,
+          ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED.code,
         );
       }
     });

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -22,7 +22,6 @@ const createMockRepository = (overrides?: {
   updateWrappedDEK?: ReturnType<typeof mock>;
   updateWrappedDEKIfNull?: ReturnType<typeof mock>;
   hasRecoveryKey?: ReturnType<typeof mock>;
-  updateKeyCheck?: ReturnType<typeof mock>;
   updateKeyCheckIfNull?: ReturnType<typeof mock>;
   hasVaultCode?: ReturnType<typeof mock>;
   getVaultStatus?: ReturnType<typeof mock>;
@@ -42,14 +41,8 @@ const createMockRepository = (overrides?: {
       : mock(() => Promise.resolve(true))),
   hasRecoveryKey:
     overrides?.hasRecoveryKey ?? mock(() => Promise.resolve(false)),
-  updateKeyCheck: overrides?.updateKeyCheck ?? mock(() => Promise.resolve()),
   updateKeyCheckIfNull:
-    overrides?.updateKeyCheckIfNull ??
-    (overrides?.updateKeyCheck
-      ? mock((userId: string, keyCheck: string) =>
-          overrides.updateKeyCheck!(userId, keyCheck),
-        )
-      : mock(() => Promise.resolve())),
+    overrides?.updateKeyCheckIfNull ?? mock(() => Promise.resolve()),
   hasVaultCode: overrides?.hasVaultCode ?? mock(() => Promise.resolve(false)),
   getVaultStatus:
     overrides?.getVaultStatus ??
@@ -302,81 +295,6 @@ describe('EncryptionService', () => {
       const result = service.tryDecryptAmount(encrypted, dek2, fallback);
 
       expect(result).toBe(fallback);
-    });
-  });
-
-  describe('encryptAmounts', () => {
-    beforeEach(() => {
-      service = new EncryptionService(
-        mockConfigService as any,
-        mockRepository as any,
-      );
-    });
-
-    it('should encrypt multiple amounts', () => {
-      const dek = randomBytes(32);
-      const amounts = [100.5, 200.75, 300.25];
-
-      const encrypted = service.encryptAmounts(amounts, dek);
-
-      expect(encrypted.length).toBe(amounts.length);
-      expect(encrypted.every((ct) => typeof ct === 'string')).toBe(true);
-    });
-
-    it('should handle empty array', () => {
-      const dek = randomBytes(32);
-      const amounts: number[] = [];
-
-      const encrypted = service.encryptAmounts(amounts, dek);
-
-      expect(encrypted).toEqual([]);
-    });
-
-    it('should handle single amount', () => {
-      const dek = randomBytes(32);
-      const amounts = [1234.56];
-
-      const encrypted = service.encryptAmounts(amounts, dek);
-
-      expect(encrypted.length).toBe(1);
-    });
-  });
-
-  describe('decryptAmounts', () => {
-    beforeEach(() => {
-      service = new EncryptionService(
-        mockConfigService as any,
-        mockRepository as any,
-      );
-    });
-
-    it('should decrypt multiple amounts', () => {
-      const dek = randomBytes(32);
-      const amounts = [100.5, 200.75, 300.25];
-
-      const encrypted = service.encryptAmounts(amounts, dek);
-      const decrypted = service.decryptAmounts(encrypted, dek);
-
-      expect(decrypted).toEqual(amounts);
-    });
-
-    it('should handle empty array', () => {
-      const dek = randomBytes(32);
-      const ciphertexts: string[] = [];
-
-      const decrypted = service.decryptAmounts(ciphertexts, dek);
-
-      expect(decrypted).toEqual([]);
-    });
-
-    it('should handle single ciphertext', () => {
-      const dek = randomBytes(32);
-      const amounts = [1234.56];
-
-      const encrypted = service.encryptAmounts(amounts, dek);
-      const decrypted = service.decryptAmounts(encrypted, dek);
-
-      expect(decrypted).toEqual(amounts);
     });
   });
 
@@ -861,25 +779,6 @@ describe('EncryptionService', () => {
       );
     });
 
-    it('should roundtrip batch encryption and decryption', () => {
-      const dek = randomBytes(32);
-      const amounts = [100.5, 0, 0.01, 99999.99, -500.25];
-
-      const encrypted = service.encryptAmounts(amounts, dek);
-      const decrypted = service.decryptAmounts(encrypted, dek);
-
-      expect(decrypted).toEqual(amounts);
-    });
-
-    it('should produce different ciphertexts for batch with same plaintext values', () => {
-      const dek = randomBytes(32);
-      const amounts = [1234.56, 1234.56];
-
-      const encrypted = service.encryptAmounts(amounts, dek);
-
-      expect(encrypted[0]).not.toBe(encrypted[1]);
-    });
-
     it('should encrypt and decrypt with derived DEK end-to-end', async () => {
       const existingSalt = randomBytes(16).toString('hex');
       const findSaltByUserId = mock(() =>
@@ -1178,33 +1077,6 @@ describe('EncryptionService', () => {
       await expect(
         service.verifyAndEnsureKeyCheck(TEST_USER_ID, TEST_CLIENT_KEY),
       ).rejects.toThrow('Database connection failed');
-    });
-  });
-
-  describe('storeKeyCheck', () => {
-    it('should delegate to repository updateKeyCheck', async () => {
-      const updateKeyCheck = mock(() => Promise.resolve());
-      const repo = createMockRepository({ updateKeyCheck });
-      service = new EncryptionService(mockConfigService as any, repo as any);
-
-      const keyCheck = 'test-key-check-value';
-      await service.storeKeyCheck(TEST_USER_ID, keyCheck);
-
-      expect(updateKeyCheck).toHaveBeenCalledWith(TEST_USER_ID, keyCheck);
-    });
-
-    it('should await repository call', async () => {
-      let resolved = false;
-      const updateKeyCheck = mock(async () => {
-        await new Promise((r) => setTimeout(r, 10));
-        resolved = true;
-      });
-      const repo = createMockRepository({ updateKeyCheck });
-      service = new EncryptionService(mockConfigService as any, repo as any);
-
-      await service.storeKeyCheck(TEST_USER_ID, 'test-key-check');
-
-      expect(resolved).toBe(true);
     });
   });
 

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -1835,7 +1835,7 @@ describe('EncryptionService', () => {
     const newClientKey = randomBytes(32);
     const mockSupabase = {} as any;
 
-    function setupServiceWithValidKeyCheck() {
+    async function setupServiceWithValidKeyCheck(): Promise<Buffer> {
       // Bootstrap service to derive DEK and generate a valid keyCheck
       const bootstrapFindSalt = mock(() =>
         Promise.resolve({
@@ -1852,8 +1852,7 @@ describe('EncryptionService', () => {
         mockConfigService as any,
         bootstrapRepo as any,
       );
-      const dek = bootstrapService.getUserDEK(TEST_USER_ID, oldClientKey);
-      return dek;
+      return bootstrapService.getUserDEK(TEST_USER_ID, oldClientKey);
     }
 
     it('should throw ENCRYPTION_SAME_KEY when old and new keys are identical', async () => {
@@ -1959,7 +1958,7 @@ describe('EncryptionService', () => {
 
     it('should re-encrypt data and return keyCheck on success (no recovery)', async () => {
       const dek = await setupServiceWithValidKeyCheck();
-      const validKeyCheck = service.generateKeyCheck(await dek);
+      const validKeyCheck = service.generateKeyCheck(dek);
 
       const findByUserId = mock(() =>
         Promise.resolve({
@@ -2011,7 +2010,7 @@ describe('EncryptionService', () => {
 
     it('should re-wrap with new recovery key AFTER re-encryption when recovery exists', async () => {
       const dek = await setupServiceWithValidKeyCheck();
-      const validKeyCheck = service.generateKeyCheck(await dek);
+      const validKeyCheck = service.generateKeyCheck(dek);
       const callOrder: string[] = [];
 
       const findByUserId = mock(() =>
@@ -2076,7 +2075,7 @@ describe('EncryptionService', () => {
 
     it('should NOT nullify wrapped_dek when re-encryption fails', async () => {
       const dek = await setupServiceWithValidKeyCheck();
-      const validKeyCheck = service.generateKeyCheck(await dek);
+      const validKeyCheck = service.generateKeyCheck(dek);
 
       const findByUserId = mock(() =>
         Promise.resolve({
@@ -2164,7 +2163,7 @@ describe('EncryptionService', () => {
 
     it('should nullify wrapped_dek and throw REKEY_PARTIAL_FAILURE when recovery re-wrap fails', async () => {
       const dek = await setupServiceWithValidKeyCheck();
-      const validKeyCheck = service.generateKeyCheck(await dek);
+      const validKeyCheck = service.generateKeyCheck(dek);
 
       const findByUserId = mock(() =>
         Promise.resolve({
@@ -2248,7 +2247,7 @@ describe('EncryptionService', () => {
 
     it('should zero DEK buffers after successful re-encryption', async () => {
       const dek = await setupServiceWithValidKeyCheck();
-      const validKeyCheck = service.generateKeyCheck(await dek);
+      const validKeyCheck = service.generateKeyCheck(dek);
 
       const findByUserId = mock(() =>
         Promise.resolve({
@@ -2299,7 +2298,7 @@ describe('EncryptionService', () => {
 
     it('should zero DEK buffers even when re-encryption fails', async () => {
       const dek = await setupServiceWithValidKeyCheck();
-      const validKeyCheck = service.generateKeyCheck(await dek);
+      const validKeyCheck = service.generateKeyCheck(dek);
 
       const findByUserId = mock(() =>
         Promise.resolve({

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -1619,7 +1619,7 @@ describe('EncryptionService', () => {
           TEST_USER_ID,
           recoveryKeyFormatted,
           newClientKey,
-          mock(() => Promise.resolve()),
+          {} as any,
         );
         expect.unreachable('Should have thrown');
       } catch (error: any) {
@@ -1658,7 +1658,7 @@ describe('EncryptionService', () => {
           TEST_USER_ID,
           invalidRecoveryKey,
           newClientKey,
-          mock(() => Promise.resolve()),
+          {} as any,
         );
         expect.unreachable('Should have thrown');
       } catch (error: any) {
@@ -1737,14 +1737,21 @@ describe('EncryptionService', () => {
       );
 
       const newClientKey = randomBytes(32);
-      const reEncryptUserData = mock(() => Promise.resolve());
+      const mockSupabase = {} as any;
+
+      const reEncryptSpy = spyOn(
+        svc2,
+        'reEncryptAllUserData',
+      ).mockResolvedValue('mock-key-check');
 
       await svc2.recoverWithKey(
         TEST_USER_ID,
         formatted,
         newClientKey,
-        reEncryptUserData,
+        mockSupabase,
       );
+
+      reEncryptSpy.mockRestore();
 
       // First updateWrappedDEK call should be null (invalidation before re-encryption)
       expect(updateWrappedDEK2).toHaveBeenCalledTimes(2);
@@ -1806,7 +1813,6 @@ describe('EncryptionService', () => {
       await service.regenerateRecoveryKey(TEST_USER_ID, clientKey);
       expect(wrappedDek).not.toBe(firstWrapped);
 
-      const reEncryptUserData = mock(() => Promise.resolve());
       const newClientKey = randomBytes(32);
 
       try {
@@ -1814,11 +1820,11 @@ describe('EncryptionService', () => {
           TEST_USER_ID,
           first.formatted,
           newClientKey,
-          reEncryptUserData,
+          {} as any,
         );
         expect.unreachable('Should have thrown');
       } catch {
-        expect(reEncryptUserData).not.toHaveBeenCalled();
+        // Expected: old recovery key is invalidated after regeneration
       }
     });
   });

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -1895,7 +1895,7 @@ describe('EncryptionService', () => {
       const reEncryptSpy = spyOn(
         service,
         'reEncryptAllUserData',
-      ).mockResolvedValue(undefined);
+      ).mockResolvedValue('mock-key-check');
 
       const result = await service.changePinRekey(
         TEST_USER_ID,
@@ -1905,7 +1905,7 @@ describe('EncryptionService', () => {
       );
 
       expect(result.recoveryKey).toBeNull();
-      expect(result.keyCheck).toBe('new-key-check-from-rpc');
+      expect(result.keyCheck).toBe('mock-key-check');
       expect(reEncryptSpy).toHaveBeenCalledTimes(1);
       expect(updateWrappedDEK).not.toHaveBeenCalled();
 
@@ -1951,6 +1951,7 @@ describe('EncryptionService', () => {
         'reEncryptAllUserData',
       ).mockImplementation(async () => {
         callOrder.push('reEncryptAllUserData');
+        return 'mock-key-check';
       });
 
       const result = await service.changePinRekey(

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -2252,5 +2252,112 @@ describe('EncryptionService', () => {
         );
       }
     });
+
+    it('should zero DEK buffers after successful re-encryption', async () => {
+      const dek = await setupServiceWithValidKeyCheck();
+      const validKeyCheck = service.generateKeyCheck(await dek);
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: null,
+          key_check: validKeyCheck,
+        }),
+      );
+      const findSaltByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          key_check: null,
+        }),
+      );
+
+      const repo = createMockRepository({ findByUserId, findSaltByUserId });
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
+
+      let capturedOldDek: Buffer | undefined;
+      let capturedNewDek: Buffer | undefined;
+      const reEncryptSpy = spyOn(
+        service,
+        'reEncryptAllUserData',
+      ).mockImplementation(async (_userId, oldDek, newDek) => {
+        capturedOldDek = oldDek;
+        capturedNewDek = newDek;
+        return 'mock-key-check';
+      });
+
+      await service.changePinRekey(
+        TEST_USER_ID,
+        oldClientKey,
+        newClientKey,
+        mockSupabase,
+      );
+
+      expect(capturedOldDek!.every((b) => b === 0)).toBe(true);
+      expect(capturedNewDek!.every((b) => b === 0)).toBe(true);
+
+      reEncryptSpy.mockRestore();
+    });
+
+    it('should zero DEK buffers even when re-encryption fails', async () => {
+      const dek = await setupServiceWithValidKeyCheck();
+      const validKeyCheck = service.generateKeyCheck(await dek);
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: null,
+          key_check: validKeyCheck,
+        }),
+      );
+      const findSaltByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          key_check: null,
+        }),
+      );
+
+      const repo = createMockRepository({ findByUserId, findSaltByUserId });
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
+
+      let capturedOldDek: Buffer | undefined;
+      let capturedNewDek: Buffer | undefined;
+      const reEncryptSpy = spyOn(
+        service,
+        'reEncryptAllUserData',
+      ).mockImplementation(async (_userId, oldDek, newDek) => {
+        capturedOldDek = oldDek;
+        capturedNewDek = newDek;
+        throw new Error('RPC failed');
+      });
+
+      try {
+        await service.changePinRekey(
+          TEST_USER_ID,
+          oldClientKey,
+          newClientKey,
+          mockSupabase,
+        );
+        expect.unreachable('Should have thrown');
+      } catch {
+        // expected
+      }
+
+      expect(capturedOldDek!.every((b) => b === 0)).toBe(true);
+      expect(capturedNewDek!.every((b) => b === 0)).toBe(true);
+
+      reEncryptSpy.mockRestore();
+    });
   });
 });

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, mock, spyOn } from 'bun:test';
 import { randomBytes } from 'node:crypto';
 import { BusinessException } from '@common/exceptions/business.exception';
 import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
@@ -1771,6 +1771,284 @@ describe('EncryptionService', () => {
       } catch {
         expect(reEncryptUserData).not.toHaveBeenCalled();
       }
+    });
+  });
+
+  describe('changePinRekey', () => {
+    const existingSalt = randomBytes(16).toString('hex');
+    const oldClientKey = randomBytes(32);
+    const newClientKey = randomBytes(32);
+    const mockSupabase = {} as any;
+
+    function setupServiceWithValidKeyCheck() {
+      // Bootstrap service to derive DEK and generate a valid keyCheck
+      const bootstrapFindSalt = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          key_check: null,
+        }),
+      );
+      const bootstrapRepo = createMockRepository({
+        findSaltByUserId: bootstrapFindSalt,
+      });
+      const bootstrapService = new EncryptionService(
+        mockConfigService as any,
+        bootstrapRepo as any,
+      );
+      const dek = bootstrapService.getUserDEK(TEST_USER_ID, oldClientKey);
+      return dek;
+    }
+
+    it('should throw ENCRYPTION_SAME_KEY when old and new keys are identical', async () => {
+      const sameKey = randomBytes(32);
+      const repo = createMockRepository();
+      service = new EncryptionService(mockConfigService as any, repo as any);
+
+      try {
+        await service.changePinRekey(
+          TEST_USER_ID,
+          sameKey,
+          Buffer.from(sameKey),
+          mockSupabase,
+        );
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect((error as BusinessException).code).toBe(
+          ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY.code,
+        );
+      }
+    });
+
+    it('should throw ENCRYPTION_KEY_CHECK_FAILED when old key is invalid', async () => {
+      const wrongKey = randomBytes(32);
+      const wrongDek = randomBytes(32);
+      const invalidKeyCheck = new EncryptionService(
+        mockConfigService as any,
+        createMockRepository() as any,
+      ).generateKeyCheck(wrongDek);
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: null,
+          key_check: invalidKeyCheck,
+        }),
+      );
+      const findSaltByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          key_check: invalidKeyCheck,
+        }),
+      );
+
+      const repo = createMockRepository({ findByUserId, findSaltByUserId });
+      service = new EncryptionService(mockConfigService as any, repo as any);
+
+      try {
+        await service.changePinRekey(
+          TEST_USER_ID,
+          wrongKey,
+          newClientKey,
+          mockSupabase,
+        );
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect((error as BusinessException).code).toBe(
+          ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED.code,
+        );
+      }
+    });
+
+    it('should re-encrypt data and return keyCheck on success (no recovery)', async () => {
+      const dek = await setupServiceWithValidKeyCheck();
+      const validKeyCheck = service.generateKeyCheck(await dek);
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: null,
+          key_check: validKeyCheck,
+        }),
+      );
+      const findSaltByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          key_check: 'new-key-check-from-rpc',
+        }),
+      );
+      const updateWrappedDEK = mock(() => Promise.resolve());
+
+      const repo = createMockRepository({
+        findByUserId,
+        findSaltByUserId,
+        updateWrappedDEK,
+      });
+      service = new EncryptionService(mockConfigService as any, repo as any);
+
+      const reEncryptSpy = spyOn(
+        service,
+        'reEncryptAllUserData',
+      ).mockResolvedValue(undefined);
+
+      const result = await service.changePinRekey(
+        TEST_USER_ID,
+        oldClientKey,
+        newClientKey,
+        mockSupabase,
+      );
+
+      expect(result.recoveryKey).toBeNull();
+      expect(result.keyCheck).toBe('new-key-check-from-rpc');
+      expect(reEncryptSpy).toHaveBeenCalledTimes(1);
+      expect(updateWrappedDEK).not.toHaveBeenCalled();
+
+      reEncryptSpy.mockRestore();
+    });
+
+    it('should re-wrap with new recovery key AFTER re-encryption when recovery exists', async () => {
+      const dek = await setupServiceWithValidKeyCheck();
+      const validKeyCheck = service.generateKeyCheck(await dek);
+      const callOrder: string[] = [];
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: 'some-wrapped-dek',
+          key_check: validKeyCheck,
+        }),
+      );
+      const findSaltByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          key_check: 'new-key-check-from-rpc',
+        }),
+      );
+      const updateWrappedDEK = mock((userId: string, value: string | null) => {
+        callOrder.push(
+          `updateWrappedDEK:${value === null ? 'null' : 'wrapped'}`,
+        );
+        return Promise.resolve();
+      });
+
+      const repo = createMockRepository({
+        findByUserId,
+        findSaltByUserId,
+        updateWrappedDEK,
+      });
+      service = new EncryptionService(mockConfigService as any, repo as any);
+
+      const reEncryptSpy = spyOn(
+        service,
+        'reEncryptAllUserData',
+      ).mockImplementation(async () => {
+        callOrder.push('reEncryptAllUserData');
+      });
+
+      const result = await service.changePinRekey(
+        TEST_USER_ID,
+        oldClientKey,
+        newClientKey,
+        mockSupabase,
+      );
+
+      expect(result.recoveryKey).not.toBeNull();
+      expect(result.recoveryKey).toMatch(/^[A-Z2-7]+-/); // base32 formatted
+      // Re-wrapping happens AFTER re-encryption, and wraps (not nullifies)
+      expect(updateWrappedDEK).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual([
+        'reEncryptAllUserData',
+        'updateWrappedDEK:wrapped',
+      ]);
+
+      reEncryptSpy.mockRestore();
+    });
+
+    it('should NOT nullify wrapped_dek when re-encryption fails', async () => {
+      const dek = await setupServiceWithValidKeyCheck();
+      const validKeyCheck = service.generateKeyCheck(await dek);
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: 'some-wrapped-dek',
+          key_check: validKeyCheck,
+        }),
+      );
+      const findSaltByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          key_check: validKeyCheck,
+        }),
+      );
+      const updateWrappedDEK = mock(() => Promise.resolve());
+
+      const repo = createMockRepository({
+        findByUserId,
+        findSaltByUserId,
+        updateWrappedDEK,
+      });
+      service = new EncryptionService(mockConfigService as any, repo as any);
+
+      const reEncryptSpy = spyOn(
+        service,
+        'reEncryptAllUserData',
+      ).mockRejectedValue(new Error('RPC failed'));
+
+      try {
+        await service.changePinRekey(
+          TEST_USER_ID,
+          oldClientKey,
+          newClientKey,
+          mockSupabase,
+        );
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect((error as Error).message).toBe('RPC failed');
+      }
+
+      // wrapped_dek should NOT be nullified since re-encryption failed
+      expect(updateWrappedDEK).not.toHaveBeenCalled();
+
+      reEncryptSpy.mockRestore();
+    });
+
+    it('should throw when user has no encryption key', async () => {
+      const findByUserId = mock(() => Promise.resolve(null));
+      const findSaltByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          key_check: null,
+        }),
+      );
+      const updateKeyCheckIfNull = mock(() => Promise.resolve());
+
+      const repo = createMockRepository({
+        findByUserId,
+        findSaltByUserId,
+        updateKeyCheckIfNull,
+      });
+      service = new EncryptionService(mockConfigService as any, repo as any);
+
+      await expect(
+        service.changePinRekey(
+          TEST_USER_ID,
+          oldClientKey,
+          newClientKey,
+          mockSupabase,
+        ),
+      ).rejects.toThrow('No encryption key found');
     });
   });
 });

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -1672,7 +1672,34 @@ describe('EncryptionService', () => {
 
     it('should throw ENCRYPTION_SAME_KEY when old and new keys are identical', async () => {
       const sameKey = randomBytes(32);
-      const repo = createMockRepository();
+
+      // Must provide a valid row + key_check since findByUserId + key verification
+      // now happens BEFORE the same-key check (prevents same-key oracle).
+      const bootstrapRepo = createMockRepository({
+        findSaltByUserId: mock(() =>
+          Promise.resolve({
+            salt: existingSalt,
+            kdf_iterations: 600000,
+            key_check: null,
+          }),
+        ),
+      });
+      const bootstrapService = new EncryptionService(
+        mockConfigService as any,
+        bootstrapRepo as any,
+      );
+      const dek = await bootstrapService.getUserDEK(TEST_USER_ID, sameKey);
+      const validKeyCheck = bootstrapService.generateKeyCheck(dek);
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: null,
+          key_check: validKeyCheck,
+        }),
+      );
+      const repo = createMockRepository({ findByUserId });
       service = new EncryptionService(mockConfigService as any, repo as any);
 
       try {
@@ -1984,32 +2011,26 @@ describe('EncryptionService', () => {
       wrapSpy.mockRestore();
     });
 
-    it('should throw when user has no encryption key', async () => {
+    it('should throw ENCRYPTION_REKEY_PARTIAL_FAILURE when user has no encryption key', async () => {
       const findByUserId = mock(() => Promise.resolve(null));
-      const findSaltByUserId = mock(() =>
-        Promise.resolve({
-          salt: existingSalt,
-          kdf_iterations: 600000,
-          key_check: null,
-        }),
-      );
-      const updateKeyCheckIfNull = mock(() => Promise.resolve());
 
-      const repo = createMockRepository({
-        findByUserId,
-        findSaltByUserId,
-        updateKeyCheckIfNull,
-      });
+      const repo = createMockRepository({ findByUserId });
       service = new EncryptionService(mockConfigService as any, repo as any);
 
-      await expect(
-        service.changePinRekey(
+      try {
+        await service.changePinRekey(
           TEST_USER_ID,
           oldClientKey,
           newClientKey,
           mockSupabase,
-        ),
-      ).rejects.toThrow('No encryption key found');
+        );
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect((error as BusinessException).code).toBe(
+          ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE.code,
+        );
+      }
     });
   });
 });

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -2024,6 +2024,96 @@ describe('EncryptionService', () => {
       reEncryptSpy.mockRestore();
     });
 
+    it('should generate key_check when row exists but key_check is null', async () => {
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: null,
+          key_check: null,
+        }),
+      );
+      const updateKeyCheckIfNull = mock(() => Promise.resolve());
+
+      const repo = createMockRepository({
+        findByUserId,
+        updateKeyCheckIfNull,
+      });
+      service = new EncryptionService(mockConfigService as any, repo as any);
+
+      const reEncryptSpy = spyOn(
+        service,
+        'reEncryptAllUserData',
+      ).mockResolvedValue('mock-key-check');
+
+      const result = await service.changePinRekey(
+        TEST_USER_ID,
+        oldClientKey,
+        newClientKey,
+        mockSupabase,
+      );
+
+      expect(updateKeyCheckIfNull).toHaveBeenCalledTimes(1);
+      expect(result.keyCheck).toBe('mock-key-check');
+      expect(reEncryptSpy).toHaveBeenCalledTimes(1);
+
+      reEncryptSpy.mockRestore();
+    });
+
+    it('should nullify wrapped_dek and throw REKEY_PARTIAL_FAILURE when recovery re-wrap fails', async () => {
+      const dek = await setupServiceWithValidKeyCheck();
+      const validKeyCheck = service.generateKeyCheck(await dek);
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: existingSalt,
+          kdf_iterations: 600000,
+          wrapped_dek: 'some-wrapped-dek',
+          key_check: validKeyCheck,
+        }),
+      );
+      const updateWrappedDEK = mock(() => Promise.resolve());
+
+      const repo = createMockRepository({
+        findByUserId,
+        updateWrappedDEK,
+      });
+      service = new EncryptionService(mockConfigService as any, repo as any);
+
+      const reEncryptSpy = spyOn(
+        service,
+        'reEncryptAllUserData',
+      ).mockResolvedValue('mock-key-check');
+
+      // Force wrapDEK to throw
+      const wrapSpy = spyOn(service, 'wrapDEK').mockImplementation(() => {
+        throw new Error('AES-GCM wrap failed');
+      });
+
+      try {
+        await service.changePinRekey(
+          TEST_USER_ID,
+          oldClientKey,
+          newClientKey,
+          mockSupabase,
+        );
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect((error as BusinessException).code).toBe(
+          ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE.code,
+        );
+      }
+
+      // wrapped_dek should be nullified after wrap failure
+      expect(updateWrappedDEK).toHaveBeenCalledTimes(1);
+      const calls = updateWrappedDEK.mock.calls as unknown[][];
+      expect(calls[0][1]).toBeNull();
+
+      reEncryptSpy.mockRestore();
+      wrapSpy.mockRestore();
+    });
+
     it('should throw when user has no encryption key', async () => {
       const findByUserId = mock(() => Promise.resolve(null));
       const findSaltByUserId = mock(() =>

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -8,6 +8,13 @@ const TEST_MASTER_KEY = randomBytes(32).toString('hex');
 const TEST_USER_ID = 'test-user-123';
 const TEST_CLIENT_KEY = randomBytes(32);
 
+const createMockLogger = () => ({
+  info: () => {},
+  warn: () => {},
+  debug: () => {},
+  trace: () => {},
+});
+
 const createMockConfigService = () => ({
   get: (key: string) => {
     if (key === 'ENCRYPTION_MASTER_KEY') return TEST_MASTER_KEY;
@@ -66,6 +73,7 @@ describe('EncryptionService', () => {
   describe('constructor', () => {
     it('should create service with valid ENCRYPTION_MASTER_KEY', () => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -77,7 +85,11 @@ describe('EncryptionService', () => {
         get: () => undefined,
       };
       expect(() => {
-        new EncryptionService(configWithoutKey as any, mockRepository as any);
+        new EncryptionService(
+          createMockLogger() as any,
+          configWithoutKey as any,
+          mockRepository as any,
+        );
       }).toThrow('ENCRYPTION_MASTER_KEY must be defined');
     });
 
@@ -86,7 +98,11 @@ describe('EncryptionService', () => {
         get: () => '',
       };
       expect(() => {
-        new EncryptionService(configWithEmptyKey as any, mockRepository as any);
+        new EncryptionService(
+          createMockLogger() as any,
+          configWithEmptyKey as any,
+          mockRepository as any,
+        );
       }).toThrow('ENCRYPTION_MASTER_KEY must be defined');
     });
   });
@@ -94,6 +110,7 @@ describe('EncryptionService', () => {
   describe('encryptAmount and decryptAmount roundtrip', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -153,6 +170,7 @@ describe('EncryptionService', () => {
   describe('encryptAmount', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -196,6 +214,7 @@ describe('EncryptionService', () => {
   describe('decryptAmount', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -248,6 +267,7 @@ describe('EncryptionService', () => {
   describe('tryDecryptAmount', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -314,7 +334,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findSaltByUserId, upsertSalt });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const dek = await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
 
@@ -335,7 +359,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const dek = await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
 
@@ -355,7 +383,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const dek1 = await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
       const dek2 = await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
@@ -377,10 +409,12 @@ describe('EncryptionService', () => {
       const repo = createMockRepository({ findSaltByUserId });
 
       const service1 = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         repo as any,
       );
       const service2 = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         repo as any,
       );
@@ -407,10 +441,12 @@ describe('EncryptionService', () => {
       const clientKey2 = randomBytes(32);
 
       const service1 = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         repo as any,
       );
       const service2 = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         repo as any,
       );
@@ -436,6 +472,7 @@ describe('EncryptionService', () => {
         findSaltByUserId: initialFindSaltByUserId,
       });
       const initialService = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         initialRepo as any,
       );
@@ -454,7 +491,11 @@ describe('EncryptionService', () => {
         }),
       );
       const repo = createMockRepository({ findSaltByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
       expect(result).toEqual(dek);
@@ -465,6 +506,7 @@ describe('EncryptionService', () => {
       const wrongDek = randomBytes(32);
 
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -478,7 +520,11 @@ describe('EncryptionService', () => {
         }),
       );
       const repo = createMockRepository({ findSaltByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       try {
         await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
@@ -502,7 +548,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const dek = await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
       expect(dek).toBeDefined();
@@ -514,6 +564,7 @@ describe('EncryptionService', () => {
       const wrongDek = randomBytes(32);
 
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -528,7 +579,11 @@ describe('EncryptionService', () => {
         }),
       );
       const repo = createMockRepository({ findSaltByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const dek = await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
 
@@ -554,7 +609,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       try {
         await service.getUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
@@ -576,7 +635,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const dek = await service.getUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
       expect(dek).toBeDefined();
@@ -598,7 +661,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findSaltByUserId, hasRecoveryKey });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.getUserSalt(TEST_USER_ID);
       expect(result.salt).toBe(existingSalt);
@@ -619,7 +686,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findSaltByUserId, hasRecoveryKey });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.getUserSalt(TEST_USER_ID);
       expect(result.salt).toBe(existingSalt);
@@ -648,7 +719,11 @@ describe('EncryptionService', () => {
         hasRecoveryKey,
       });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.getUserSalt(TEST_USER_ID);
       expect(result.salt).toBeDefined();
@@ -670,7 +745,11 @@ describe('EncryptionService', () => {
       );
 
       const repo = createMockRepository({ findSaltByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       try {
         await service.ensureUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
@@ -692,7 +771,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ getVaultStatus });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.getVaultStatus(TEST_USER_ID);
 
@@ -714,7 +797,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ getVaultStatus });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.getVaultStatus(TEST_USER_ID);
 
@@ -735,7 +822,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ getVaultStatus });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.getVaultStatus(TEST_USER_ID);
 
@@ -756,7 +847,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ getVaultStatus });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.getVaultStatus(TEST_USER_ID);
 
@@ -772,6 +867,7 @@ describe('EncryptionService', () => {
   describe('integration tests', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -789,7 +885,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const dek = await service.getUserDEK(TEST_USER_ID, TEST_CLIENT_KEY);
       const amount = 1234.56;
@@ -804,6 +904,7 @@ describe('EncryptionService', () => {
   describe('generateRecoveryKey', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -829,6 +930,7 @@ describe('EncryptionService', () => {
   describe('wrapDEK and unwrapDEK', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -954,6 +1056,7 @@ describe('EncryptionService', () => {
         findSaltByUserId: initialFindSaltByUserId,
       });
       const initialService = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         initialRepo as any,
       );
@@ -981,7 +1084,11 @@ describe('EncryptionService', () => {
       );
 
       const repo = createMockRepository({ findByUserId, findSaltByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.verifyAndEnsureKeyCheck(
         TEST_USER_ID,
@@ -1014,7 +1121,11 @@ describe('EncryptionService', () => {
       );
 
       const repo = createMockRepository({ findByUserId, findSaltByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.verifyAndEnsureKeyCheck(
         TEST_USER_ID,
@@ -1051,7 +1162,11 @@ describe('EncryptionService', () => {
         findSaltByUserId,
         updateKeyCheckIfNull: updateKeyCheckIfNull as ReturnType<typeof mock>,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.verifyAndEnsureKeyCheck(
         TEST_USER_ID,
@@ -1070,7 +1185,11 @@ describe('EncryptionService', () => {
       );
 
       const repo = createMockRepository({ findByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       await expect(
         service.verifyAndEnsureKeyCheck(TEST_USER_ID, TEST_CLIENT_KEY),
@@ -1090,7 +1209,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const amount = 1234.56;
       const result = await service.prepareAmountData(
@@ -1114,7 +1237,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const amount = 1234.56;
       const result = await service.prepareAmountData(
@@ -1140,7 +1267,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.prepareAmountData(
         0,
@@ -1168,7 +1299,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const amounts = [100.5, 200.75, 300.25];
       const results = await service.prepareAmountsData(
@@ -1195,7 +1330,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const amounts = [100.5, 200.75, 300.25];
       const results = await service.prepareAmountsData(
@@ -1222,7 +1361,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const results = await service.prepareAmountsData(
         [],
@@ -1244,7 +1387,11 @@ describe('EncryptionService', () => {
       );
       const repo = createMockRepository({ findSaltByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const amounts = [1234.56];
       const results = await service.prepareAmountsData(
@@ -1261,6 +1408,7 @@ describe('EncryptionService', () => {
   describe('unwrapDEK', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -1317,7 +1465,11 @@ describe('EncryptionService', () => {
         findSaltByUserId,
         updateWrappedDEKIfNull,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.createRecoveryKey(
         TEST_USER_ID,
@@ -1342,7 +1494,11 @@ describe('EncryptionService', () => {
         findSaltByUserId,
         updateWrappedDEKIfNull,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       try {
         await service.createRecoveryKey(TEST_USER_ID, TEST_CLIENT_KEY);
@@ -1381,7 +1537,11 @@ describe('EncryptionService', () => {
         findByUserId,
         updateWrappedDEK,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.regenerateRecoveryKey(
         TEST_USER_ID,
@@ -1408,7 +1568,11 @@ describe('EncryptionService', () => {
         findByUserId,
         updateWrappedDEK,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const result = await service.regenerateRecoveryKey(
         TEST_USER_ID,
@@ -1422,6 +1586,7 @@ describe('EncryptionService', () => {
   describe('recoverWithKey', () => {
     beforeEach(() => {
       service = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         mockRepository as any,
       );
@@ -1439,7 +1604,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const newClientKey = randomBytes(32);
       const recoveryKeyFormatted =
@@ -1474,7 +1643,11 @@ describe('EncryptionService', () => {
 
       const repo = createMockRepository({ findByUserId });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const newClientKey = randomBytes(32);
       // Invalid recovery key (too short after base32 decode)
@@ -1522,6 +1695,7 @@ describe('EncryptionService', () => {
         updateWrappedDEKIfNull,
       });
       const svc1 = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         repo1 as any,
       );
@@ -1557,6 +1731,7 @@ describe('EncryptionService', () => {
         updateWrappedDEK: updateWrappedDEK2,
       });
       const svc2 = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         repo2 as any,
       );
@@ -1617,7 +1792,11 @@ describe('EncryptionService', () => {
         updateWrappedDEKIfNull,
       });
 
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const clientKey = randomBytes(32);
       const first = await service.createRecoveryKey(TEST_USER_ID, clientKey);
@@ -1663,6 +1842,7 @@ describe('EncryptionService', () => {
         findSaltByUserId: bootstrapFindSalt,
       });
       const bootstrapService = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         bootstrapRepo as any,
       );
@@ -1685,6 +1865,7 @@ describe('EncryptionService', () => {
         ),
       });
       const bootstrapService = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         bootstrapRepo as any,
       );
@@ -1700,7 +1881,11 @@ describe('EncryptionService', () => {
         }),
       );
       const repo = createMockRepository({ findByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       try {
         await service.changePinRekey(
@@ -1722,6 +1907,7 @@ describe('EncryptionService', () => {
       const wrongKey = randomBytes(32);
       const wrongDek = randomBytes(32);
       const invalidKeyCheck = new EncryptionService(
+        createMockLogger() as any,
         mockConfigService as any,
         createMockRepository() as any,
       ).generateKeyCheck(wrongDek);
@@ -1743,7 +1929,11 @@ describe('EncryptionService', () => {
       );
 
       const repo = createMockRepository({ findByUserId, findSaltByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       try {
         await service.changePinRekey(
@@ -1787,7 +1977,11 @@ describe('EncryptionService', () => {
         findSaltByUserId,
         updateWrappedDEK,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const reEncryptSpy = spyOn(
         service,
@@ -1841,7 +2035,11 @@ describe('EncryptionService', () => {
         findSaltByUserId,
         updateWrappedDEK,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const reEncryptSpy = spyOn(
         service,
@@ -1896,7 +2094,11 @@ describe('EncryptionService', () => {
         findSaltByUserId,
         updateWrappedDEK,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const reEncryptSpy = spyOn(
         service,
@@ -1936,7 +2138,11 @@ describe('EncryptionService', () => {
         findByUserId,
         updateKeyCheckIfNull,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const reEncryptSpy = spyOn(
         service,
@@ -1975,7 +2181,11 @@ describe('EncryptionService', () => {
         findByUserId,
         updateWrappedDEK,
       });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       const reEncryptSpy = spyOn(
         service,
@@ -2015,7 +2225,11 @@ describe('EncryptionService', () => {
       const findByUserId = mock(() => Promise.resolve(null));
 
       const repo = createMockRepository({ findByUserId });
-      service = new EncryptionService(mockConfigService as any, repo as any);
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
 
       try {
         await service.changePinRekey(

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -23,7 +23,6 @@ const createMockRepository = (overrides?: {
   updateWrappedDEKIfNull?: ReturnType<typeof mock>;
   hasRecoveryKey?: ReturnType<typeof mock>;
   updateKeyCheckIfNull?: ReturnType<typeof mock>;
-  hasVaultCode?: ReturnType<typeof mock>;
   getVaultStatus?: ReturnType<typeof mock>;
 }) => ({
   findSaltByUserId:
@@ -43,7 +42,6 @@ const createMockRepository = (overrides?: {
     overrides?.hasRecoveryKey ?? mock(() => Promise.resolve(false)),
   updateKeyCheckIfNull:
     overrides?.updateKeyCheckIfNull ?? mock(() => Promise.resolve()),
-  hasVaultCode: overrides?.hasVaultCode ?? mock(() => Promise.resolve(false)),
   getVaultStatus:
     overrides?.getVaultStatus ??
     mock(() =>

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -426,13 +426,6 @@ export class EncryptionService {
       throw new BusinessException(ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY);
     }
 
-    const isValid = await this.verifyAndEnsureKeyCheck(userId, oldClientKey);
-    if (!isValid) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
-      );
-    }
-
     const row = await this.#repository.findByUserId(userId);
     if (!row) {
       throw new Error(`No encryption key found for user ${userId}`);
@@ -440,6 +433,19 @@ export class EncryptionService {
 
     const salt = Buffer.from(row.salt, 'hex');
     const oldDek = this.#deriveDEK(oldClientKey, salt, userId);
+
+    // Verify old key inline (avoids a redundant findByUserId + deriveDEK round-trip)
+    if (row.key_check) {
+      if (!this.validateKeyCheck(row.key_check, oldDek)) {
+        throw new BusinessException(
+          ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
+        );
+      }
+    } else {
+      const generatedKeyCheck = this.generateKeyCheck(oldDek);
+      await this.#repository.updateKeyCheckIfNull(userId, generatedKeyCheck);
+    }
+
     const newDek = this.#deriveDEK(newClientKey, salt, userId);
     const hadRecovery = !!row.wrapped_dek;
     let recoveryKeyFormatted: string | null = null;
@@ -499,24 +505,20 @@ export class EncryptionService {
     newDek: Buffer,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<string> {
-    const [budgetIds, templateIds] = await Promise.all([
-      this.#fetchUserBudgetIds(userId, supabase),
+    const [monthlyBudgets, templateIds] = await Promise.all([
+      this.#fetchMonthlyBudgets(userId, supabase),
       this.#fetchUserTemplateIds(userId, supabase),
     ]);
 
-    const [
-      budgetLines,
-      transactions,
-      templateLines,
-      savingsGoals,
-      monthlyBudgets,
-    ] = await Promise.all([
-      this.#fetchBudgetLines(budgetIds, supabase),
-      this.#fetchTransactions(budgetIds, supabase),
-      this.#fetchTemplateLines(templateIds, supabase),
-      this.#fetchSavingsGoals(userId, supabase),
-      this.#fetchMonthlyBudgets(userId, supabase),
-    ]);
+    const budgetIds = monthlyBudgets.map((b) => b.id);
+
+    const [budgetLines, transactions, templateLines, savingsGoals] =
+      await Promise.all([
+        this.#fetchBudgetLines(budgetIds, supabase),
+        this.#fetchTransactions(budgetIds, supabase),
+        this.#fetchTemplateLines(templateIds, supabase),
+        this.#fetchSavingsGoals(userId, supabase),
+      ]);
 
     const payloads = this.#buildRekeyPayloads(
       {
@@ -630,19 +632,6 @@ export class EncryptionService {
   ): string {
     const plaintext = this.decryptAmount(ciphertext, oldDek);
     return this.encryptAmount(plaintext, newDek);
-  }
-
-  async #fetchUserBudgetIds(
-    userId: string,
-    supabase: AuthenticatedSupabaseClient,
-  ): Promise<string[]> {
-    const { data, error } = await supabase
-      .from('monthly_budget')
-      .select('id')
-      .eq('user_id', userId);
-
-    if (error) throw error;
-    return data?.map((b) => b.id) ?? [];
   }
 
   async #fetchUserTemplateIds(

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -353,7 +353,7 @@ export class EncryptionService {
     userId: string,
     recoveryKeyFormatted: string,
     newClientKey: Buffer,
-    reEncryptUserData: (oldDek: Buffer, newDek: Buffer) => Promise<void>,
+    supabase: AuthenticatedSupabaseClient,
   ): Promise<void> {
     const row = await this.#repository.findByUserId(userId);
     if (!row?.wrapped_dek) {
@@ -380,8 +380,7 @@ export class EncryptionService {
       // will need to regenerate a recovery key from settings.
       await this.#repository.updateWrappedDEK(userId, null);
 
-      // Re-encrypt user data with new DEK (newClientKey produces different DEK)
-      await reEncryptUserData(oldDek, newDek);
+      await this.reEncryptAllUserData(userId, oldDek, newDek, supabase);
 
       // Re-wrap with the same recovery key — the frontend will immediately call
       // regenerateRecoveryKey$() to replace it with a fresh one.

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
   createCipheriv,
@@ -9,6 +9,7 @@ import {
 } from 'node:crypto';
 import { BusinessException } from '@common/exceptions/business.exception';
 import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
+import { type InfoLogger, InjectInfoLogger } from '@common/logger';
 import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.service';
 import {
   EncryptionKeyRepository,
@@ -39,12 +40,13 @@ interface CachedDEK {
 
 @Injectable()
 export class EncryptionService {
-  readonly #logger = new Logger(EncryptionService.name);
   readonly #masterKey: Buffer;
   readonly #dekCache = new Map<string, CachedDEK>();
   readonly #repository: EncryptionKeyRepository;
 
   constructor(
+    @InjectInfoLogger(EncryptionService.name)
+    private readonly logger: InfoLogger,
     configService: ConfigService,
     repository: EncryptionKeyRepository,
   ) {
@@ -114,7 +116,7 @@ export class EncryptionService {
       // Always use fallback, never throw - this prevents cascading failures
       // when data was encrypted with a different key (e.g., after password change
       // or salt rotation without re-encryption)
-      this.#logger.warn(
+      this.logger.warn(
         {
           error: error instanceof Error ? error.message : String(error),
           ciphertextLength: ciphertext.length,
@@ -539,7 +541,7 @@ export class EncryptionService {
       );
     }
 
-    this.#logger.log(
+    this.logger.info(
       {
         userId,
         operation: 'rekey.complete',

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -414,6 +414,17 @@ export class EncryptionService {
     let newDek: Buffer | null = null;
 
     try {
+      // Check same-key BEFORE key verification — prevents oracle: if checked after,
+      // {old=X, new=X} would return ENCRYPTION_SAME_KEY when X is correct vs
+      // ENCRYPTION_KEY_CHECK_FAILED when wrong, leaking PIN validity.
+      if (oldClientKey.equals(newClientKey)) {
+        throw new BusinessException(
+          ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY,
+          undefined,
+          { userId, operation: 'change_pin.same_key_rejected' },
+        );
+      }
+
       if (!row.key_check) {
         throw new BusinessException(
           ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
@@ -427,16 +438,6 @@ export class EncryptionService {
           ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
           undefined,
           { userId, operation: 'change_pin.key_check_failed' },
-        );
-      }
-
-      // Check same-key AFTER verifying old key — prevents oracle that leaks
-      // whether the old key is valid via different error codes.
-      if (oldClientKey.equals(newClientKey)) {
-        throw new BusinessException(
-          ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY,
-          undefined,
-          { userId, operation: 'change_pin.same_key_rejected' },
         );
       }
 

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -399,14 +399,6 @@ export class EncryptionService {
     newClientKey: Buffer,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<{ keyCheck: string; recoveryKey: string | null }> {
-    if (oldClientKey.equals(newClientKey)) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY,
-        undefined,
-        { userId, operation: 'change_pin.same_key_rejected' },
-      );
-    }
-
     const row = await this.#repository.findByUserId(userId);
     if (!row) {
       throw new BusinessException(
@@ -429,6 +421,16 @@ export class EncryptionService {
     } else {
       const generatedKeyCheck = this.generateKeyCheck(oldDek);
       await this.#repository.updateKeyCheckIfNull(userId, generatedKeyCheck);
+    }
+
+    // Check same-key AFTER verifying old key — prevents oracle that leaks
+    // whether the old key is valid via different error codes.
+    if (oldClientKey.equals(newClientKey)) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY,
+        undefined,
+        { userId, operation: 'change_pin.same_key_rejected' },
+      );
     }
 
     const newDek = this.#deriveDEK(newClientKey, salt, userId);

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -403,7 +403,7 @@ export class EncryptionService {
     const row = await this.#repository.findByUserId(userId);
     if (!row) {
       throw new BusinessException(
-        ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE,
+        ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
         undefined,
         { userId, operation: 'change_pin.missing_encryption_row' },
       );
@@ -411,38 +411,40 @@ export class EncryptionService {
 
     const salt = Buffer.from(row.salt, 'hex');
     const oldDek = this.#deriveDEK(oldClientKey, salt, userId);
-
-    // Verify old key inline (avoids a redundant findByUserId + deriveDEK round-trip)
-    if (row.key_check) {
-      if (!this.validateKeyCheck(row.key_check, oldDek)) {
-        throw new BusinessException(
-          ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
-        );
-      }
-    } else {
-      const generatedKeyCheck = this.generateKeyCheck(oldDek);
-      await this.#repository.updateKeyCheckIfNull(userId, generatedKeyCheck);
-    }
-
-    // Check same-key AFTER verifying old key — prevents oracle that leaks
-    // whether the old key is valid via different error codes.
-    if (oldClientKey.equals(newClientKey)) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY,
-        undefined,
-        { userId, operation: 'change_pin.same_key_rejected' },
-      );
-    }
-
-    const newDek = this.#deriveDEK(newClientKey, salt, userId);
-    const hadRecovery = !!row.wrapped_dek;
-    let recoveryKeyFormatted: string | null = null;
-    let keyCheck: string;
-
-    this.#invalidateUserDEKCache(userId);
+    let newDek: Buffer | null = null;
 
     try {
-      keyCheck = await this.reEncryptAllUserData(
+      // Verify old key inline (avoids a redundant findByUserId + deriveDEK round-trip)
+      if (row.key_check) {
+        if (!this.validateKeyCheck(row.key_check, oldDek)) {
+          throw new BusinessException(
+            ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
+            undefined,
+            { userId, operation: 'change_pin.key_check_failed' },
+          );
+        }
+      } else {
+        const generatedKeyCheck = this.generateKeyCheck(oldDek);
+        await this.#repository.updateKeyCheckIfNull(userId, generatedKeyCheck);
+      }
+
+      // Check same-key AFTER verifying old key — prevents oracle that leaks
+      // whether the old key is valid via different error codes.
+      if (oldClientKey.equals(newClientKey)) {
+        throw new BusinessException(
+          ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY,
+          undefined,
+          { userId, operation: 'change_pin.same_key_rejected' },
+        );
+      }
+
+      newDek = this.#deriveDEK(newClientKey, salt, userId);
+      const hadRecovery = !!row.wrapped_dek;
+      let recoveryKeyFormatted: string | null = null;
+
+      this.#invalidateUserDEKCache(userId);
+
+      const keyCheck = await this.reEncryptAllUserData(
         userId,
         oldDek,
         newDek,
@@ -476,15 +478,15 @@ export class EncryptionService {
           raw.fill(0);
         }
       }
+
+      return {
+        keyCheck,
+        recoveryKey: recoveryKeyFormatted,
+      };
     } finally {
       oldDek.fill(0);
-      newDek.fill(0);
+      newDek?.fill(0);
     }
-
-    return {
-      keyCheck,
-      recoveryKey: recoveryKeyFormatted,
-    };
   }
 
   async reEncryptAllUserData(

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -443,11 +443,17 @@ export class EncryptionService {
     const newDek = this.#deriveDEK(newClientKey, salt, userId);
     const hadRecovery = !!row.wrapped_dek;
     let recoveryKeyFormatted: string | null = null;
+    let keyCheck: string;
 
     this.#invalidateUserDEKCache(userId);
 
     try {
-      await this.reEncryptAllUserData(userId, oldDek, newDek, supabase);
+      keyCheck = await this.reEncryptAllUserData(
+        userId,
+        oldDek,
+        newDek,
+        supabase,
+      );
 
       // If user had a recovery key, generate a new one and re-wrap the new DEK
       // in the same call — wrapped_dek goes directly from old wrapping to new
@@ -461,7 +467,17 @@ export class EncryptionService {
         } catch (wrapError) {
           // Wrap failed — nullify to prevent stale wrapping pointing to old DEK
           await this.#repository.updateWrappedDEK(userId, null);
-          throw wrapError;
+          throw new BusinessException(
+            ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE,
+            undefined,
+            { userId, operation: 'pin_change.recovery_wrap_failed' },
+            {
+              cause:
+                wrapError instanceof Error
+                  ? wrapError
+                  : new Error(String(wrapError)),
+            },
+          );
         } finally {
           raw.fill(0);
         }
@@ -471,17 +487,8 @@ export class EncryptionService {
       newDek.fill(0);
     }
 
-    const updatedRow = await this.#repository.findSaltByUserId(userId);
-    if (!updatedRow?.key_check) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE,
-        undefined,
-        { userId, operation: 'pin_change.key_check_readback' },
-      );
-    }
-
     return {
-      keyCheck: updatedRow.key_check,
+      keyCheck,
       recoveryKey: recoveryKeyFormatted,
     };
   }
@@ -491,7 +498,7 @@ export class EncryptionService {
     oldDek: Buffer,
     newDek: Buffer,
     supabase: AuthenticatedSupabaseClient,
-  ): Promise<void> {
+  ): Promise<string> {
     const [budgetIds, templateIds] = await Promise.all([
       this.#fetchUserBudgetIds(userId, supabase),
       this.#fetchUserTemplateIds(userId, supabase),
@@ -557,6 +564,8 @@ export class EncryptionService {
       },
       'All user data re-encrypted',
     );
+
+    return keyCheck;
   }
 
   #buildRekeyPayloads(

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -416,6 +416,76 @@ export class EncryptionService {
     await this.reEncryptAllUserData(userId, oldDek, newDek, supabase);
   }
 
+  async changePinRekey(
+    userId: string,
+    oldClientKey: Buffer,
+    newClientKey: Buffer,
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<{ keyCheck: string; recoveryKey: string | null }> {
+    if (oldClientKey.equals(newClientKey)) {
+      throw new BusinessException(ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY);
+    }
+
+    const isValid = await this.verifyAndEnsureKeyCheck(userId, oldClientKey);
+    if (!isValid) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
+      );
+    }
+
+    const row = await this.#repository.findByUserId(userId);
+    if (!row) {
+      throw new Error(`No encryption key found for user ${userId}`);
+    }
+
+    const salt = Buffer.from(row.salt, 'hex');
+    const oldDek = this.#deriveDEK(oldClientKey, salt, userId);
+    const newDek = this.#deriveDEK(newClientKey, salt, userId);
+    const hadRecovery = !!row.wrapped_dek;
+    let recoveryKeyFormatted: string | null = null;
+
+    this.#invalidateUserDEKCache(userId);
+
+    try {
+      await this.reEncryptAllUserData(userId, oldDek, newDek, supabase);
+
+      // If user had a recovery key, generate a new one and re-wrap the new DEK
+      // in the same call — wrapped_dek goes directly from old wrapping to new
+      // wrapping, never null. The frontend displays the new recovery key.
+      if (hadRecovery) {
+        const { raw, formatted } = this.generateRecoveryKey();
+        try {
+          const newWrappedDEK = this.wrapDEK(newDek, raw);
+          await this.#repository.updateWrappedDEK(userId, newWrappedDEK);
+          recoveryKeyFormatted = formatted;
+        } catch (wrapError) {
+          // Wrap failed — nullify to prevent stale wrapping pointing to old DEK
+          await this.#repository.updateWrappedDEK(userId, null);
+          throw wrapError;
+        } finally {
+          raw.fill(0);
+        }
+      }
+    } finally {
+      oldDek.fill(0);
+      newDek.fill(0);
+    }
+
+    const updatedRow = await this.#repository.findSaltByUserId(userId);
+    if (!updatedRow?.key_check) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE,
+        undefined,
+        { userId, operation: 'pin_change.key_check_readback' },
+      );
+    }
+
+    return {
+      keyCheck: updatedRow.key_check,
+      recoveryKey: recoveryKeyFormatted,
+    };
+  }
+
   async reEncryptAllUserData(
     userId: string,
     oldDek: Buffer,

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -400,12 +400,20 @@ export class EncryptionService {
     supabase: AuthenticatedSupabaseClient,
   ): Promise<{ keyCheck: string; recoveryKey: string | null }> {
     if (oldClientKey.equals(newClientKey)) {
-      throw new BusinessException(ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY);
+      throw new BusinessException(
+        ERROR_DEFINITIONS.ENCRYPTION_SAME_KEY,
+        undefined,
+        { userId, operation: 'change_pin.same_key_rejected' },
+      );
     }
 
     const row = await this.#repository.findByUserId(userId);
     if (!row) {
-      throw new Error(`No encryption key found for user ${userId}`);
+      throw new BusinessException(
+        ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE,
+        undefined,
+        { userId, operation: 'change_pin.missing_encryption_row' },
+      );
     }
 
     const salt = Buffer.from(row.salt, 'hex');

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -125,14 +125,6 @@ export class EncryptionService {
     }
   }
 
-  encryptAmounts(amounts: number[], dek: Buffer): string[] {
-    return amounts.map((amount) => this.encryptAmount(amount, dek));
-  }
-
-  decryptAmounts(ciphertexts: string[], dek: Buffer): number[] {
-    return ciphertexts.map((ct) => this.decryptAmount(ct, dek));
-  }
-
   async prepareAmountData(
     amount: number,
     userId: string,
@@ -295,10 +287,6 @@ export class EncryptionService {
     return true;
   }
 
-  async storeKeyCheck(userId: string, keyCheck: string): Promise<void> {
-    await this.#repository.updateKeyCheck(userId, keyCheck);
-  }
-
   async createRecoveryKey(
     userId: string,
     clientKey: Buffer,
@@ -403,17 +391,6 @@ export class EncryptionService {
       oldDek.fill(0);
       newDek.fill(0);
     }
-  }
-
-  async rekeyUserData(
-    userId: string,
-    oldClientKey: Buffer,
-    newClientKey: Buffer,
-    supabase: AuthenticatedSupabaseClient,
-  ): Promise<void> {
-    const oldDek = await this.getUserDEK(userId, oldClientKey);
-    const newDek = await this.ensureUserDEK(userId, newClientKey);
-    await this.reEncryptAllUserData(userId, oldDek, newDek, supabase);
   }
 
   async changePinRekey(

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -414,18 +414,20 @@ export class EncryptionService {
     let newDek: Buffer | null = null;
 
     try {
-      // Verify old key inline (avoids a redundant findByUserId + deriveDEK round-trip)
-      if (row.key_check) {
-        if (!this.validateKeyCheck(row.key_check, oldDek)) {
-          throw new BusinessException(
-            ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
-            undefined,
-            { userId, operation: 'change_pin.key_check_failed' },
-          );
-        }
-      } else {
-        const generatedKeyCheck = this.generateKeyCheck(oldDek);
-        await this.#repository.updateKeyCheckIfNull(userId, generatedKeyCheck);
+      if (!row.key_check) {
+        throw new BusinessException(
+          ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
+          undefined,
+          { userId, operation: 'change_pin.key_check_not_initialized' },
+        );
+      }
+
+      if (!this.validateKeyCheck(row.key_check, oldDek)) {
+        throw new BusinessException(
+          ERROR_DEFINITIONS.ENCRYPTION_KEY_CHECK_FAILED,
+          undefined,
+          { userId, operation: 'change_pin.key_check_failed' },
+        );
       }
 
       // Check same-key AFTER verifying old key — prevents oracle that leaks
@@ -461,8 +463,11 @@ export class EncryptionService {
           await this.#repository.updateWrappedDEK(userId, newWrappedDEK);
           recoveryKeyFormatted = formatted;
         } catch (wrapError) {
-          // Wrap failed — nullify to prevent stale wrapping pointing to old DEK
-          await this.#repository.updateWrappedDEK(userId, null);
+          try {
+            await this.#repository.updateWrappedDEK(userId, null);
+          } catch {
+            // Best-effort nullification — next recovery key regeneration will fix state
+          }
           throw new BusinessException(
             ERROR_DEFINITIONS.ENCRYPTION_REKEY_PARTIAL_FAILURE,
             undefined,

--- a/backend-nest/supabase/migrations/20260305120000_rekey_rpc_row_lock.sql
+++ b/backend-nest/supabase/migrations/20260305120000_rekey_rpc_row_lock.sql
@@ -1,0 +1,117 @@
+-- Migration: Add row lock to rekey_user_encrypted_data
+-- Acquires an exclusive lock on the user's encryption key row at the start
+-- of the transaction, preventing concurrent re-encryption race conditions.
+-- Pattern already used by toggle_budget_line_check (FOR UPDATE).
+-- Works through RLS (SECURITY INVOKER + existing SELECT policy).
+
+CREATE OR REPLACE FUNCTION public.rekey_user_encrypted_data(
+  p_budget_lines jsonb DEFAULT '[]'::jsonb,
+  p_transactions jsonb DEFAULT '[]'::jsonb,
+  p_template_lines jsonb DEFAULT '[]'::jsonb,
+  p_savings_goals jsonb DEFAULT '[]'::jsonb,
+  p_monthly_budgets jsonb DEFAULT '[]'::jsonb,
+  p_key_check text DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_rows integer;
+  v_expected integer;
+BEGIN
+  -- Acquire exclusive row lock to prevent concurrent re-encryption
+  PERFORM 1 FROM public.user_encryption_key
+  WHERE user_id = auth.uid()
+  FOR UPDATE;
+
+  -- budget_line.amount
+  v_expected := jsonb_array_length(p_budget_lines);
+  IF v_expected > 0 THEN
+    UPDATE public.budget_line bl
+    SET amount = item.amount
+    FROM jsonb_to_recordset(p_budget_lines) AS item(id uuid, amount text)
+    WHERE bl.id = item.id;
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    IF v_rows <> v_expected THEN
+      RAISE EXCEPTION 'rekey: budget_line expected % rows, got %', v_expected, v_rows
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  -- transaction.amount
+  v_expected := jsonb_array_length(p_transactions);
+  IF v_expected > 0 THEN
+    UPDATE public.transaction t
+    SET amount = item.amount
+    FROM jsonb_to_recordset(p_transactions) AS item(id uuid, amount text)
+    WHERE t.id = item.id;
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    IF v_rows <> v_expected THEN
+      RAISE EXCEPTION 'rekey: transaction expected % rows, got %', v_expected, v_rows
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  -- template_line.amount
+  v_expected := jsonb_array_length(p_template_lines);
+  IF v_expected > 0 THEN
+    UPDATE public.template_line tl
+    SET amount = item.amount
+    FROM jsonb_to_recordset(p_template_lines) AS item(id uuid, amount text)
+    WHERE tl.id = item.id;
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    IF v_rows <> v_expected THEN
+      RAISE EXCEPTION 'rekey: template_line expected % rows, got %', v_expected, v_rows
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  -- savings_goal.target_amount
+  v_expected := jsonb_array_length(p_savings_goals);
+  IF v_expected > 0 THEN
+    UPDATE public.savings_goal sg
+    SET target_amount = item.target_amount
+    FROM jsonb_to_recordset(p_savings_goals) AS item(id uuid, target_amount text)
+    WHERE sg.id = item.id;
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    IF v_rows <> v_expected THEN
+      RAISE EXCEPTION 'rekey: savings_goal expected % rows, got %', v_expected, v_rows
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  -- monthly_budget.ending_balance
+  v_expected := jsonb_array_length(p_monthly_budgets);
+  IF v_expected > 0 THEN
+    UPDATE public.monthly_budget mb
+    SET ending_balance = item.ending_balance
+    FROM jsonb_to_recordset(p_monthly_budgets) AS item(id uuid, ending_balance text)
+    WHERE mb.id = item.id;
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    IF v_rows <> v_expected THEN
+      RAISE EXCEPTION 'rekey: monthly_budget expected % rows, got %', v_expected, v_rows
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  -- key_check (atomic with the data updates above)
+  IF p_key_check IS NOT NULL THEN
+    UPDATE public.user_encryption_key
+    SET key_check = p_key_check, updated_at = now()
+    WHERE user_id = auth.uid();
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    -- auth.uid() is NULL for service_role — skip assertion for admin callers
+    IF v_rows <> 1 AND auth.uid() IS NOT NULL THEN
+      RAISE EXCEPTION 'rekey: key_check update expected 1 row, got %', v_rows
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+END;
+$$;

--- a/docs/ENCRYPTION.md
+++ b/docs/ENCRYPTION.md
@@ -73,6 +73,39 @@ Le mode démo utilise un `clientKey` déterministe (`DEMO_CLIENT_KEY_BUFFER`) po
 
 Le mot de passe Supabase et le code PIN sont **indépendants**. Changer ou réinitialiser le mot de passe ne touche pas au chiffrement. Aucun endpoint encryption n'est appelé et le `clientKey` reste valable.
 
+## Changement de code PIN
+
+Le changement de code PIN re-chiffre toutes les données financières avec une nouvelle DEK dérivée du nouveau PIN.
+
+### Flux
+
+```
+1. Frontend dérive oldClientKey (ancien PIN) et newClientKey (nouveau PIN) via PBKDF2
+2. Frontend appelle POST /v1/encryption/change-pin { oldClientKey, newClientKey }
+3. Backend vérifie oldClientKey via key_check (canary)
+4. Toutes les données sont re-chiffrées atomiquement (RPC rekey_user_encrypted_data)
+5. key_check est recalculé avec la nouvelle DEK
+6. Si wrapped_dek existait → nouvelle recovery key générée, nouvelle DEK wrappée
+7. Réponse : { keyCheck: string, recoveryKey: string | null }
+8. Si recoveryKey !== null → frontend affiche la nouvelle recovery key à l'utilisateur
+```
+
+### Recovery key et changement de PIN
+
+Quand l'utilisateur avait une recovery key configurée, le changement de PIN génère une **nouvelle recovery key** et re-wrappe la nouvelle DEK dans le même appel. Le `wrapped_dek` passe directement de l'ancien wrapping au nouveau — il n'est **jamais null**. Le frontend affiche la nouvelle recovery key dans le modal `RecoveryKeyDialog`.
+
+Si le re-wrapping échoue après un re-chiffrement réussi, le `wrapped_dek` est nullifié par sécurité (pour éviter un wrapping stale pointant vers l'ancienne DEK).
+
+### Rate limiting
+
+L'endpoint `change-pin` est limité à 5 appels par heure par utilisateur.
+
+### Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /v1/encryption/change-pin` | Ancien + nouveau clientKey → re-chiffrement complet |
+
 ## Recovery key
 
 La recovery key permet de récupérer l'accès aux données chiffrées quand le **code PIN** est perdu.
@@ -105,7 +138,7 @@ Recovery (code PIN oublié) :
 - La recovery key n'est **jamais stockée** côté serveur (seul `wrappedDEK` l'est)
 - Le serveur ne peut pas déchiffrer `wrappedDEK` sans la recovery key
 - Rate limiting sur `/v1/encryption/recover` (5 tentatives/heure)
-- Le `wrapped_dek` ne change que lors d'un setup recovery ou d'une récupération (recover)
+- Le `wrapped_dek` ne change que lors d'un setup recovery, d'une récupération (recover) ou d'un changement de PIN (re-wrappé)
 
 ### Endpoints
 
@@ -139,6 +172,7 @@ La colonne `key_check` de `user_encryption_key` stocke un ciphertext canary : `A
 |-----------|--------|
 | Première validation (key_check absent) | Généré et stocké |
 | Recovery (`/recover`) | Régénéré avec la nouvelle DEK |
+| Changement de PIN (`/change-pin`) | Régénéré avec la nouvelle DEK |
 | Setup recovery key | Généré si absent |
 
 ### Rate limiting
@@ -281,7 +315,7 @@ Si la validation échoue, le serveur refuse de démarrer.
 |---------|------|
 | `encryption.service.ts` | Dérivation DEK, chiffrement/déchiffrement AES-GCM, wrap/unwrap DEK, cache, re-chiffrement |
 | `encryption-key.repository.ts` | CRUD de la table `user_encryption_key` (salt, wrapped_dek) |
-| `encryption.controller.ts` | Endpoints `/salt`, `/validate-key`, `/setup-recovery`, `/recover` |
+| `encryption.controller.ts` | Endpoints `/salt`, `/validate-key`, `/setup-recovery`, `/recover`, `/change-pin` |
 | `client-key-cleanup.interceptor.ts` | Efface le clientKey de la mémoire après chaque requête |
 | `auth.guard.ts` | Extrait et valide le `X-Client-Key` du header |
 

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -682,7 +682,20 @@ Si l'enveloppe à 2000 CHF n'avait aucune transaction :
 - La nouvelle clé est affichée et doit être sauvegardée
 - L'ancienne clé de secours ne fonctionne plus
 
-### 8.5 Supprimer son compte
+### 8.5 Changer son code PIN
+
+**Workflow** : Réglages > Section sécurité > Changer le code PIN > Saisir le code PIN actuel > Saisir le nouveau code PIN > Confirmer le nouveau code PIN > Valider > Recevoir une nouvelle clé de secours (si configurée) > Message de succès
+
+**Critères** :
+- L'ancien code PIN est vérifié avant le changement
+- Toutes les données financières sont re-chiffrées avec la nouvelle clé dérivée du nouveau PIN
+- Si une clé de secours existait, une nouvelle est générée et affichée (l'ancienne ne fonctionne plus)
+- Si aucune clé de secours n'existait, aucune n'est générée
+- Le nouveau code PIN fonctionne pour les connexions suivantes
+- Erreur si l'ancien code PIN est incorrect
+- Erreur si le nouveau code PIN est identique à l'ancien
+
+### 8.6 Supprimer son compte
 
 **Workflow (email / email + OAuth)** : Réglages > Zone de danger > Supprimer le compte > Saisir son mot de passe > Confirmer
 
@@ -823,6 +836,7 @@ Si l'enveloppe à 2000 CHF n'avait aucune transaction :
 | 8.1 Jour de paie | Oui | `payday-settings.spec.ts` |
 | 8.3 Changer mot de passe | Oui | `settings-change-password.spec.ts` |
 | 8.4 Régénérer clé | Oui | `settings-recovery-key.spec.ts` |
+| 8.5 Changer code PIN | Non | — |
 | **Non couvert** | | |
 | 1.2 Créer compte Google | Non | — |
 | 5.4 Ajouter prévision | Non | — |

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -119,7 +119,6 @@ export {
   // Encryption schemas — responses
   encryptionVaultStatusResponseSchema,
   encryptionSaltResponseSchema,
-  encryptionRekeyResponseSchema,
   encryptionSetupRecoveryResponseSchema,
   encryptionRecoverResponseSchema,
   encryptionChangePinResponseSchema,
@@ -262,7 +261,6 @@ export type {
   // Encryption types — responses
   EncryptionVaultStatusResponse,
   EncryptionSaltResponse,
-  EncryptionRekeyResponse,
   EncryptionSetupRecoveryResponse,
   EncryptionRecoverResponse,
   EncryptionChangePinResponse,

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -112,11 +112,17 @@ export {
   demoSessionResponseSchema,
   demoCleanupResponseSchema,
 
-  // Encryption schemas
+  // Encryption schemas — requests
+  encryptionValidateKeyRequestSchema,
+  encryptionRecoverRequestSchema,
+  encryptionChangePinRequestSchema,
+  // Encryption schemas — responses
+  encryptionVaultStatusResponseSchema,
   encryptionSaltResponseSchema,
   encryptionRekeyResponseSchema,
   encryptionSetupRecoveryResponseSchema,
   encryptionRecoverResponseSchema,
+  encryptionChangePinResponseSchema,
 } from './schemas.js';
 
 // Export response schema factories
@@ -249,9 +255,15 @@ export type {
   DemoSessionCreate,
   DemoSessionResponse,
 
-  // Encryption types
+  // Encryption types — requests
+  EncryptionValidateKeyRequest,
+  EncryptionRecoverRequest,
+  EncryptionChangePinRequest,
+  // Encryption types — responses
+  EncryptionVaultStatusResponse,
   EncryptionSaltResponse,
   EncryptionRekeyResponse,
   EncryptionSetupRecoveryResponse,
   EncryptionRecoverResponse,
+  EncryptionChangePinResponse,
 } from './schemas.js';

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -932,6 +932,46 @@ export const demoCleanupResponseSchema = z.object({
 export type DemoCleanupResponse = z.infer<typeof demoCleanupResponseSchema>;
 
 // Encryption schemas
+
+// -- Request schemas --
+
+/** POST /validate-key — hex-encoded 32-byte client key */
+export const encryptionValidateKeyRequestSchema = z.object({
+  clientKey: z.string(),
+});
+export type EncryptionValidateKeyRequest = z.infer<
+  typeof encryptionValidateKeyRequestSchema
+>;
+
+/** POST /recover — recovery key + new hex-encoded client key */
+export const encryptionRecoverRequestSchema = z.object({
+  recoveryKey: z.string(),
+  newClientKey: z.string(),
+});
+export type EncryptionRecoverRequest = z.infer<
+  typeof encryptionRecoverRequestSchema
+>;
+
+/** POST /change-pin — old + new hex-encoded client keys */
+export const encryptionChangePinRequestSchema = z.object({
+  oldClientKey: z.string(),
+  newClientKey: z.string(),
+});
+export type EncryptionChangePinRequest = z.infer<
+  typeof encryptionChangePinRequestSchema
+>;
+
+// -- Response schemas --
+
+export const encryptionVaultStatusResponseSchema = z.object({
+  pinCodeConfigured: z.boolean(),
+  recoveryKeyConfigured: z.boolean(),
+  vaultCodeConfigured: z.boolean(),
+});
+export type EncryptionVaultStatusResponse = z.infer<
+  typeof encryptionVaultStatusResponseSchema
+>;
+
 export const encryptionSaltResponseSchema = z.object({
   salt: z.string(),
   kdfIterations: z.number().int().positive(),
@@ -960,4 +1000,12 @@ export const encryptionRecoverResponseSchema = z.object({
 });
 export type EncryptionRecoverResponse = z.infer<
   typeof encryptionRecoverResponseSchema
+>;
+
+export const encryptionChangePinResponseSchema = z.object({
+  keyCheck: z.string(),
+  recoveryKey: z.string().nullable(),
+});
+export type EncryptionChangePinResponse = z.infer<
+  typeof encryptionChangePinResponseSchema
 >;

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -981,13 +981,6 @@ export type EncryptionSaltResponse = z.infer<
   typeof encryptionSaltResponseSchema
 >;
 
-export const encryptionRekeyResponseSchema = z.object({
-  success: z.literal(true),
-});
-export type EncryptionRekeyResponse = z.infer<
-  typeof encryptionRekeyResponseSchema
->;
-
 export const encryptionSetupRecoveryResponseSchema = z.object({
   recoveryKey: z.string(),
 });

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -935,9 +935,12 @@ export type DemoCleanupResponse = z.infer<typeof demoCleanupResponseSchema>;
 
 // -- Request schemas --
 
+/** Hex-encoded 32-byte key (64 hex chars) */
+const hexKey64 = z.string().regex(/^[0-9a-f]{64}$/i);
+
 /** POST /validate-key — hex-encoded 32-byte client key */
 export const encryptionValidateKeyRequestSchema = z.object({
-  clientKey: z.string(),
+  clientKey: hexKey64,
 });
 export type EncryptionValidateKeyRequest = z.infer<
   typeof encryptionValidateKeyRequestSchema
@@ -946,7 +949,7 @@ export type EncryptionValidateKeyRequest = z.infer<
 /** POST /recover — recovery key + new hex-encoded client key */
 export const encryptionRecoverRequestSchema = z.object({
   recoveryKey: z.string(),
-  newClientKey: z.string(),
+  newClientKey: hexKey64,
 });
 export type EncryptionRecoverRequest = z.infer<
   typeof encryptionRecoverRequestSchema
@@ -954,8 +957,8 @@ export type EncryptionRecoverRequest = z.infer<
 
 /** POST /change-pin — old + new hex-encoded client keys */
 export const encryptionChangePinRequestSchema = z.object({
-  oldClientKey: z.string(),
-  newClientKey: z.string(),
+  oldClientKey: hexKey64,
+  newClientKey: hexKey64,
 });
 export type EncryptionChangePinRequest = z.infer<
   typeof encryptionChangePinRequestSchema


### PR DESCRIPTION
## Summary

• Add change-pin endpoint with automatic re-encryption of all user data
• Full test coverage: unit, HTTP pipeline, and E2E tests
• Zod schemas and DTOs for encryption request/response contracts
• Architecture documentation for API contracts

## Changes

- **Backend**: change-pin endpoint with EncryptionService integration
- **Tests**: 661 lines of comprehensive test coverage (unit + HTTP + E2E)
- **Docs**: ENCRYPTION.md and SCENARIOS.md updated with flow diagrams and scenario 8.5
- **Schemas**: Shared encryption request/response DTOs with Zod validation

## Type

feat