### PR TITLE
feat(ios-pin): implement change PIN flow with shared components

### DIFF
--- a/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
@@ -17,6 +17,7 @@ enum AnalyticsEvent: String, CaseIterable {
     case logoutCompleted = "logout_completed"
     case pinSetupCompleted = "pin_setup_completed"
     case pinEntered = "pin_entered"
+    case pinChanged = "pin_changed"
 
     // MARK: - Budget
     case budgetCreated = "budget_created"

--- a/ios/Pulpe/Core/Auth/PinValidation.swift
+++ b/ios/Pulpe/Core/Auth/PinValidation.swift
@@ -34,9 +34,19 @@ enum PinValidation {
         encryptionAPI: any PinEncryptionValidation
     ) async throws -> DeriveResult {
         let salt = try await encryptionAPI.getSalt()
+        return try await derive(pin: pin, cachedSalt: salt, cryptoService: cryptoService)
+    }
+
+    /// Derives a client key using a previously fetched salt (avoids redundant network call).
+    /// Used by ChangePinViewModel which already fetched salt during old PIN validation.
+    static func derive(
+        pin: String,
+        cachedSalt: EncryptionSaltResponse,
+        cryptoService: any PinCryptoKeyDerivation
+    ) async throws -> DeriveResult {
         let clientKeyHex = try await cryptoService.deriveClientKey(
-            pin: pin, saltHex: salt.salt, iterations: salt.kdfIterations
+            pin: pin, saltHex: cachedSalt.salt, iterations: cachedSalt.kdfIterations
         )
-        return DeriveResult(clientKeyHex: clientKeyHex, saltResponse: salt)
+        return DeriveResult(clientKeyHex: clientKeyHex, saltResponse: cachedSalt)
     }
 }

--- a/ios/Pulpe/Core/Encryption/EncryptionAPI.swift
+++ b/ios/Pulpe/Core/Encryption/EncryptionAPI.swift
@@ -74,6 +74,16 @@ struct RecoverRequest: Codable, Sendable {
     let newClientKey: String
 }
 
