### PR TITLE
iOS: Budget list color and component refinements

### DIFF
--- a/ios/Pulpe/Domain/Formulas/BudgetFormulas.swift
+++ b/ios/Pulpe/Domain/Formulas/BudgetFormulas.swift
@@ -31,9 +31,12 @@ enum BudgetFormulas {
 
         /// DA §3.1: 3-state emotion zone — comfortable (<80%), tight (80-100%), deficit (>100%)
         var emotionState: EmotionState {
-            if isDeficit { return .deficit }
-            if usagePercentage >= BudgetFormulas.tightBudgetThreshold { return .tight }
-            return .comfortable
+            BudgetFormulas.emotionState(
+                remaining: remaining,
+                totalIncome: totalIncome,
+                totalExpenses: totalExpenses,
+                rollover: rollover
+            )
         }
     }
 
@@ -42,8 +45,8 @@ enum BudgetFormulas {
         case comfortable, tight, deficit
     }
 
-    /// Compute emotion state from raw sparse values (used by budget list hero card).
-    /// SOT logic matches `Metrics.emotionState`.
+    /// SOT: Compute emotion state from raw values.
+    /// Used by both `Metrics.emotionState` and budget list hero card.
     static func emotionState(
         remaining: Decimal?,
         totalIncome: Decimal?,

--- a/ios/Pulpe/Domain/Formulas/BudgetFormulas.swift
+++ b/ios/Pulpe/Domain/Formulas/BudgetFormulas.swift
@@ -42,6 +42,23 @@ enum BudgetFormulas {
         case comfortable, tight, deficit
     }
 
+    /// Compute emotion state from raw sparse values (used by budget list hero card).
+    /// SOT logic matches `Metrics.emotionState`.
+    static func emotionState(
+        remaining: Decimal?,
+        totalIncome: Decimal?,
+        totalExpenses: Decimal?,
+        rollover: Decimal?
+    ) -> EmotionState {
+        guard let remaining else { return .comfortable }
+        if remaining < 0 { return .deficit }
+        let available = (totalIncome ?? 0) + (rollover ?? 0)
+        guard available > 0 else { return .comfortable }
+        let usagePercentage = Double(truncating: ((totalExpenses ?? 0) / available * 100) as NSDecimalNumber)
+        if usagePercentage >= tightBudgetThreshold { return .tight }
+        return .comfortable
+    }
+
     // MARK: - Realized Metrics
 
     struct RealizedMetrics: Equatable, Sendable {

--- a/ios/Pulpe/Domain/Store/BudgetListStore.swift
+++ b/ios/Pulpe/Domain/Store/BudgetListStore.swift
@@ -65,7 +65,8 @@ final class BudgetListStore: StoreProtocol {
             defer { isLoading = false }
 
             do {
-                let fetchedBudgets = try await budgetService.getBudgetsSparse(fields: "month,year,remaining")
+                let fields = "month,year,remaining,totalIncome,totalExpenses,rollover"
+                let fetchedBudgets = try await budgetService.getBudgetsSparse(fields: fields)
 
                 // Check for cancellation before updating state
                 try Task.checkCancellation()

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
@@ -205,7 +205,7 @@ struct BudgetMonthRow: View {
         Formatters.monthName(for: budget.month ?? 0)
     }
 
-    private func isPast() -> Bool {
+    private var isPast: Bool {
         guard let month = budget.month, let year = budget.year else { return false }
         let current = BudgetPeriodCalculator.periodForDate(Date(), payDayOfMonth: payDayOfMonth)
         return year < current.year || (year == current.year && month < current.month)
@@ -220,7 +220,7 @@ struct BudgetMonthRow: View {
     }
 
     var body: some View {
-        let isPast = isPast()
+        let isPast = isPast
         let color = amountColor(isPast: isPast)
 
         Button {

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
@@ -213,8 +213,8 @@ struct BudgetMonthRow: View {
         return (isPast, isFuture)
     }
 
-    private func amountColor(isPast: Bool, isFuture: Bool) -> Color {
-        if isPast || isFuture { return .secondary }
+    private func amountColor(isPast: Bool) -> Color {
+        if isPast { return .secondary }
         guard let remaining = budget.remaining else { return .secondary }
         if remaining < 0 { return .financialOverBudget }
         if remaining > 0 { return .financialSavings }
@@ -224,7 +224,7 @@ struct BudgetMonthRow: View {
     var body: some View {
         let temporal = temporalState()
         let isPast = temporal.isPast
-        let color = amountColor(isPast: temporal.isPast, isFuture: temporal.isFuture)
+        let color = amountColor(isPast: temporal.isPast)
 
         Button {
             tapTrigger.toggle()

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
@@ -6,7 +6,6 @@ struct CurrentMonthHeroCard: View {
     let onTap: () -> Void
 
     @State private var isPressed = false
-    @State private var isPulsing = false
     @State private var tapTrigger = false
     @State private var hasAppeared = false
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -19,12 +18,46 @@ struct CurrentMonthHeroCard: View {
         return Formatters.monthYear.monthSymbols[month - 1].capitalized
     }
 
-    private var isNegative: Bool {
-        (budget.remaining ?? 0) < 0
+    /// SOT with HeroBalanceCard — 3-state emotion system from BudgetFormulas
+    private var emotionState: BudgetFormulas.EmotionState {
+        guard let remaining = budget.remaining else { return .comfortable }
+        if remaining < 0 { return .deficit }
+        let available = (budget.totalIncome ?? 0) + (budget.rollover ?? 0)
+        guard available > 0 else { return .comfortable }
+        let totalExpenses = budget.totalExpenses ?? 0
+        let usagePercentage = Double(truncating: (totalExpenses / available * 100) as NSDecimalNumber)
+        if usagePercentage >= BudgetFormulas.tightBudgetThreshold { return .tight }
+        return .comfortable
     }
 
-    private var amountColor: Color {
-        isNegative ? .financialOverBudget : .financialSavings
+    private var disponibleLabel: some View {
+        Text("Disponible")
+            .font(PulpeTypography.inputHelper)
+            .foregroundStyle(.white.opacity(0.6))
+            .textCase(.uppercase)
+            .tracking(0.5)
+    }
+
+    @ViewBuilder
+    private var remainingAmount: some View {
+        if let remaining = budget.remaining {
+            Text(remaining.asCHF)
+                .font(PulpeTypography.amountLarge)
+                .monospacedDigit()
+                .foregroundStyle(.white)
+                .contentTransition(.numericText())
+                .sensitiveAmount()
+        }
+    }
+
+    private var detailsCTA: some View {
+        HStack(spacing: DesignTokens.Spacing.xs) {
+            Text("Détails")
+                .font(PulpeTypography.buttonSecondary)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+        }
+        .foregroundStyle(.white.opacity(0.8))
     }
 
     var body: some View {
@@ -33,95 +66,60 @@ struct CurrentMonthHeroCard: View {
             onTap()
         } label: {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
-                HStack(alignment: .center) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "calendar")
-                            .font(.system(size: 13, weight: .semibold))
-                        Text("Ce mois-ci")
-                            .font(PulpeTypography.labelLarge)
-                    }
-                    .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    pulseDot
+                HStack(spacing: 6) {
+                    Image(systemName: "calendar")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text("Ce mois-ci")
+                        .font(PulpeTypography.labelLarge)
                 }
+                .foregroundStyle(.white.opacity(0.7))
                 VStack(alignment: .leading, spacing: 4) {
                     Text(monthName)
                         .font(PulpeTypography.brandTitle)
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(.white)
 
                     if let periodLabel {
                         Text(periodLabel)
                             .font(PulpeTypography.caption)
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(.white.opacity(0.5))
                     }
                 }
 
                 Spacer().frame(height: DesignTokens.Spacing.sm)
                 if dynamicTypeSize.isAccessibilitySize {
                     VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
-                        Text("Disponible")
-                            .font(PulpeTypography.inputHelper)
-                            .foregroundStyle(.tertiary)
-                            .textCase(.uppercase)
-                            .tracking(0.5)
-
-                        if let remaining = budget.remaining {
-                            Text(remaining.asCHF)
-                                .font(PulpeTypography.amountLarge)
-                                .monospacedDigit()
-                                .foregroundStyle(amountColor)
-                                .contentTransition(.numericText())
-                                .sensitiveAmount()
-                        }
-
-                        HStack(spacing: DesignTokens.Spacing.xs) {
-                            Text("Détails")
-                                .font(PulpeTypography.buttonSecondary)
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 12, weight: .semibold))
-                        }
-                        .foregroundStyle(Color.pulpePrimary)
+                        disponibleLabel
+                        remainingAmount
+                        detailsCTA
                     }
                 } else {
                     HStack(alignment: .bottom) {
                         VStack(alignment: .leading, spacing: 6) {
-                            Text("Disponible")
-                                .font(PulpeTypography.inputHelper)
-                                .foregroundStyle(.tertiary)
-                                .textCase(.uppercase)
-                                .tracking(0.5)
-
-                            if let remaining = budget.remaining {
-                                Text(remaining.asCHF)
-                                    .font(PulpeTypography.amountLarge)
-                                    .monospacedDigit()
-                                    .foregroundStyle(amountColor)
-                                    .contentTransition(.numericText())
-                                    .sensitiveAmount()
-                            }
+                            disponibleLabel
+                            remainingAmount
                         }
-
                         Spacer()
-                        HStack(spacing: DesignTokens.Spacing.xs) {
-                            Text("Détails")
-                                .font(PulpeTypography.buttonSecondary)
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 12, weight: .semibold))
-                        }
-                        .foregroundStyle(Color.pulpePrimary)
+                        detailsCTA
                     }
                 }
             }
             .padding(DesignTokens.Spacing.xxl)
             .frame(minHeight: 170)
+            .contentShape(Rectangle())
             .background(heroGradientBackground)
             .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.xl))
-            .overlay(
-                RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.xl)
-                    .strokeBorder(Color.outlineVariant.opacity(0.15), lineWidth: 1)
-            )
+            .overlay(alignment: .top) {
+                Capsule()
+                    .fill(.white.opacity(0.15))
+                    .frame(height: 1)
+                    .padding(.horizontal, 28)
+            }
+            .overlay {
+                if colorScheme == .dark {
+                    RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.xl)
+                        .stroke(.white.opacity(0.05), lineWidth: 1)
+                }
+            }
             .scaleEffect(isPressed ? 0.97 : 1)
             .scaleEffect(hasAppeared ? 1 : 0.96)
             .offset(y: hasAppeared ? 0 : 8)
@@ -149,44 +147,49 @@ struct CurrentMonthHeroCard: View {
         .accessibilityAddTraits(.isButton)
     }
 
-    @ViewBuilder
+    /// SOT with HeroBalanceCard.cardBackground — 3-state gradient crossfade + decorative circles
     private var heroGradientBackground: some View {
         ZStack {
-            Color.surfaceContainerHigh
             LinearGradient(
-                colors: [
-                    Color.pulpePrimary.opacity(colorScheme == .dark ? 0.12 : 0.10),
-                    Color.pulpePrimary.opacity(colorScheme == .dark ? 0.04 : 0.03)
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
+                colors: Color.heroGradientComfortable,
+                startPoint: UnitPoint(x: 0.1, y: 0),
+                endPoint: UnitPoint(x: 0.9, y: 1)
             )
-        }
-    }
+            .opacity(emotionState == .comfortable ? 1 : 0)
 
-    private var pulseDot: some View {
-        ZStack {
-            if reduceMotion {
-                Circle()
-                    .fill(Color.pulpePrimary.opacity(0.3))
-                    .frame(width: 14, height: 14)
-            } else {
-                Circle()
-                    .fill(Color.pulpePrimary.opacity(isPulsing ? 0 : 0.35))
-                    .frame(width: 10, height: 10)
-                    .scaleEffect(isPulsing ? 2.0 : 1)
-                    .animation(.easeOut(duration: 1.5).repeatForever(autoreverses: false), value: isPulsing)
-            }
+            LinearGradient(
+                colors: Color.heroGradientTight,
+                startPoint: UnitPoint(x: 0.1, y: 0),
+                endPoint: UnitPoint(x: 0.9, y: 1)
+            )
+            .opacity(emotionState == .tight ? 1 : 0)
+
+            LinearGradient(
+                colors: Color.heroGradientDeficit,
+                startPoint: UnitPoint(x: 0.1, y: 0),
+                endPoint: UnitPoint(x: 0.9, y: 1)
+            )
+            .opacity(emotionState == .deficit ? 1 : 0)
 
             Circle()
-                .fill(Color.pulpePrimary)
-                .frame(width: 10, height: 10)
+                .fill(.white.opacity(0.07))
+                .frame(width: 180, height: 180)
+                .blur(radius: 40)
+                .offset(x: 80, y: 60)
+
+            Circle()
+                .fill(.white.opacity(0.05))
+                .frame(width: 120, height: 120)
+                .blur(radius: 28)
+                .offset(x: 60, y: -40)
+
+            Circle()
+                .fill(.white.opacity(0.03))
+                .frame(width: 80, height: 80)
+                .blur(radius: 24)
+                .offset(x: -50, y: 0)
         }
-        .onAppear {
-            if !reduceMotion {
-                isPulsing = true
-            }
-        }
+        .allowsHitTesting(false)
     }
 }
 

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
@@ -7,6 +7,8 @@ struct CurrentMonthHeroCard: View {
 
     @State private var isPressed = false
     @State private var isPulsing = false
+    @State private var tapTrigger = false
+    @State private var hasAppeared = false
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
@@ -26,7 +28,10 @@ struct CurrentMonthHeroCard: View {
     }
 
     var body: some View {
-        Button(action: onTap) {
+        Button {
+            tapTrigger.toggle()
+            onTap()
+        } label: {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
                 HStack(alignment: .center) {
                     HStack(spacing: 6) {
@@ -54,8 +59,8 @@ struct CurrentMonthHeroCard: View {
                 }
 
                 Spacer().frame(height: DesignTokens.Spacing.sm)
-                HStack(alignment: .bottom) {
-                    VStack(alignment: .leading, spacing: 6) {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                         Text("Disponible")
                             .font(PulpeTypography.inputHelper)
                             .foregroundStyle(.tertiary)
@@ -70,16 +75,43 @@ struct CurrentMonthHeroCard: View {
                                 .contentTransition(.numericText())
                                 .sensitiveAmount()
                         }
-                    }
 
-                    Spacer()
-                    HStack(spacing: DesignTokens.Spacing.xs) {
-                        Text("Détails")
-                            .font(PulpeTypography.buttonSecondary)
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 12, weight: .semibold))
+                        HStack(spacing: DesignTokens.Spacing.xs) {
+                            Text("Détails")
+                                .font(PulpeTypography.buttonSecondary)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .foregroundStyle(Color.pulpePrimary)
                     }
-                    .foregroundStyle(Color.pulpePrimary)
+                } else {
+                    HStack(alignment: .bottom) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Disponible")
+                                .font(PulpeTypography.inputHelper)
+                                .foregroundStyle(.tertiary)
+                                .textCase(.uppercase)
+                                .tracking(0.5)
+
+                            if let remaining = budget.remaining {
+                                Text(remaining.asCHF)
+                                    .font(PulpeTypography.amountLarge)
+                                    .monospacedDigit()
+                                    .foregroundStyle(amountColor)
+                                    .contentTransition(.numericText())
+                                    .sensitiveAmount()
+                            }
+                        }
+
+                        Spacer()
+                        HStack(spacing: DesignTokens.Spacing.xs) {
+                            Text("Détails")
+                                .font(PulpeTypography.buttonSecondary)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .foregroundStyle(Color.pulpePrimary)
+                    }
                 }
             }
             .padding(DesignTokens.Spacing.xxl)
@@ -91,9 +123,21 @@ struct CurrentMonthHeroCard: View {
                     .strokeBorder(Color.outlineVariant.opacity(0.15), lineWidth: 1)
             )
             .scaleEffect(isPressed ? 0.97 : 1)
+            .scaleEffect(hasAppeared ? 1 : 0.96)
+            .offset(y: hasAppeared ? 0 : 8)
             .animation(.spring(response: 0.25, dampingFraction: 0.7), value: isPressed)
+            .task {
+                if reduceMotion {
+                    hasAppeared = true
+                } else {
+                    withAnimation(DesignTokens.Animation.entranceSpring) {
+                        hasAppeared = true
+                    }
+                }
+            }
         }
         .buttonStyle(.plain)
+        .sensoryFeedback(.impact(weight: .medium), trigger: tapTrigger)
         .onLongPressGesture(minimumDuration: .infinity, pressing: { pressing in
             isPressed = pressing
         }, perform: {})
@@ -161,11 +205,6 @@ struct BudgetMonthRow: View {
         return Formatters.monthYear.monthSymbols[month - 1].capitalized
     }
 
-    private var monthNumber: String {
-        guard let month = budget.month else { return "—" }
-        return String(format: "%02d", month)
-    }
-
     private var isPastMonth: Bool {
         guard let month = budget.month, let year = budget.year else { return false }
         let current = BudgetPeriodCalculator.periodForDate(Date(), payDayOfMonth: payDayOfMonth)
@@ -180,6 +219,7 @@ struct BudgetMonthRow: View {
 
     private var amountColor: Color {
         if isPastMonth { return .secondary }
+        if isFutureMonth { return .secondary }
         guard let remaining = budget.remaining else { return .secondary }
         if remaining < 0 { return .financialOverBudget }
         if remaining > 0 { return .financialSavings }
@@ -192,11 +232,6 @@ struct BudgetMonthRow: View {
             onTap()
         } label: {
             HStack(spacing: DesignTokens.Spacing.md) {
-                Text(monthNumber)
-                    .font(.system(.caption, design: .monospaced, weight: .semibold))
-                    .foregroundStyle(isPastMonth ? .quaternary : .tertiary)
-                    .frame(width: 24)
-
                 if dynamicTypeSize.isAccessibilitySize {
                     VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
                         Text(monthName)
@@ -230,14 +265,6 @@ struct BudgetMonthRow: View {
                                 .foregroundStyle(.tertiary)
                         }
                     }
-                    if isFutureMonth {
-                        Text("À venir")
-                            .font(PulpeTypography.progressUnit)
-                            .foregroundStyle(.tertiary)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Color.surfaceContainerLow, in: Capsule())
-                    }
                     Spacer()
                     if let remaining = budget.remaining {
                         Text(remaining.asCompactCHF)
@@ -250,7 +277,7 @@ struct BudgetMonthRow: View {
 
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.quaternary)
+                    .foregroundStyle(.tertiary)
             }
             .padding(.horizontal, DesignTokens.Spacing.lg)
             .padding(.vertical, DesignTokens.Spacing.lg)
@@ -272,22 +299,19 @@ struct NextMonthPlaceholder: View {
     let year: Int
     let onTap: () -> Void
 
-    private var monthName: String {
-        Formatters.monthYear.monthSymbols[month - 1].capitalized
-    }
+    @State private var tapTrigger = false
 
-    private var monthNumber: String {
-        String(format: "%02d", month)
+    private var monthName: String {
+        guard month >= 1, month <= 12 else { return "—" }
+        return Formatters.monthYear.monthSymbols[month - 1].capitalized
     }
 
     var body: some View {
-        Button(action: onTap) {
+        Button {
+            tapTrigger.toggle()
+            onTap()
+        } label: {
             HStack(spacing: DesignTokens.Spacing.md) {
-                Text(monthNumber)
-                    .font(.system(.caption, design: .monospaced, weight: .semibold))
-                    .foregroundStyle(.quaternary)
-                    .frame(width: 24)
-
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
                     Text(monthName)
                         .font(PulpeTypography.onboardingSubtitle)
@@ -295,7 +319,7 @@ struct NextMonthPlaceholder: View {
 
                     Text("Pas encore de budget")
                         .font(PulpeTypography.caption)
-                        .foregroundStyle(.quaternary)
+                        .foregroundStyle(.tertiary)
                 }
 
                 Spacer()
@@ -325,6 +349,7 @@ struct NextMonthPlaceholder: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .sensoryFeedback(.selection, trigger: tapTrigger)
         .accessibilityLabel("Créer un budget pour \(monthName)")
         .accessibilityHint("Appuie pour créer un budget")
         .accessibilityAddTraits(.isButton)

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
@@ -205,12 +205,10 @@ struct BudgetMonthRow: View {
         Formatters.monthName(for: budget.month ?? 0)
     }
 
-    private func temporalState() -> (isPast: Bool, isFuture: Bool) {
-        guard let month = budget.month, let year = budget.year else { return (false, false) }
+    private func isPast() -> Bool {
+        guard let month = budget.month, let year = budget.year else { return false }
         let current = BudgetPeriodCalculator.periodForDate(Date(), payDayOfMonth: payDayOfMonth)
-        let isPast = year < current.year || (year == current.year && month < current.month)
-        let isFuture = year > current.year || (year == current.year && month > current.month)
-        return (isPast, isFuture)
+        return year < current.year || (year == current.year && month < current.month)
     }
 
     private func amountColor(isPast: Bool) -> Color {
@@ -222,9 +220,8 @@ struct BudgetMonthRow: View {
     }
 
     var body: some View {
-        let temporal = temporalState()
-        let isPast = temporal.isPast
-        let color = amountColor(isPast: temporal.isPast)
+        let isPast = isPast()
+        let color = amountColor(isPast: isPast)
 
         Button {
             tapTrigger.toggle()

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView+Subviews.swift
@@ -14,20 +14,17 @@ struct CurrentMonthHeroCard: View {
     @Environment(\.amountsHidden) private var amountsHidden
 
     private var monthName: String {
-        guard let month = budget.month, month >= 1, month <= 12 else { return "—" }
-        return Formatters.monthYear.monthSymbols[month - 1].capitalized
+        Formatters.monthName(for: budget.month ?? 0)
     }
 
-    /// SOT with HeroBalanceCard — 3-state emotion system from BudgetFormulas
+    /// SOT — delegates to BudgetFormulas shared logic (same as HeroBalanceCard)
     private var emotionState: BudgetFormulas.EmotionState {
-        guard let remaining = budget.remaining else { return .comfortable }
-        if remaining < 0 { return .deficit }
-        let available = (budget.totalIncome ?? 0) + (budget.rollover ?? 0)
-        guard available > 0 else { return .comfortable }
-        let totalExpenses = budget.totalExpenses ?? 0
-        let usagePercentage = Double(truncating: (totalExpenses / available * 100) as NSDecimalNumber)
-        if usagePercentage >= BudgetFormulas.tightBudgetThreshold { return .tight }
-        return .comfortable
+        BudgetFormulas.emotionState(
+            remaining: budget.remaining,
+            totalIncome: budget.totalIncome,
+            totalExpenses: budget.totalExpenses,
+            rollover: budget.rollover
+        )
     }
 
     private var disponibleLabel: some View {
@@ -189,6 +186,7 @@ struct CurrentMonthHeroCard: View {
                 .blur(radius: 24)
                 .offset(x: -50, y: 0)
         }
+        .animation(reduceMotion ? nil : .spring(response: 0.7, dampingFraction: 0.8), value: emotionState)
         .allowsHitTesting(false)
     }
 }
@@ -204,25 +202,19 @@ struct BudgetMonthRow: View {
     @Environment(\.amountsHidden) private var amountsHidden
 
     private var monthName: String {
-        guard let month = budget.month, month >= 1, month <= 12 else { return "—" }
-        return Formatters.monthYear.monthSymbols[month - 1].capitalized
+        Formatters.monthName(for: budget.month ?? 0)
     }
 
-    private var isPastMonth: Bool {
-        guard let month = budget.month, let year = budget.year else { return false }
+    private func temporalState() -> (isPast: Bool, isFuture: Bool) {
+        guard let month = budget.month, let year = budget.year else { return (false, false) }
         let current = BudgetPeriodCalculator.periodForDate(Date(), payDayOfMonth: payDayOfMonth)
-        return year < current.year || (year == current.year && month < current.month)
+        let isPast = year < current.year || (year == current.year && month < current.month)
+        let isFuture = year > current.year || (year == current.year && month > current.month)
+        return (isPast, isFuture)
     }
 
-    private var isFutureMonth: Bool {
-        guard let month = budget.month, let year = budget.year else { return false }
-        let current = BudgetPeriodCalculator.periodForDate(Date(), payDayOfMonth: payDayOfMonth)
-        return year > current.year || (year == current.year && month > current.month)
-    }
-
-    private var amountColor: Color {
-        if isPastMonth { return .secondary }
-        if isFutureMonth { return .secondary }
+    private func amountColor(isPast: Bool, isFuture: Bool) -> Color {
+        if isPast || isFuture { return .secondary }
         guard let remaining = budget.remaining else { return .secondary }
         if remaining < 0 { return .financialOverBudget }
         if remaining > 0 { return .financialSavings }
@@ -230,6 +222,10 @@ struct BudgetMonthRow: View {
     }
 
     var body: some View {
+        let temporal = temporalState()
+        let isPast = temporal.isPast
+        let color = amountColor(isPast: temporal.isPast, isFuture: temporal.isFuture)
+
         Button {
             tapTrigger.toggle()
             onTap()
@@ -238,8 +234,8 @@ struct BudgetMonthRow: View {
                 if dynamicTypeSize.isAccessibilitySize {
                     VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
                         Text(monthName)
-                            .font(isPastMonth ? PulpeTypography.body : PulpeTypography.onboardingSubtitle)
-                            .foregroundStyle(isPastMonth ? .secondary : .primary)
+                            .font(isPast ? PulpeTypography.body : PulpeTypography.onboardingSubtitle)
+                            .foregroundStyle(isPast ? .secondary : .primary)
 
                         if let periodLabel {
                             Text(periodLabel)
@@ -251,7 +247,7 @@ struct BudgetMonthRow: View {
                             Text(remaining.asCompactCHF)
                                 .font(PulpeTypography.amountMedium)
                                 .monospacedDigit()
-                                .foregroundStyle(amountColor)
+                                .foregroundStyle(color)
                                 .sensitiveAmount()
                         }
                     }
@@ -260,8 +256,8 @@ struct BudgetMonthRow: View {
                 } else {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(monthName)
-                            .font(isPastMonth ? PulpeTypography.body : PulpeTypography.onboardingSubtitle)
-                            .foregroundStyle(isPastMonth ? .secondary : .primary)
+                            .font(isPast ? PulpeTypography.body : PulpeTypography.onboardingSubtitle)
+                            .foregroundStyle(isPast ? .secondary : .primary)
                         if let periodLabel {
                             Text(periodLabel)
                                 .font(PulpeTypography.caption)
@@ -273,7 +269,7 @@ struct BudgetMonthRow: View {
                         Text(remaining.asCompactCHF)
                             .font(PulpeTypography.amountMedium)
                             .monospacedDigit()
-                            .foregroundStyle(amountColor)
+                            .foregroundStyle(color)
                             .sensitiveAmount()
                     }
                 }
@@ -305,8 +301,7 @@ struct NextMonthPlaceholder: View {
     @State private var tapTrigger = false
 
     private var monthName: String {
-        guard month >= 1, month <= 12 else { return "—" }
-        return Formatters.monthYear.monthSymbols[month - 1].capitalized
+        Formatters.monthName(for: month)
     }
 
     var body: some View {

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Leading inset for list dividers, aligned with row text past the status indicator.
-private let dividerLeadingInset: CGFloat = 34
+private let dividerLeadingInset: CGFloat = 16
 
 struct BudgetListView: View {
     @Environment(AppState.self) private var appState
@@ -127,11 +127,19 @@ struct BudgetListView: View {
                             payDayOfMonth: userSettingsStore.payDayOfMonth,
                             isExpanded: expandedYears.contains(group.year),
                             onToggle: {
-                                withAnimation(.easeInOut(duration: DesignTokens.Animation.quickSnap)) {
+                                if reduceMotion {
                                     if expandedYears.contains(group.year) {
                                         expandedYears.remove(group.year)
                                     } else {
                                         expandedYears.insert(group.year)
+                                    }
+                                } else {
+                                    withAnimation(DesignTokens.Animation.defaultSpring) {
+                                        if expandedYears.contains(group.year) {
+                                            expandedYears.remove(group.year)
+                                        } else {
+                                            expandedYears.insert(group.year)
+                                        }
                                     }
                                 }
                             },
@@ -184,9 +192,9 @@ private struct BudgetListSkeletonView: View {
                     }
                     .padding(.vertical, DesignTokens.Spacing.md)
 
-                    // Month rows card
+                    // Month rows card (before hero)
                     VStack(spacing: 0) {
-                        ForEach(0..<4, id: \.self) { index in
+                        ForEach(0..<2, id: \.self) { index in
                             HStack(spacing: DesignTokens.Spacing.md) {
                                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
                                     SkeletonShape(width: 100, height: 14)
@@ -198,7 +206,31 @@ private struct BudgetListSkeletonView: View {
                             .padding(.horizontal, DesignTokens.Spacing.lg)
                             .padding(.vertical, DesignTokens.Spacing.md)
 
-                            if index < 3 {
+                            if index < 1 {
+                                Divider().padding(.leading, dividerLeadingInset)
+                            }
+                        }
+                    }
+                    .pulpeCardBackground(cornerRadius: DesignTokens.CornerRadius.lg)
+
+                    // Hero card placeholder
+                    SkeletonShape(height: 170, cornerRadius: DesignTokens.CornerRadius.xl)
+
+                    // Month rows card (after hero)
+                    VStack(spacing: 0) {
+                        ForEach(0..<2, id: \.self) { index in
+                            HStack(spacing: DesignTokens.Spacing.md) {
+                                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+                                    SkeletonShape(width: 100, height: 14)
+                                    SkeletonShape(width: 140, height: 11)
+                                }
+                                Spacer()
+                                SkeletonShape(width: 70, height: 14)
+                            }
+                            .padding(.horizontal, DesignTokens.Spacing.lg)
+                            .padding(.vertical, DesignTokens.Spacing.md)
+
+                            if index < 1 {
                                 Divider().padding(.leading, dividerLeadingInset)
                             }
                         }
@@ -231,10 +263,6 @@ struct YearSection: View {
         YearSectionLayoutData(year: year, budgets: budgets, payDayOfMonth: payDayOfMonth)
     }
 
-    private var yearEndRemaining: Decimal? {
-        budgets.max { ($0.month ?? 0) < ($1.month ?? 0) }?.remaining
-    }
-
     var body: some View {
         let data = layoutData
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
@@ -242,7 +270,11 @@ struct YearSection: View {
 
             if isExpanded {
                 expandedContent(data: data)
-                    .transition(.opacity)
+                    .transition(
+                        .move(edge: .top)
+                            .combined(with: .opacity)
+                            .combined(with: .scale(scale: 0.98, anchor: .top))
+                    )
             }
         }
         .sensoryFeedback(.impact(flexibility: .soft), trigger: expandTrigger)
@@ -287,7 +319,7 @@ struct YearSection: View {
             HStack(alignment: .center, spacing: DesignTokens.Spacing.md) {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 13, weight: .bold))
-                    .foregroundStyle(data.isPastYear ? .quaternary : .tertiary)
+                    .foregroundStyle(data.isPastYear ? .tertiary : .secondary)
                     .rotationEffect(.degrees(isExpanded ? 90 : 0))
                 Text(String(year))
                     .font(PulpeTypography.stepTitle)
@@ -297,25 +329,21 @@ struct YearSection: View {
                 }
 
                 Spacer()
-                if let endBalance = yearEndRemaining {
-                    HStack(spacing: DesignTokens.Spacing.xs) {
-                        Image(systemName: endBalance >= 0 ? "arrow.up.right" : "arrow.down.right")
-                            .font(.system(size: 11, weight: .bold))
-                        Text(endBalance.asCompactCHF)
-                            .font(PulpeTypography.labelLarge)
-                            .monospacedDigit()
-                    }
-                    .foregroundStyle(endBalance >= 0 ? Color.financialSavings : .financialOverBudget)
-                    .sensitiveAmount()
-                }
             }
             .padding(.vertical, DesignTokens.Spacing.md)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Année \(year)")
+        .accessibilityLabel(yearAccessibilityLabel)
+        .accessibilityValue(isExpanded ? "développé" : "réduit")
         .accessibilityHint(isExpanded ? "Appuie pour réduire" : "Appuie pour développer")
         .accessibilityAddTraits(.isHeader)
+    }
+
+    private var yearAccessibilityLabel: String {
+        var label = "Année \(year)"
+        if layoutData.isCurrentYear { label += ", en cours" }
+        return label
     }
 
     private var enCoursBadge: some View {

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -260,25 +260,23 @@ struct YearSection: View {
     @ViewBuilder
     private func expandedContent(data: YearSectionLayoutData) -> some View {
         VStack(spacing: DesignTokens.Spacing.lg) {
-            if data.currentMonthBudget != nil {
+            if let current = data.currentMonthBudget {
                 if !data.monthsBefore.isEmpty {
                     monthListCard(months: data.monthsBefore)
                 }
-                if let current = data.currentMonthBudget {
-                    CurrentMonthHeroCard(
-                        budget: current,
-                        periodLabel: current.month.flatMap { month in
-                            current.year.flatMap { year in
-                                BudgetPeriodCalculator.formatPeriod(
-                                    month: month, year: year, payDayOfMonth: payDayOfMonth
-                                )
-                            }
+                CurrentMonthHeroCard(
+                    budget: current,
+                    periodLabel: current.month.flatMap { month in
+                        current.year.flatMap { year in
+                            BudgetPeriodCalculator.formatPeriod(
+                                month: month, year: year, payDayOfMonth: payDayOfMonth
+                            )
                         }
-                    ) {
-                        onSelect(current)
                     }
-                    .id("currentMonthHero")
+                ) {
+                    onSelect(current)
                 }
+                .id("currentMonthHero")
                 if !data.monthsAfter.isEmpty {
                     monthListCard(months: data.monthsAfter)
                 }

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -251,7 +251,6 @@ struct YearSection: View {
                     .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .top)))
             }
         }
-        .clipped()
         .sensoryFeedback(.impact(flexibility: .soft), trigger: expandTrigger)
         .onChange(of: isExpanded) { _, _ in
             expandTrigger.toggle()
@@ -355,7 +354,7 @@ struct YearSection: View {
             }
         }
         .pulpeCardBackground(cornerRadius: DesignTokens.CornerRadius.lg)
-        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 2)
+        .shadow(DesignTokens.Shadow.card)
     }
 }
 

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -127,20 +127,17 @@ struct BudgetListView: View {
                             payDayOfMonth: userSettingsStore.payDayOfMonth,
                             isExpanded: expandedYears.contains(group.year),
                             onToggle: {
-                                if reduceMotion {
+                                let toggle = {
                                     if expandedYears.contains(group.year) {
                                         expandedYears.remove(group.year)
                                     } else {
                                         expandedYears.insert(group.year)
                                     }
+                                }
+                                if reduceMotion {
+                                    toggle()
                                 } else {
-                                    withAnimation(DesignTokens.Animation.defaultSpring) {
-                                        if expandedYears.contains(group.year) {
-                                            expandedYears.remove(group.year)
-                                        } else {
-                                            expandedYears.insert(group.year)
-                                        }
-                                    }
+                                    withAnimation(DesignTokens.Animation.defaultSpring) { toggle() }
                                 }
                             },
                             onSelect: { budget in
@@ -192,50 +189,9 @@ private struct BudgetListSkeletonView: View {
                     }
                     .padding(.vertical, DesignTokens.Spacing.md)
 
-                    // Month rows card (before hero)
-                    VStack(spacing: 0) {
-                        ForEach(0..<2, id: \.self) { index in
-                            HStack(spacing: DesignTokens.Spacing.md) {
-                                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
-                                    SkeletonShape(width: 100, height: 14)
-                                    SkeletonShape(width: 140, height: 11)
-                                }
-                                Spacer()
-                                SkeletonShape(width: 70, height: 14)
-                            }
-                            .padding(.horizontal, DesignTokens.Spacing.lg)
-                            .padding(.vertical, DesignTokens.Spacing.md)
-
-                            if index < 1 {
-                                Divider().padding(.leading, dividerLeadingInset)
-                            }
-                        }
-                    }
-                    .pulpeCardBackground(cornerRadius: DesignTokens.CornerRadius.lg)
-
-                    // Hero card placeholder
+                    skeletonMonthRowsCard
                     SkeletonShape(height: 170, cornerRadius: DesignTokens.CornerRadius.xl)
-
-                    // Month rows card (after hero)
-                    VStack(spacing: 0) {
-                        ForEach(0..<2, id: \.self) { index in
-                            HStack(spacing: DesignTokens.Spacing.md) {
-                                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
-                                    SkeletonShape(width: 100, height: 14)
-                                    SkeletonShape(width: 140, height: 11)
-                                }
-                                Spacer()
-                                SkeletonShape(width: 70, height: 14)
-                            }
-                            .padding(.horizontal, DesignTokens.Spacing.lg)
-                            .padding(.vertical, DesignTokens.Spacing.md)
-
-                            if index < 1 {
-                                Divider().padding(.leading, dividerLeadingInset)
-                            }
-                        }
-                    }
-                    .pulpeCardBackground(cornerRadius: DesignTokens.CornerRadius.lg)
+                    skeletonMonthRowsCard
                 }
             }
             .padding(.horizontal, DesignTokens.Spacing.xl)
@@ -245,6 +201,28 @@ private struct BudgetListSkeletonView: View {
         .shimmering()
         .pulpeBackground()
         .accessibilityLabel("Chargement des budgets")
+    }
+
+    private var skeletonMonthRowsCard: some View {
+        VStack(spacing: 0) {
+            ForEach(0..<2, id: \.self) { index in
+                HStack(spacing: DesignTokens.Spacing.md) {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+                        SkeletonShape(width: 100, height: 14)
+                        SkeletonShape(width: 140, height: 11)
+                    }
+                    Spacer()
+                    SkeletonShape(width: 70, height: 14)
+                }
+                .padding(.horizontal, DesignTokens.Spacing.lg)
+                .padding(.vertical, DesignTokens.Spacing.md)
+
+                if index < 1 {
+                    Divider().padding(.leading, dividerLeadingInset)
+                }
+            }
+        }
+        .pulpeCardBackground(cornerRadius: DesignTokens.CornerRadius.lg)
     }
 }
 
@@ -331,16 +309,10 @@ struct YearSection: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(yearAccessibilityLabel)
+        .accessibilityLabel(data.isCurrentYear ? "Année \(year), en cours" : "Année \(year)")
         .accessibilityValue(isExpanded ? "développé" : "réduit")
         .accessibilityHint(isExpanded ? "Appuie pour réduire" : "Appuie pour développer")
         .accessibilityAddTraits(.isHeader)
-    }
-
-    private var yearAccessibilityLabel: String {
-        var label = "Année \(year)"
-        if layoutData.isCurrentYear { label += ", en cours" }
-        return label
     }
 
     private var enCoursBadge: some View {

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -270,13 +270,10 @@ struct YearSection: View {
 
             if isExpanded {
                 expandedContent(data: data)
-                    .transition(
-                        .move(edge: .top)
-                            .combined(with: .opacity)
-                            .combined(with: .scale(scale: 0.98, anchor: .top))
-                    )
+                    .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .top)))
             }
         }
+        .clipped()
         .sensoryFeedback(.impact(flexibility: .soft), trigger: expandTrigger)
         .onChange(of: isExpanded) { _, _ in
             expandTrigger.toggle()

--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -282,7 +282,7 @@ struct YearSection: View {
 
     @ViewBuilder
     private func expandedContent(data: YearSectionLayoutData) -> some View {
-        VStack(spacing: DesignTokens.Spacing.md) {
+        VStack(spacing: DesignTokens.Spacing.lg) {
             if data.currentMonthBudget != nil {
                 if !data.monthsBefore.isEmpty {
                     monthListCard(months: data.monthsBefore)
@@ -383,6 +383,7 @@ struct YearSection: View {
             }
         }
         .pulpeCardBackground(cornerRadius: DesignTokens.CornerRadius.lg)
+        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 2)
     }
 }
 

--- a/ios/Pulpe/Resources/Assets.xcassets/FinancialSavings.colorset/Contents.json
+++ b/ios/Pulpe/Resources/Assets.xcassets/FinancialSavings.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.298",
-          "green" : "0.541",
-          "red" : "0.118"
+          "blue" : "0.220",
+          "green" : "0.439",
+          "red" : "0.082"
         }
       },
       "idiom" : "universal"

--- a/ios/Pulpe/Shared/Extensions/Color+Pulpe.swift
+++ b/ios/Pulpe/Shared/Extensions/Color+Pulpe.swift
@@ -10,11 +10,11 @@ extension Color {
     /// Expense indicator color - Orange (#B35800 light, #F0A050 dark)
     static let financialExpense = Color("FinancialExpense")
 
-    /// Savings indicator color - Green (#1E8A4C light, #50C882 dark)
+    /// Savings indicator color - Green (#157038 light, #50C882 dark)
     static let financialSavings = Color("FinancialSavings")
 
-    /// Over-budget indicator - Warm amber, not aggressive red (#C27A00 light, #E5A33A dark)
-    static let financialOverBudget = Color(light: Color(hex: 0xC27A00), dark: Color(hex: 0xE5A33A))
+    /// Over-budget indicator - Warm amber, not aggressive red (#A86800 light, #E5A33A dark)
+    static let financialOverBudget = Color(light: Color(hex: 0xA86800), dark: Color(hex: 0xE5A33A))
 
     // MARK: - Hero Card Gradient Colors (4-stop, 150° linear)
     // Aligned with frontend --pulpe-hero-* tokens (base → color-mix 75% black)

--- a/ios/Pulpe/Shared/Formatters/Formatters.swift
+++ b/ios/Pulpe/Shared/Formatters/Formatters.swift
@@ -38,6 +38,14 @@ enum Formatters {
         return formatter
     }()
 
+    // MARK: - Month Name
+
+    /// Bounds-checked month name from 1-based month number, capitalized.
+    static func monthName(for month: Int) -> String {
+        guard month >= 1, month <= 12 else { return "—" }
+        return monthYear.monthSymbols[month - 1].capitalized
+    }
+
     // MARK: - Dates
 
     static let monthYear: DateFormatter = {

--- a/ios/PulpeTests/Domain/Formulas/BudgetFormulasExtendedTests.swift
+++ b/ios/PulpeTests/Domain/Formulas/BudgetFormulasExtendedTests.swift
@@ -319,4 +319,42 @@ struct BudgetFormulasExtendedTests {
         let metrics = BudgetFormulas.calculateAllMetrics(budgetLines: [])
         #expect(metrics.emotionState == .comfortable)
     }
+
+    // MARK: - Emotion State (static — optional Decimal? paths)
+
+    @Test func emotionState_static_nilRemaining_returnsComfortable() {
+        let result = BudgetFormulas.emotionState(
+            remaining: nil, totalIncome: 1000, totalExpenses: 900, rollover: nil
+        )
+        #expect(result == .comfortable)
+    }
+
+    @Test func emotionState_static_nilExpenses_returnsComfortable() {
+        let result = BudgetFormulas.emotionState(
+            remaining: 100, totalIncome: 1000, totalExpenses: nil, rollover: nil
+        )
+        #expect(result == .comfortable)
+    }
+
+    @Test func emotionState_static_allNilExceptPositiveRemaining_returnsComfortable() {
+        // totalIncome=nil, rollover=nil → available=0 → guard returns .comfortable
+        let result = BudgetFormulas.emotionState(
+            remaining: 100, totalIncome: nil, totalExpenses: nil, rollover: nil
+        )
+        #expect(result == .comfortable)
+    }
+
+    @Test func emotionState_static_negativeRemaining_returnsDeficit() {
+        let result = BudgetFormulas.emotionState(
+            remaining: -50, totalIncome: 1000, totalExpenses: 1050, rollover: nil
+        )
+        #expect(result == .deficit)
+    }
+
+    @Test func emotionState_static_tightUsage_returnsTight() {
+        let result = BudgetFormulas.emotionState(
+            remaining: 100, totalIncome: 1000, totalExpenses: 900, rollover: nil
+        )
+        #expect(result == .tight)
+    }
 }

--- a/memory-bank/DA.md
+++ b/memory-bank/DA.md
@@ -487,10 +487,10 @@ Polices : Manrope (titres/brand) + SF Pro système (corps, labels, captions, mon
 |-------|--------|-------|
 | xs | 4pt | Progress bars, indicateurs fins |
 | sm | 8pt | Badges, chips |
-| md | 12pt | Cartes, inputs |
+| md | 24pt | Cartes, inputs |
 | button | 14pt | Boutons primaires |
-| lg | 16pt | Sheets, modals |
-| xl | 20pt | Hero cards |
+| lg | 30pt | Sheets, modals |
+| xl | 32pt | Hero cards |
 
 #### Motion
 


### PR DESCRIPTION
## Summary

• Color budget amounts (green/amber) for current and future months, not just current
• Consolidate budget list view components and reusable formatters
• Align budget list hero card with dashboard design (emotions, dark theme, full-card tap)
• Refine budget list colors and fix animation transitions
• Improve overall visual consistency with shared design system

## Type

feat/refactor