### PR TITLE
feat(ios): redesign AccountView with grouped submenus

### DIFF
--- a/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
+++ b/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
@@ -54,7 +54,7 @@ final class OnboardingBootstrapper {
 
             pendingOnboardingData = nil
             AnalyticsService.shared.capture(.firstBudgetCreated, properties: [
-                "has_pay_day": onboardingData.monthlyIncome != nil,
+                "has_pay_day": false,
                 "charges_count": [
                     onboardingData.housingCosts,
                     onboardingData.healthInsurance,

--- a/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
+++ b/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
@@ -53,7 +53,16 @@ final class OnboardingBootstrapper {
             _ = try await createBudget(budgetData)
 
             pendingOnboardingData = nil
-            AnalyticsService.shared.capture(.firstBudgetCreated)
+            AnalyticsService.shared.capture(.firstBudgetCreated, properties: [
+                "has_pay_day": onboardingData.monthlyIncome != nil,
+                "charges_count": [
+                    onboardingData.housingCosts,
+                    onboardingData.healthInsurance,
+                    onboardingData.phonePlan,
+                    onboardingData.transportCosts,
+                    onboardingData.leasingCredit
+                ].compactMap { $0 }.count
+            ])
             return true
         } catch {
             Logger.auth.error("OnboardingBootstrapper: failed to create template/budget - \(error)")

--- a/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
+++ b/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
@@ -53,6 +53,7 @@ final class OnboardingBootstrapper {
             _ = try await createBudget(budgetData)
 
             pendingOnboardingData = nil
+            AnalyticsService.shared.capture(.firstBudgetCreated)
             return true
         } catch {
             Logger.auth.error("OnboardingBootstrapper: failed to create template/budget - \(error)")

--- a/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
@@ -10,6 +10,7 @@ enum AnalyticsEvent: String, CaseIterable {
     case signupStarted = "signup_started"
     case signupCompleted = "signup_completed"
     case onboardingStepCompleted = "onboarding_step_completed"
+    case onboardingAbandoned = "onboarding_abandoned"
 
     // MARK: - Auth
     case loginCompleted = "login_completed"
@@ -19,6 +20,7 @@ enum AnalyticsEvent: String, CaseIterable {
 
     // MARK: - Budget
     case budgetCreated = "budget_created"
+    case firstBudgetCreated = "first_budget_created"
 
     // MARK: - Transaction
     case transactionCreated = "transaction_created"

--- a/ios/Pulpe/Features/Account/AccountView.swift
+++ b/ios/Pulpe/Features/Account/AccountView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct AccountView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AppState.self) private var appState
-    @State private var showDeleteConfirmation = false
     @State private var showLogoutConfirmation = false
     @State private var isDebugVisible = false
     @State private var debugToggleTrigger = false
@@ -13,10 +12,8 @@ struct AccountView: View {
             List {
                 personalInfoSection
                 appSettingsSection
-                applicationSection
                 supportSection
                 logoutSection
-                dangerZoneSection
                 legalFooterSection
             }
             .alert("Déconnexion", isPresented: $showLogoutConfirmation) {
@@ -29,20 +26,6 @@ struct AccountView: View {
                 }
             } message: {
                 Text("Tu devras te reconnecter avec ton email et mot de passe.")
-            }
-            .alert("Supprimer mon compte", isPresented: $showDeleteConfirmation) {
-                Button("Annuler", role: .cancel) { }
-                Button("Supprimer", role: .destructive) {
-                    Task {
-                        await appState.deleteAccount()
-                        dismiss()
-                    }
-                }
-            } message: {
-                Text(
-                    "Ton compte sera définitivement supprimé " +
-                    "après un délai de 3 jours. Cette action est irréversible."
-                )
             }
             .sensoryFeedback(.impact, trigger: debugToggleTrigger)
             .listStyle(.insetGrouped)
@@ -63,6 +46,12 @@ extension AccountView {
     private var personalInfoSection: some View {
         Section {
             LabeledContent("E-mail", value: appState.currentUser?.email ?? "Non connecté(e)")
+
+            NavigationLink {
+                SecuritySettingsView()
+            } label: {
+                LabeledContent("Mot de passe", value: "••••••••")
+            }
         } header: {
             Text("INFORMATIONS PERSONNELLES")
         }
@@ -87,40 +76,6 @@ extension AccountView {
             }
         } header: {
             Text("PARAMÈTRES DE L'APPLICATION")
-        }
-    }
-
-    private var applicationSection: some View {
-        Section {
-            LabeledContent("Version", value: AppConfiguration.appVersion)
-            LabeledContent("Build", value: AppConfiguration.buildNumber)
-
-            if isDebugVisible {
-                Group {
-                    LabeledContent("Environnement", value: AppConfiguration.environment.rawValue)
-                    LabeledContent("API") {
-                        Text(AppConfiguration.apiBaseURL.host() ?? AppConfiguration.apiBaseURL.absoluteString)
-                            .font(.footnote.monospaced())
-                    }
-                    LabeledContent("Supabase") {
-                        Text(AppConfiguration.supabaseURL.host() ?? AppConfiguration.supabaseURL.absoluteString)
-                            .font(.footnote.monospaced())
-                    }
-                    LabeledContent("Anon Key") {
-                        Text(AppConfiguration.supabaseAnonKey)
-                            .font(.caption2.monospaced())
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
-                }
-                .transition(.opacity.combined(with: .move(edge: .top)))
-            }
-        } header: {
-            Text("APPLICATION")
-                .onLongPressGesture(minimumDuration: 5) {
-                    debugToggleTrigger.toggle()
-                    withAnimation(.easeInOut(duration: DesignTokens.Animation.normal)) { isDebugVisible.toggle() }
-                }
         }
     }
 
@@ -156,42 +111,17 @@ extension AccountView {
         }
     }
 
-    private var dangerZoneSection: some View {
-        Section {
-            HStack(spacing: DesignTokens.Spacing.md) {
-                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
-                    Text("Supprimer mon compte")
-                        .font(PulpeTypography.labelLarge)
-                        .foregroundStyle(Color.destructivePrimary)
-                    Text("Tes données seront supprimées définitivement après 3 jours.")
-                        .font(PulpeTypography.labelMedium)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 0)
-
-                Button("Supprimer") {
-                    showDeleteConfirmation = true
-                }
-                .buttonStyle(.borderedProminent)
-                .buttonBorderShape(.capsule)
-                .tint(.destructivePrimary)
-            }
-        } header: {
-            Text("ZONE DE DANGER")
-                .foregroundStyle(Color.destructivePrimary)
-        }
-        .listRowBackground(Color.destructiveBackground)
-    }
-
     private var legalFooterSection: some View {
         Section {
             VStack(spacing: DesignTokens.Spacing.sm) {
-                // swiftlint:disable:next force_try
-                Text(try! AttributedString(
-                    markdown: "Les [Conditions générales](\(AppURLs.terms)) et " +
-                        "l'[Avis de confidentialité](\(AppURLs.privacy)) de Pulpe s'appliquent."
-                ))
+                Text(
+                    (try? AttributedString(
+                        markdown: "Les [Conditions générales](\(AppURLs.terms)) et " +
+                            "l'[Avis de confidentialité](\(AppURLs.privacy)) de Pulpe s'appliquent."
+                    )) ?? AttributedString(
+                        "Les Conditions générales et l'Avis de confidentialité de Pulpe s'appliquent."
+                    )
+                )
                 .font(PulpeTypography.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -201,10 +131,38 @@ extension AccountView {
                     .font(PulpeTypography.caption)
                     .foregroundStyle(.tertiary)
                     .padding(.top, DesignTokens.Spacing.xs)
+                    .onLongPressGesture(minimumDuration: 5) {
+                        debugToggleTrigger.toggle()
+                        withAnimation(.easeInOut(duration: DesignTokens.Animation.normal)) {
+                            isDebugVisible.toggle()
+                        }
+                    }
 
                 Text("iOS \(Self.iOSVersion)")
                     .font(PulpeTypography.caption)
                     .foregroundStyle(.tertiary)
+
+                if isDebugVisible {
+                    Group {
+                        LabeledContent("Env", value: AppConfiguration.environment.rawValue)
+                        LabeledContent("API") {
+                            Text(AppConfiguration.apiBaseURL.host() ?? AppConfiguration.apiBaseURL.absoluteString)
+                                .font(.footnote.monospaced())
+                        }
+                        LabeledContent("Supabase") {
+                            Text(AppConfiguration.supabaseURL.host() ?? AppConfiguration.supabaseURL.absoluteString)
+                                .font(.footnote.monospaced())
+                        }
+                        LabeledContent("Anon Key") {
+                            Text(AppConfiguration.supabaseAnonKey)
+                                .font(.caption2.monospaced())
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                    .font(PulpeTypography.caption)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
             }
             .frame(maxWidth: .infinity)
         }

--- a/ios/Pulpe/Features/Account/AccountView.swift
+++ b/ios/Pulpe/Features/Account/AccountView.swift
@@ -18,9 +18,12 @@ struct AccountView: View {
                 personalInfoSection
                 PayDaySettingView()
                 securitySection
+                settingsSection
                 applicationSection
+                supportSection
                 logoutSection
                 dangerZoneSection
+                legalFooterSection
             }
             .onAppear {
                 biometricToggle = appState.biometricEnabled
@@ -70,8 +73,6 @@ struct AccountView: View {
             }
             .sensoryFeedback(.impact, trigger: debugToggleTrigger)
             .listStyle(.insetGrouped)
-            .scrollContentBackground(.hidden)
-            .background(Color.surface)
             .trackScreen("Account")
             .navigationTitle("Compte")
             .toolbar {
@@ -128,19 +129,33 @@ extension AccountView {
             LabeledContent("E-mail", value: appState.currentUser?.email ?? "Non connecté(e)")
         } header: {
             Text("INFORMATIONS PERSONNELLES")
-                .font(PulpeTypography.labelLarge)
         }
-        .listRowBackground(Color.surfaceContainerHigh)
     }
 
     private var securitySection: some View {
         Section {
             LabeledContent("Code PIN") {
                 Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
+                    .foregroundStyle(Color.financialSavings)
             }
 
-            if BiometricService.shared.canUseBiometrics() {
+            chevronRow("Mot de passe", detail: "••••••••") {
+                showChangePassword = true
+            }
+
+            chevronRow("Clé de secours", detail: "Régénérer") {
+                securityViewModel.showConfirmPassword = true
+            }
+            .disabled(securityViewModel.isRegenerating)
+        } header: {
+            Text("SÉCURITÉ")
+        }
+    }
+
+    @ViewBuilder
+    private var settingsSection: some View {
+        if BiometricService.shared.canUseBiometrics() {
+            Section {
                 Toggle(
                     BiometricService.shared.biometryDisplayName,
                     isOn: $biometricToggle
@@ -163,31 +178,10 @@ extension AccountView {
                         showDisableBiometricConfirmation = true
                     }
                 }
+            } header: {
+                Text("PARAMÈTRES DE L'APPLICATION")
             }
-
-            LabeledContent("Mot de passe") {
-                Button("Changer") {
-                    showChangePassword = true
-                }
-                .buttonStyle(.bordered)
-                .buttonBorderShape(.capsule)
-                .tint(.pulpePrimary)
-            }
-
-            LabeledContent("Clé de secours") {
-                Button("Régénérer") {
-                    securityViewModel.showConfirmPassword = true
-                }
-                .buttonStyle(.bordered)
-                .buttonBorderShape(.capsule)
-                .tint(.pulpePrimary)
-                .disabled(securityViewModel.isRegenerating)
-            }
-        } header: {
-            Text("SÉCURITÉ")
-                .font(PulpeTypography.labelLarge)
         }
-        .listRowBackground(Color.surfaceContainerHigh)
     }
 
     private var applicationSection: some View {
@@ -217,13 +211,31 @@ extension AccountView {
             }
         } header: {
             Text("APPLICATION")
-                .font(PulpeTypography.labelLarge)
                 .onLongPressGesture(minimumDuration: 5) {
                     debugToggleTrigger.toggle()
                     withAnimation(.easeInOut(duration: DesignTokens.Animation.normal)) { isDebugVisible.toggle() }
                 }
         }
-        .listRowBackground(Color.surfaceContainerHigh)
+    }
+
+    private var supportSection: some View {
+        Section {
+            iconChevronLink(
+                icon: "questionmark.circle",
+                title: "FAQ et support",
+                subtitle: "Aide et questions fréquentes",
+                url: AppURLs.support
+            )
+
+            iconChevronLink(
+                icon: "sparkles",
+                title: "Nouveautés",
+                subtitle: "Dernières mises à jour",
+                url: AppURLs.changelog
+            )
+        } header: {
+            Text("SUPPORT")
+        }
     }
 
     private var logoutSection: some View {
@@ -234,8 +246,8 @@ extension AccountView {
                 Text("Déconnexion")
                     .foregroundStyle(Color.errorPrimary)
             }
+            .buttonStyle(.plain)
         }
-        .listRowBackground(Color.surfaceContainerHigh)
     }
 
     private var dangerZoneSection: some View {
@@ -261,10 +273,86 @@ extension AccountView {
             }
         } header: {
             Text("ZONE DE DANGER")
-                .font(PulpeTypography.labelLarge)
                 .foregroundStyle(Color.destructivePrimary)
         }
         .listRowBackground(Color.destructiveBackground)
+    }
+
+    private var legalFooterSection: some View {
+        Section {
+            VStack(spacing: DesignTokens.Spacing.sm) {
+                // swiftlint:disable:next force_try
+                Text(try! AttributedString(
+                    markdown: "Les [Conditions générales](\(AppURLs.terms)) et " +
+                        "l'[Avis de confidentialité](\(AppURLs.privacy)) de Pulpe s'appliquent."
+                ))
+                .font(PulpeTypography.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .tint(Color.pulpePrimary)
+
+                Text("Version \(AppConfiguration.appVersion) - \(AppConfiguration.buildNumber)")
+                    .font(PulpeTypography.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(.top, DesignTokens.Spacing.xs)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .listRowBackground(Color.clear)
+    }
+}
+
+// MARK: - Row Helpers
+
+extension AccountView {
+    private func chevronRow(
+        _ title: String,
+        detail: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(detail)
+                    .foregroundStyle(.secondary)
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func iconChevronLink(
+        icon: String,
+        title: String,
+        subtitle: String,
+        url: URL
+    ) -> some View {
+        Link(destination: url) {
+            HStack(spacing: DesignTokens.Spacing.md) {
+                Image(systemName: icon)
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.pulpePrimary)
+                    .frame(
+                        width: DesignTokens.IconSize.compact,
+                        height: DesignTokens.IconSize.compact
+                    )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(PulpeTypography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
     }
 }
 

--- a/ios/Pulpe/Features/Account/AccountView.swift
+++ b/ios/Pulpe/Features/Account/AccountView.swift
@@ -46,12 +46,6 @@ extension AccountView {
     private var personalInfoSection: some View {
         Section {
             LabeledContent("E-mail", value: appState.currentUser?.email ?? "Non connecté(e)")
-
-            NavigationLink {
-                SecuritySettingsView()
-            } label: {
-                LabeledContent("Mot de passe", value: "••••••••")
-            }
         } header: {
             Text("INFORMATIONS PERSONNELLES")
         }

--- a/ios/Pulpe/Features/Account/AccountView.swift
+++ b/ios/Pulpe/Features/Account/AccountView.swift
@@ -3,12 +3,8 @@ import SwiftUI
 struct AccountView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AppState.self) private var appState
-    @State private var biometricToggle = false
     @State private var showDeleteConfirmation = false
     @State private var showLogoutConfirmation = false
-    @State private var showDisableBiometricConfirmation = false
-    @State private var showChangePassword = false
-    @State private var securityViewModel = AccountSecurityViewModel()
     @State private var isDebugVisible = false
     @State private var debugToggleTrigger = false
 
@@ -16,17 +12,12 @@ struct AccountView: View {
         NavigationStack {
             List {
                 personalInfoSection
-                PayDaySettingView()
-                securitySection
-                settingsSection
+                appSettingsSection
                 applicationSection
                 supportSection
                 logoutSection
                 dangerZoneSection
                 legalFooterSection
-            }
-            .onAppear {
-                biometricToggle = appState.biometricEnabled
             }
             .alert("Déconnexion", isPresented: $showLogoutConfirmation) {
                 Button("Annuler", role: .cancel) { }
@@ -38,24 +29,6 @@ struct AccountView: View {
                 }
             } message: {
                 Text("Tu devras te reconnecter avec ton email et mot de passe.")
-            }
-            .alert(
-                "Désactiver \(BiometricService.shared.biometryDisplayName) ?",
-                isPresented: $showDisableBiometricConfirmation
-            ) {
-                Button("Annuler", role: .cancel) { }
-                Button("Désactiver", role: .destructive) {
-                    Task {
-                        await appState.disableBiometric()
-                        biometricToggle = false
-                        appState.toastManager.show(
-                            "\(BiometricService.shared.biometryDisplayName) désactivé",
-                            type: .success
-                        )
-                    }
-                }
-            } message: {
-                Text("Tu devras utiliser ton code PIN pour te connecter.")
             }
             .alert("Supprimer mon compte", isPresented: $showDeleteConfirmation) {
                 Button("Annuler", role: .cancel) { }
@@ -80,43 +53,6 @@ struct AccountView: View {
                     Button("Fermer") { dismiss() }
                 }
             }
-            .sheet(isPresented: $showChangePassword) {
-                ChangePasswordSheet {
-                    appState.toastManager.show("Mot de passe modifié", type: .success)
-                }
-            }
-            .sheet(isPresented: $securityViewModel.showConfirmPassword) {
-                ConfirmPasswordSheet { password in
-                    let error = await securityViewModel.verifyAndRegenerateRecoveryKey(
-                        password: password,
-                        email: appState.currentUser?.email
-                    )
-                    if error == nil {
-                        appState.toastManager.show("Clé de secours régénérée", type: .success)
-                    }
-                    return error
-                }
-            }
-            .sheet(isPresented: $securityViewModel.showRecoveryKeySheet) {
-                if let recoveryKey = securityViewModel.generatedRecoveryKey {
-                    RecoveryKeySheet(recoveryKey: recoveryKey) {
-                        securityViewModel.showRecoveryKeySheet = false
-                    }
-                }
-            }
-            .overlay {
-                if securityViewModel.isRegenerating {
-                    Color.black.opacity(0.4)
-                        .ignoresSafeArea()
-                    VStack(spacing: DesignTokens.Spacing.md) {
-                        ProgressView()
-                            .tint(.white)
-                        Text("Génération de la nouvelle clé...")
-                            .foregroundStyle(.white)
-                            .font(PulpeTypography.labelLarge)
-                    }
-                }
-            }
         }
     }
 }
@@ -132,55 +68,25 @@ extension AccountView {
         }
     }
 
-    private var securitySection: some View {
+    private var appSettingsSection: some View {
         Section {
-            LabeledContent("Code PIN") {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(Color.financialSavings)
+            settingsNavigationRow(
+                icon: "lock.shield",
+                title: "Sécurité",
+                subtitle: "Code PIN, Mot de passe, Biométrie"
+            ) {
+                SecuritySettingsView()
             }
 
-            chevronRow("Mot de passe", detail: "••••••••") {
-                showChangePassword = true
+            settingsNavigationRow(
+                icon: "gearshape",
+                title: "Préférences",
+                subtitle: "Jour de paie"
+            ) {
+                PreferencesView()
             }
-
-            chevronRow("Clé de secours", detail: "Régénérer") {
-                securityViewModel.showConfirmPassword = true
-            }
-            .disabled(securityViewModel.isRegenerating)
         } header: {
-            Text("SÉCURITÉ")
-        }
-    }
-
-    @ViewBuilder
-    private var settingsSection: some View {
-        if BiometricService.shared.canUseBiometrics() {
-            Section {
-                Toggle(
-                    BiometricService.shared.biometryDisplayName,
-                    isOn: $biometricToggle
-                )
-                .onChange(of: biometricToggle) { _, newValue in
-                    guard newValue != appState.biometricEnabled else { return }
-                    if newValue {
-                        Task {
-                            let displayName = BiometricService.shared.biometryDisplayName
-                            let success = await appState.enableBiometric()
-                            if success {
-                                appState.toastManager.show("\(displayName) activé", type: .success)
-                            } else {
-                                appState.toastManager.show("Impossible d'activer \(displayName)", type: .error)
-                            }
-                            biometricToggle = appState.biometricEnabled
-                        }
-                    } else {
-                        biometricToggle = true
-                        showDisableBiometricConfirmation = true
-                    }
-                }
-            } header: {
-                Text("PARAMÈTRES DE L'APPLICATION")
-            }
+            Text("PARAMÈTRES DE L'APPLICATION")
         }
     }
 
@@ -295,34 +201,46 @@ extension AccountView {
                     .font(PulpeTypography.caption)
                     .foregroundStyle(.tertiary)
                     .padding(.top, DesignTokens.Spacing.xs)
+
+                Text("iOS \(Self.iOSVersion)")
+                    .font(PulpeTypography.caption)
+                    .foregroundStyle(.tertiary)
             }
             .frame(maxWidth: .infinity)
         }
         .listRowBackground(Color.clear)
     }
+
+    private static let iOSVersion = UIDevice.current.systemVersion
 }
 
 // MARK: - Row Helpers
 
 extension AccountView {
-    private func chevronRow(
-        _ title: String,
-        detail: String,
-        action: @escaping () -> Void
+    private func settingsNavigationRow<Destination: View>(
+        icon: String,
+        title: String,
+        subtitle: String,
+        @ViewBuilder destination: () -> Destination
     ) -> some View {
-        Button(action: action) {
-            HStack {
-                Text(title)
-                    .foregroundStyle(.primary)
-                Spacer()
-                Text(detail)
+        NavigationLink(destination: destination) {
+            HStack(spacing: DesignTokens.Spacing.md) {
+                Image(systemName: icon)
+                    .font(.system(size: 16))
                     .foregroundStyle(.secondary)
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .frame(
+                        width: DesignTokens.IconSize.compact,
+                        height: DesignTokens.IconSize.compact
+                    )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(PulpeTypography.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
-        .buttonStyle(.plain)
     }
 
     private func iconChevronLink(
@@ -335,7 +253,7 @@ extension AccountView {
             HStack(spacing: DesignTokens.Spacing.md) {
                 Image(systemName: icon)
                     .font(.system(size: 16))
-                    .foregroundStyle(Color.pulpePrimary)
+                    .foregroundStyle(.secondary)
                     .frame(
                         width: DesignTokens.IconSize.compact,
                         height: DesignTokens.IconSize.compact
@@ -353,64 +271,7 @@ extension AccountView {
                     .foregroundStyle(.tertiary)
             }
         }
-    }
-}
-
-@Observable @MainActor
-final class AccountSecurityViewModel {
-    var showConfirmPassword = false
-    var showRecoveryKeySheet = false
-    var isRegenerating = false
-    var generatedRecoveryKey: String?
-
-    private let dependencies: AccountSecurityDependencies
-
-    init(dependencies: AccountSecurityDependencies? = nil) {
-        self.dependencies = dependencies ?? .live
-    }
-
-    func verifyAndRegenerateRecoveryKey(
-        password: String,
-        email: String?
-    ) async -> String? {
-        guard let email, !email.isEmpty else {
-            return "Utilisateur non connecté"
-        }
-
-        isRegenerating = true
-        defer { isRegenerating = false }
-
-        do {
-            try await dependencies.verifyPassword(email, password)
-            let key = try await dependencies.setupRecoveryKey()
-            generatedRecoveryKey = key
-            showRecoveryKeySheet = true
-            return nil
-        } catch {
-            if AuthErrorLocalizer.isInvalidCredentials(error) {
-                return "Mot de passe incorrect"
-            }
-            if error is APIError {
-                return "Erreur lors de la génération"
-            }
-            return AuthErrorLocalizer.localize(error)
-        }
-    }
-}
-
-struct AccountSecurityDependencies: Sendable {
-    var verifyPassword: @Sendable (String, String) async throws -> Void
-    var setupRecoveryKey: @Sendable () async throws -> String
-
-    static var live: AccountSecurityDependencies {
-        AccountSecurityDependencies(
-        verifyPassword: { email, password in
-            try await AuthService.shared.verifyPassword(email: email, password: password)
-        },
-        setupRecoveryKey: {
-            try await EncryptionAPI.shared.regenerateRecoveryKey()
-        }
-        )
+        .tint(.primary)
     }
 }
 

--- a/ios/Pulpe/Features/Account/ChangePasswordSheet.swift
+++ b/ios/Pulpe/Features/Account/ChangePasswordSheet.swift
@@ -126,12 +126,8 @@ struct ChangePasswordSheet: View {
     }
 
     private var passwordRequirementsHint: some View {
-        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
-            PasswordCriteriaRow(met: viewModel.hasMinLength, text: "8 caractères minimum")
-            PasswordCriteriaRow(met: viewModel.hasNumber, text: "Au moins un chiffre")
-            PasswordCriteriaRow(met: viewModel.hasLetter, text: "Au moins une lettre")
-        }
-        .padding(.top, DesignTokens.Spacing.xs)
+        PasswordCriteriaList(validator: viewModel.passwordValidator)
+            .padding(.top, DesignTokens.Spacing.xs)
     }
 
     private var confirmPasswordField: some View {
@@ -176,22 +172,12 @@ final class ChangePasswordViewModel {
 
     var isCurrentPasswordValid: Bool { !currentPassword.isEmpty }
 
-    var hasLetter: Bool {
-        newPassword.contains(where: { $0.isLetter })
-    }
+    var passwordValidator: PasswordValidator { PasswordValidator(password: newPassword) }
 
-    var hasNumber: Bool {
-        newPassword.contains(where: { $0.isNumber })
-    }
-
-    var hasMinLength: Bool { newPassword.count >= 8 }
-
-    var isNewPasswordValid: Bool {
-        hasMinLength && hasLetter && hasNumber
-    }
+    var isNewPasswordValid: Bool { passwordValidator.isValid }
 
     var isPasswordConfirmed: Bool {
-        !confirmPassword.isEmpty && newPassword == confirmPassword
+        PasswordValidator.isConfirmed(password: newPassword, confirmation: confirmPassword)
     }
 
     var canSubmit: Bool {

--- a/ios/Pulpe/Features/Account/ChangePasswordSheet.swift
+++ b/ios/Pulpe/Features/Account/ChangePasswordSheet.swift
@@ -81,7 +81,7 @@ struct ChangePasswordSheet: View {
                     Button("Annuler") { dismiss() }
                 }
             }
-            .background(Color.surface)
+            .background(Color.sheetBackground)
         }
     }
 

--- a/ios/Pulpe/Features/Account/ConfirmPasswordSheet.swift
+++ b/ios/Pulpe/Features/Account/ConfirmPasswordSheet.swift
@@ -69,7 +69,7 @@ struct ConfirmPasswordSheet: View {
                     Button("Annuler") { dismiss() }
                 }
             }
-            .background(Color.surface)
+            .background(Color.sheetBackground)
             .interactiveDismissDisabled(isVerifying)
             .onDisappear { verifyTask?.cancel() }
         }

--- a/ios/Pulpe/Features/Account/PayDaySettingView.swift
+++ b/ios/Pulpe/Features/Account/PayDaySettingView.swift
@@ -1,96 +1,180 @@
 import SwiftUI
 
-struct PayDaySettingView: View {
+// MARK: - PayDay Picker Sheet (Revolut-style)
+
+struct PayDayPickerSheet: View {
     @Environment(AppState.self) private var appState
     @Environment(UserSettingsStore.self) private var userSettingsStore
     @Environment(CurrentMonthStore.self) private var currentMonthStore
     @Environment(BudgetListStore.self) private var budgetListStore
     @Environment(DashboardStore.self) private var dashboardStore
+    @Environment(\.dismiss) private var dismiss
+
     @State private var viewModel: PayDaySettingViewModel?
 
+    private static let gridColumns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 7)
+
     var body: some View {
-        Section {
-            payDayPicker
-            if let viewModel, viewModel.hasChanges {
-                actionButtons
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: DesignTokens.Spacing.xl) {
+                    header
+
+                    dayGrid
+                        .padding(DesignTokens.Spacing.lg)
+                        .background(Color.surface)
+                        .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+
+                    hintCard
+                }
+                .padding(.horizontal)
+                .padding(.top, DesignTokens.Spacing.sm)
+                .padding(.bottom, 100)
             }
-        } header: {
-            Text("PR\u{00C9}F\u{00C9}RENCES")
-        } footer: {
-            Text(hintText)
-                .font(PulpeTypography.caption)
-        }
-        .onChange(of: userSettingsStore.payDayOfMonth) { _, newValue in
-            if viewModel == nil {
-                viewModel = PayDaySettingViewModel(currentPayDay: newValue)
-            } else {
-                viewModel?.syncInitialDay(newValue)
+            .background(Color.sheetBackground)
+            .safeAreaInset(edge: .bottom) {
+                continueButton
+                    .padding(.horizontal, DesignTokens.Spacing.xxl)
+                    .padding(.bottom, DesignTokens.Spacing.xxl)
+                    .background(.ultraThinMaterial)
             }
-        }
-        .onAppear {
-            if viewModel == nil {
-                viewModel = PayDaySettingViewModel(currentPayDay: userSettingsStore.payDayOfMonth)
-            }
-        }
-    }
-
-    // MARK: - Subviews
-
-    private var payDayPicker: some View {
-        let selectedDay = Binding<Int>(
-            get: { viewModel?.selectedDay ?? 0 },
-            set: { viewModel?.selectDay($0 == 0 ? nil : $0) }
-        )
-
-        return Picker("Jour de paie", selection: selectedDay) {
-            Text("Calendrier standard").tag(0)
-            ForEach(2...31, id: \.self) { day in
-                Text("\(day)").tag(day)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var actionButtons: some View {
-        HStack {
-            Button("Annuler") {
-                viewModel?.reset()
-            }
-            .buttonStyle(.bordered)
-            .buttonBorderShape(.capsule)
-
-            Spacer()
-
-            Button("Sauvegarder") {
-                Task {
-                    await viewModel?.save(using: userSettingsStore)
-                    if userSettingsStore.error == nil {
-                        viewModel?.commitSave()
-                        appState.toastManager.show("Jour de paie enregistr\u{00E9}", type: .success)
-                        currentMonthStore.setPayDay(userSettingsStore.payDayOfMonth)
-                        dashboardStore.setPayDay(userSettingsStore.payDayOfMonth)
-                        async let refreshMonth: Void = currentMonthStore.forceRefresh()
-                        async let refreshList: Void = budgetListStore.forceRefresh()
-                        async let refreshDashboard: Void = dashboardStore.forceRefresh()
-                        _ = await (refreshMonth, refreshList, refreshDashboard)
-                    } else {
-                        appState.toastManager.show("Erreur lors de la sauvegarde", type: .error)
-                    }
+            .navigationTitle("Jour de paie")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    SheetCloseButton()
                 }
             }
-            .buttonStyle(.borderedProminent)
-            .buttonBorderShape(.capsule)
-            .tint(.pulpePrimary)
-            .disabled(viewModel?.isSaving ?? false)
+        }
+        .standardSheetPresentation()
+        .onAppear {
+            let currentDay = userSettingsStore.payDayOfMonth
+            viewModel = PayDaySettingViewModel(currentPayDay: currentDay)
+        }
+        .onChange(of: userSettingsStore.payDayOfMonth) { _, newValue in
+            viewModel?.syncInitialDay(newValue)
         }
     }
 
-    // MARK: - Hint Text
+    // MARK: - Header
 
-    private var hintText: String {
-        guard let day = viewModel?.selectedDay, day > 1 else {
-            return "Le budget suit le calendrier mensuel standard."
+    private var header: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            Text("Le mois commencera un...")
+                .font(PulpeTypography.stepTitle)
+                .foregroundStyle(Color.textPrimary)
+
+            Text(
+                "Choisis la date à laquelle tu souhaites commencer " +
+                "à suivre tes dépenses et revenus (ton jour de paie, par exemple)."
+            )
+                .font(PulpeTypography.subheadline)
+                .foregroundStyle(Color.onSurfaceVariant)
         }
+    }
+
+    // MARK: - Day Grid
+
+    private var dayGrid: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
+            Text("S\u{00E9}lectionne une date")
+                .font(PulpeTypography.caption)
+                .foregroundStyle(Color.onSurfaceVariant)
+
+            LazyVGrid(columns: Self.gridColumns, spacing: DesignTokens.Spacing.sm) {
+                ForEach(1...31, id: \.self) { day in
+                    dayCell(day)
+                }
+            }
+        }
+    }
+
+    private func dayCell(_ day: Int) -> some View {
+        let isSelected = day == 1
+            ? viewModel?.selectedDay == nil
+            : viewModel?.selectedDay == day
+
+        return Button {
+            withAnimation(DesignTokens.Animation.defaultSpring) {
+                viewModel?.selectDay(day == 1 ? nil : day)
+            }
+        } label: {
+            Text("\(day)")
+                .font(PulpeTypography.labelLarge)
+                .foregroundStyle(isSelected ? Color.textOnPrimary : Color.textPrimary)
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+                .background {
+                    if isSelected {
+                        Circle()
+                            .fill(Color.pulpePrimary)
+                    }
+                }
+                .animation(DesignTokens.Animation.defaultSpring, value: isSelected)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Jour \(day)")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    // MARK: - Hint Card
+
+    @ViewBuilder
+    private var hintCard: some View {
+        if let day = viewModel?.selectedDay, day >= 2 {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+                Text("Ton mois budg\u{00E9}taire")
+                    .font(PulpeTypography.labelLargeBold)
+                    .foregroundStyle(Color.textPrimary)
+
+                Text(hintPeriod(for: day))
+                    .font(PulpeTypography.subheadline)
+                    .foregroundStyle(Color.onSurfaceVariant)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(DesignTokens.Spacing.lg)
+            .background(Color.surface)
+            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+    }
+
+    // MARK: - Continue Button
+
+    private var continueButton: some View {
+        Button {
+            Task {
+                guard let viewModel else { return }
+                await viewModel.save(using: userSettingsStore)
+                if userSettingsStore.error == nil {
+                    viewModel.commitSave()
+                    appState.toastManager.show("Jour de paie enregistr\u{00E9}", type: .success)
+                    currentMonthStore.setPayDay(userSettingsStore.payDayOfMonth)
+                    dashboardStore.setPayDay(userSettingsStore.payDayOfMonth)
+                    async let refreshMonth: Void = currentMonthStore.forceRefresh()
+                    async let refreshList: Void = budgetListStore.forceRefresh()
+                    async let refreshDashboard: Void = dashboardStore.forceRefresh()
+                    _ = await (refreshMonth, refreshList, refreshDashboard)
+                    dismiss()
+                } else {
+                    appState.toastManager.show("Erreur lors de la sauvegarde", type: .error)
+                }
+            }
+        } label: {
+            if viewModel?.isSaving == true {
+                ProgressView()
+            } else {
+                Text("Continuer")
+            }
+        }
+        .primaryButtonStyle(isEnabled: true)
+        .disabled(viewModel?.isSaving == true)
+    }
+
+    // MARK: - Helpers
+
+    private func hintPeriod(for day: Int) -> String {
         let calendar = Calendar.current
         let now = Date()
         let exampleMonth = calendar.component(.month, from: now)
@@ -101,7 +185,32 @@ struct PayDaySettingView: View {
             return "Le budget suit le calendrier mensuel standard."
         }
         let monthName = Formatters.monthYear.monthSymbols[exampleMonth - 1].capitalized
-        return "Ton budget \u{00AB} \(monthName) \u{00BB} couvrira du \(period)."
+        return "Ton budget \u{00AB}\u{00A0}\(monthName)\u{00A0}\u{00BB} couvrira du \(period)."
+    }
+}
+
+// MARK: - Row for PreferencesView
+
+struct PayDaySettingRow: View {
+    @Environment(UserSettingsStore.self) private var userSettingsStore
+
+    var body: some View {
+        HStack {
+            Text("Jour de paie")
+            Spacer()
+            Text(displayValue)
+                .foregroundStyle(Color.onSurfaceVariant)
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var displayValue: String {
+        guard let day = userSettingsStore.payDayOfMonth else {
+            return "1er du mois"
+        }
+        return "Le \(day)"
     }
 }
 
@@ -131,7 +240,6 @@ final class PayDaySettingViewModel {
         await store.updatePayDay(selectedDay)
     }
 
-    /// Call after a successful save to update the baseline and hide buttons
     func commitSave() {
         initialDay = selectedDay
         hasChanges = false
@@ -142,8 +250,6 @@ final class PayDaySettingViewModel {
         hasChanges = false
     }
 
-    /// Update baseline when the store changes externally (e.g., async load completing)
-    /// and the user hasn't started editing yet.
     func syncInitialDay(_ day: Int?) {
         guard !hasChanges else { return }
         initialDay = day
@@ -152,13 +258,10 @@ final class PayDaySettingViewModel {
 }
 
 #Preview {
-    List {
-        PayDaySettingView()
-    }
-    .listStyle(.insetGrouped)
-    .environment(AppState())
-    .environment(UserSettingsStore())
-    .environment(CurrentMonthStore())
-    .environment(BudgetListStore())
-    .environment(DashboardStore())
+    PayDayPickerSheet()
+        .environment(AppState())
+        .environment(UserSettingsStore())
+        .environment(CurrentMonthStore())
+        .environment(BudgetListStore())
+        .environment(DashboardStore())
 }

--- a/ios/Pulpe/Features/Account/PayDaySettingView.swift
+++ b/ios/Pulpe/Features/Account/PayDaySettingView.swift
@@ -16,12 +16,10 @@ struct PayDaySettingView: View {
             }
         } header: {
             Text("PR\u{00C9}F\u{00C9}RENCES")
-                .font(PulpeTypography.labelLarge)
         } footer: {
             Text(hintText)
                 .font(PulpeTypography.caption)
         }
-        .listRowBackground(Color.surfaceContainerHigh)
         .onChange(of: userSettingsStore.payDayOfMonth) { _, newValue in
             if viewModel == nil {
                 viewModel = PayDaySettingViewModel(currentPayDay: newValue)
@@ -158,8 +156,6 @@ final class PayDaySettingViewModel {
         PayDaySettingView()
     }
     .listStyle(.insetGrouped)
-    .scrollContentBackground(.hidden)
-    .background(Color.surface)
     .environment(AppState())
     .environment(UserSettingsStore())
     .environment(CurrentMonthStore())

--- a/ios/Pulpe/Features/Account/PayDaySettingView.swift
+++ b/ios/Pulpe/Features/Account/PayDaySettingView.swift
@@ -47,6 +47,7 @@ struct PayDayPickerSheet: View {
             }
         }
         .standardSheetPresentation()
+        .presentationDragIndicator(.hidden)
         .onAppear {
             let currentDay = userSettingsStore.payDayOfMonth
             viewModel = PayDaySettingViewModel(currentPayDay: currentDay)
@@ -185,7 +186,8 @@ struct PayDayPickerSheet: View {
             return "Le budget suit le calendrier mensuel standard."
         }
         let monthName = Formatters.monthYear.monthSymbols[exampleMonth - 1].capitalized
-        return "Ton budget \u{00AB}\u{00A0}\(monthName)\u{00A0}\u{00BB} couvrira du \(period)."
+        let suffix = period.hasSuffix(".") ? "" : "."
+        return "Ton budget \u{00AB}\u{00A0}\(monthName)\u{00A0}\u{00BB} couvrira du \(period)\(suffix)"
     }
 }
 

--- a/ios/Pulpe/Features/Account/PayDaySettingView.swift
+++ b/ios/Pulpe/Features/Account/PayDaySettingView.swift
@@ -147,6 +147,10 @@ struct PayDayPickerSheet: View {
         Button {
             Task {
                 guard let viewModel else { return }
+                guard viewModel.hasChanges else {
+                    dismiss()
+                    return
+                }
                 await viewModel.save(using: userSettingsStore)
                 if userSettingsStore.error == nil {
                     viewModel.commitSave()

--- a/ios/Pulpe/Features/Account/PayDaySettingView.swift
+++ b/ios/Pulpe/Features/Account/PayDaySettingView.swift
@@ -131,7 +131,7 @@ struct PayDayPickerSheet: View {
                 Text(hintPeriod(for: day))
                     .font(PulpeTypography.subheadline)
                     .foregroundStyle(Color.onSurfaceVariant)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .minimumScaleFactor(0.85)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(DesignTokens.Spacing.lg)

--- a/ios/Pulpe/Features/Account/PreferencesView.swift
+++ b/ios/Pulpe/Features/Account/PreferencesView.swift
@@ -10,10 +10,9 @@ struct PreferencesView: View {
                     showPayDayPicker = true
                 } label: {
                     PayDaySettingRow()
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-            } header: {
-                Text("PR\u{00C9}F\u{00C9}RENCES")
             }
         }
         .listStyle(.insetGrouped)

--- a/ios/Pulpe/Features/Account/PreferencesView.swift
+++ b/ios/Pulpe/Features/Account/PreferencesView.swift
@@ -1,12 +1,26 @@
 import SwiftUI
 
 struct PreferencesView: View {
+    @State private var showPayDayPicker = false
+
     var body: some View {
         List {
-            PayDaySettingView()
+            Section {
+                Button {
+                    showPayDayPicker = true
+                } label: {
+                    PayDaySettingRow()
+                }
+                .buttonStyle(.plain)
+            } header: {
+                Text("PR\u{00C9}F\u{00C9}RENCES")
+            }
         }
         .listStyle(.insetGrouped)
-        .navigationTitle("Préférences")
+        .navigationTitle("Pr\u{00E9}f\u{00E9}rences")
+        .sheet(isPresented: $showPayDayPicker) {
+            PayDayPickerSheet()
+        }
     }
 }
 

--- a/ios/Pulpe/Features/Account/PreferencesView.swift
+++ b/ios/Pulpe/Features/Account/PreferencesView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct PreferencesView: View {
+    var body: some View {
+        List {
+            PayDaySettingView()
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Préférences")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PreferencesView()
+            .environment(AppState())
+            .environment(UserSettingsStore())
+            .environment(CurrentMonthStore())
+            .environment(BudgetListStore())
+            .environment(DashboardStore())
+    }
+}

--- a/ios/Pulpe/Features/Account/SecuritySettingsView.swift
+++ b/ios/Pulpe/Features/Account/SecuritySettingsView.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 struct SecuritySettingsView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
     @State private var biometricToggle = false
     @State private var showDisableBiometricConfirmation = false
     @State private var showChangePassword = false
+    @State private var showDeleteConfirmation = false
     @State private var securityViewModel = AccountSecurityViewModel()
 
     private let canUseBiometrics = BiometricService.shared.canUseBiometrics()
@@ -55,6 +57,33 @@ struct SecuritySettingsView: View {
                     Text("BIOMÉTRIE")
                 }
             }
+            Section {
+                HStack(spacing: DesignTokens.Spacing.md) {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+                        Text("Supprimer mon compte")
+                            .font(PulpeTypography.labelLarge)
+                            .foregroundStyle(Color.destructivePrimary)
+                        Text("Tes données seront supprimées définitivement après 3 jours.")
+                            .font(PulpeTypography.labelMedium)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    Button("Supprimer") {
+                        showDeleteConfirmation = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .buttonBorderShape(.capsule)
+                    .tint(.destructivePrimary)
+                    .accessibilityLabel("Supprimer le compte")
+                    .accessibilityHint("Demande la suppression définitive de ton compte Pulpe")
+                }
+            } header: {
+                Text("ZONE DE DANGER")
+                    .foregroundStyle(Color.destructivePrimary)
+            }
+            .listRowBackground(Color.destructiveBackground)
         }
         .onAppear {
             biometricToggle = appState.biometricEnabled
@@ -113,6 +142,20 @@ struct SecuritySettingsView: View {
                         .font(PulpeTypography.labelLarge)
                 }
             }
+        }
+        .alert("Supprimer mon compte", isPresented: $showDeleteConfirmation) {
+            Button("Annuler", role: .cancel) { }
+            Button("Supprimer", role: .destructive) {
+                Task {
+                    await appState.deleteAccount()
+                    dismiss()
+                }
+            }
+        } message: {
+            Text(
+                "Ton compte sera définitivement supprimé " +
+                "après un délai de 3 jours. Cette action est irréversible."
+            )
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Sécurité")

--- a/ios/Pulpe/Features/Account/SecuritySettingsView.swift
+++ b/ios/Pulpe/Features/Account/SecuritySettingsView.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+
+struct SecuritySettingsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var biometricToggle = false
+    @State private var showDisableBiometricConfirmation = false
+    @State private var showChangePassword = false
+    @State private var securityViewModel = AccountSecurityViewModel()
+
+    private let canUseBiometrics = BiometricService.shared.canUseBiometrics()
+    private let biometricDisplayName = BiometricService.shared.biometryDisplayName
+
+    var body: some View {
+        List {
+            Section {
+                LabeledContent("Code PIN") {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(Color.financialSavings)
+                }
+
+                chevronRow("Mot de passe", detail: "••••••••") {
+                    showChangePassword = true
+                }
+
+                chevronRow("Clé de secours", detail: "Régénérer") {
+                    securityViewModel.showConfirmPassword = true
+                }
+                .disabled(securityViewModel.isRegenerating)
+            }
+
+            if canUseBiometrics {
+                Section {
+                    Toggle(biometricDisplayName, isOn: $biometricToggle)
+                        .onChange(of: biometricToggle) { _, newValue in
+                            guard newValue != appState.biometricEnabled else { return }
+                            if newValue {
+                                Task {
+                                    let success = await appState.enableBiometric()
+                                    if success {
+                                        appState.toastManager.show("\(biometricDisplayName) activé", type: .success)
+                                    } else {
+                                        appState.toastManager.show(
+                                            "Impossible d'activer \(biometricDisplayName)",
+                                            type: .error
+                                        )
+                                    }
+                                    biometricToggle = appState.biometricEnabled
+                                }
+                            } else {
+                                biometricToggle = true
+                                showDisableBiometricConfirmation = true
+                            }
+                        }
+                } header: {
+                    Text("BIOMÉTRIE")
+                }
+            }
+        }
+        .onAppear {
+            biometricToggle = appState.biometricEnabled
+        }
+        .alert(
+            "Désactiver \(biometricDisplayName) ?",
+            isPresented: $showDisableBiometricConfirmation
+        ) {
+            Button("Annuler", role: .cancel) { }
+            Button("Désactiver", role: .destructive) {
+                Task {
+                    await appState.disableBiometric()
+                    biometricToggle = false
+                    appState.toastManager.show(
+                        "\(biometricDisplayName) désactivé",
+                        type: .success
+                    )
+                }
+            }
+        } message: {
+            Text("Tu devras utiliser ton code PIN pour te connecter.")
+        }
+        .sheet(isPresented: $showChangePassword) {
+            ChangePasswordSheet {
+                appState.toastManager.show("Mot de passe modifié", type: .success)
+            }
+        }
+        .sheet(isPresented: $securityViewModel.showConfirmPassword) {
+            ConfirmPasswordSheet { password in
+                let error = await securityViewModel.verifyAndRegenerateRecoveryKey(
+                    password: password,
+                    email: appState.currentUser?.email
+                )
+                if error == nil {
+                    appState.toastManager.show("Clé de secours régénérée", type: .success)
+                }
+                return error
+            }
+        }
+        .sheet(isPresented: $securityViewModel.showRecoveryKeySheet) {
+            if let recoveryKey = securityViewModel.generatedRecoveryKey {
+                RecoveryKeySheet(recoveryKey: recoveryKey) {
+                    securityViewModel.showRecoveryKeySheet = false
+                }
+            }
+        }
+        .overlay {
+            if securityViewModel.isRegenerating {
+                Color.black.opacity(0.4)
+                    .ignoresSafeArea()
+                VStack(spacing: DesignTokens.Spacing.md) {
+                    ProgressView()
+                        .tint(.white)
+                    Text("Génération de la nouvelle clé...")
+                        .foregroundStyle(.white)
+                        .font(PulpeTypography.labelLarge)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Sécurité")
+    }
+
+    private func chevronRow(
+        _ title: String,
+        detail: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(detail)
+                    .foregroundStyle(.secondary)
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - ViewModel
+
+@Observable @MainActor
+final class AccountSecurityViewModel {
+    var showConfirmPassword = false
+    var showRecoveryKeySheet = false
+    var isRegenerating = false
+    var generatedRecoveryKey: String?
+
+    private let dependencies: AccountSecurityDependencies
+
+    init(dependencies: AccountSecurityDependencies? = nil) {
+        self.dependencies = dependencies ?? .live
+    }
+
+    func verifyAndRegenerateRecoveryKey(
+        password: String,
+        email: String?
+    ) async -> String? {
+        guard let email, !email.isEmpty else {
+            return "Utilisateur non connecté"
+        }
+
+        isRegenerating = true
+        defer { isRegenerating = false }
+
+        do {
+            try await dependencies.verifyPassword(email, password)
+            let key = try await dependencies.setupRecoveryKey()
+            generatedRecoveryKey = key
+            showRecoveryKeySheet = true
+            return nil
+        } catch {
+            if AuthErrorLocalizer.isInvalidCredentials(error) {
+                return "Mot de passe incorrect"
+            }
+            if error is APIError {
+                return "Erreur lors de la génération"
+            }
+            return AuthErrorLocalizer.localize(error)
+        }
+    }
+}
+
+struct AccountSecurityDependencies: Sendable {
+    var verifyPassword: @Sendable (String, String) async throws -> Void
+    var setupRecoveryKey: @Sendable () async throws -> String
+
+    static var live: AccountSecurityDependencies {
+        AccountSecurityDependencies(
+        verifyPassword: { email, password in
+            try await AuthService.shared.verifyPassword(email: email, password: password)
+        },
+        setupRecoveryKey: {
+            try await EncryptionAPI.shared.regenerateRecoveryKey()
+        }
+        )
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SecuritySettingsView()
+            .environment(AppState())
+    }
+}

--- a/ios/Pulpe/Features/Auth/ForgotPasswordSheet.swift
+++ b/ios/Pulpe/Features/Auth/ForgotPasswordSheet.swift
@@ -17,7 +17,7 @@ struct ForgotPasswordSheet: View {
                 }
             }
             .padding(DesignTokens.Spacing.xl)
-            .background(Color.surface)
+            .background(Color.sheetBackground)
             .navigationTitle("Mot de passe oublié")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -31,7 +31,7 @@ struct ForgotPasswordSheet: View {
         }
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
-        .presentationBackground(Color.surface)
+        .presentationBackground(Color.sheetBackground)
         .task { isEmailFocused = true }
         .accessibilityIdentifier("forgotPasswordPage")
     }

--- a/ios/Pulpe/Features/Auth/ForgotPasswordSheet.swift
+++ b/ios/Pulpe/Features/Auth/ForgotPasswordSheet.swift
@@ -134,8 +134,7 @@ final class ForgotPasswordViewModel {
     }
 
     var isEmailValid: Bool {
-        let pattern = /^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$/
-        return email.wholeMatch(of: pattern) != nil
+        email.isValidEmail
     }
 
     var canSubmit: Bool {

--- a/ios/Pulpe/Features/Auth/LoginView.swift
+++ b/ios/Pulpe/Features/Auth/LoginView.swift
@@ -129,7 +129,7 @@ extension LoginView {
     private var emailField: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             Text("E-mail")
-                .font(PulpeTypography.buttonSecondary)
+                .font(PulpeTypography.inputLabel)
                 .foregroundStyle(Color.textPrimaryOnboarding)
 
             AuthTextField(
@@ -153,7 +153,7 @@ extension LoginView {
     private var passwordField: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             Text("Mot de passe")
-                .font(PulpeTypography.buttonSecondary)
+                .font(PulpeTypography.inputLabel)
                 .foregroundStyle(Color.textPrimaryOnboarding)
 
             AuthSecureField(
@@ -178,8 +178,7 @@ extension LoginView {
                 forgotPasswordPresentation = ForgotPasswordPresentation()
             }
             .font(PulpeTypography.labelMedium)
-            .foregroundStyle(Color.textPrimaryOnboarding.opacity(0.9))
-            .underline()
+            .foregroundStyle(Color.pulpePrimary)
             .accessibilityIdentifier("forgotPasswordButton")
         }
     }

--- a/ios/Pulpe/Features/Auth/LoginViewModel.swift
+++ b/ios/Pulpe/Features/Auth/LoginViewModel.swift
@@ -19,8 +19,7 @@ final class LoginViewModel {
     }
 
     var isEmailValid: Bool {
-        let pattern = /^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$/
-        return email.wholeMatch(of: pattern) != nil
+        email.isValidEmail
     }
 
     var isPasswordValid: Bool {

--- a/ios/Pulpe/Features/Auth/Pin/Components/NumpadView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/Components/NumpadView.swift
@@ -125,11 +125,11 @@ private struct NumpadButton<Label: View>: View {
     let action: () -> Void
     @ViewBuilder let label: () -> Label
 
-    @State private var tapCount = 0
+    @State private var feedbackTrigger = false
 
     var body: some View {
         Button {
-            tapCount += 1
+            feedbackTrigger.toggle()
             action()
         } label: {
             label()
@@ -138,7 +138,7 @@ private struct NumpadButton<Label: View>: View {
                 .overlay(Circle().stroke(Color.pinButtonStroke, lineWidth: 1))
         }
         .buttonStyle(NumpadButtonStyle())
-        .sensoryFeedback(.impact(flexibility: .soft), trigger: tapCount)
+        .sensoryFeedback(.impact(flexibility: .soft), trigger: feedbackTrigger)
         .disabled(isDisabled)
     }
 }

--- a/ios/Pulpe/Features/Auth/Pin/Components/NumpadView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/Components/NumpadView.swift
@@ -84,7 +84,7 @@ struct NumpadView: View {
 
         case .empty:
             Color.clear
-                .frame(width: 75, height: 75)
+                .frame(width: DesignTokens.Numpad.buttonSize, height: DesignTokens.Numpad.buttonSize)
         }
     }
 
@@ -133,7 +133,7 @@ private struct NumpadButton<Label: View>: View {
             action()
         } label: {
             label()
-                .frame(width: 75, height: 75)
+                .frame(width: DesignTokens.Numpad.buttonSize, height: DesignTokens.Numpad.buttonSize)
                 .background(Circle().fill(Color.pinButtonFill))
                 .overlay(Circle().stroke(Color.pinButtonStroke, lineWidth: 1))
         }
@@ -156,7 +156,7 @@ private struct NumpadButtonStyle: ButtonStyle {
 
 #Preview {
     ZStack {
-        Color.pinBackground.ignoresSafeArea()
+        Color.loginGradientBackground
         NumpadView(
             onDigit: { _ in },
             onDelete: {},

--- a/ios/Pulpe/Features/Auth/Pin/Components/PinDotsView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/Components/PinDotsView.swift
@@ -12,7 +12,7 @@ struct PinDotsView: View {
             ForEach(0..<maxDigits, id: \.self) { index in
                 Circle()
                     .fill(dotColor(at: index))
-                    .frame(width: 14, height: 14)
+                    .frame(width: DesignTokens.Numpad.dotSize, height: DesignTokens.Numpad.dotSize)
                     .scaleEffect(index < enteredCount ? 1.0 : 0.7)
                     .animation(.spring(response: 0.2, dampingFraction: 0.7), value: enteredCount)
             }
@@ -38,7 +38,7 @@ struct PinDotsView: View {
 
 #Preview {
     ZStack {
-        Color.pinBackground.ignoresSafeArea()
+        Color.loginGradientBackground
         VStack(spacing: 40) {
             PinDotsView(enteredCount: 0, maxDigits: 6, isError: false)
             PinDotsView(enteredCount: 3, maxDigits: 6, isError: false)

--- a/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
@@ -52,7 +52,7 @@ struct PinSetupView: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .pulpeBackground()
+            .background { Color.loginGradientBackground }
             .sensoryFeedback(.error, trigger: viewModel.hapticError)
             .sensoryFeedback(.success, trigger: viewModel.hapticSuccess)
             .sheet(item: recoveryKeySheetItemBinding) { item in
@@ -76,9 +76,9 @@ struct PinSetupView: View {
             }
             Spacer()
             headerSection
-            Spacer().frame(height: 40)
+            Spacer().frame(height: DesignTokens.Spacing.sectionGap)
             dotsSection
-            Spacer().frame(height: 48)
+            Spacer().frame(height: DesignTokens.Spacing.stepHeaderTop)
             NumpadView(
                 onDigit: { viewModel.appendDigit($0) },
                 onDelete: { viewModel.deleteLastDigit() },
@@ -87,9 +87,7 @@ struct PinSetupView: View {
                 } : nil,
                 isDisabled: viewModel.isValidating
             )
-            Spacer().frame(height: 24)
-            Spacer().frame(height: 20)
-            Spacer().frame(height: 16)
+            Spacer().frame(height: DesignTokens.Spacing.xxxl + DesignTokens.Spacing.xxl)
         }
         .padding(.horizontal, DesignTokens.Spacing.xl)
     }

--- a/ios/Pulpe/Features/Auth/Pin/RecoveryKeySheet.swift
+++ b/ios/Pulpe/Features/Auth/Pin/RecoveryKeySheet.swift
@@ -7,6 +7,12 @@ struct RecoveryKeySheet: View {
     @State private var copied = false
     @State private var copyResetTask: Task<Void, Never>?
 
+    // Staggered entrance states
+    @State private var showHeader = false
+    @State private var showKey = false
+    @State private var showWarning = false
+    @State private var showButton = false
+
     var body: some View {
         VStack(spacing: 0) {
             ScrollView {
@@ -24,18 +30,37 @@ struct RecoveryKeySheet: View {
             acknowledgeButton
                 .padding(.horizontal, DesignTokens.Spacing.xxl)
                 .padding(.bottom, DesignTokens.Spacing.lg)
+                .blurSlide(showButton)
         }
         .pulpeBackground()
         .interactiveDismissDisabled()
+        .allowsHitTesting(showButton)
+        .task {
+            guard !showHeader else { return }
+            await delayedAnimation(0.3, animation: DesignTokens.Animation.entranceSpring) {
+                showHeader = true
+            }
+            await delayedAnimation(0.2, animation: DesignTokens.Animation.defaultSpring) {
+                showKey = true
+            }
+            await delayedAnimation(0.2) { showWarning = true }
+            await delayedAnimation(0.15) { showButton = true }
+        }
     }
 
     // MARK: - Header
 
     private var headerSection: some View {
         VStack(spacing: DesignTokens.Spacing.lg) {
-            Image(systemName: "key.horizontal.fill")
-                .font(PulpeTypography.brandTitle)
-                .foregroundStyle(Color.pulpePrimary)
+            ZStack {
+                Circle()
+                    .fill(Color.pulpePrimary.opacity(DesignTokens.Opacity.badgeBackground))
+                    .frame(width: 56, height: 56)
+
+                Image(systemName: "key.horizontal.fill")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(Color.pulpePrimary)
+            }
 
             VStack(spacing: DesignTokens.Spacing.sm) {
                 Text("Clé de récupération")
@@ -51,6 +76,7 @@ struct RecoveryKeySheet: View {
                     .multilineTextAlignment(.center)
             }
         }
+        .blurSlide(showHeader)
     }
 
     // MARK: - Key Card
@@ -98,7 +124,9 @@ struct RecoveryKeySheet: View {
                 )
             }
             .sensoryFeedback(.success, trigger: copied)
-            .accessibilityLabel(copied ? "Clé copiée" : "Copier la clé de récupération")
+            .accessibilityLabel(
+                copied ? "Clé copiée" : "Copier la clé de récupération"
+            )
         }
         .padding(DesignTokens.Spacing.xxl)
         .frame(maxWidth: .infinity)
@@ -110,6 +138,8 @@ struct RecoveryKeySheet: View {
                         .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
                 }
         }
+        .scaleEffect(showKey ? 1 : 0.95)
+        .opacity(showKey ? 1 : 0)
     }
 
     // MARK: - Warning Text
@@ -119,7 +149,10 @@ struct RecoveryKeySheet: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(PulpeTypography.subheadline)
                 .foregroundStyle(Color.warningPrimary)
-            Text("Sans cette clé et sans ton code PIN, tes données financières seront définitivement inaccessibles.")
+            Text(
+                "Sans cette clé et sans ton code PIN, tes données " +
+                "financières seront définitivement inaccessibles."
+            )
                 .font(PulpeTypography.footnote)
                 .foregroundStyle(Color.textPrimary)
         }
@@ -129,6 +162,7 @@ struct RecoveryKeySheet: View {
             Color.warningBackground,
             in: .rect(cornerRadius: DesignTokens.CornerRadius.md)
         )
+        .blurSlide(showWarning)
     }
 
     // MARK: - Acknowledge Button

--- a/ios/Pulpe/Features/Auth/Pin/RecoveryKeySheet.swift
+++ b/ios/Pulpe/Features/Auth/Pin/RecoveryKeySheet.swift
@@ -32,7 +32,7 @@ struct RecoveryKeySheet: View {
                 .padding(.bottom, DesignTokens.Spacing.lg)
                 .blurSlide(showButton)
         }
-        .pulpeBackground()
+        .background { Color.loginGradientBackground }
         .interactiveDismissDisabled()
         .allowsHitTesting(showButton)
         .task {
@@ -132,10 +132,10 @@ struct RecoveryKeySheet: View {
         .frame(maxWidth: .infinity)
         .background {
             RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.lg, style: .continuous)
-                .fill(Color.surfaceContainerHigh)
+                .fill(Color.onboardingCardBackground)
                 .overlay {
                     RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.lg, style: .continuous)
-                        .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                        .strokeBorder(Color.outlineVariant.opacity(0.3), lineWidth: 1)
                 }
         }
         .scaleEffect(showKey ? 1 : 0.95)

--- a/ios/Pulpe/Features/Auth/Pin/RecoveryKeySheet.swift
+++ b/ios/Pulpe/Features/Auth/Pin/RecoveryKeySheet.swift
@@ -4,6 +4,9 @@ struct RecoveryKeySheet: View {
     let recoveryKey: String
     let onAcknowledge: () -> Void
 
+    /// Clipboard auto-expires after 2 minutes for security
+    private static let clipboardExpirationSeconds: TimeInterval = 120
+
     @State private var copied = false
     @State private var copyResetTask: Task<Void, Never>?
 
@@ -93,7 +96,7 @@ struct RecoveryKeySheet: View {
                 UIPasteboard.general.setItems(
                     [[UIPasteboard.typeAutomatic: recoveryKey]],
                     options: [
-                        .expirationDate: Date().addingTimeInterval(120),
+                        .expirationDate: Date().addingTimeInterval(Self.clipboardExpirationSeconds),
                         .localOnly: true
                     ]
                 )

--- a/ios/Pulpe/Features/Auth/ResetPasswordFlowView.swift
+++ b/ios/Pulpe/Features/Auth/ResetPasswordFlowView.swift
@@ -29,7 +29,7 @@ struct ResetPasswordFlowView: View {
                 }
             }
             .padding(DesignTokens.Spacing.xl)
-            .background(Color.surface)
+            .background(Color.sheetBackground)
             .navigationTitle("Réinitialiser le mot de passe")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/ios/Pulpe/Features/Auth/ResetPasswordFlowView.swift
+++ b/ios/Pulpe/Features/Auth/ResetPasswordFlowView.swift
@@ -147,11 +147,7 @@ struct ResetPasswordFlowView: View {
             .accessibilityLabel("Nouveau mot de passe")
             .accessibilityHint("Saisis ton nouveau mot de passe")
 
-            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
-                PasswordCriteriaRow(met: viewModel.hasMinLength, text: "8 caractères minimum")
-                PasswordCriteriaRow(met: viewModel.hasNumber, text: "Au moins un chiffre")
-                PasswordCriteriaRow(met: viewModel.hasLetter, text: "Au moins une lettre")
-            }
+            PasswordCriteriaList(validator: viewModel.passwordValidator)
         }
     }
 
@@ -224,14 +220,12 @@ final class ResetPasswordFlowViewModel {
         self.dependencies = dependencies ?? .live
     }
 
-    var hasMinLength: Bool { newPassword.count >= 8 }
-    var hasNumber: Bool { newPassword.contains(where: { $0.isNumber }) }
-    var hasLetter: Bool { newPassword.contains(where: { $0.isLetter }) }
+    var passwordValidator: PasswordValidator { PasswordValidator(password: newPassword) }
 
-    var isNewPasswordValid: Bool { hasMinLength && hasNumber && hasLetter }
+    var isNewPasswordValid: Bool { passwordValidator.isValid }
 
     var isPasswordConfirmed: Bool {
-        !confirmPassword.isEmpty && newPassword == confirmPassword
+        PasswordValidator.isConfirmed(password: newPassword, confirmation: confirmPassword)
     }
 
     var canSubmit: Bool {

--- a/ios/Pulpe/Features/Budgets/BudgetList/CreateBudgetView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/CreateBudgetView.swift
@@ -46,7 +46,7 @@ struct CreateBudgetView: View {
                 .padding(.bottom, DesignTokens.Spacing.xxxl)
             }
             .scrollIndicators(.hidden)
-            .background(Color.surface)
+            .background(Color.sheetBackground)
             .navigationTitle("Nouveau budget")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
@@ -51,7 +51,7 @@ struct LinkedTransactionsSheet: View {
                 .padding(.top, DesignTokens.Spacing.sm)
                 .padding(.bottom, 100)
             }
-            .background(Color.surface)
+            .background(Color.sheetBackground)
             .safeAreaInset(edge: .bottom) {
                 addTransactionButton
             }

--- a/ios/Pulpe/Features/CurrentMonth/Components/RealizedBalanceSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/RealizedBalanceSheet.swift
@@ -23,7 +23,7 @@ struct RealizedBalanceSheet: View {
                 }
                 .padding()
             }
-            .background(Color.surface)
+            .background(Color.sheetBackground)
             .navigationTitle("Suivi du budget")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/ios/Pulpe/Features/Onboarding/Components/OnboardingNavigationButtons.swift
+++ b/ios/Pulpe/Features/Onboarding/Components/OnboardingNavigationButtons.swift
@@ -39,7 +39,7 @@ struct OnboardingNavigationButtons: View {
                 Button(action: onBack) {
                     HStack(spacing: DesignTokens.Spacing.xs) {
                         Image(systemName: "chevron.left")
-                            .font(PulpeTypography.inputHelper)
+                            .font(PulpeTypography.footnote)
                         Text("Retour")
                             .font(PulpeTypography.buttonSecondary)
                     }

--- a/ios/Pulpe/Features/Onboarding/Components/OnboardingProgressIndicator.swift
+++ b/ios/Pulpe/Features/Onboarding/Components/OnboardingProgressIndicator.swift
@@ -13,7 +13,7 @@ struct OnboardingProgressIndicator: View {
         HStack(spacing: DesignTokens.Spacing.xs) {
             ForEach(1..<totalSteps, id: \.self) { index in
                 Capsule()
-                    .fill(index <= stepIndex ? Color.pulpePrimary : Color.secondary.opacity(0.2))
+                    .fill(index <= stepIndex ? Color.pulpePrimary : Color.secondary.opacity(0.15))
                     .frame(height: DesignTokens.Spacing.xs)
             }
         }

--- a/ios/Pulpe/Features/Onboarding/Components/OnboardingStepHeader.swift
+++ b/ios/Pulpe/Features/Onboarding/Components/OnboardingStepHeader.swift
@@ -5,13 +5,13 @@ struct OnboardingStepHeader: View {
     let step: OnboardingStep
 
     var body: some View {
-        VStack(spacing: DesignTokens.Spacing.md) {
+        VStack(spacing: DesignTokens.Spacing.lg) {
             Text(step.title)
                 .font(PulpeTypography.onboardingTitle)
                 .foregroundStyle(Color.textPrimaryOnboarding)
 
             Text(step.subtitle)
-                .font(PulpeTypography.stepSubtitle)
+                .font(PulpeTypography.onboardingSubtitle)
                 .foregroundStyle(Color.textSecondaryOnboarding)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, DesignTokens.Spacing.lg)
@@ -36,7 +36,7 @@ struct OptionalBadge: View {
         .foregroundStyle(Color.textTertiaryOnboarding)
         .padding(.horizontal, 14)
         .padding(.vertical, 6)
-        .background(Color.secondary.opacity(0.08), in: Capsule())
+        .background(Color.textTertiaryOnboarding.opacity(0.15), in: Capsule())
     }
 }
 

--- a/ios/Pulpe/Features/Onboarding/Components/OnboardingStepHeader.swift
+++ b/ios/Pulpe/Features/Onboarding/Components/OnboardingStepHeader.swift
@@ -1,47 +1,23 @@
 import SwiftUI
 
-/// Unified header for onboarding steps with animated icon
+/// Unified header for onboarding steps — bold editorial typography, no icon
 struct OnboardingStepHeader: View {
     let step: OnboardingStep
-    @State private var iconScale: CGFloat = 0.5
-    @State private var iconOpacity: Double = 0
 
     var body: some View {
-        VStack(spacing: DesignTokens.Spacing.lg) {
-            // Animated icon in colored circle
-            ZStack {
-                Circle()
-                    .fill(step.iconColor.opacity(0.12))
-                    .frame(width: 80, height: 80)
-
-                Image(systemName: step.iconName)
-                    .font(PulpeTypography.brandTitle)
-                    .foregroundStyle(step.iconColor)
-                    .scaleEffect(iconScale)
-                    .opacity(iconOpacity)
-            }
-
-            // Title
+        VStack(spacing: DesignTokens.Spacing.md) {
             Text(step.title)
-                .font(PulpeTypography.stepTitle)
+                .font(PulpeTypography.onboardingTitle)
                 .foregroundStyle(Color.textPrimaryOnboarding)
 
-            // Subtitle
             Text(step.subtitle)
                 .font(PulpeTypography.stepSubtitle)
                 .foregroundStyle(Color.textSecondaryOnboarding)
                 .multilineTextAlignment(.center)
-                .padding(.horizontal, DesignTokens.Spacing.xxxl)
+                .padding(.horizontal, DesignTokens.Spacing.lg)
 
-            // Optional badge
             if step.isOptional {
                 OptionalBadge()
-            }
-        }
-        .onAppear {
-            withAnimation(PulpeAnimations.iconEntrance.delay(0.1)) {
-                iconScale = 1.0
-                iconOpacity = 1.0
             }
         }
     }

--- a/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct OnboardingFlow: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
     @State private var state = OnboardingState()
 
     var body: some View {
@@ -30,6 +31,14 @@ struct OnboardingFlow: View {
                 }
             }
             .toolbar(.hidden, for: .navigationBar)
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .background, state.currentStep != .welcome {
+                    AnalyticsService.shared.capture(
+                        .onboardingAbandoned,
+                        properties: ["last_step": state.currentStep.analyticsName]
+                    )
+                }
+            }
         }
     }
 
@@ -80,29 +89,24 @@ struct OnboardingStepView<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var contentOpacity: Double = 0
-    @State private var contentOffset: CGFloat = 20
+    @State private var showContent = false
 
     var body: some View {
         VStack(spacing: 0) {
             ScrollView {
-                VStack(spacing: DesignTokens.Spacing.xxl) {
-                    // New animated header with icon
+                VStack(spacing: DesignTokens.Spacing.xxxl) {
                     OnboardingStepHeader(step: step)
-                        .padding(.top, DesignTokens.Spacing.xxl)
+                        .padding(.top, 48)
 
-                    // Content with entrance animation
                     content()
                         .padding(.horizontal, DesignTokens.Spacing.xxl)
-                        .opacity(contentOpacity)
-                        .offset(y: contentOffset)
+                        .blurSlide(showContent)
                 }
             }
             .scrollBounceBehavior(.basedOnSize)
 
             Spacer()
 
-            // Error display
             if let error = state.error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
                     state.error = nil
@@ -112,7 +116,6 @@ struct OnboardingStepView<Content: View>: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
-            // New gradient navigation buttons
             OnboardingNavigationButtons(
                 step: step,
                 canProceed: canProceed,
@@ -123,15 +126,12 @@ struct OnboardingStepView<Content: View>: View {
         }
         .background(Color.clear)
         .dismissKeyboardOnTap()
-        .onAppear {
+        .task {
+            guard !showContent else { return }
             if reduceMotion {
-                contentOpacity = 1
-                contentOffset = 0
+                showContent = true
             } else {
-                withAnimation(.easeOut(duration: 0.4).delay(0.2)) {
-                    contentOpacity = 1
-                    contentOffset = 0
-                }
+                await delayedAnimation(0.25) { showContent = true }
             }
         }
     }

--- a/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
@@ -32,7 +32,9 @@ struct OnboardingFlow: View {
             }
             .toolbar(.hidden, for: .navigationBar)
             .onChange(of: scenePhase) { _, newPhase in
-                if newPhase == .background, state.currentStep != .welcome {
+                if newPhase == .background,
+                   state.currentStep != .welcome,
+                   !state.hasCompleted {
                     AnalyticsService.shared.capture(
                         .onboardingAbandoned,
                         properties: ["last_step": state.currentStep.analyticsName]
@@ -58,6 +60,7 @@ struct OnboardingFlow: View {
         case .registration:
             RegistrationStep(state: state) { user in
                 Task {
+                    state.hasCompleted = true
                     await appState.completeOnboarding(user: user, onboardingData: state.createTemplateData())
                     if appState.showPostAuthError {
                         state.error = APIError.serverError(message: "La création du budget a échoué. Réessaie.")
@@ -96,12 +99,13 @@ struct OnboardingStepView<Content: View>: View {
             ScrollView {
                 VStack(spacing: DesignTokens.Spacing.xxxl) {
                     OnboardingStepHeader(step: step)
-                        .padding(.top, 48)
+                        .padding(.top, DesignTokens.Spacing.stepHeaderTop)
 
                     content()
                         .padding(.horizontal, DesignTokens.Spacing.xxl)
                         .blurSlide(showContent)
                 }
+                .padding(.bottom, DesignTokens.Spacing.xxxl)
             }
             .scrollBounceBehavior(.basedOnSize)
 

--- a/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
@@ -34,7 +34,9 @@ struct OnboardingFlow: View {
             .onChange(of: scenePhase) { _, newPhase in
                 if newPhase == .background,
                    state.currentStep != .welcome,
-                   !state.hasCompleted {
+                   !state.hasCompleted,
+                   !state.hasAbandoned {
+                    state.hasAbandoned = true
                     AnalyticsService.shared.capture(
                         .onboardingAbandoned,
                         properties: ["last_step": state.currentStep.analyticsName]
@@ -60,10 +62,11 @@ struct OnboardingFlow: View {
         case .registration:
             RegistrationStep(state: state) { user in
                 Task {
-                    state.hasCompleted = true
                     await appState.completeOnboarding(user: user, onboardingData: state.createTemplateData())
                     if appState.showPostAuthError {
                         state.error = APIError.serverError(message: "La création du budget a échoué. Réessaie.")
+                    } else {
+                        state.hasCompleted = true
                     }
                 }
             }

--- a/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
@@ -35,6 +35,7 @@ struct OnboardingFlow: View {
                 if newPhase == .background,
                    state.currentStep != .welcome,
                    !state.hasCompleted,
+                   !state.isSubmitting,
                    !state.hasAbandoned {
                     state.hasAbandoned = true
                     AnalyticsService.shared.capture(
@@ -62,6 +63,8 @@ struct OnboardingFlow: View {
         case .registration:
             RegistrationStep(state: state) { user in
                 Task {
+                    state.isSubmitting = true
+                    defer { state.isSubmitting = false }
                     await appState.completeOnboarding(user: user, onboardingData: state.createTemplateData())
                     if appState.showPostAuthError {
                         state.error = APIError.serverError(message: "La création du budget a échoué. Réessaie.")

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -27,6 +27,7 @@ final class OnboardingState {
     var isMovingForward: Bool = true
     var hasCompleted: Bool = false
     var hasAbandoned: Bool = false
+    var isSubmitting: Bool = false
 
     // MARK: - Persistence Keys
 

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -25,6 +25,7 @@ final class OnboardingState {
     var isLoading: Bool = false
     var error: Error?
     var isMovingForward: Bool = true
+    var hasCompleted: Bool = false
 
     // MARK: - Persistence Keys
 

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -48,8 +48,7 @@ final class OnboardingState {
     }
 
     var isEmailValid: Bool {
-        let pattern = /^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$/
-        return email.wholeMatch(of: pattern) != nil
+        email.isValidEmail
     }
 
     var canSubmitRegistration: Bool {
@@ -199,17 +198,17 @@ enum OnboardingStep: String, CaseIterable, Identifiable {
         case .personalInfo: "Qui es-tu ?"
         case .expenses: "Tes charges fixes"
         case .budgetPreview: "Ton budget"
-        case .registration: "Dernière étape"
+        case .registration: "Crée ton compte"
         }
     }
 
     var subtitle: String {
         switch self {
         case .welcome: "Reprends le contrôle de tes finances"
-        case .personalInfo: "On fait connaissance"
+        case .personalInfo: "Juste ton prénom et tes revenus"
         case .expenses: "Renseigne ce que tu connais — le reste peut attendre"
         case .budgetPreview: "Voici ce que ça donne"
-        case .registration: "On y est presque !"
+        case .registration: "Pour sauvegarder ton budget"
         }
     }
 

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -26,6 +26,7 @@ final class OnboardingState {
     var error: Error?
     var isMovingForward: Bool = true
     var hasCompleted: Bool = false
+    var hasAbandoned: Bool = false
 
     // MARK: - Persistence Keys
 

--- a/ios/Pulpe/Features/Onboarding/Steps/BudgetPreviewStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/BudgetPreviewStep.swift
@@ -86,6 +86,8 @@ struct BudgetPreviewStep: View {
             )
 
             Divider()
+                .opacity(0.15)
+                .padding(.horizontal, DesignTokens.Spacing.xs)
 
             if state.totalExpenses > 0 {
                 breakdownRow(
@@ -96,6 +98,8 @@ struct BudgetPreviewStep: View {
                 )
 
                 Divider()
+                    .opacity(0.15)
+                    .padding(.horizontal, DesignTokens.Spacing.xs)
             }
 
             HStack {
@@ -128,7 +132,7 @@ struct BudgetPreviewStep: View {
 
             Text("Tu pourras affiner tout \u{00e7}a plus tard.")
                 .font(PulpeTypography.footnote)
-                .foregroundStyle(Color.textTertiaryOnboarding.opacity(0.7))
+                .foregroundStyle(Color.textTertiaryOnboarding)
         }
         .multilineTextAlignment(.center)
         .blurSlide(showMessage)

--- a/ios/Pulpe/Features/Onboarding/Steps/BudgetPreviewStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/BudgetPreviewStep.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct BudgetPreviewStep: View {
     let state: OnboardingState
 
+    @State private var showCheckmark = false
     @State private var showHero = false
     @State private var showCard = false
     @State private var showMessage = false
@@ -19,20 +20,6 @@ struct BudgetPreviewStep: View {
                     breakdownCard
                     encouragingMessage
                 }
-                .task {
-                    try? await Task.sleep(for: .milliseconds(300))
-                    withAnimation(DesignTokens.Animation.entranceSpring) {
-                        showHero = true
-                    } completion: {
-                        withAnimation(DesignTokens.Animation.defaultSpring) {
-                            showCard = true
-                        } completion: {
-                            withAnimation(.easeOut(duration: 0.4)) {
-                                showMessage = true
-                            }
-                        }
-                    }
-                }
             }
         )
         .trackScreen("Onboarding_BudgetPreview")
@@ -41,7 +28,21 @@ struct BudgetPreviewStep: View {
     // MARK: - Hero Section
 
     private var heroSection: some View {
-        VStack(spacing: DesignTokens.Spacing.xs) {
+        VStack(spacing: DesignTokens.Spacing.sm) {
+            // Celebration checkmark — peak moment opener
+            ZStack {
+                Circle()
+                    .fill(Color.pulpePrimary.opacity(DesignTokens.Opacity.badgeBackground))
+                    .frame(width: 56, height: 56)
+
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 28, weight: .medium))
+                    .foregroundStyle(Color.pulpePrimary)
+                    .symbolEffect(.bounce, value: showCheckmark)
+            }
+            .scaleEffect(showCheckmark ? 1 : 0.3)
+            .opacity(showCheckmark ? 1 : 0)
+
             Text(state.availableToSpend.asCHF)
                 .font(PulpeTypography.amountHero)
                 .monospacedDigit()
@@ -52,9 +53,25 @@ struct BudgetPreviewStep: View {
                 .font(PulpeTypography.onboardingSubtitle)
                 .foregroundStyle(Color.textSecondaryOnboarding)
         }
-        .padding(.vertical, DesignTokens.Spacing.xxl)
-        .scaleEffect(showHero ? 1 : 0.85)
+        .padding(.vertical, DesignTokens.Spacing.xl)
         .opacity(showHero ? 1 : 0)
+        .offset(y: showHero ? 0 : 10)
+        .task {
+            // Stagger: checkmark first (peak opener), then amount, then card, then message
+            try? await Task.sleep(for: .milliseconds(400))
+            await delayedAnimation(0, animation: DesignTokens.Animation.bouncySpring) {
+                showCheckmark = true
+            }
+            await delayedAnimation(0.15, animation: DesignTokens.Animation.entranceSpring) {
+                showHero = true
+            }
+            await delayedAnimation(0.25, animation: DesignTokens.Animation.defaultSpring) {
+                showCard = true
+            }
+            await delayedAnimation(0.2) {
+                showMessage = true
+            }
+        }
     }
 
     // MARK: - Breakdown Card
@@ -62,6 +79,7 @@ struct BudgetPreviewStep: View {
     private var breakdownCard: some View {
         VStack(spacing: DesignTokens.Spacing.md) {
             breakdownRow(
+                icon: "arrow.down.circle.fill",
                 label: "Revenus",
                 value: "+\((state.monthlyIncome ?? 0).asCHF)",
                 color: .pulpePrimary
@@ -71,6 +89,7 @@ struct BudgetPreviewStep: View {
 
             if state.totalExpenses > 0 {
                 breakdownRow(
+                    icon: "arrow.up.circle.fill",
                     label: "Charges fixes",
                     value: "-\(state.totalExpenses.asCHF)",
                     color: .secondary
@@ -102,21 +121,32 @@ struct BudgetPreviewStep: View {
     // MARK: - Encouraging Message
 
     private var encouragingMessage: some View {
-        Text("On y voit plus clair, non ?")
-            .font(PulpeTypography.onboardingSubtitle)
-            .foregroundStyle(Color.textTertiaryOnboarding)
-            .multilineTextAlignment(.center)
-            .opacity(showMessage ? 1 : 0)
-            .offset(y: showMessage ? 0 : 8)
+        VStack(spacing: DesignTokens.Spacing.xs) {
+            Text("On y voit plus clair, non ?")
+                .font(PulpeTypography.onboardingSubtitle)
+                .foregroundStyle(Color.textTertiaryOnboarding)
+
+            Text("Tu pourras affiner tout \u{00e7}a plus tard.")
+                .font(PulpeTypography.footnote)
+                .foregroundStyle(Color.textTertiaryOnboarding.opacity(0.7))
+        }
+        .multilineTextAlignment(.center)
+        .blurSlide(showMessage)
     }
 
     // MARK: - Helpers
 
-    private func breakdownRow(label: String, value: String, color: Color) -> some View {
-        HStack {
+    private func breakdownRow(icon: String, label: String, value: String, color: Color) -> some View {
+        HStack(spacing: DesignTokens.Spacing.sm) {
+            Image(systemName: icon)
+                .font(PulpeTypography.body)
+                .foregroundStyle(color)
+
             Text(label)
                 .font(PulpeTypography.bodyLarge)
+
             Spacer()
+
             Text(value)
                 .font(PulpeTypography.onboardingSubtitle)
                 .monospacedDigit()

--- a/ios/Pulpe/Features/Onboarding/Steps/ExpensesStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/ExpensesStep.swift
@@ -10,17 +10,17 @@ struct ExpensesStep: View {
             canProceed: true,
             onNext: { state.nextStep() },
             content: {
-                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxxl) {
-                    expenseSection("Logement") {
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.sectionGap) {
+                    expenseSection("Logement", icon: "house.fill") {
                         CurrencyField(value: $state.housingCosts, hint: "1500", label: "Loyer mensuel")
                     }
 
-                    expenseSection("Assurance & Abonnements") {
+                    expenseSection("Assurance & Abonnements", icon: "heart.text.square.fill") {
                         CurrencyField(value: $state.healthInsurance, hint: "400", label: "Assurance maladie")
                         CurrencyField(value: $state.phonePlan, hint: "50", label: "Forfait t\u{00e9}l\u{00e9}phone")
                     }
 
-                    expenseSection("Mobilit\u{00e9} & Cr\u{00e9}dit") {
+                    expenseSection("Mobilit\u{00e9} & Cr\u{00e9}dit", icon: "car.fill") {
                         CurrencyField(
                             value: $state.transportCosts, hint: "100",
                             label: "Transport (abonnement, essence...)"
@@ -38,12 +38,18 @@ struct ExpensesStep: View {
 
     private func expenseSection<Content: View>(
         _ title: String,
+        icon: String,
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
-            Text(title)
-                .font(PulpeTypography.labelLarge)
-                .foregroundStyle(Color.textSecondaryOnboarding)
+            HStack(spacing: DesignTokens.Spacing.sm) {
+                Image(systemName: icon)
+                    .font(PulpeTypography.labelLarge)
+                    .foregroundStyle(Color.onboardingSectionIcon)
+                Text(title)
+                    .font(PulpeTypography.labelLarge)
+                    .foregroundStyle(Color.textSecondaryOnboarding)
+            }
 
             content()
         }

--- a/ios/Pulpe/Features/Onboarding/Steps/ExpensesStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/ExpensesStep.swift
@@ -10,18 +10,43 @@ struct ExpensesStep: View {
             canProceed: true,
             onNext: { state.nextStep() },
             content: {
-                VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
-                    CurrencyField(value: $state.housingCosts, hint: "1500", label: "Loyer mensuel")
-                    CurrencyField(value: $state.healthInsurance, hint: "400", label: "Assurance maladie")
-                    CurrencyField(value: $state.phonePlan, hint: "50", label: "Forfait téléphone")
-                    CurrencyField(
-                        value: $state.transportCosts, hint: "100", label: "Transport (abonnement, essence...)"
-                    )
-                    CurrencyField(value: $state.leasingCredit, hint: "300", label: "Leasing ou mensualité de crédit")
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxxl) {
+                    expenseSection("Logement") {
+                        CurrencyField(value: $state.housingCosts, hint: "1500", label: "Loyer mensuel")
+                    }
+
+                    expenseSection("Assurance & Abonnements") {
+                        CurrencyField(value: $state.healthInsurance, hint: "400", label: "Assurance maladie")
+                        CurrencyField(value: $state.phonePlan, hint: "50", label: "Forfait t\u{00e9}l\u{00e9}phone")
+                    }
+
+                    expenseSection("Mobilit\u{00e9} & Cr\u{00e9}dit") {
+                        CurrencyField(
+                            value: $state.transportCosts, hint: "100",
+                            label: "Transport (abonnement, essence...)"
+                        )
+                        CurrencyField(
+                            value: $state.leasingCredit, hint: "300",
+                            label: "Leasing ou mensualit\u{00e9} de cr\u{00e9}dit"
+                        )
+                    }
                 }
             }
         )
         .trackScreen("Onboarding_Expenses")
+    }
+
+    private func expenseSection<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
+            Text(title)
+                .font(PulpeTypography.labelLarge)
+                .foregroundStyle(Color.textSecondaryOnboarding)
+
+            content()
+        }
     }
 }
 

--- a/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
@@ -11,7 +11,7 @@ struct PersonalInfoStep: View {
             canProceed: state.isFirstNameValid && state.isIncomeValid,
             onNext: { state.nextStep() },
             content: {
-                VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxl) {
                     VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                         Text("Prénom")
                             .font(PulpeTypography.inputLabel)

--- a/ios/Pulpe/Features/Onboarding/Steps/RegistrationStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/RegistrationStep.swift
@@ -49,7 +49,7 @@ extension RegistrationStep {
     private var emailSection: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
             Text("Email")
-                .font(PulpeTypography.buttonSecondary)
+                .font(PulpeTypography.inputLabel)
                 .foregroundStyle(Color.textPrimaryOnboarding)
 
             AuthTextField(
@@ -73,7 +73,7 @@ extension RegistrationStep {
     private var passwordSection: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
             Text("Mot de passe")
-                .font(PulpeTypography.buttonSecondary)
+                .font(PulpeTypography.inputLabel)
                 .foregroundStyle(Color.textPrimaryOnboarding)
 
             AuthSecureField(
@@ -96,7 +96,7 @@ extension RegistrationStep {
     private var confirmPasswordSection: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
             Text("Confirmer le mot de passe")
-                .font(PulpeTypography.buttonSecondary)
+                .font(PulpeTypography.inputLabel)
                 .foregroundStyle(Color.textPrimaryOnboarding)
 
             AuthSecureField(
@@ -131,7 +131,7 @@ extension RegistrationStep {
                                 Color.textPrimaryOnboarding.opacity(0.4),
                             lineWidth: 2
                         )
-                        .frame(width: 24, height: 24)
+                        .frame(width: DesignTokens.Checkbox.size, height: DesignTokens.Checkbox.size)
                         .background {
                             if !state.acceptTerms {
                                 RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.sm, style: .continuous)

--- a/ios/Pulpe/Features/Onboarding/Steps/RegistrationStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/RegistrationStep.swift
@@ -14,17 +14,14 @@ struct RegistrationStep: View {
         case email, password, passwordConfirmation
     }
 
-    private var hasMinLength: Bool { password.count >= 8 }
-    private var hasNumber: Bool { password.contains(where: { $0.isNumber }) }
-    private var hasLetter: Bool { password.contains(where: { $0.isLetter }) }
-    private var isPasswordValid: Bool { hasMinLength && hasNumber && hasLetter }
+    private var passwordValidator: PasswordValidator { PasswordValidator(password: password) }
 
     private var isPasswordConfirmed: Bool {
-        !passwordConfirmation.isEmpty && password == passwordConfirmation
+        PasswordValidator.isConfirmed(password: password, confirmation: passwordConfirmation)
     }
 
     private var canSubmit: Bool {
-        state.canSubmitRegistration && isPasswordValid && isPasswordConfirmed
+        state.canSubmitRegistration && passwordValidator.isValid && isPasswordConfirmed
     }
 
     var body: some View {
@@ -35,12 +32,6 @@ struct RegistrationStep: View {
             onNext: { Task { await submitRegistration() } },
             content: {
                 VStack(spacing: DesignTokens.Spacing.xxl) {
-                    Text("Crée ton compte pour sauvegarder ton budget")
-                        .font(PulpeTypography.body.weight(.medium))
-                        .foregroundStyle(Color.textPrimaryOnboarding)
-                        .multilineTextAlignment(.center)
-                        .padding(.bottom, DesignTokens.Spacing.sm)
-
                     emailSection
                     passwordSection
                     confirmPasswordSection
@@ -98,11 +89,7 @@ extension RegistrationStep {
             .accessibilityLabel("Mot de passe")
             .accessibilityHint("Crée ton mot de passe")
 
-            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
-                PasswordCriteriaRow(met: hasMinLength, text: "8 caractères minimum")
-                PasswordCriteriaRow(met: hasNumber, text: "Au moins un chiffre")
-                PasswordCriteriaRow(met: hasLetter, text: "Au moins une lettre")
-            }
+            PasswordCriteriaList(validator: passwordValidator)
         }
     }
 

--- a/ios/Pulpe/Features/Onboarding/Steps/WelcomeStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/WelcomeStep.swift
@@ -61,7 +61,7 @@ struct WelcomeStep: View {
                     Button {
                         showLogin = true
                     } label: {
-                        Text("Se connecter")
+                        Text("J'ai déjà un compte")
                     }
                     .secondaryButtonStyle()
                 }

--- a/ios/Pulpe/Features/Templates/TemplateList/CreateTemplateView.swift
+++ b/ios/Pulpe/Features/Templates/TemplateList/CreateTemplateView.swift
@@ -212,7 +212,7 @@ struct AddTemplateLineSheet: View {
                 .padding(.top, DesignTokens.Spacing.xxxl)
                 .padding(.bottom, DesignTokens.Spacing.xl)
             }
-            .background(Color.surface)
+            .background(Color.sheetBackground)
             .navigationTitle("Nouvelle ligne")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/ios/Pulpe/Shared/AppURLs.swift
+++ b/ios/Pulpe/Shared/AppURLs.swift
@@ -4,5 +4,7 @@ enum AppURLs {
     // swiftlint:disable force_unwrapping
     static let terms = URL(string: "https://pulpe.app/legal/cgu")!
     static let privacy = URL(string: "https://pulpe.app/legal/confidentialite")!
+    static let support = URL(string: "https://pulpe.app/support")!
+    static let changelog = URL(string: "https://pulpe.app/changelog")!
     // swiftlint:enable force_unwrapping
 }

--- a/ios/Pulpe/Shared/Components/AuthTextField.swift
+++ b/ios/Pulpe/Shared/Components/AuthTextField.swift
@@ -8,19 +8,21 @@ private struct AuthFieldContainer<Content: View>: View {
     var isFilled: Bool = false
     @ViewBuilder let content: () -> Content
 
+    @Environment(\.colorScheme) private var colorScheme
+
     private var fillColor: Color {
         hasError ? Color.errorBackground : Color.authInputBackground
     }
 
     private var borderColor: Color {
         if hasError { return Color.errorPrimary.opacity(0.5) }
-        if isFocused { return Color.pulpePrimary.opacity(0.6) }
-        if isFilled { return Color.pulpePrimary.opacity(0.3) }
+        if isFocused { return Color.pulpePrimary.opacity(0.45) }
+        if isFilled { return Color.pulpePrimary.opacity(0.2) }
         return Color.authInputBorder
     }
 
     private var strokeWidth: CGFloat {
-        (isFocused || hasError) ? 2 : 1
+        (isFocused || hasError) ? 2 : 0.75
     }
 
     private var showCheckmark: Bool {
@@ -57,7 +59,9 @@ private struct AuthFieldContainer<Content: View>: View {
                         .strokeBorder(borderColor, lineWidth: strokeWidth)
                 }
         }
-        .shadow(DesignTokens.Shadow.input)
+        .shadow(colorScheme == .dark
+            ? ShadowStyle(color: .black.opacity(0.01), radius: 2, y: 1)
+            : DesignTokens.Shadow.input)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: showCheckmark)
     }

--- a/ios/Pulpe/Shared/Components/CurrencyField.swift
+++ b/ios/Pulpe/Shared/Components/CurrencyField.swift
@@ -21,6 +21,7 @@ struct CurrencyField: View {
     let label: String?
     let visualStyle: VisualStyle
 
+    @Environment(\.colorScheme) private var colorScheme
     @FocusState private var internalFocus: Bool
     @State private var textValue: String
     @State private var hasInitialized = false
@@ -129,11 +130,11 @@ struct CurrencyField: View {
     }
 
     private var borderColor: Color {
-        effectiveFocus ? Color.pulpePrimary.opacity(0.6) : Color.authInputBorder
+        effectiveFocus ? Color.pulpePrimary.opacity(0.45) : Color.authInputBorder
     }
 
     private var borderWidth: CGFloat {
-        effectiveFocus ? 2 : 1
+        effectiveFocus ? 2 : 0.75
     }
 
     @ViewBuilder
@@ -168,7 +169,7 @@ struct CurrencyField: View {
     private var prefixColor: Color {
         switch visualStyle {
         case .onboarding:
-            return Color.textSecondaryOnboarding
+            return Color.textSecondaryOnboarding.opacity(0.7)
         case .flat:
             return Color.pulpeTextTertiary
         }
@@ -186,7 +187,9 @@ struct CurrencyField: View {
     private var shadowStyle: ShadowStyle? {
         switch visualStyle {
         case .onboarding:
-            return DesignTokens.Shadow.input
+            return colorScheme == .dark
+                ? ShadowStyle(color: .black.opacity(0.01), radius: 2, y: 1)
+                : DesignTokens.Shadow.input
         case .flat:
             return nil
         }

--- a/ios/Pulpe/Shared/Components/PasswordCriteriaList.swift
+++ b/ios/Pulpe/Shared/Components/PasswordCriteriaList.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// Reusable password criteria list that displays validation state.
+/// Replaces duplicated VStack+PasswordCriteriaRow blocks across auth flows.
+struct PasswordCriteriaList: View {
+    let validator: PasswordValidator
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+            PasswordCriteriaRow(met: validator.hasMinLength, text: "8 caractères minimum")
+            PasswordCriteriaRow(met: validator.hasNumber, text: "Au moins un chiffre")
+            PasswordCriteriaRow(met: validator.hasLetter, text: "Au moins une lettre")
+        }
+    }
+}

--- a/ios/Pulpe/Shared/Components/PasswordValidator.swift
+++ b/ios/Pulpe/Shared/Components/PasswordValidator.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Centralized password validation logic.
+/// Used by RegistrationStep, ChangePasswordViewModel, and ResetPasswordFlowViewModel.
+struct PasswordValidator {
+    let password: String
+
+    var hasMinLength: Bool { password.count >= 8 }
+    var hasNumber: Bool { password.contains(where: { $0.isNumber }) }
+    var hasLetter: Bool { password.contains(where: { $0.isLetter }) }
+    var isValid: Bool { hasMinLength && hasNumber && hasLetter }
+
+    static func isConfirmed(password: String, confirmation: String) -> Bool {
+        !confirmation.isEmpty && password == confirmation
+    }
+}

--- a/ios/Pulpe/Shared/Design/DesignTokens.swift
+++ b/ios/Pulpe/Shared/Design/DesignTokens.swift
@@ -31,6 +31,10 @@ enum DesignTokens {
         static let xl: CGFloat = 20
         static let xxl: CGFloat = 24
         static let xxxl: CGFloat = 32
+        /// Gap between form sections (onboarding)
+        static let sectionGap: CGFloat = 40
+        /// Top padding for step headers (onboarding)
+        static let stepHeaderTop: CGFloat = 48
     }
 
     // MARK: - Shadows
@@ -205,6 +209,19 @@ enum DesignTokens {
         static let progressBar: CGFloat = 8
         /// Thin separator lines
         static let separator: CGFloat = 1
+    }
+
+    // MARK: - Numpad
+
+    enum Numpad {
+        static let buttonSize: CGFloat = 75
+        static let dotSize: CGFloat = 14
+    }
+
+    // MARK: - Checkbox
+
+    enum Checkbox {
+        static let size: CGFloat = 24
     }
 
     // MARK: - Amount Input

--- a/ios/Pulpe/Shared/Extensions/Color+Pulpe.swift
+++ b/ios/Pulpe/Shared/Extensions/Color+Pulpe.swift
@@ -109,11 +109,11 @@ extension Color {
 
     // MARK: - Destructive Colors (true red for irreversible actions)
 
-    /// Destructive primary — true red for account deletion, danger zones (#C62828 light, #EF5350 dark)
-    static let destructivePrimary = Color(light: Color(hex: 0xC62828), dark: Color(hex: 0xEF5350))
+    /// Destructive primary — true red for account deletion, danger zones (#C62828 light, #FF6B6B dark)
+    static let destructivePrimary = Color(light: Color(hex: 0xC62828), dark: Color(hex: 0xFF6B6B))
 
-    /// Destructive background — soft red tint for danger zone cards (#FDECEA light, #2A1414 dark)
-    static let destructiveBackground = Color(light: Color(hex: 0xFDECEA), dark: Color(hex: 0x2A1414))
+    /// Destructive background — soft red tint for danger zone cards (#FDECEA light, #3A1818 dark)
+    static let destructiveBackground = Color(light: Color(hex: 0xFDECEA), dark: Color(hex: 0x3A1818))
 
     // MARK: - Warning Colors
 

--- a/ios/Pulpe/Shared/Extensions/Color+Pulpe.swift
+++ b/ios/Pulpe/Shared/Extensions/Color+Pulpe.swift
@@ -63,6 +63,11 @@ extension Color {
     // iOS default systemGroupedBackground is #F2F2F7 light / #000000 dark.
     static let appBackground = Color(uiColor: .systemGroupedBackground)
 
+    // MARK: - Sheet Background
+    // Custom color to ensure visible contrast between sheet bg and row bg in dark mode.
+    // Light: system grouped background (#F2F2F7). Dark: #111111 (darker than row bg #1C1C1E).
+    static let sheetBackground = Color(light: Color(uiColor: .systemGroupedBackground), dark: Color(hex: 0x111111))
+
     // MARK: - Surface (iOS System Colors — neutral gray hierarchy)
 
     static let surface = Color(uiColor: .systemBackground)
@@ -155,14 +160,18 @@ extension Color {
 
     /// High-contrast text colors for onboarding
     static let textPrimaryOnboarding = Color(light: Color(hex: 0x1A1A1A), dark: Color(hex: 0xF5F5F5))
-    /// Secondary text - improved dark mode contrast (#D0D0D0 ≈ 81% luminance for better readability)
-    static let textSecondaryOnboarding = Color(light: Color(hex: 0x4A4A4A), dark: Color(hex: 0xD0D0D0))
-    /// Tertiary text - improved dark mode contrast (#ABABAB ≈ 67% luminance)
-    static let textTertiaryOnboarding = Color(light: Color(hex: 0x6B6B6B), dark: Color(hex: 0xABABAB))
+    /// Secondary text - subtle green tint in dark mode for brand cohesion
+    static let textSecondaryOnboarding = Color(light: Color(hex: 0x4A4A4A), dark: Color(hex: 0xC8D0CA))
+    /// Tertiary text - subtle green tint in dark mode for brand cohesion
+    static let textTertiaryOnboarding = Color(light: Color(hex: 0x6B6B6B), dark: Color(hex: 0xA0B0A4))
 
     /// Onboarding backgrounds
-    static let onboardingBackground = Color(light: Color(hex: 0xF8FAF9), dark: Color(hex: 0x1C1C1E))
-    static let onboardingCardBackground = Color(light: .white, dark: Color(hex: 0x2C2C2E))
+    static let onboardingBackground = Color(light: Color(hex: 0xF8FAF9), dark: Color(hex: 0x111614))
+    static let onboardingCardBackground = Color(light: .white, dark: Color(hex: 0x1E2822))
+
+    /// Section icon color for ExpensesStep
+    static let onboardingSectionIcon =
+        Color(light: Color(hex: 0x006E25).opacity(0.7), dark: Color(hex: 0x7EDB83).opacity(0.5))
 
     // MARK: - Auth Screen Gradient Colors
 
@@ -176,12 +185,12 @@ extension Color {
 
     /// Login gradient — subtle branded tint, form stays on clean white
     private static let loginGradientStops: [Gradient.Stop] = [
-        .init(color: Color(light: Color(hex: 0xD6F2DE), dark: Color(hex: 0x1A3520)), location: 0.0),
-        .init(color: Color(light: .white, dark: Color(hex: 0x1C1C1E)), location: 0.30),
+        .init(color: Color(light: Color(hex: 0xD6F2DE), dark: Color(hex: 0x0D1A12)), location: 0.0),
+        .init(color: Color(light: .white, dark: Color(hex: 0x141A16)), location: 0.30),
     ]
 
     /// Base color behind gradient shapes
-    private static let authBase = Color(light: .white, dark: Color(hex: 0x1C1C1E))
+    private static let authBase = Color(light: .white, dark: Color(hex: 0x111614))
 
     /// Welcome sky gradient — covers top ~55%, fades out with a soft convex curve at the bottom
     @ViewBuilder
@@ -235,13 +244,13 @@ extension Color {
     static let authCardGlass = Color(light: .white.opacity(0.85), dark: Color(hex: 0x1C1C1E).opacity(0.75))
 
     /// Input field background for auth screens (high contrast - fully opaque)
-    static let authInputBackground = Color(light: .white, dark: Color(hex: 0x2C2C2E))
+    static let authInputBackground = Color(light: .white, dark: Color(hex: 0x1C2420))
 
     /// Input field text color for auth screens
     static let authInputText = Color(light: Color(hex: 0x1A1A1A), dark: .white)
 
     /// Input field border color for auth screens
-    static let authInputBorder = Color(light: Color(hex: 0xE0E0E0), dark: Color(hex: 0x3C3C3E))
+    static let authInputBorder = Color(light: Color(hex: 0xE0E0E0), dark: Color(hex: 0x2A3028))
 
     /// Mint green background matching landing page suggestion
     static let mintBackground = Color(light: Color(hex: 0xBDF5B7), dark: Color(hex: 0x1A3A1A))
@@ -258,20 +267,20 @@ extension Color {
     static let stepTransport = Color(light: Color(hex: 0xEF6C00), dark: Color(hex: 0xFFA726))
     static let stepCredit = Color(light: Color(hex: 0x37474F), dark: Color(hex: 0x78909C))
 
-    /// Onboarding accent gradient
+    /// Onboarding accent gradient — brighter dark mode for visibility on deep backgrounds
     static let onboardingGradient = LinearGradient(
-        colors: [Color(light: Color(hex: 0x006E25), dark: Color(hex: 0x2E7D32)),
-                 Color(light: Color(hex: 0x00A838), dark: Color(hex: 0x4CAF50))],
+        colors: [Color(light: Color(hex: 0x006E25), dark: Color(hex: 0x338A36)),
+                 Color(light: Color(hex: 0x00A838), dark: Color(hex: 0x56C45A))],
         startPoint: .leading,
         endPoint: .trailing
     )
 
     // MARK: - PIN Screen Colors (adaptive light/dark)
 
-    /// PIN background gradient stops
-    static let pinGradientTop = Color(light: Color(hex: 0xF0F2F5), dark: Color(hex: 0x0F1923))
-    static let pinGradientMid = Color(light: Color(hex: 0xE8EBF0), dark: Color(hex: 0x1A2733))
-    static let pinGradientBottom = Color(light: Color(hex: 0xE0E4EA), dark: Color(hex: 0x0D1520))
+    /// PIN background gradient stops — aligned with onboarding loginGradientStops
+    static let pinGradientTop = Color(light: Color(hex: 0xD6F2DE), dark: Color(hex: 0x0D1A12))
+    static let pinGradientMid = Color(light: Color(hex: 0xF0F5F2), dark: Color(hex: 0x111614))
+    static let pinGradientBottom = Color(light: .white, dark: Color(hex: 0x141A16))
 
     /// PIN screen gradient
     static let pinBackground = LinearGradient(
@@ -281,22 +290,22 @@ extension Color {
     )
 
     /// Primary text on PIN screens
-    static let pinText = Color(light: Color(hex: 0x1A1F2B), dark: .white)
+    static let pinText = Color(light: Color(hex: 0x1A1A1A), dark: .white)
 
-    /// Secondary text on PIN screens (subtitles, links) - improved dark mode contrast (70% opacity)
-    static let pinTextSecondary = Color(light: Color(hex: 0x5A6070), dark: .white.opacity(0.7))
+    /// Secondary text on PIN screens (subtitles, links)
+    static let pinTextSecondary = Color(light: Color(hex: 0x4A4A4A), dark: Color(hex: 0xC8D0CA))
 
-    /// Numpad button fill
-    static let pinButtonFill = Color(light: Color(hex: 0x1A1F2B).opacity(0.06), dark: .white.opacity(0.08))
+    /// Numpad button fill — adjusted for green-tinted PIN background
+    static let pinButtonFill = Color(light: Color(hex: 0x1A1A1A).opacity(0.06), dark: .white.opacity(0.08))
 
     /// Numpad button stroke
-    static let pinButtonStroke = Color(light: Color(hex: 0x1A1F2B).opacity(0.10), dark: .white.opacity(0.15))
+    static let pinButtonStroke = Color(light: Color(hex: 0x1A1A1A).opacity(0.10), dark: .white.opacity(0.12))
 
     /// PIN dot color (filled state)
-    static let pinDotFilled = Color(light: Color(hex: 0x1A1F2B), dark: .white)
+    static let pinDotFilled = Color(light: Color(hex: 0x1A1A1A), dark: .white)
 
     /// PIN dot color (empty state)
-    static let pinDotEmpty = Color(light: Color(hex: 0x1A1F2B).opacity(0.2), dark: .white.opacity(0.3))
+    static let pinDotEmpty = Color(light: Color(hex: 0x1A1A1A).opacity(0.2), dark: .white.opacity(0.3))
 
     /// Recovery key input field background
     static let pinInputBackground = Color(light: Color(hex: 0x1A1F2B).opacity(0.05), dark: .white.opacity(0.08))

--- a/ios/Pulpe/Shared/Extensions/String+Validation.swift
+++ b/ios/Pulpe/Shared/Extensions/String+Validation.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension String {
+    /// Validates email format using a shared regex pattern.
+    /// Used by OnboardingState, LoginViewModel, and ForgotPasswordViewModel.
+    var isValidEmail: Bool {
+        wholeMatch(of: Self.emailPattern) != nil
+    }
+
+    private static let emailPattern = /^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$/
+}

--- a/ios/Pulpe/Shared/Extensions/View+BlurSlide.swift
+++ b/ios/Pulpe/Shared/Extensions/View+BlurSlide.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+extension View {
+    /// Staggered blur-slide entrance effect inspired by Apple's onboarding.
+    /// Compositing group ensures blur applies to the grouped view, not individual nodes.
+    func blurSlide(_ show: Bool) -> some View {
+        self
+            .compositingGroup()
+            .blur(radius: show ? 0 : 10)
+            .opacity(show ? 1 : 0)
+            .offset(y: show ? 0 : 40)
+    }
+}
+
+/// Runs a delayed animation — useful for staggering entrance sequences.
+@MainActor
+func delayedAnimation(_ delay: Double, animation: Animation = .smooth, action: @escaping () -> Void) async {
+    try? await Task.sleep(for: .seconds(delay))
+    withAnimation(animation) {
+        action()
+    }
+}

--- a/ios/Pulpe/Shared/Extensions/View+BlurSlide.swift
+++ b/ios/Pulpe/Shared/Extensions/View+BlurSlide.swift
@@ -16,6 +16,7 @@ extension View {
 @MainActor
 func delayedAnimation(_ delay: Double, animation: Animation = .smooth, action: @escaping () -> Void) async {
     try? await Task.sleep(for: .seconds(delay))
+    guard !Task.isCancelled else { return }
     withAnimation(animation) {
         action()
     }

--- a/ios/Pulpe/Shared/Extensions/View+Extensions.swift
+++ b/ios/Pulpe/Shared/Extensions/View+Extensions.swift
@@ -241,7 +241,7 @@ extension View {
             .presentationDetents(detents)
             .presentationDragIndicator(.visible)
             .presentationCornerRadius(DesignTokens.CornerRadius.xl)
-            .presentationBackground(Color.surface)
+            .presentationBackground(Color.sheetBackground)
     }
 }
 

--- a/ios/PulpeTests/Features/Account/ChangePasswordViewModelTests.swift
+++ b/ios/PulpeTests/Features/Account/ChangePasswordViewModelTests.swift
@@ -66,32 +66,32 @@ struct ChangePasswordViewModelTests {
 
         // Empty password
         viewModel.newPassword = ""
-        #expect(!viewModel.hasLetter)
-        #expect(!viewModel.hasNumber)
+        #expect(!viewModel.passwordValidator.hasLetter)
+        #expect(!viewModel.passwordValidator.hasNumber)
         #expect(!viewModel.isNewPasswordValid)
 
         // Only letters
         viewModel.newPassword = "abcdefgh"
-        #expect(viewModel.hasLetter)
-        #expect(!viewModel.hasNumber)
+        #expect(viewModel.passwordValidator.hasLetter)
+        #expect(!viewModel.passwordValidator.hasNumber)
         #expect(!viewModel.isNewPasswordValid)
 
         // Only numbers
         viewModel.newPassword = "12345678"
-        #expect(!viewModel.hasLetter)
-        #expect(viewModel.hasNumber)
+        #expect(!viewModel.passwordValidator.hasLetter)
+        #expect(viewModel.passwordValidator.hasNumber)
         #expect(!viewModel.isNewPasswordValid)
 
         // Letters + numbers but too short
         viewModel.newPassword = "abc123"
-        #expect(viewModel.hasLetter)
-        #expect(viewModel.hasNumber)
+        #expect(viewModel.passwordValidator.hasLetter)
+        #expect(viewModel.passwordValidator.hasNumber)
         #expect(!viewModel.isNewPasswordValid)
 
         // Valid: 8+ chars with letters and numbers
         viewModel.newPassword = "password123"
-        #expect(viewModel.hasLetter)
-        #expect(viewModel.hasNumber)
+        #expect(viewModel.passwordValidator.hasLetter)
+        #expect(viewModel.passwordValidator.hasNumber)
         #expect(viewModel.isNewPasswordValid)
     }
 


### PR DESCRIPTION
## Summary
- Restructure Account screen with Viseca-inspired grouped submenus: Security (PIN, password, recovery key, biometrics) and Preferences (pay day) are now NavigationLink rows instead of flat top-level items
- Fix support section colors: green-tinted icons/text → neutral `.secondary` gray + `.tint(.primary)` on Links
- Improve danger zone dark mode contrast: `destructivePrimary` dark `#EF5350` → `#FF6B6B`, `destructiveBackground` dark `#2A1414` → `#3A1818`
- Add iOS version to legal footer

## Test plan
- [ ] Light & dark mode: support section icons/text are neutral gray (not blue or green)
- [ ] Light & dark mode: danger zone red text pops clearly
- [ ] Navigate Security → see PIN status, password change, recovery key, biometric toggle
- [ ] Navigate Preferences → see pay day picker
- [ ] iOS version visible in footer
- [ ] All existing functionality preserved (logout, delete account, sheets, alerts)