+struct ChangePinRequest: Codable, Sendable {
+    let oldClientKey: String
+    let newClientKey: String
+}
+
+struct ChangePinResponse: Codable, Sendable {
+    let keyCheck: String
+    let recoveryKey: String
+}
+
 // MARK: - EncryptionAPI
 
 actor EncryptionAPI {
@@ -116,5 +126,11 @@ actor EncryptionAPI {
     func recover(recoveryKey: String, newClientKeyHex: String) async throws {
         let body = RecoverRequest(recoveryKey: recoveryKey, newClientKey: newClientKeyHex)
         try await apiClient.requestVoid(.encryptionRecover, body: body)
+    }
+
+    /// Change PIN by re-encrypting all data with a new client key
+    func changePin(oldClientKeyHex: String, newClientKeyHex: String) async throws -> ChangePinResponse {
+        let body = ChangePinRequest(oldClientKey: oldClientKeyHex, newClientKey: newClientKeyHex)
+        return try await apiClient.request(.encryptionChangePin, body: body)
     }
 }

--- a/ios/Pulpe/Core/Network/Endpoints.swift
+++ b/ios/Pulpe/Core/Network/Endpoints.swift
@@ -62,6 +62,7 @@ enum Endpoint {
     case encryptionSetupRecovery
     case encryptionRegenerateRecovery
     case encryptionRecover
+    case encryptionChangePin
 
     // MARK: - Path
 
@@ -117,6 +118,7 @@ enum Endpoint {
         case .encryptionSetupRecovery: return "/encryption/setup-recovery"
         case .encryptionRegenerateRecovery: return "/encryption/regenerate-recovery"
         case .encryptionRecover: return "/encryption/recover"
+        case .encryptionChangePin: return "/encryption/change-pin"
         }
     }
 
@@ -127,7 +129,8 @@ enum Endpoint {
         case .budgets, .budgetLines, .budgetLinesCreate, .transactionsCreate, .templates,
              .templateLines, .templateFromOnboarding, .templateLinesBulk,
              .budgetLineToggle, .budgetLineResetFromTemplate, .transactionToggle,
-             .encryptionValidateKey, .encryptionSetupRecovery, .encryptionRegenerateRecovery, .encryptionRecover:
+             .encryptionValidateKey, .encryptionSetupRecovery, .encryptionRegenerateRecovery, .encryptionRecover,
+             .encryptionChangePin:
             return .post
 
         case .validateSession, .userProfile, .budget, .budgetDetails, .budgetsExport,

--- a/ios/Pulpe/Features/Account/AccountView.swift
+++ b/ios/Pulpe/Features/Account/AccountView.swift
@@ -105,17 +105,19 @@ extension AccountView {
         }
     }
 
+    private static let legalText: AttributedString = {
+        (try? AttributedString(
+            markdown: "Les [Conditions générales](\(AppURLs.terms)) et " +
+                "l'[Avis de confidentialité](\(AppURLs.privacy)) de Pulpe s'appliquent."
+        )) ?? AttributedString(
+            "Les Conditions générales et l'Avis de confidentialité de Pulpe s'appliquent."
+        )
+    }()
+
     private var legalFooterSection: some View {
         Section {
             VStack(spacing: DesignTokens.Spacing.sm) {
-                Text(
-                    (try? AttributedString(
-                        markdown: "Les [Conditions générales](\(AppURLs.terms)) et " +
-                            "l'[Avis de confidentialité](\(AppURLs.privacy)) de Pulpe s'appliquent."
-                    )) ?? AttributedString(
-                        "Les Conditions générales et l'Avis de confidentialité de Pulpe s'appliquent."
-                    )
-                )
+                Text(Self.legalText)
                 .font(PulpeTypography.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/ios/Pulpe/Features/Account/SecuritySettingsView.swift
+++ b/ios/Pulpe/Features/Account/SecuritySettingsView.swift
@@ -5,6 +5,7 @@ struct SecuritySettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var biometricToggle = false
     @State private var showDisableBiometricConfirmation = false
+    @State private var showChangePin = false
     @State private var showChangePassword = false
     @State private var showDeleteConfirmation = false
     @State private var securityViewModel = AccountSecurityViewModel()
@@ -15,9 +16,8 @@ struct SecuritySettingsView: View {
     var body: some View {
         List {
             Section {
-                LabeledContent("Code PIN") {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(Color.financialSavings)
+                chevronRow("Code PIN", detail: "Modifier") {
+                    showChangePin = true
                 }
 
                 chevronRow("Mot de passe", detail: "••••••••") {
@@ -105,6 +105,12 @@ struct SecuritySettingsView: View {
             }
         } message: {
             Text("Tu devras utiliser ton code PIN pour te connecter.")
+        }
+        .navigationDestination(isPresented: $showChangePin) {
+            ChangePinView {
+                showChangePin = false
+                appState.toastManager.show("Code PIN modifié", type: .success)
+            }
         }
         .sheet(isPresented: $showChangePassword) {
             ChangePasswordSheet {

--- a/ios/Pulpe/Features/Account/SecuritySettingsView.swift
+++ b/ios/Pulpe/Features/Account/SecuritySettingsView.swift
@@ -16,15 +16,15 @@ struct SecuritySettingsView: View {
     var body: some View {
         List {
             Section {
-                chevronRow("Code PIN", detail: "Modifier") {
+                navigationRow("Code PIN", detail: "Modifier") {
                     showChangePin = true
                 }
 
-                chevronRow("Mot de passe", detail: "••••••••") {
+                actionRow("Mot de passe", detail: "••••••••") {
                     showChangePassword = true
                 }
 
-                chevronRow("Clé de secours", detail: "Régénérer") {
+                actionRow("Clé de secours", detail: "Régénérer") {
                     securityViewModel.showConfirmPassword = true
                 }
                 .disabled(securityViewModel.isRegenerating)
@@ -165,9 +165,27 @@ struct SecuritySettingsView: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Sécurité")
+        .trackScreen("Security")
     }
 
-    private func chevronRow(
+    private func actionRow(
+        _ title: String,
+        detail: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(detail)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func navigationRow(
         _ title: String,
         detail: String,
         action: @escaping () -> Void

--- a/ios/Pulpe/Features/Account/SecuritySettingsView.swift
+++ b/ios/Pulpe/Features/Account/SecuritySettingsView.swift
@@ -16,15 +16,15 @@ struct SecuritySettingsView: View {
     var body: some View {
         List {
             Section {
-                navigationRow("Code PIN", detail: "Modifier") {
+                chevronRow("Code PIN", detail: "Modifier") {
                     showChangePin = true
                 }
 
-                actionRow("Mot de passe", detail: "••••••••") {
+                chevronRow("Mot de passe", detail: "••••••••") {
                     showChangePassword = true
                 }
 
-                actionRow("Clé de secours", detail: "Régénérer") {
+                chevronRow("Clé de secours", detail: "Régénérer") {
                     securityViewModel.showConfirmPassword = true
                 }
                 .disabled(securityViewModel.isRegenerating)
@@ -168,24 +168,7 @@ struct SecuritySettingsView: View {
         .trackScreen("Security")
     }
 
-    private func actionRow(
-        _ title: String,
-        detail: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            HStack {
-                Text(title)
-                    .foregroundStyle(.primary)
-                Spacer()
-                Text(detail)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func navigationRow(
+    private func chevronRow(
         _ title: String,
         detail: String,
         action: @escaping () -> Void

--- a/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
@@ -1,0 +1,353 @@
+import OSLog
+import SwiftUI
+
+// MARK: - Step
+
+enum ChangePinStep: Equatable {
+    case enterOldPin
+    case enterNewPin
+    case processing
+}
+
+// MARK: - View
+
+struct ChangePinView: View {
+    let onSuccess: () -> Void
+
+    @State private var viewModel = ChangePinViewModel()
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .pulpeBackground()
+            .navigationTitle("Code PIN")
+            .navigationBarTitleDisplayMode(.inline)
+            .sensoryFeedback(.error, trigger: viewModel.hapticError)
+            .sensoryFeedback(.success, trigger: viewModel.hapticSuccess)
+            .onAppear { viewModel.biometricEnabled = appState.biometricEnabled }
+            .sheet(item: recoveryKeySheetBinding) { item in
+                RecoveryKeySheet(recoveryKey: item.recoveryKey) {
+                    viewModel.clearRecoveryKey()
+                    onSuccess()
+                }
+            }
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            switch viewModel.step {
+            case .enterOldPin:
+                pinStep(title: "Saisis ton ancien code PIN")
+            case .enterNewPin:
+                pinStep(title: "Saisis ton nouveau code PIN")
+            case .processing:
+                processingStep
+            }
+
+            Spacer().frame(height: DesignTokens.Spacing.lg)
+        }
+        .padding(.horizontal, DesignTokens.Spacing.xl)
+    }
+
+    // MARK: - PIN Step
+
+    private func pinStep(title: String) -> some View {
+        VStack(spacing: 0) {
+            VStack(spacing: DesignTokens.Spacing.sm) {
+                Text(title)
+                    .font(PulpeTypography.onboardingTitle)
+                    .foregroundStyle(Color.textPrimaryOnboarding)
+
+                Text(viewModel.stepLabel)
+                    .font(PulpeTypography.stepSubtitle)
+                    .foregroundStyle(Color.textSecondaryOnboarding)
+            }
+
+            Spacer().frame(height: DesignTokens.Spacing.sectionGap)
+
+            PinDotsErrorView(
+                enteredCount: viewModel.digits.count,
+                maxDigits: viewModel.maxDigits,
+                isError: viewModel.isError,
+                errorMessage: viewModel.errorMessage
+            )
+
+            Spacer().frame(height: DesignTokens.Spacing.stepHeaderTop)
+
+            NumpadView(
+                onDigit: { viewModel.appendDigit($0) },
+                onDelete: { viewModel.deleteLastDigit() },
+                onConfirm: viewModel.canConfirm ? {
+                    Task { await viewModel.confirm() }
+                } : nil,
+                isDisabled: viewModel.isProcessing
+            )
+
+            Spacer().frame(height: DesignTokens.Spacing.xxl)
+
+            if viewModel.step == .enterNewPin {
+                Button {
+                    viewModel.goBack()
+                } label: {
+                    Text("Revenir")
+                        .font(PulpeTypography.stepSubtitle)
+                        .foregroundStyle(Color.textSecondaryOnboarding)
+                }
+                .accessibilityHint("Revenir à l'étape précédente")
+            }
+        }
+    }
+
+    // MARK: - Processing Step
+
+    private var processingStep: some View {
+        PinProcessingView(
+            title: "Changement en cours...",
+            subtitle: "Tes données sont en cours de re-chiffrement"
+        )
+    }
+
+    // MARK: - Recovery Key Sheet Binding
+
+    private var recoveryKeySheetBinding: Binding<RecoveryKeySheetItem?> {
+        Binding<RecoveryKeySheetItem?>(
+            get: {
+                guard let key = viewModel.recoveryKey else { return nil }
+                return RecoveryKeySheetItem(recoveryKey: key)
+            },
+            set: { item in
+                guard item == nil else { return }
+                viewModel.clearRecoveryKey()
+            }
+        )
+    }
+}
+
+// MARK: - ViewModel
+
+@Observable @MainActor
+final class ChangePinViewModel {
+    // MARK: - Public State
+
+    private(set) var step: ChangePinStep = .enterOldPin
+    private(set) var digits: [Int] = []
+    private(set) var isError = false
+    private(set) var errorMessage: String?
+    private(set) var isProcessing = false
+    private(set) var hapticSuccess = false
+    private(set) var hapticError = false
+    private(set) var recoveryKey: String?
+
+    let maxDigits = 6
+    let minDigits = 4
+
+    var canConfirm: Bool {
+        digits.count >= minDigits && !isProcessing
+    }
+
+    var stepLabel: String {
+        switch step {
+        case .enterOldPin: "Étape 1 sur 2"
+        case .enterNewPin: "Étape 2 sur 2"
+        case .processing: ""
+        }
+    }
+
+    var biometricEnabled = false
+
+    private var pinString: String {
+        digits.map(String.init).joined()
+    }
+
+    // MARK: - Private
+
+    private static let logger = Logger(subsystem: "com.pulpe.app", category: "ChangePinViewModel")
+    private var oldClientKeyHex: String?
+    private var cachedSalt: EncryptionSaltResponse?
+    nonisolated(unsafe) private var errorResetTask: Task<Void, Never>?
+    private let cryptoService: any PinCryptoKeyDerivation
+    private let encryptionAPI: any PinEncryptionChangePin
+    private let clientKeyManager: any PinClientKeyStorage
+
+    deinit {
+        errorResetTask?.cancel()
+    }
+
+    // MARK: - Init
+
+    init(
+        cryptoService: any PinCryptoKeyDerivation = CryptoService.shared,
+        encryptionAPI: any PinEncryptionChangePin = EncryptionAPI.shared,
+        clientKeyManager: any PinClientKeyStorage = ClientKeyManager.shared
+    ) {
+        self.cryptoService = cryptoService
+        self.encryptionAPI = encryptionAPI
+        self.clientKeyManager = clientKeyManager
+    }
+
+    // MARK: - Actions
+
+    func appendDigit(_ digit: Int) {
+        guard digits.count < maxDigits, !isProcessing else { return }
+        if isError { clearError() }
+        digits.append(digit)
+
+        if digits.count == maxDigits {
+            isProcessing = true
+            Task { await handlePinComplete() }
+        }
+    }
+
+    func deleteLastDigit() {
+        guard !digits.isEmpty, !isProcessing else { return }
+        digits.removeLast()
+        clearError()
+    }
+
+    func confirm() async {
+        guard canConfirm else { return }
+        isProcessing = true
+        await handlePinComplete()
+    }
+
+    // MARK: - Flow
+
+    private func handlePinComplete() async {
+        switch step {
+        case .enterOldPin:
+            await validateOldPin()
+        case .enterNewPin:
+            await executeChangePin()
+        case .processing:
+            break
+        }
+    }
+
+    func goBack() {
+        guard !isProcessing else { return }
+        step = .enterOldPin
+        digits = []
+        oldClientKeyHex = nil
+        cachedSalt = nil
+        clearError()
+    }
+
+    // MARK: - Old PIN Validation
+
+    private func validateOldPin() async {
+        defer { isProcessing = false }
+
+        do {
+            let result = try await PinValidation.deriveValidateAndStore(
+                pin: pinString,
+                cryptoService: cryptoService,
+                encryptionAPI: encryptionAPI,
+                clientKeyManager: clientKeyManager
+            )
+            oldClientKeyHex = result.clientKeyHex
+            cachedSalt = result.saltResponse
+            hapticSuccess.toggle()
+            withAnimation(DesignTokens.Animation.stepTransition) {
+                step = .enterNewPin
+                digits = []
+            }
+        } catch let error as APIError {
+            handleAPIError(error)
+        } catch let error as CryptoServiceError {
+            handleCryptoError(error)
+        } catch {
+            showError("Erreur inattendue, réessaie")
+        }
+    }
+
+    // MARK: - Change PIN Execution
+
+    private func executeChangePin() async {
+        guard let oldClientKeyHex, let cachedSalt else { return }
+
+        step = .processing
+        defer { isProcessing = false }
+
+        do {
+            let result = try await PinValidation.derive(
+                pin: pinString,
+                cachedSalt: cachedSalt,
+                cryptoService: cryptoService
+            )
+
+            guard result.clientKeyHex != oldClientKeyHex else {
+                step = .enterNewPin
+                digits = []
+                showError("Le nouveau code doit être différent")
+                return
+            }
+
+            let response = try await encryptionAPI.changePin(
+                oldClientKeyHex: oldClientKeyHex,
+                newClientKeyHex: result.clientKeyHex
+            )
+
+            await clientKeyManager.store(result.clientKeyHex, enableBiometric: biometricEnabled)
+            self.oldClientKeyHex = nil
+            self.cachedSalt = nil
+            hapticSuccess.toggle()
+            recoveryKey = response.recoveryKey
+        } catch let error as APIError {
+            step = .enterNewPin
+            handleAPIError(error)
+        } catch let error as CryptoServiceError {
+            step = .enterNewPin
+            handleCryptoError(error)
+        } catch {
+            step = .enterNewPin
+            showError("Erreur inattendue, réessaie")
+        }
+    }
+
+    // MARK: - Error Handling
+
+    private func handleAPIError(_ error: APIError) {
+        Self.logger.warning("API error during PIN change: \(String(describing: error))")
+        showError(error.pinValidationMessage)
+    }
+
+    private func handleCryptoError(_ error: CryptoServiceError) {
+        Self.logger.error("Crypto error during PIN change: \(String(describing: error))")
+        showError(error.pinUserMessage)
+    }
+
+    private func showError(_ message: String) {
+        errorMessage = message
+        isError = true
+        digits = []
+        hapticError.toggle()
+
+        errorResetTask?.cancel()
+        errorResetTask = Task {
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            clearError()
+        }
+    }
+
+    func clearRecoveryKey() {
+        recoveryKey = nil
+    }
+
+    private func clearError() {
+        isError = false
+        errorMessage = nil
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ChangePinView(onSuccess: {})
+        .environment(AppState())
+}

--- a/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
@@ -296,6 +296,7 @@ final class ChangePinViewModel {
             self.oldClientKeyHex = nil
             self.cachedSalt = nil
             hapticSuccess.toggle()
+            AnalyticsService.shared.capture(.pinChanged)
             recoveryKey = response.recoveryKey
         } catch let error as APIError {
             step = .enterNewPin

--- a/ios/Pulpe/Features/Auth/Pin/Components/PinDotsErrorView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/Components/PinDotsErrorView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Composite view: PIN dots + optional error message with animated transition.
+/// Replaces duplicated VStack pattern across PinEntry, PinSetup, PinRecovery, and ChangePin views.
+struct PinDotsErrorView: View {
+    let enteredCount: Int
+    let maxDigits: Int
+    let isError: Bool
+    let errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: DesignTokens.Spacing.md) {
+            PinDotsView(
+                enteredCount: enteredCount,
+                maxDigits: maxDigits,
+                isError: isError
+            )
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(PulpeTypography.footnote)
+                    .foregroundStyle(Color.errorPrimary)
+                    .transition(.opacity)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Code PIN")
+        .accessibilityValue(accessibilityDescription)
+        .animation(.easeInOut(duration: DesignTokens.Animation.fast), value: errorMessage)
+    }
+
+    private var accessibilityDescription: String {
+        var description = "\(enteredCount) chiffres sur \(maxDigits) saisis"
+        if let errorMessage {
+            description += ". \(errorMessage)"
+        }
+        return description
+    }
+}

--- a/ios/Pulpe/Features/Auth/Pin/Components/PinDotsView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/Components/PinDotsView.swift
@@ -18,6 +18,7 @@ struct PinDotsView: View {
             }
         }
         .offset(x: shakeOffset)
+        .accessibilityHidden(true)
         .onChange(of: isError) { _, newValue in
             guard newValue else { return }
             withAnimation(.easeInOut(duration: 0.08).repeatCount(5, autoreverses: true)) {

--- a/ios/Pulpe/Features/Auth/Pin/Components/PinProcessingView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/Components/PinProcessingView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Shared processing spinner with title and subtitle.
+/// Used during PIN change and PIN recovery re-encryption.
+struct PinProcessingView: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(spacing: DesignTokens.Spacing.xl) {
+            ProgressView()
+                .tint(Color.textPrimaryOnboarding)
+                .scaleEffect(1.5)
+
+            Text(title)
+                .font(PulpeTypography.onboardingTitle)
+                .foregroundStyle(Color.textPrimaryOnboarding)
+
+            Text(subtitle)
+                .font(PulpeTypography.stepSubtitle)
+                .foregroundStyle(Color.textSecondaryOnboarding)
+                .multilineTextAlignment(.center)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/ios/Pulpe/Features/Auth/Pin/PinCryptoProtocols.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinCryptoProtocols.swift
@@ -47,6 +47,13 @@ protocol PinEncryptionRecovery: PinEncryptionValidation {
     func regenerateRecoveryKey() async throws -> String
 }
 
+/// Extended encryption operations for PIN change flow.
+protocol PinEncryptionChangePin: PinEncryptionValidation {
+    /// Changes the PIN by re-encrypting all data with a new client key.
+    /// Returns the new recovery key and key check.
+    func changePin(oldClientKeyHex: String, newClientKeyHex: String) async throws -> ChangePinResponse
+}
+
 /// Securely stores the client encryption key.
 protocol PinClientKeyStorage: Sendable {
     /// Stores the client key in memory and optionally in biometric-protected keychain.
@@ -64,3 +71,28 @@ extension ClientKeyManager: PinClientKeyStorage {}
 extension EncryptionAPI: PinEncryptionValidation {}
 extension EncryptionAPI: PinEncryptionSetup {}
 extension EncryptionAPI: PinEncryptionRecovery {}
+extension EncryptionAPI: PinEncryptionChangePin {}
+
+// MARK: - PIN Error Messages
+
+extension APIError {
+    /// User-facing message for PIN validation errors (entry, change).
+    var pinValidationMessage: String {
+        switch self {
+        case .rateLimited: "Trop de tentatives, patiente un moment"
+        case .networkError: "Erreur de connexion, réessaie"
+        default: "Ce code ne semble pas correct"
+        }
+    }
+}
+
+extension CryptoServiceError {
+    /// User-facing message for crypto errors during PIN flows.
+    var pinUserMessage: String {
+        switch self {
+        case .invalidSalt, .invalidIterations: "Erreur de sécurité, contacte le support"
+        case .derivationFailed: "Erreur de chiffrement, réessaie"
+        case .invalidPin: "Code invalide"
+        }
+    }
+}

--- a/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
@@ -93,21 +93,12 @@ struct PinEntryView: View {
     // MARK: - Dots + Error
 
     private var dotsSection: some View {
-        VStack(spacing: DesignTokens.Spacing.md) {
-            PinDotsView(
-                enteredCount: viewModel.digits.count,
-                maxDigits: viewModel.maxDigits,
-                isError: viewModel.isError
-            )
-
-            if let errorMessage = viewModel.errorMessage {
-                Text(errorMessage)
-                    .font(PulpeTypography.footnote)
-                    .foregroundStyle(Color.errorPrimary)
-                    .transition(.opacity)
-            }
-        }
-        .animation(.easeInOut(duration: DesignTokens.Animation.fast), value: viewModel.errorMessage)
+        PinDotsErrorView(
+            enteredCount: viewModel.digits.count,
+            maxDigits: viewModel.maxDigits,
+            isError: viewModel.isError,
+            errorMessage: viewModel.errorMessage
+        )
     }
 
     // MARK: - Forgot PIN

--- a/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
@@ -37,9 +37,9 @@ struct PinEntryView: View {
             logoutButton
             Spacer()
             headerSection
-            Spacer().frame(height: 40)
+            Spacer().frame(height: DesignTokens.Spacing.sectionGap)
             dotsSection
-            Spacer().frame(height: 48)
+            Spacer().frame(height: DesignTokens.Spacing.stepHeaderTop)
             NumpadView(
                 onDigit: { viewModel.appendDigit($0) },
                 onDelete: { viewModel.deleteLastDigit() },
@@ -166,6 +166,7 @@ final class PinEntryViewModel {
 
     func appendDigit(_ digit: Int) {
         guard digits.count < maxDigits, !isValidating else { return }
+        if isError { clearError() }
         digits.append(digit)
     }
 
@@ -212,25 +213,11 @@ final class PinEntryViewModel {
     // MARK: - Error Handling
 
     private func handleAPIError(_ error: APIError) {
-        switch error {
-        case .rateLimited:
-            showError("Trop de tentatives, patiente un moment")
-        case .networkError:
-            showError("Erreur de connexion, réessaie")
-        default:
-            showError("Ce code ne semble pas correct")
-        }
+        showError(error.pinValidationMessage)
     }
 
     private func handleCryptoError(_ error: CryptoServiceError) {
-        switch error {
-        case .invalidSalt, .invalidIterations:
-            showError("Erreur de sécurité, contacte le support")
-        case .derivationFailed:
-            showError("Erreur de chiffrement, réessaie")
-        case .invalidPin:
-            showError("Code invalide")
-        }
+        showError(error.pinUserMessage)
     }
 
     private func showError(_ message: String) {
@@ -241,9 +228,9 @@ final class PinEntryViewModel {
 
         errorResetTask?.cancel()
         errorResetTask = Task {
-            try? await Task.sleep(for: .seconds(1))
+            try? await Task.sleep(for: .seconds(3))
             guard !Task.isCancelled else { return }
-            isError = false
+            clearError()
         }
     }
 

--- a/ios/Pulpe/Features/Auth/Pin/PinRecoveryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinRecoveryView.swift
@@ -293,6 +293,7 @@ final class PinRecoveryViewModel {
 
     func appendDigit(_ digit: Int) {
         guard digits.count < maxDigits, !isProcessing else { return }
+        if isError { clearError() }
         digits.append(digit)
 
         if digits.count == maxDigits {

--- a/ios/Pulpe/Features/Auth/Pin/PinRecoveryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinRecoveryView.swift
@@ -157,7 +157,7 @@ struct PinRecoveryView: View {
                 }
             }
 
-            Spacer().frame(height: 40)
+            Spacer().frame(height: DesignTokens.Spacing.sectionGap)
 
             PinDotsErrorView(
                 enteredCount: viewModel.digits.count,
@@ -166,7 +166,7 @@ struct PinRecoveryView: View {
                 errorMessage: viewModel.errorMessage
             )
 
-            Spacer().frame(height: 48)
+            Spacer().frame(height: DesignTokens.Spacing.stepHeaderTop)
 
             NumpadView(
                 onDigit: { viewModel.appendDigit($0) },
@@ -451,9 +451,9 @@ final class PinRecoveryViewModel {
 
         errorResetTask?.cancel()
         errorResetTask = Task {
-            try? await Task.sleep(for: .seconds(2))
+            try? await Task.sleep(for: .seconds(3))
             guard !Task.isCancelled else { return }
-            isError = false
+            clearError()
         }
     }
 

--- a/ios/Pulpe/Features/Auth/Pin/PinRecoveryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinRecoveryView.swift
@@ -13,11 +13,6 @@ enum RecoveryStep: Equatable {
 // MARK: - View
 
 struct PinRecoveryView: View {
-    private struct RecoveryKeySheetItem: Identifiable {
-        let key: String
-        var id: String { key }
-    }
-
     let onComplete: () -> Void
     let onCancel: () -> Void
     let onSessionExpired: () -> Void
@@ -29,7 +24,7 @@ struct PinRecoveryView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .pulpeBackground()
             .sheet(item: recoveryKeySheetItemBinding) { item in
-                RecoveryKeySheet(recoveryKey: item.key) {
+                RecoveryKeySheet(recoveryKey: item.recoveryKey) {
                     onComplete()
                 }
             }
@@ -164,21 +159,12 @@ struct PinRecoveryView: View {
 
             Spacer().frame(height: 40)
 
-            VStack(spacing: DesignTokens.Spacing.md) {
-                PinDotsView(
-                    enteredCount: viewModel.digits.count,
-                    maxDigits: viewModel.maxDigits,
-                    isError: viewModel.isError
-                )
-
-                if let error = viewModel.errorMessage {
-                    Text(error)
-                        .font(PulpeTypography.footnote)
-                        .foregroundStyle(Color.errorPrimary)
-                        .transition(.opacity)
-                }
-            }
-            .animation(.easeInOut(duration: DesignTokens.Animation.fast), value: viewModel.errorMessage)
+            PinDotsErrorView(
+                enteredCount: viewModel.digits.count,
+                maxDigits: viewModel.maxDigits,
+                isError: viewModel.isError,
+                errorMessage: viewModel.errorMessage
+            )
 
             Spacer().frame(height: 48)
 
@@ -206,20 +192,10 @@ struct PinRecoveryView: View {
     // MARK: - Processing Step
 
     private var processingStep: some View {
-        VStack(spacing: DesignTokens.Spacing.xl) {
-            ProgressView()
-                .tint(Color.textPrimaryOnboarding)
-                .scaleEffect(1.5)
-
-            Text("Récupération en cours...")
-                .font(PulpeTypography.onboardingTitle)
-                .foregroundStyle(Color.textPrimaryOnboarding)
-
-            Text("Tes données sont en cours de re-chiffrement")
-                .font(PulpeTypography.stepSubtitle)
-                .foregroundStyle(Color.textSecondaryOnboarding)
-                .multilineTextAlignment(.center)
-        }
+        PinProcessingView(
+            title: "Récupération en cours...",
+            subtitle: "Tes données sont en cours de re-chiffrement"
+        )
     }
 
     // MARK: - Cancel Button
@@ -238,7 +214,7 @@ struct PinRecoveryView: View {
         Binding<RecoveryKeySheetItem?>(
             get: {
                 guard viewModel.showRecoverySheet, let key = viewModel.newRecoveryKey else { return nil }
-                return RecoveryKeySheetItem(key: key)
+                return RecoveryKeySheetItem(recoveryKey: key)
             },
             set: { item in
                 guard item == nil else { return }

--- a/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
@@ -208,6 +208,7 @@ final class PinSetupViewModel {
 
     func appendDigit(_ digit: Int) {
         guard digits.count < maxDigits, !isValidating else { return }
+        if isError { clearError() }
         digits.append(digit)
 
         if digits.count == maxDigits {

--- a/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
@@ -27,11 +27,6 @@ enum PinSetupStep {
 // MARK: - View
 
 struct PinSetupView: View {
-    private struct RecoveryKeySheetItem: Identifiable {
-        let key: String
-        var id: String { key }
-    }
-
     let mode: PinSetupMode
     let onComplete: () async -> Void
     let onLogout: (() async -> Void)?
@@ -56,7 +51,7 @@ struct PinSetupView: View {
             .sensoryFeedback(.error, trigger: viewModel.hapticError)
             .sensoryFeedback(.success, trigger: viewModel.hapticSuccess)
             .sheet(item: recoveryKeySheetItemBinding) { item in
-                RecoveryKeySheet(recoveryKey: item.key) {
+                RecoveryKeySheet(recoveryKey: item.recoveryKey) {
                     Task { await onComplete() }
                 }
             }
@@ -125,28 +120,19 @@ struct PinSetupView: View {
     // MARK: - Dots + Error
 
     private var dotsSection: some View {
-        VStack(spacing: DesignTokens.Spacing.md) {
-            PinDotsView(
-                enteredCount: viewModel.digits.count,
-                maxDigits: viewModel.maxDigits,
-                isError: viewModel.isError
-            )
-
-            if let errorMessage = viewModel.errorMessage {
-                Text(errorMessage)
-                    .font(PulpeTypography.footnote)
-                    .foregroundStyle(Color.errorPrimary)
-                    .transition(.opacity)
-            }
-        }
-        .animation(.easeInOut(duration: DesignTokens.Animation.fast), value: viewModel.errorMessage)
+        PinDotsErrorView(
+            enteredCount: viewModel.digits.count,
+            maxDigits: viewModel.maxDigits,
+            isError: viewModel.isError,
+            errorMessage: viewModel.errorMessage
+        )
     }
 
     private var recoveryKeySheetItemBinding: Binding<RecoveryKeySheetItem?> {
         Binding<RecoveryKeySheetItem?>(
             get: {
                 guard viewModel.showRecoverySheet, let key = viewModel.recoveryKey else { return nil }
-                return RecoveryKeySheetItem(key: key)
+                return RecoveryKeySheetItem(recoveryKey: key)
             },
             set: { item in
                 guard item == nil else { return }

--- a/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinSetupView.swift
@@ -309,9 +309,9 @@ final class PinSetupViewModel {
 
         errorResetTask?.cancel()
         errorResetTask = Task {
-            try? await Task.sleep(for: .seconds(1))
+            try? await Task.sleep(for: .seconds(3))
             guard !Task.isCancelled else { return }
-            isError = false
+            clearError()
         }
     }
 


### PR DESCRIPTION
## Summary

• Implement full PIN change feature with two-step validation flow (old PIN → new PIN)
• Extract `PinDotsErrorView` and `PinProcessingView` as reusable components
• Refactor PIN Entry/Setup/Recovery views to use shared components (DRY)
• Deduplicate error messages via `APIError.pinValidationMessage` extension

## Changes

**Core Feature:**
- New `ChangePinView` with two-step flow: validate old PIN, then enter new PIN
- Recovery key display via modal sheet after successful change
- Integration with Security Settings screen

**Components:**
- `PinDotsErrorView`: Consolidated PIN dots + error message (replaces 4× duplications)
- `PinProcessingView`: Reusable spinner + title/subtitle pattern
- Updated `PinDotsView` with VoiceOver support ("X digits on Y entered")

**Quality Improvements:**
- Shared error messages via protocol extensions (`APIError`, `CryptoServiceError`)
- Design tokens for spacing (`sectionGap`, `stepHeaderTop`) and animations (`stepTransition`)
- Error state cleanup: `clearError()` on both timer expiration and user input
- 3-second error display timeout (vs 1s) for better readability

**Refactoring:**
- `PinEntryView`, `PinSetupView`, `PinRecoveryView` now use `PinDotsErrorView`
- All PIN flows share consistent error handling and messaging

## Fixes

- ✅ pul-80: Implement PIN change screen in iOS settings

## Testing Notes

- ✅ Build passes (xcodebuild)
- ✅ Accessibility: VoiceOver announces PIN progress
- ✅ Error state clears on user input (no stale messages)
- ✅ 3s error timeout allows readable error messages
- ✅ Recovery key displayed and copyable after change