### PR TITLE
Add pointé toggle to creation forms

### DIFF
--- a/.claude/rules/01-standards/clean-code.md
+++ b/.claude/rules/01-standards/clean-code.md
@@ -12,7 +12,7 @@ paths: "**/*.ts"
 - Use explicit constants, never magic numbers
 - Avoid double negatives (`!isInvalid` → `isValid`)
 - Write the simplest code possible
-- Eliminate duplication (DRY)
+- Eliminate duplication (DRY) — but DRY applies to **logic**, not trivial expressions. A one-liner ternary repeated in 4 files does NOT warrant a shared utility. Three similar lines are better than a premature abstraction. Only extract when the duplicated code contains **branching, computation, or is likely to diverge**.
 
 ```typescript
 // Good

--- a/.claude/skills/workflow-clean-code-angular/SKILL.md
+++ b/.claude/skills/workflow-clean-code-angular/SKILL.md
@@ -1,99 +1,127 @@
 ---
 name: workflow-clean-code-angular
-description: "Systematic Angular 21 clean code workflow — scans, fixes anti-patterns, enforces architecture rules, and verifies. Uses parallel agents, Angular MCP tools, and project-specific rules."
-argument-hint: "<scope> [-a auto] [-e economy] [-s save] [--arch] [--signals] [--styling] [--testing]"
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, AskUserQuestion, mcp__angular-cli__*, mcp__plugin_context7_context7__*
+description: "Deep Angular 21 clean code audit with parallel specialist agents and senior team lead. Scans architecture, signals, stores, AI slop, ViewModel patterns, and more. Guarantees craftsman-level output. Use whenever the user says 'clean code', 'audit Angular', 'review frontend', 'check quality', 'anti-patterns', wants Angular code reviewed, or needs senior-level code standards enforced — even if they don't say 'clean code' explicitly."
+argument-hint: "<scope> [-a auto] [-e economy] [-s save] [--quick] [--deep] [--arch] [--signals] [--styling] [--testing] [--slop] [--vm]"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, mcp__angular-cli__*, mcp__plugin_context7_context7__*
 ---
 
 <objective>
-Fast, systematic clean code improvements for Angular 21+ projects. Enforces Pulpe architecture rules,
-modern signal patterns, Material 3 styling, and Angular best practices with documented sources and concrete fixes.
+Guarantee that Angular code in the target scope meets the standard of a senior developer who crafted it by hand — clean, clear, no AI slop, proper architecture, correct signal patterns, and clear ViewModel separation.
 </objective>
+
+<philosophy>
+This isn't a linter. Linters catch syntax. This skill catches **design decisions** — the kind of issues only a senior engineer spots during code review.
+
+Three things that separate senior-crafted code from AI-generated code:
+1. **Nothing unnecessary** — no defensive checks for impossible scenarios, no abstractions with one consumer, no comments that restate the code
+2. **Right responsibility in the right place** — stores own data transformations, components coordinate UI, templates just bind
+3. **Consistent patterns** — every store follows the same anatomy, every component follows the same structure, no surprise conventions
+</philosophy>
 
 <quick_start>
 
-**Basic usage (analyze and fix a feature):**
 ```bash
-/clean-code-angular feature/budget/
+/clean-code-angular feature/budget/          # Standard audit
+/clean-code-angular -a --deep feature/       # Deep audit, auto mode
+/clean-code-angular --quick core/            # Quick surface scan
+/clean-code-angular --slop --vm feature/     # Focus: AI slop + ViewModel
+/clean-code-angular diff main                # Audit changes vs main
+/clean-code-angular pending                  # Audit uncommitted changes
 ```
 
-**Auto mode (skip confirmations):**
-```bash
-/clean-code-angular -a feature/dashboard/
-```
-
-**With save (output to `.claude/output/clean-code-angular/`):**
-```bash
-/clean-code-angular -s -a core/
-```
-
-**Architecture focus:**
-```bash
-/clean-code-angular --arch feature/
-```
-
-**What it does:**
-1. Scans Angular files for anti-patterns (signals, DI, templates, architecture)
-2. Loads Angular 21 best practices via MCP + project rules
-3. Applies clean code improvements with concrete fixes
-4. Verifies with `pnpm quality` and tests
-5. Commits changes
 </quick_start>
 
 <parameters>
 
 | Flag | Description |
 |------|-------------|
-| `-a` | Auto mode: skip confirmations |
-| `-e` | Economy mode: no subagents, direct tools only |
-| `-s` | Save mode: output to `.claude/output/clean-code-angular/` |
-| `-r` | Resume mode: continue from previous task |
-| `--arch` | Force architecture analysis (dependency direction, cross-feature imports) |
-| `--signals` | Force signal patterns analysis (effect misuse, computed, linkedSignal) |
-| `--styling` | Force styling analysis (::ng-deep, legacy Material, Tailwind v4) |
-| `--testing` | Force testing analysis (AAA, naming, test coverage) |
+| `-a` | Auto mode — skip confirmations |
+| `-e` | Economy mode — no subagents, direct analysis only |
+| `-s` | Save — output reports to `.claude/output/clean-code-angular/` |
+| `-r` | Resume — continue from a previous run |
+| `--quick` | Surface scan only (grep patterns, no semantic analysis) |
+| `--deep` | Full depth: all domains including AI slop + ViewModel + cross-file |
+| `--arch` | Force architecture analysis |
+| `--signals` | Force signal patterns analysis |
+| `--styling` | Force styling analysis |
+| `--testing` | Force testing analysis |
+| `--slop` | Force AI slop detection |
+| `--vm` | Force ViewModel/DataModel analysis |
 
-<examples>
-```bash
-/clean-code-angular feature/budget/          # Basic - scan a feature
-/clean-code-angular -a feature/dashboard/    # Auto mode
-/clean-code-angular -e -a core/              # Economy + auto
-/clean-code-angular -s pattern/              # Save outputs
-/clean-code-angular -r budget-feature        # Resume
-/clean-code-angular --arch --signals layout/ # Force specific checks
-/clean-code-angular pending                  # Scan pending git changes
-/clean-code-angular diff main               # Scan diff against main
-```
-</examples>
+Default depth (no flag): grep + targeted semantic analysis of key files.
+`--deep` enables all specialist domains.
 
 </parameters>
 
 <workflow>
 ```
-SCAN ──────────► APPLY ──────────► VERIFY
-  │                │                  │
-  │                │                  └─ pnpm quality, test, commit
-  │                └─ Load Angular MCP docs, apply fixes
-  └─ Parse scope, detect anti-patterns, check architecture
+SCAN ─────────────────► APPLY ─────────────► VERIFY
+  │                       │                     │
+  ├─ Parse scope          ├─ Load docs/refs     ├─ pnpm quality
+  ├─ Launch specialists   ├─ Apply fixes        ├─ Run tests
+  │  (up to 10 agents)    │  (parallel agents)  ├─ Team lead final
+  ├─ Team lead review     ├─ Team lead          │  craftsman review
+  └─ Consolidated issues  │  coherence check    └─ Commit
+                          └─ Track progress
 ```
 </workflow>
+
+<agent_model>
+
+## Specialist Agents
+
+Up to 10 domain-focused agents launched in parallel. Count scales with scope size:
+
+| Scope | Agents | Coverage |
+|-------|--------|----------|
+| 1-4 files | 3 + lead | Architecture, Angular/Signals, TypeScript/Styling |
+| 5-15 files | 5 + lead | + Store patterns, Component design |
+| 16-30 files | 7 + lead | + Templates, AI slop |
+| 31+ files | 10 + lead | All 10 domains |
+
+### The 10 Domains
+
+| # | Domain | Focus |
+|---|--------|-------|
+| 1 | Architecture & Dependencies | Layer violations, cross-feature imports, dependency direction |
+| 2 | Signals & Reactivity | `effect()` misuse, `computed()` opportunities, `linkedSignal()`, cleanup |
+| 3 | Store Patterns | 6-section anatomy, cache-first, optimistic updates, resource usage |
+| 4 | Component Design | OnPush, responsibility, size, `input()`/`output()`, `inject()` |
+| 5 | Template Quality | Control flow, expression complexity, wrapper bloat, accessibility |
+| 6 | TypeScript Quality | `any` types, `#` fields, modern APIs, dead code |
+| 7 | Styling | `::ng-deep`, Material M3 tokens, Tailwind v4, `!important` |
+| 8 | AI Slop | Over-engineering, unnecessary comments, defensive theater, verbose naming |
+| 9 | ViewModel & Data Flow | DataModel vs ViewModel, transformation location, duplicate derivations |
+| 10 | Security, Performance & Code Health | XSS, workarounds/hacks, design smells, `@defer`, lazy loading |
+
+### Team Lead
+
+Launched after specialists complete. A senior Angular architect who:
+- Merges all specialist reports into one deduplicated list
+- Removes false positives by reading the actual code
+- Resolves contradictions between specialists
+- Adds cross-cutting observations no single specialist caught
+- Prioritizes the final issue list
+- Verifies fix coherence in step-02
+- Does final craftsman review in step-03
+
+</agent_model>
 
 <state_variables>
 
 | Variable | Type | Description |
 |----------|------|-------------|
-| `{task_description}` | string | Scope to analyze (path or git scope) |
+| `{task_description}` | string | Scope to analyze |
 | `{task_id}` | string | Kebab-case identifier |
 | `{auto_mode}` | boolean | Skip confirmations |
 | `{economy_mode}` | boolean | No subagents |
-| `{save_mode}` | boolean | Save outputs |
-| `{force_arch}` | boolean | Force architecture check |
-| `{force_signals}` | boolean | Force signals check |
-| `{force_styling}` | boolean | Force styling check |
-| `{force_testing}` | boolean | Force testing check |
+| `{save_mode}` | boolean | Save reports |
+| `{depth}` | quick / standard / deep | Analysis depth |
+| `{force_*}` | boolean | Per-domain force flags |
 | `{scoped_files}` | string[] | Files in scope |
-| `{issues}` | array | Issues found with file:line |
+| `{issues}` | array | Consolidated issue list |
 | `{workspace_path}` | string | Path to angular.json |
+| `{agent_count}` | number | Specialists to launch |
 
 </state_variables>
 
@@ -101,9 +129,12 @@ SCAN ──────────► APPLY ──────────► V
 
 | File | When Loaded |
 |------|-------------|
-| `references/angular-clean-code.md` | Always |
-| `references/angular-architecture.md` | Architecture issues detected / `--arch` |
-| `references/angular-anti-patterns.md` | Always (checklist for scanning) |
+| `references/angular-anti-patterns.md` | Always (scanning checklist) |
+| `references/angular-clean-code.md` | Always (correct patterns) |
+| `references/angular-style-guide.md` | Always (official Angular conventions) |
+| `references/angular-architecture.md` | Architecture issues or `--arch` |
+| `references/ai-slop-detection.md` | Deep mode, `--slop` |
+| `references/viewmodel-patterns.md` | Deep mode, `--vm` |
 
 </reference_files>
 
@@ -117,29 +148,31 @@ Load `steps/step-01-scan.md`
 
 | Step | File | Purpose |
 |------|------|---------|
-| 01 | `step-01-scan.md` | Init + scope + scan for anti-patterns |
-| 02 | `step-02-apply.md` | Load docs + recommend + apply fixes |
-| 03 | `step-03-verify.md` | Quality check + test + commit |
+| 01 | `step-01-scan.md` | Parse scope, launch specialists, team lead consolidation |
+| 02 | `step-02-apply.md` | Load docs, apply fixes, team lead coherence check |
+| 03 | `step-03-verify.md` | Quality gate, craftsman review, commit |
 
 </step_files>
 
 <execution_rules>
 - Load one step at a time
-- Use parallel agents in step-01 (unless economy mode)
-- Always call `mcp__angular-cli__get_best_practices` with workspace path
-- Always call `mcp__angular-cli__list_projects` to get workspace context
-- Follow patterns from reference files and Angular MCP docs
-- Run `pnpm quality` before completing
+- Scale agent count to scope size (economy mode = 0 agents, direct tools only)
+- Call `mcp__angular-cli__list_projects` and `mcp__angular-cli__get_best_practices` for Angular context
+- Use the Grep tool for pattern detection (not bash grep)
 - Scope-aware: only touch files within the specified scope
+- Every finding: `file:line` reference required
+- Every fix: source citation required
+- Team lead reviews after scan AND after apply
 </execution_rules>
 
 <success_criteria>
-- Scope correctly parsed (path, pending, diff)
-- Angular anti-patterns identified with file:line references
-- Architecture rules enforced (dependency direction, feature isolation)
-- Signal patterns modernized (computed over effect, linkedSignal, etc.)
-- Fixes applied with documented sources
+After this workflow, the scoped code reads as if a senior Angular developer wrote it by hand:
+- Zero architecture violations
+- Modern signal patterns throughout
+- Stores follow 6-section anatomy with proper ViewModel selectors
+- No AI slop — no unnecessary comments, abstractions, or defensive code
+- Clean ViewModel separation — stores transform, components bind, templates stay simple
+- Consistent patterns across all files in scope
 - `pnpm quality` passes
-- Tests pass (if tests exist for scope)
-- Changes committed with clear message
+- Tests pass
 </success_criteria>

--- a/.claude/skills/workflow-clean-code-angular/references/ai-slop-detection.md
+++ b/.claude/skills/workflow-clean-code-angular/references/ai-slop-detection.md
@@ -1,0 +1,215 @@
+# AI Slop Detection Guide
+
+> Reference for identifying AI-generated code patterns that a senior developer would never write by hand.
+> These patterns pass linting and type-checking but add noise, complexity, and maintenance burden.
+
+---
+
+## The Litmus Test
+
+For every line of code, ask: **"Would a senior developer who cares about their craft write this?"**
+
+If the answer is "a junior might, but a senior wouldn't bother" — it's slop.
+
+---
+
+## 1. Over-Commenting
+
+AI loves to explain the obvious. A senior trusts the reader to understand code.
+
+| Slop | Clean |
+|------|-------|
+| `// Set loading to true` above `this.#state.set(true)` | _(no comment — the code says it)_ |
+| `// Create a new budget` above `createBudget()` call | _(the method name says it)_ |
+| `/** Returns the budget name */` on a getter | _(self-documenting)_ |
+| `// ---- Actions ----` section dividers | _(use the 6-section store anatomy comments only)_ |
+
+**Detection:** Comments that restate what the next line does. JSDoc on obvious methods. Section dividers in files under 100 lines. Multi-line comments that could be a single line.
+
+**Rule:** Comments explain WHY, never WHAT. If the code needs a WHAT comment, rewrite the code to be clearer.
+
+---
+
+## 2. Over-Engineering
+
+AI defaults to "flexible" and "configurable" even when the requirement is simple.
+
+| Slop | Clean |
+|------|-------|
+| Factory function for a single implementation | Direct instantiation |
+| Options object with 1 property | Single parameter |
+| Generic wrapper around a framework function | Use the framework directly |
+| Abstract base class with one child | Just the concrete class |
+| `config.ts` exporting a single constant | Inline the constant |
+| Strategy pattern with one strategy | Direct call |
+| `interface` + `class` when just `class` would do | Just the class |
+| `enum` for 2 values | Boolean or union type |
+
+**Detection:**
+- Classes/functions with a single consumer
+- Abstractions that pass through without transforming (wrappers that just delegate)
+- Generics with only one concrete type ever used
+- Files containing a single export that could be inlined
+- "Utility" modules with 1-2 functions
+
+**Rule:** Three similar lines of code is better than a premature abstraction. Only abstract with 3+ concrete uses.
+
+---
+
+## 3. Defensive Programming Theater
+
+AI adds safety checks for scenarios that can't happen — it doesn't trust the type system or framework guarantees.
+
+| Slop | Clean |
+|------|-------|
+| `if (store !== null && store !== undefined)` — store is `inject()`ed | Direct access — DI guarantees it |
+| `try/catch` around `signal.set()` | Direct call — signals don't throw |
+| `?? []` on `signal<Item[]>([])` | The signal already has `[]` as default |
+| Null check on `input.required()` | Angular guarantees it's set |
+| `if (typeof x === 'string')` when `x: string` | TypeScript already guarantees it |
+| Fallback value on `computed()` fed by non-nullable chain | Trust the signal chain |
+| `?.` on injected services | DI guarantees non-null |
+
+**Detection:**
+- `!= null` / `!= undefined` on DI-injected or type-guaranteed values
+- `try/catch` around synchronous, non-throwing code
+- Optional chaining `?.` on non-optional types
+- Nullish coalescing `??` on signals with explicit defaults
+- Type guards on already-typed parameters
+- Error states for operations that have no failure path
+
+**Rule:** Trust the type system. Trust Angular's DI. Trust signal initialization. Validate only at system boundaries (user input, API responses via Zod).
+
+---
+
+## 4. Verbose Naming
+
+AI uses overly descriptive names that add noise without clarity.
+
+| Slop | Clean |
+|------|-------|
+| `budgetItemsArrayForCurrentMonth` | `budgets` |
+| `isUserCurrentlyAuthenticated` | `isAuthenticated` |
+| `handleBudgetCardClickEvent` | `onCardClick` |
+| `filteredAndSortedBudgetList` | `sortedBudgets` |
+| `budgetServiceInstance` | `#api` |
+| `currentBudgetData` | `budget` |
+
+**Detection:** Variable/method names longer than ~25 characters. Names that include their type (`Array`, `List`, `Map`). Names that repeat context already clear from the class/file name.
+
+**Rule:** Name length proportional to scope size. A local variable in a 5-line method can be short. A public API property deserves more.
+
+---
+
+## 5. Unnecessary Wrapping
+
+AI creates helpers and utilities that are used exactly once.
+
+| Slop | Clean |
+|------|-------|
+| `formatBudgetAmount(budget)` called once | Inline the formatting |
+| `buildQueryParams(filters)` with 2 params | Inline `{ month, year }` |
+| `mapBudgetToViewModel(budget)` as standalone function | `computed()` in the store |
+| Private method called from one place | Inline it |
+| Utility file with 1-2 exports | Keep code where it's used |
+| `pipe()` with a single RxJS operator | Just call the method |
+
+**Detection:**
+- Private methods called from exactly one place
+- Functions/methods with a single caller
+- Utility files with fewer than 3 exports
+- Pipes with a single operator
+
+**Rule:** Extract when you have 2+ callers OR the code is genuinely complex (>10 lines of non-trivial logic). Simple one-liners never need extraction.
+
+---
+
+## 6. Template Bloat
+
+AI generates templates with excessive structure and redundant wrapper elements.
+
+| Slop | Clean |
+|------|-------|
+| `<div class="wrapper"><div class="container"><div class="content">...` | Single element with combined classes |
+| `@if (items().length > 0)` before `@for` | `@for` with `@empty` block |
+| `{{ budget.lines.filter(...).reduce(...) \| currency }}` | `computed()` signal in store |
+| `<ng-container>` wrapping a single element | Just the element |
+| Repeated `@if` checking the same condition | Single `@if` block |
+| Deeply nested `@if` chains (3+ levels) | Flatten with early returns or `@switch` |
+
+**Detection:**
+- Nested `<div>`s with single children (wrapper soup)
+- Template expressions longer than ~40 characters
+- `@if` guarding `@for` on same data (use `@empty`)
+- `<ng-container>` around a single child element
+- 3+ levels of nested `@if`
+
+---
+
+## 7. Copy-Paste Signatures
+
+AI generates boilerplate patterns that look professional but add zero information.
+
+| Slop | Clean |
+|------|-------|
+| `/** @class BudgetStore */` | _(TypeScript knows it's a class)_ |
+| `/** Constructor */` | _(obvious)_ |
+| `/** @param id - The budget ID */` | _(the type says `id: string`)_ |
+| `/** @returns void */` | _(useless)_ |
+| `/** @see BudgetService */` on an `inject()` | _(navigate via IDE)_ |
+| `// #region` / `// #endregion` | _(IDE folding works without them)_ |
+| `// eslint-disable-next-line` without explanation | Add WHY or fix the lint issue |
+
+**Detection:** JSDoc that adds zero information beyond TypeScript types. `@param` tags that just repeat the parameter name. `@returns` on void methods. Region comments.
+
+**Rule:** JSDoc is for public library APIs and complex algorithms. Application code should be self-documenting.
+
+---
+
+## 8. Excessive Error Handling
+
+AI wraps everything in try/catch as if every line could throw.
+
+| Slop | Clean |
+|------|-------|
+| `try/catch` around `signal.update()` | Direct call |
+| `try/catch` around `router.navigate()` with no handler | Let it propagate |
+| `catch (e) { console.error(e); throw e; }` | Don't catch — same result |
+| Error signal for a synchronous operation | Remove the signal |
+| Multiple nested try/catch | Single try/catch at the right level |
+
+**Detection:**
+- `try/catch` around synchronous, non-throwing code
+- `catch` blocks that log and re-throw (catch-log-throw)
+- Error signals for operations with no async/failure path
+- Multiple nested try/catch in one method
+
+**Rule:** Catch only when you can handle meaningfully. In stores: catch API errors for optimistic rollback. Everything else: let the global error handler deal with it.
+
+---
+
+## 9. Dead Code & Artifacts
+
+AI leaves behind artifacts from iterations or imports things "just in case."
+
+**Detection:**
+- Imported types/functions used nowhere
+- Methods that nothing calls (search for all references)
+- Commented-out code blocks (git has history — delete it)
+- `console.log` left from debugging (use Logger service)
+- Unused constructor parameters
+- Empty `ngOnInit` / `ngOnDestroy` methods
+
+---
+
+## Priority Order (scan in this order)
+
+1. **Over-engineering** — highest complexity impact
+2. **Defensive programming theater** — noise that hides real logic
+3. **Over-commenting** — visual clutter
+4. **Unnecessary wrapping** — indirection for no reason
+5. **Template bloat** — DOM complexity
+6. **Excessive error handling** — false safety
+7. **Verbose naming** — readability
+8. **Copy-paste signatures** — noise
+9. **Dead code** — usually caught by tooling

--- a/.claude/skills/workflow-clean-code-angular/references/angular-anti-patterns.md
+++ b/.claude/skills/workflow-clean-code-angular/references/angular-anti-patterns.md
@@ -208,17 +208,157 @@ grep -n "console\." "$file"
 
 ---
 
+## 12. Store Pattern Anti-Patterns
+
+| # | Anti-Pattern | Modern | Severity | Source |
+|---|-------------|--------|----------|--------|
+| 12.1 | No 6-section anatomy in store | Follow: Dependencies → State → Resource → Selectors → Mutations → Private utils | 🟡 | `.claude/rules/03-frameworks-and-libraries/angular-store-pattern.md` |
+| 12.2 | `inject(HttpClient)` in store/service | `inject(ApiClient)` — Zod validation enforced by design | 🔴 | Same |
+| 12.3 | `subscribe()` in store mutations | `async/await` + `firstValueFrom()` | 🔴 | Same |
+| 12.4 | `providedIn: 'root'` on feature store | `@Injectable()` + route providers | 🔴 | Same |
+| 12.5 | Manual stale data signal in store | Cache fallback via `api.cache.get()` in selector | 🟡 | Same |
+| 12.6 | Cascade before replacing temp ID | Replace temp → real ID BEFORE invalidation/cascade | 🔴 | Same (DR-005) |
+| 12.7 | Public mutable state in store | Private `#state` signal + public `computed()` selectors | 🔴 | Store pattern |
+
+---
+
+## 13. ViewModel Anti-Patterns
+
+| # | Anti-Pattern | Modern | Severity | Source |
+|---|-------------|--------|----------|--------|
+| 13.1 | `.filter()`/`.reduce()` in template | `computed()` in store | 🔴 | `references/viewmodel-patterns.md` |
+| 13.2 | Transformation `computed()` in component | Move to store — shared, testable | 🟡 | Same |
+| 13.3 | Store returns formatted strings | Store returns data, template formats via pipe | 🟡 | Same |
+| 13.4 | Duplicate derivations across components | Shared store selector | 🟡 | Same |
+| 13.5 | God ViewModel object (`computed(() => ({...20 fields}))`) | Separate `computed()` per concern | 🔴 | Same |
+| 13.6 | Manual ViewModel in `ngOnInit` | `computed()` signals — reactive | 🔴 | Same |
+
+---
+
+## 14. AI Slop Anti-Patterns
+
+| # | Anti-Pattern | Fix | Severity | Source |
+|---|-------------|-----|----------|--------|
+| 14.1 | Comments restating code | Delete — code should be self-documenting | 🟡 | `references/ai-slop-detection.md` |
+| 14.2 | Over-engineered abstraction (single consumer) | Inline it | 🟡 | Same |
+| 14.3 | Defensive null check on DI/typed value | Remove — trust the type system | 🟡 | Same |
+| 14.4 | `try/catch` on non-throwing code | Remove — signals/navigation don't throw | 🟡 | Same |
+| 14.5 | Single-use helper function | Inline | 🟡 | Same |
+| 14.6 | JSDoc that repeats TypeScript types | Delete | 🟡 | Same |
+| 14.7 | Verbose variable name (>25 chars) | Shorten — proportional to scope | 🟡 | Same |
+
+---
+
+## 15. Workarounds & Framework Hacks
+
+These patterns indicate the developer fought the framework instead of working with it. They compile and run, but they mask real bugs or design problems.
+
+| # | Anti-Pattern | Why It's Bad | Fix | Severity | Source |
+|---|-------------|-------------|-----|----------|--------|
+| 15.1 | `setTimeout(() => ..., 0)` | Change detection hack — masks a reactivity bug | Restructure to signal flow or `afterNextRender()` | 🔴 | angular.dev/best-practices |
+| 15.2 | `ChangeDetectorRef.detectChanges()` | Forces sync CD — usually means signals aren't wired correctly | Fix the signal/async pipe chain | 🔴 | Same |
+| 15.3 | `ChangeDetectorRef.markForCheck()` | Sometimes valid, but often a signal would solve it | Evaluate if a `computed()` or `toSignal()` is better | 🟡 | Same |
+| 15.4 | `@ts-ignore` / `@ts-expect-error` | Bypasses the type system entirely — pure debt | Fix the type error or properly type the code | 🔴 | TypeScript best practices |
+| 15.5 | `as any` cast | Throws away all type safety at that point | Use `unknown` + type guard, or fix the generic | 🔴 | Same |
+| 15.6 | `eslint-disable` without explanation | Hides a real issue behind a suppression | Fix the lint error, or add a WHY comment | 🟡 | ESLint best practices |
+| 15.7 | `zone.runOutsideAngular()` | Sometimes valid (perf), but often a hack to avoid proper CD | Evaluate if OnPush + signals solves the real issue | 🟡 | angular.dev/best-practices |
+| 15.8 | `ngAfterViewInit` for state initialization | Should be reactive — `effect()` or `afterNextRender()` | Use signal primitives for reactive init | 🟡 | angular.dev/style-guide |
+| 15.9 | `document.querySelector()` in component | Bypasses Angular's view abstraction entirely | Use `viewChild()` or `ElementRef` with `inject()` | 🔴 | angular.dev/best-practices |
+| 15.10 | `window.location` for navigation | Breaks SPA routing, loses app state | Use `Router.navigate()` | 🔴 | angular.dev/guide/routing |
+
+**Grep patterns:**
+```bash
+grep -n "setTimeout" "$file"
+grep -n "detectChanges" "$file"
+grep -n "markForCheck" "$file"
+grep -n "@ts-ignore" "$file"
+grep -n "@ts-expect-error" "$file"
+grep -n "as any" "$file"
+grep -n "eslint-disable" "$file"
+grep -n "runOutsideAngular" "$file"
+grep -n "document\." "$file"
+grep -n "window\.location" "$file"
+```
+
+---
+
+## 16. Design Smells
+
+These aren't syntax issues — they're structural problems that make the codebase harder to maintain, extend, and test. A linter won't catch them. Only a developer who understands the domain will.
+
+| # | Smell | Detection | Severity | Source |
+|---|-------|-----------|----------|--------|
+| 16.1 | **God Component** — component with 6+ `inject()` calls, doing multiple unrelated things | Count `inject()` calls; check if component handles multiple concerns (data loading + form + navigation + analytics) | 🔴 | Clean code / SRP |
+| 16.2 | **Feature Envy** — method that accesses 5+ properties of another object | A method that chains through `budget.lines[0].category.name` repeatedly — the logic probably belongs closer to the data | 🟡 | Refactoring / Fowler |
+| 16.3 | **Primitive Obsession** — using `string` where a domain type should exist | `budgetId: string` everywhere instead of a branded type or distinct type; `status: string` instead of `'active' \| 'archived'` | 🟡 | TypeScript best practices |
+| 16.4 | **Shotgun Surgery** — a single business change requires modifying 5+ files | Adding a field requires touching schema, backend, shared type, store, component, template, test — check if abstractions are missing | 🟡 | Refactoring / Fowler |
+| 16.5 | **Dead Feature** — route, component, or service that is no longer reachable | Component not referenced in any route or template; service never injected | 🟡 | Clean code |
+| 16.6 | **Inappropriate Intimacy** — two classes that know too much about each other's internals | Component directly mutating store private state; service reaching into another service's internals | 🔴 | Refactoring / Fowler |
+| 16.7 | **Long Parameter List** — method with 4+ parameters | Especially in store mutations or service methods — use an options/config object or a domain type | 🟡 | Clean code |
+| 16.8 | **Duplicated Derivation** — same transformation logic in 2+ places | Two components both filtering budget lines by type — should be a shared store selector | 🟡 | DRY / ViewModel patterns |
+
+---
+
+## 17. Angular Style Guide Violations
+
+Official conventions from angular.dev/style-guide that affect code quality.
+
+| # | Anti-Pattern | Modern | Severity | Source |
+|---|-------------|--------|----------|--------|
+| 17.1 | Template-only member is `public` | `protected` for template-only | 🟡 | angular.dev/style-guide |
+| 17.2 | Missing `readonly` on `input()`, `output()`, `model()`, queries | Add `readonly` | 🟡 | Same |
+| 17.3 | Event handler named by event (`handleClick`, `onClick`) | Name by action (`saveData`, `deleteBudget`) | 🟡 | Same |
+| 17.4 | Properties and methods mixed randomly | Angular properties first, then methods | 🟡 | Same |
+| 17.5 | `ngOnInit` without `implements OnInit` | Add lifecycle interface | 🟡 | Same |
+| 17.6 | Complex logic directly in lifecycle hook (>10 lines) | Delegate to well-named methods | 🟡 | Same |
+| 17.7 | Empty lifecycle hook (`ngOnInit() {}`) | Remove entirely — dead code | 🟡 | Clean code |
+| 17.8 | Multiple classes/concepts in one file | One concept per file, split | 🟡 | angular.dev/style-guide |
+
+For detailed reference: see `references/angular-style-guide.md`.
+
+---
+
+## 18. Error Handling Anti-Patterns
+
+Errors should be surfaced at the callsite — the code that initiated the operation has the context to handle it. The global `ErrorHandler` is for unexpected/fatal errors only (logging, analytics), not for recoverable flow.
+
+| # | Anti-Pattern | Why It's Bad | Fix | Severity | Source |
+|---|-------------|-------------|-----|----------|--------|
+| 18.1 | Empty `catch` block — `catch (e) {}` | Swallows the error silently, user gets no feedback, devs get no signal | Handle the error: display message, revert state, or rethrow with context | 🔴 | angular.dev/best-practices/error-handling |
+| 18.2 | `catch (e: any)` — untyped error | Loses all type information, leads to unsafe property access | Use `unknown` + type narrowing (`isApiError()`, `instanceof`, Zod schema) | 🟡 | TypeScript best practices |
+| 18.3 | `async` store method without `try/catch` around API call | Error bubbles unhandled — resource state becomes corrupted, UI hangs | Wrap callsite in `try/catch`, handle loading/error state, revert optimistic updates | 🔴 | angular.dev/best-practices/error-handling |
+| 18.4 | `resource()` / `httpResource()` without checking `.error()` in template | User sees stale data or empty screen on failure, no error feedback | Check `resource.error()` or `resource.status()` in template with `@if` | 🔴 | angular.dev/api/core/resource |
+| 18.5 | Zod `.parse()` without error boundary at non-API callsite | `.parse()` throws `ZodError` on invalid data — unhandled in component code | Use `.safeParse()` for graceful handling, or `.parse()` only in `httpResource({ parse })` where Angular handles it | 🟡 | Zod docs |
+| 18.6 | Relying on global `ErrorHandler` for recoverable errors | Global handler has no context to recover — can only log and hope | Handle at callsite: `try/catch` for promises, `catchError` for Observables | 🔴 | angular.dev/best-practices/error-handling |
+| 18.7 | `firstValueFrom()` without `catch` | Promise rejection goes unhandled if Observable errors | Wrap in `try/catch` or chain `.catch()` | 🟡 | RxJS docs |
+| 18.8 | `catchError` that returns `EMPTY` or `of(null)` without notifying user | Error is "handled" but user has no idea something failed | At minimum: log + notify user (toast/snackbar), then recover or rethrow | 🟡 | RxJS best practices |
+
+**What NOT to flag:**
+- `try/catch` around actual async API calls — that's correct
+- `catchError` in RxJS pipes for HTTP errors with proper recovery — that's correct
+- `.parse()` in `httpResource({ parse })` option — Angular handles the error via resource status
+- `resource()` that checks `.status()` === `'error'` — that's correct
+
+---
+
 ## Priority Order
 
 **Scan in this order (highest impact first):**
 
 1. 🔴 Security (innerHTML, bypassSecurity)
-2. 🔴 Architecture violations (cross-feature imports, forbidden deps)
-3. 🔴 Signal misuse (effect for derived, mutation, missing cleanup)
-4. 🔴 Missing OnPush
-5. 🔴 `any` types
-6. 🟡 Legacy Angular patterns (decorators → functions)
-7. 🟡 TypeScript modernization
-8. 🟡 Styling issues
-9. 🟡 Naming conventions
-10. 🟡 Testing patterns
+2. 🔴 Error handling (silent catch, unhandled async, missing resource error state)
+3. 🔴 Workarounds & hacks (setTimeout(0), detectChanges, @ts-ignore, as any)
+4. 🔴 Architecture violations (cross-feature imports, forbidden deps)
+5. 🔴 Design smells (god component, inappropriate intimacy)
+6. 🔴 Signal misuse (effect for derived, mutation, missing cleanup)
+7. 🔴 Store pattern violations (HttpClient direct, subscribe in mutations, public mutable state)
+8. 🔴 ViewModel violations (template expressions, god ViewModel, manual construction)
+9. 🔴 Missing OnPush
+10. 🔴 `any` types
+11. 🟡 AI Slop (comments, over-engineering, defensive theater)
+12. 🟡 Angular style guide (protected, readonly, handler naming, member order)
+13. 🟡 Legacy Angular patterns (decorators → functions)
+14. 🟡 TypeScript modernization
+15. 🟡 Styling issues
+16. 🟡 Naming conventions
+17. 🟡 Testing patterns

--- a/.claude/skills/workflow-clean-code-angular/references/angular-clean-code.md
+++ b/.claude/skills/workflow-clean-code-angular/references/angular-clean-code.md
@@ -332,3 +332,200 @@ readonly budgets = httpResource(() => `/api/budgets`, {
 - Types derived with `z.infer<>`
 - `parse` at API boundaries
 - Never import types directly from backend
+
+---
+
+## 10. ViewModel Separation
+
+The store's `computed()` selectors form the ViewModel layer. Components just bind.
+
+```
+API (DataModel) → Store computed() (ViewModel) → Component → Template
+```
+
+| Rule | Rationale |
+|------|-----------|
+| No `.filter()`/`.map()`/`.reduce()` in templates | Templates should bind, not transform |
+| No `computed()` in components reading store data | Move to store — shared, testable, reactive |
+| Store returns numbers/enums, not formatted strings | Formatting is a view concern (pipes, Decimal extensions) |
+| One `computed()` per concern, not one god object | Fine-grained signal tracking |
+| No manual ViewModel construction in `ngOnInit` | Breaks reactivity — use `computed()` |
+
+For detailed patterns and anti-patterns: see `references/viewmodel-patterns.md`.
+
+---
+
+## 11. AI Slop Prevention
+
+Code should read like a senior developer wrote it by hand. Remove:
+
+| Slop | Action |
+|------|--------|
+| Comments that restate the next line | Delete |
+| `try/catch` around non-throwing code | Remove |
+| Null checks on DI-injected or typed values | Remove — trust types |
+| Single-use helper functions | Inline |
+| JSDoc on obvious methods | Delete |
+| Abstractions with one consumer | Inline |
+| Verbose variable names (>25 chars) | Shorten |
+
+For detailed detection guide: see `references/ai-slop-detection.md`.
+
+---
+
+## 12. Angular Style Guide Conventions
+
+From angular.dev/style-guide — official Angular team recommendations.
+
+### Member Visibility
+
+```typescript
+@Component({
+  template: `<p>{{ fullName() }}</p>`,
+})
+export class UserProfileComponent {
+  readonly firstName = input<string>();
+  readonly lastName = input<string>();
+
+  // Only accessed by template — protected, not public
+  protected readonly fullName = computed(() =>
+    `${this.firstName()} ${this.lastName()}`
+  );
+
+  // Public API — called by parent components
+  resetForm(): void { /* ... */ }
+}
+```
+
+**Rule**: `protected` for template-only members. `public` only for the component's external API.
+
+### Readonly on Angular-Initialized Properties
+
+```typescript
+readonly userId = input<string>();
+readonly userSaved = output<void>();
+readonly userName = model<string>();
+readonly nameInput = viewChild<ElementRef>('nameInput');
+```
+
+Applies to: `input()`, `input.required()`, `output()`, `model()`, `viewChild()`, `viewChildren()`, `contentChild()`, `contentChildren()`.
+
+### Event Handler Naming
+
+```html
+<!-- Name for what they do, not the event -->
+<button (click)="saveUserData()">Save</button>
+<button (click)="deleteBudget()">Delete</button>
+
+<!-- Not this -->
+<button (click)="handleClick()">Save</button>
+<button (click)="onClick()">Delete</button>
+```
+
+### Component Member Order
+
+```typescript
+export class BudgetCardComponent {
+  // 1. Injected dependencies
+  readonly #store = inject(BudgetStore);
+
+  // 2. Inputs
+  readonly budget = input.required<Budget>();
+
+  // 3. Outputs
+  readonly selected = output<Budget>();
+
+  // 4. Queries
+  readonly nameInput = viewChild<ElementRef>('nameInput');
+
+  // 5. Computed / derived state
+  protected readonly displayName = computed(() => this.budget().name);
+
+  // 6. Methods
+  selectBudget(): void { /* ... */ }
+}
+```
+
+### Lifecycle Hooks
+
+- Always `implements OnInit`, `implements OnDestroy` — guarantees correct method name
+- Keep hooks thin — delegate to well-named methods
+- Empty hooks are dead code — remove them
+
+For full reference: see `references/angular-style-guide.md`.
+
+---
+
+## 13. Error Handling
+
+Errors should be handled at the callsite — the code that started the operation has the context to recover. The global `ErrorHandler` is for fatal/unexpected errors only (logging, analytics).
+
+### Store async methods — always handle errors
+
+```typescript
+async loadBudgets(): Promise<void> {
+  this.#state.update(s => ({ ...s, isLoading: true, error: null }));
+  try {
+    const budgets = await firstValueFrom(this.#budgetApi.getBudgets$());
+    this.#state.update(s => ({ ...s, budgets, isLoading: false }));
+  } catch (error) {
+    this.#state.update(s => ({
+      ...s,
+      isLoading: false,
+      error: isApiError(error) ? error.message : 'Erreur inattendue',
+    }));
+  }
+}
+```
+
+### Resource error state in templates
+
+```html
+@if (store.budgets.status() === 'error') {
+  <app-error [message]="store.budgets.error()?.message" />
+} @else if (store.budgets.isLoading()) {
+  <app-spinner />
+} @else {
+  @for (budget of store.budgets.value(); track budget.id) {
+    <app-budget-card [budget]="budget" />
+  }
+}
+```
+
+### Zod at API boundaries
+
+```typescript
+// In httpResource parse option — Angular handles ZodError via resource status
+readonly budgets = httpResource(() => `/api/budgets`, {
+  parse: budgetListSchema.parse,
+});
+
+// In component code — use safeParse for graceful handling
+const result = budgetSchema.safeParse(formValue);
+if (!result.success) {
+  this.#formErrors.set(result.error.flatten().fieldErrors);
+  return;
+}
+```
+
+### Error typing
+
+```typescript
+// Use unknown + narrowing, not any
+catch (error: unknown) {
+  if (isApiError(error)) {
+    this.#state.update(s => ({ ...s, error: error.message }));
+  } else {
+    throw error; // Re-throw unexpected errors
+  }
+}
+```
+
+**Key rules:**
+- Every `async` store method: `try/catch` with state revert on error
+- Every `resource()` / `httpResource()`: check `.error()` or `.status()` in template
+- Zod `.parse()` only in `httpResource({ parse })` — use `.safeParse()` elsewhere
+- `catch (error: unknown)` — never `catch (e: any)`
+- Never swallow errors silently (`catch (e) {}`)
+
+**Source:** angular.dev/best-practices/error-handling

--- a/.claude/skills/workflow-clean-code-angular/references/angular-style-guide.md
+++ b/.claude/skills/workflow-clean-code-angular/references/angular-style-guide.md
@@ -1,0 +1,242 @@
+# Angular Official Style Guide (Condensed)
+
+> Condensed from angular.dev/style-guide and angular.dev/best-practices.
+> These are official Angular conventions — not project-specific opinions.
+
+---
+
+## 1. Member Visibility
+
+### `protected` for template-only members
+
+Public members form a component's API (accessible via DI and queries). Use `protected` for anything only accessed from the template — it prevents external code from depending on internal template bindings.
+
+```typescript
+@Component({
+  template: `<p>{{ fullName() }}</p>`,
+})
+export class UserProfileComponent {
+  readonly firstName = input<string>();
+  readonly lastName = input<string>();
+
+  // Not part of public API, but needed by template
+  protected readonly fullName = computed(() =>
+    `${this.firstName()} ${this.lastName()}`
+  );
+
+  // Public API — other components can call this via queries
+  resetForm(): void { /* ... */ }
+}
+```
+
+**Rule:** If a method or computed signal is ONLY read from the template, mark it `protected`. If it's part of the component's public contract (called by parents, used in tests via component reference), keep it `public`.
+
+### `readonly` on Angular-initialized properties
+
+Mark properties initialized by Angular as `readonly` — prevents accidental reassignment.
+
+```typescript
+readonly userId = input<string>();
+readonly userSaved = output<void>();
+readonly userName = model<string>();
+readonly nameInput = viewChild<ElementRef>('nameInput');
+```
+
+This applies to: `input()`, `input.required()`, `output()`, `model()`, `viewChild()`, `viewChildren()`, `contentChild()`, `contentChildren()`.
+
+---
+
+## 2. Event Handler Naming
+
+Name handlers for **what they do**, not the triggering event:
+
+```html
+<!-- Good — describes the action -->
+<button (click)="saveUserData()">Save</button>
+<button (click)="deleteBudget()">Supprimer</button>
+
+<!-- Bad — describes the event -->
+<button (click)="handleClick()">Save</button>
+<button (click)="onClick()">Supprimer</button>
+```
+
+For keyboard events, use Angular's key modifiers with specific names:
+
+```html
+<textarea
+  (keydown.control.enter)="commitNotes()"
+  (keydown.control.space)="showSuggestions()"
+>
+```
+
+Exception: when event handling is complex and delegates to multiple behaviors, a generic `handleKeydown(event)` is acceptable.
+
+---
+
+## 3. Component Member Order
+
+Group Angular-specific properties together at the top, before methods. This makes template APIs and dependencies scannable.
+
+```typescript
+export class BudgetCardComponent {
+  // 1. Injected dependencies
+  readonly #store = inject(BudgetStore);
+  readonly #router = inject(Router);
+
+  // 2. Inputs
+  readonly budget = input.required<Budget>();
+  readonly isActive = input(false);
+
+  // 3. Outputs
+  readonly selected = output<Budget>();
+
+  // 4. Queries
+  readonly nameInput = viewChild<ElementRef>('nameInput');
+
+  // 5. Computed / derived state
+  protected readonly displayName = computed(() => this.budget().name);
+
+  // 6. Methods (after all properties)
+  selectBudget(): void { /* ... */ }
+}
+```
+
+---
+
+## 4. Lifecycle Hooks
+
+### Implement interfaces
+
+Always import and `implements` the lifecycle interface — it guarantees correct method naming.
+
+```typescript
+import { Component, OnInit, OnDestroy } from '@angular/core';
+
+@Component({ /* ... */ })
+export class BudgetComponent implements OnInit, OnDestroy {
+  ngOnInit(): void { /* ... */ }
+  ngOnDestroy(): void { /* ... */ }
+}
+```
+
+### Keep hooks simple
+
+Don't put long logic in lifecycle hooks. Delegate to well-named methods — hook names describe WHEN (timing), methods describe WHAT (action).
+
+```typescript
+// Good — clear what each step does
+ngOnInit(): void {
+  this.initializeTracking();
+  this.loadInitialData();
+}
+
+// Bad — all logic inlined
+ngOnInit(): void {
+  this.analytics.setMode('info');
+  this.analytics.monitorErrors();
+  // 30 more lines...
+}
+```
+
+### Empty hooks are dead code
+
+If `ngOnInit` or `ngOnDestroy` has no body, remove it entirely. Empty lifecycle hooks are noise.
+
+---
+
+## 5. Components & Presentation
+
+### Focused on presentation
+
+Components should focus on UI coordination. Business logic, data transformations, and validation rules belong in stores, services, or standalone functions — not in the component class.
+
+### Avoid complex template logic
+
+When a template expression gets complex, move it to a `computed()` signal. There's no hard rule for "complex", but as a guideline: if it has a method call, a ternary, or accesses nested properties 3+ levels deep, it probably belongs in a `computed()`.
+
+### `class`/`style` over `ngClass`/`ngStyle`
+
+Built-in bindings are simpler and more performant:
+
+```html
+<!-- Good -->
+<div [class.admin]="isAdmin()" [class.dense]="isDense()">
+<div [style.color]="textColor()">
+
+<!-- Bad -->
+<div [ngClass]="{'admin': isAdmin(), 'dense': isDense()}">
+<div [ngStyle]="{'color': textColor()}">
+```
+
+---
+
+## 6. File & Project Organization
+
+### One concept per file
+
+Each file should focus on a single concept. One component, one service, one store per file. If a file contains multiple classes, consider splitting.
+
+### Feature-based directories
+
+Organize by feature, not by type. Don't create `components/`, `services/`, `directives/` folders.
+
+```
+# Good — organized by feature
+feature/budget/
+├── budget.ts
+├── budget.store.ts
+├── budget-card.ts
+
+# Bad — organized by type
+components/
+├── budget.ts
+├── budget-card.ts
+services/
+├── budget.store.ts
+```
+
+### File naming
+
+- Hyphen-separated words: `budget-card.ts`, not `budgetCard.ts`
+- File name matches the class: `BudgetCardComponent` → `budget-card.ts`
+- Tests alongside source: `budget-card.spec.ts` next to `budget-card.ts`
+- Same base name for component files: `budget-card.ts`, `budget-card.html`, `budget-card.scss`
+
+---
+
+## 7. Dependency Injection
+
+### Prefer `inject()` over constructor
+
+`inject()` is more readable, especially with many dependencies. Better type inference, easier to comment.
+
+```typescript
+// Good
+readonly #store = inject(BudgetStore);
+readonly #router = inject(Router);
+
+// Bad
+constructor(
+  private store: BudgetStore,
+  private router: Router,
+) {}
+```
+
+---
+
+## Anti-Pattern Summary
+
+| Angular Style Guide Rule | Anti-Pattern | Fix |
+|--------------------------|-------------|-----|
+| Protected template members | `public` method only used by template | `protected` |
+| Readonly signals | Missing `readonly` on `input()`, `output()`, etc. | Add `readonly` |
+| Action-based handlers | `handleClick()`, `onClick()` | `saveData()`, `deleteBudget()` |
+| Member ordering | Methods mixed with properties | Properties first, methods after |
+| Lifecycle interfaces | `ngOnInit()` without `implements OnInit` | Add `implements` |
+| Simple lifecycle hooks | 30+ lines in `ngOnInit` | Delegate to named methods |
+| Empty lifecycle hooks | Empty `ngOnInit() {}` | Remove entirely |
+| Class/style bindings | `[ngClass]`, `[ngStyle]` | `[class.x]`, `[style.y]` |
+| One concept per file | Multiple classes in one file | Split into separate files |
+| Feature-based organization | `components/`, `services/` folders | Feature folders |
+
+**Source:** angular.dev/style-guide

--- a/.claude/skills/workflow-clean-code-angular/references/viewmodel-patterns.md
+++ b/.claude/skills/workflow-clean-code-angular/references/viewmodel-patterns.md
@@ -1,0 +1,242 @@
+# ViewModel Patterns in Angular
+
+> Reference for separating data models from view models in the Pulpe architecture.
+> The key insight: stores transform data for views via `computed()` selectors. Components just bind.
+
+---
+
+## Why This Matters
+
+A **DataModel** is what the API returns — parsed by Zod from `pulpe-shared` schemas.
+A **ViewModel** is what the template needs — often a transformation of one or more DataModels.
+
+Without separation:
+- Templates contain complex expressions that are hard to test and debug
+- Components become transformation engines instead of UI coordinators
+- The same transformation gets duplicated across multiple components
+- API response changes break templates instead of just one store selector
+
+---
+
+## Where Transformations Belong
+
+```
+API Response (DataModel)
+    │
+    ▼
+Store — computed() selectors  ← THE VIEWMODEL LAYER
+    │
+    ▼
+Component — reads signals, coordinates UI events
+    │
+    ▼
+Template — simple bindings, pipes for formatting
+```
+
+The store's `computed()` selectors ARE the ViewModel. They transform raw API data into exactly what templates need.
+
+---
+
+## Correct Pattern
+
+```typescript
+// Store: DataModel → ViewModel via computed()
+@Injectable()
+export class BudgetDetailsStore {
+  readonly #api = inject(BudgetApi);
+
+  // ── Raw data (DataModel) ──
+  readonly #resource = resource({ /* ... */ });
+
+  // ── ViewModel selectors ──
+  readonly budgetName = computed(() => this.#resource.value()?.name ?? '');
+
+  readonly totalExpenses = computed(() => {
+    const lines = this.#resource.value()?.budget_lines ?? [];
+    return lines
+      .filter(l => l.type === 'expense')
+      .reduce((sum, l) => sum + l.amount, 0);
+  });
+
+  readonly expenseLines = computed(() => {
+    const lines = this.#resource.value()?.budget_lines ?? [];
+    return lines
+      .filter(l => l.type === 'expense')
+      .toSorted((a, b) => a.label.localeCompare(b.label));
+  });
+
+  readonly progress = computed(() => {
+    const total = this.totalExpenses();
+    const target = this.#resource.value()?.target_amount ?? 0;
+    return target > 0 ? Math.min(total / target, 1) : 0;
+  });
+
+  readonly hasExpenses = computed(() => this.expenseLines().length > 0);
+}
+```
+
+```typescript
+// Component: reads view-ready signals, zero transformation
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <h1>{{ store.budgetName() }}</h1>
+    <progress-bar [value]="store.progress()" />
+    @if (store.hasExpenses()) {
+      @for (line of store.expenseLines(); track line.id) {
+        <budget-line-card [line]="line" />
+      }
+    } @else {
+      <p>Aucune dépense</p>
+    }
+  `,
+})
+export class BudgetDetailsComponent {
+  protected readonly store = inject(BudgetDetailsStore);
+}
+```
+
+---
+
+## Anti-Patterns
+
+### 1. Raw API Data in Template
+
+```typescript
+// BAD — template is the transformation layer
+@Component({
+  template: `
+    {{ resource.value()?.budget_lines?.filter(l => l.type === 'expense')
+       ?.reduce((s, l) => s + l.amount, 0) | currency:'CHF' }}
+  `,
+})
+```
+
+The template has business logic (filtering by type, aggregating). Any change to the data structure requires a template change.
+
+**Fix:** Create a `computed()` selector in the store: `totalExpenses`. Template becomes `{{ store.totalExpenses() | currency:'CHF' }}`.
+
+### 2. Transformation in Component
+
+```typescript
+// BAD — component doing store work
+export class BudgetComponent {
+  readonly #store = inject(BudgetStore);
+
+  readonly expenses = computed(() =>
+    this.#store.data()?.lines.filter(l => l.type === 'expense') ?? []
+  );
+
+  readonly sortedExpenses = computed(() =>
+    this.expenses().toSorted((a, b) => a.amount - b.amount)
+  );
+}
+```
+
+If another component needs the same filtered/sorted list, it will duplicate this logic.
+
+**Fix:** Move both `computed()` signals to the store. Component reads `store.expenses()` and `store.sortedExpenses()`.
+
+### 3. Store Returns Formatted Strings
+
+```typescript
+// BAD — store doing view work
+readonly formattedTotal = computed(() =>
+  this.totalExpenses().toLocaleString('fr-CH', {
+    style: 'currency',
+    currency: 'CHF',
+  })
+);
+```
+
+Formatting is a view concern. The store should return the raw number — the template applies `CurrencyPipe` or the project's Decimal extensions (`asCHF`, `asCompactCHF`).
+
+**Fix:** Store exposes `totalExpenses` as a number. Template: `{{ store.totalExpenses() | currency:'CHF' }}` or use `asAmount` extension.
+
+### 4. Duplicate Derivations
+
+```typescript
+// BAD — same transformation in two components
+// In BudgetOverviewComponent:
+readonly expenses = computed(() =>
+  this.store.data()?.lines.filter(l => l.type === 'expense')
+);
+
+// In BudgetSummaryComponent:
+readonly expenseTotal = computed(() =>
+  this.store.data()?.lines.filter(l => l.type === 'expense')
+    .reduce((s, l) => s + l.amount, 0)
+);
+```
+
+Both components filter by type independently. The filter logic exists in two places.
+
+**Fix:** Store has `expenseLines` and `totalExpenses` as shared selectors. Both components just read them.
+
+### 5. God ViewModel Object
+
+```typescript
+// BAD — one massive computed defeats fine-grained reactivity
+readonly vm = computed(() => ({
+  name: this.#resource.value()?.name,
+  expenses: this.#resource.value()?.lines.filter(/* ... */),
+  income: this.#resource.value()?.lines.filter(/* ... */),
+  total: /* ... */,
+  progress: /* ... */,
+  formattedDate: /* ... */,
+  // 15 more properties...
+}));
+```
+
+Angular's signal tracking is granular. One big object means any change to any property re-evaluates everything and triggers all template bindings.
+
+**Fix:** Separate `computed()` for each concern. Each one tracks only what it depends on.
+
+### 6. Component as ViewModel Factory
+
+```typescript
+// BAD — component creates a ViewModel in ngOnInit or constructor
+export class BudgetComponent implements OnInit {
+  vm!: BudgetViewModel;
+
+  ngOnInit() {
+    const data = this.store.data();
+    this.vm = {
+      title: data.name,
+      expenses: data.lines.filter(/* ... */),
+      total: data.lines.reduce(/* ... */),
+    };
+  }
+}
+```
+
+This loses reactivity entirely. If `store.data()` changes, `vm` is stale.
+
+**Fix:** Use `computed()` signals in the store. No manual ViewModel construction needed.
+
+---
+
+## Decision Guide
+
+| Situation | Where | Why |
+|-----------|-------|-----|
+| Filter/sort/group data | Store `computed()` | Reusable, testable, reactive |
+| Combine multiple data sources | Store `computed()` | Single source of derived truth |
+| Format numbers/dates for display | Template pipe / Decimal extension | View concern, locale-dependent |
+| Boolean flags for `@if` | Store `computed()` | `hasExpenses`, `isEmpty`, `isOverBudget` |
+| Map API enum to display label | Pipe or `computed()` | Depends on reuse and complexity |
+| Paginate/slice a list | Store `computed()` with pagination signals | State + derivation |
+| Aggregate (sum, avg, count) | Store `computed()` | Business logic, testable |
+| Conditional CSS class | Template `[class.x]="signal()"` | Simple binding |
+
+---
+
+## Review Checklist
+
+1. **Template expressions** — No `.filter()`, `.map()`, `.reduce()`, `.find()` in templates. Max ~40 characters.
+2. **Component computed** — If a component has `computed()` reading store data, it probably belongs in the store
+3. **Store selectors** — Each distinct view need has its own `computed()`, not one god object
+4. **No formatting in store** — Store returns numbers/dates/enums, templates format via pipes
+5. **No duplication** — If 2+ components derive the same thing, it's a store selector
+6. **Granularity** — One `computed()` per concern for fine-grained reactivity
+7. **Reactivity preserved** — No manual ViewModel construction in `ngOnInit` or constructor

--- a/.claude/skills/workflow-clean-code-angular/steps/step-01-scan.md
+++ b/.claude/skills/workflow-clean-code-angular/steps/step-01-scan.md
@@ -1,67 +1,42 @@
 ---
 name: step-01-scan
-description: Initialize scope, detect Angular anti-patterns, and catalog issues
+description: Parse scope, launch specialist agents, team lead consolidation
 prev_step: null
 next_step: steps/step-02-apply.md
 ---
 
 # Step 1: SCAN
 
-## MANDATORY EXECUTION RULES (READ FIRST):
-
-- 🛑 NEVER modify files in this step — scan only
-- ✅ ALWAYS parse flags and resolve scope before scanning
-- 📋 YOU ARE A SCANNER, not a fixer
-- 💬 FOCUS on detection and cataloging issues with file:line
-- 🚫 FORBIDDEN to apply any changes or suggest fixes yet
-
-## EXECUTION PROTOCOLS:
-
-- 🎯 Parse flags first, resolve scope, then scan
-- 💾 Save results if `{save_mode}` = true
-- 📖 Complete full scan before moving to step-02
-- 🚫 FORBIDDEN to load step-02 until scan is complete
-
-## CONTEXT BOUNDARIES:
-
-- This is the first step — no previous context
-- Flags parsed from user input
-- Scope resolved from argument (path, `pending`, `diff main`)
-- Results passed to step-02 via memory
-
-## YOUR TASK:
-
-Parse flags, resolve file scope, load Angular project context, and find all anti-patterns in scoped files.
+Build a complete picture of every issue in the scoped code before touching anything. Understanding the full landscape first leads to better, more coherent fixes. Fixing during scan means you lose the big picture and miss higher-priority issues downstream.
 
 ---
 
-## EXECUTION SEQUENCE:
-
-### 1. Parse Flags
+## 1. Parse Flags
 
 ```yaml
 defaults:
   auto_mode: false       # -a
   economy_mode: false    # -e
   save_mode: false       # -s
+  depth: standard        # --quick → quick, --deep → deep
   force_arch: false      # --arch
   force_signals: false   # --signals
   force_styling: false   # --styling
   force_testing: false   # --testing
+  force_slop: false      # --slop
+  force_vm: false        # --vm
 ```
 
-Parse input: flags → state variables, remainder → `{task_description}`
-Generate `{task_id}` (kebab-case from description)
+Parse input: flags → state variables, remainder → `{task_description}`.
+Generate `{task_id}` (kebab-case from description).
 
-### 2. Check Resume (-r)
+`--deep` enables all force flags. `--quick` disables semantic analysis.
 
-**If `-r {id}` provided:**
-→ Find `.claude/output/clean-code-angular/{id}*/`
-→ Restore state from `00-context.md`
-→ Load appropriate step
-→ **STOP**
+## 2. Check Resume (-r)
 
-### 3. Resolve Scope
+If `-r {id}`: find `.claude/output/clean-code-angular/{id}*/`, restore state from `00-context.md`, load the appropriate step, stop.
+
+## 3. Resolve Scope
 
 | Argument | Action |
 |----------|--------|
@@ -70,159 +45,245 @@ Generate `{task_id}` (kebab-case from description)
 | `pattern/` | Glob `frontend/**/pattern/**/*.{ts,html,scss}` |
 | `layout/` | Glob `frontend/**/layout/**/*.{ts,html,scss}` |
 | `pending` | `git diff --name-only HEAD` filtered to `frontend/**/*.{ts,html,scss}` |
-| `staged` | `git diff --cached --name-only` filtered to `frontend/**/*.{ts,html,scss}` |
-| `diff main` | `git diff main --name-only` filtered to `frontend/**/*.{ts,html,scss}` |
+| `staged` | `git diff --cached --name-only` filtered |
+| `diff main` | `git diff main --name-only` filtered |
 | _(empty)_ | Ask user via AskUserQuestion |
 
-**Filter**: Only `frontend/**/*.{ts,html,scss,spec.ts}` files.
+Only `frontend/**/*.{ts,html,scss,spec.ts}` files. If 0 files: output "No Angular files found in scope" and stop.
 
-**If 0 files**: Output "No Angular files found in scope" and **STOP**.
+Store as `{scoped_files}`. Count determines `{agent_count}`:
 
-Store result in `{scoped_files}`.
+| Files | Agents |
+|-------|--------|
+| 1-4 | 3 |
+| 5-15 | 5 |
+| 16-30 | 7 |
+| 31+ | 10 |
 
-### 4. Load Angular Project Context
+## 4. Load Angular Project Context
 
-Call these tools to understand the project:
+1. `mcp__angular-cli__list_projects` → get `{workspace_path}`
+2. `mcp__angular-cli__get_best_practices` with `workspacePath`
 
-1. **`mcp__angular-cli__list_projects`** → Get `{workspace_path}` (path to angular.json)
-2. **`mcp__angular-cli__get_best_practices`** with `workspacePath` → Load Angular 21 best practices
+If either MCP call fails (server down, misconfigured), continue without it. The reference files contain enough context to run the scan — MCP data is supplementary, not blocking.
 
-Store `{workspace_path}` for step-02.
-
-### 5. Create Output (if save_mode)
+## 5. Create Output (if save_mode)
 
 ```bash
 mkdir -p .claude/output/clean-code-angular/{task_id}
 ```
 
-Write `00-context.md` with scope, flags, file list.
+Write `00-context.md` with scope, flags, file list, depth.
 
-### 6. Read Anti-Patterns Checklist
+## 6. Load Reference Files
 
-Read `references/angular-anti-patterns.md` — this is the scanning checklist.
-
-### 7. Scan Codebase
-
-**If `{economy_mode}` = true:**
-→ Direct tools only (Read, Grep, Glob) — scan files sequentially
-
-**If `{economy_mode}` = false:**
-→ Launch parallel agents (single message):
-
-| Agent | Type | Task |
-|-------|------|------|
-| 1 | explore-codebase | **Architecture scan**: Check dependency direction in `{scoped_files}` — cross-feature imports, forbidden dependencies (feature→feature, ui→core, pattern→feature), circular references |
-| 2 | explore-codebase | **Angular anti-pattern scan**: In `{scoped_files}` find: `@Input()`, `@Output()`, `*ngIf`, `*ngFor`, `[ngClass]`, `constructor(private`, `ChangeDetectionStrategy.Default`, legacy DI, missing OnPush |
-| 3 | explore-codebase | **Signal & TypeScript scan**: In `{scoped_files}` find: `effect()` for derived state, signal mutation, `any` types, `private` fields (should be `#`), `as Type` casts, missing `takeUntilDestroyed()` |
-
-**Additionally run quick grep on scoped files** (always, even in economy mode):
-
-```bash
-# For each $file in {scoped_files}:
-grep -n "::ng-deep" "$file"              # Styling violation
-grep -n "@Input()" "$file"               # Legacy input
-grep -n "@Output()" "$file"              # Legacy output
-grep -n "constructor(private" "$file"    # Legacy DI
-grep -n ": any" "$file"                  # Any type
-grep -n "private \w" "$file"             # Should be #field
-grep -n "innerHTML" "$file"              # XSS risk
-grep -n "\*ngIf" "$file"                 # Legacy control flow
-grep -n "\*ngFor" "$file"                # Legacy control flow
-grep -n "\[ngClass\]" "$file"            # Should be [class.name]
-grep -n "effect(" "$file"                # Potential misuse
-grep -n "console\." "$file"              # Raw console
-grep -n "ChangeDetectionStrategy" "$file" # Check if OnPush
-```
-
-### 8. Prioritize Files (within scope only)
-
-**Review thoroughly** (if present in scope):
-- `core/**/*.service.ts` → Wide impact
-- `*.guard.ts`, `*.interceptor.ts` → Security critical
-- Files with `effect()` → Reactive bugs
-- Files > 200 lines → Complexity smell
-- `*.store.ts` → State management patterns
-
-**Quick scan** (if present in scope):
-- Pure UI components without `inject()`
-- Test files following established patterns
-
-### 9. Catalog Issues
-
-```markdown
-## Issues Found
-
-| # | File:Line | Issue | Category | Severity |
-|---|-----------|-------|----------|----------|
-| 1 | budget.store.ts:45 | `effect()` for derived state | Signals | 🔴 Critical |
-| 2 | budget-list.ts:12 | `@Input()` instead of `input()` | Angular | 🟡 Improvement |
-| 3 | budget.service.ts:8 | `constructor(private ...)` | DI | 🟡 Improvement |
-```
-
-**Severity rules:**
-- **🔴 Critical**: Security, bugs, broken functionality, architecture violations, signal misuse
-- **🟡 Improvement**: Style, naming, legacy patterns, minor refactoring
-
-**MAX 15 issues** — report top 15 by severity. If more exist, note "N additional issues not shown".
-
-### 10. Confirm
-
-**If `{auto_mode}` = true:**
-→ Proceed to step-02
-
-**If `{auto_mode}` = false:**
-→ Display issue table, then use AskUserQuestion:
-
-```yaml
-questions:
-  - header: "Proceed"
-    question: "Found {N} issues in {M} files. Proceed to apply fixes?"
-    options:
-      - label: "Fix All (Recommended)"
-        description: "Apply all fixes"
-      - label: "Critical Only"
-        description: "Only fix critical issues"
-      - label: "Review Issues"
-        description: "Show detailed analysis first"
-      - label: "Cancel"
-        description: "Stop without changes"
-    multiSelect: false
-```
+Read with the Read tool:
+- `references/angular-anti-patterns.md` — always
+- `references/angular-style-guide.md` — always
+- `references/ai-slop-detection.md` — if deep mode or `--slop`
+- `references/viewmodel-patterns.md` — if deep mode or `--vm`
 
 ---
 
-## SUCCESS METRICS:
+## 7. Scan
 
-✅ Flags parsed correctly
-✅ Scope resolved to concrete file list
-✅ Angular project context loaded (list_projects + best_practices)
-✅ Anti-patterns checklist read
-✅ Issues cataloged with file:line format
-✅ Issues prioritized by severity
-✅ Architecture violations identified (if any)
+### Quick Mode (`--quick`)
 
-## FAILURE MODES:
+Grep-only scan using patterns from `references/angular-anti-patterns.md`. Use the **Grep tool** (not bash grep) for each pattern. No file reading, no semantic analysis. Fast surface check.
 
-❌ Modifying files during scan
-❌ Scanning files outside the specified scope
-❌ Not loading Angular MCP best practices
-❌ Not reading the anti-patterns checklist
-❌ Missing file:line references in issues
+Key Grep patterns to run on `{scoped_files}`:
+- `@Input(` — legacy input
+- `@Output(` — legacy output
+- `constructor(private` — legacy DI
+- `::ng-deep` — styling violation
+- `\\*ngIf` / `\\*ngFor` — legacy control flow
+- `effect(` — potential signal misuse
+- `: any` — untyped
+- `private \\w` — should be `#field`
+- `innerHTML` — XSS risk
+- `console\\.` — raw console
+- `ChangeDetectionStrategy` — check if OnPush
+- `setTimeout` — potential change detection workaround
+- `detectChanges` — manual CD trigger (signals should handle this)
+- `@ts-ignore` / `@ts-expect-error` — suppressed type errors
+- `as any` — type escape hatch
+- `eslint-disable` — suppressed lint rules
+- `document\\.querySelector` — direct DOM access (use `viewChild()`)
+- `NgZone` / `zone\\.run` — unnecessary in zoneless Angular
+- `catch.*\\{\\s*\\}` — empty catch block (swallowed error)
+- `catch.*: any` — untyped error catch
 
-## SCAN PROTOCOLS:
+### Economy Mode (`-e`)
 
-- Always resolve scope FIRST — never scan the entire frontend/
-- Report issues with `file.ts:line` format
-- Distinguish "missing" from "incorrectly used"
-- Check architecture rules for EVERY import in scoped files
-- Signal misuse is always 🔴 Critical
+Use Grep tool for pattern detection, then Read key files (stores, services, main components) for targeted semantic analysis. No subagents.
+
+### Standard / Deep Mode
+
+Launch specialist agents **in a single message** (all at once). Each agent is a `code-reviewer` type with:
+- The `{scoped_files}` list
+- Its domain focus and detection criteria
+- Instruction to return findings as: `file:line | issue description | category | severity`
+- The relevant reference file(s) to load
+
+**Launch these agents based on `{agent_count}`:**
 
 ---
 
-## NEXT STEP:
+**Agent 1 — Architecture & Dependencies** _(always)_
 
-After scan complete and user confirms, load `./step-02-apply.md`
+> Analyze imports in `{scoped_files}`. For each import, determine source layer and target layer from the path (`core/`, `feature/`, `pattern/`, `ui/`, `layout/`, `styles/`). Flag any forbidden dependency per the architecture reference. Check for cross-feature imports (`feature/x` importing from `feature/y`). Report: `file:line | import path | from_layer → to_layer`.
+> Load: `references/angular-architecture.md`
 
-<critical>
-SCAN ONLY — don't fix anything! Only catalog issues with file:line references.
-</critical>
+---
+
+**Agent 2 — Signals & Reactivity** _(always)_
+
+> Read `.ts` files in scope. Find: `effect()` used for derived state (should be `computed()`), `effect()` syncing signals (should be `linkedSignal()`), signal mutation (`.mutate`, in-place `.push`/`.splice`), `subscribe()` without `takeUntilDestroyed()`, `BehaviorSubject` that should be `signal()`, `toSignal()` without `initialValue`. Don't just grep — read the `effect()` body and determine if a better primitive exists.
+>
+> **RxJS nuance**: RxJS is valid and expected for event streams, WebSocket connections, complex async orchestration (race conditions, retries, debounce chains), and router/form `valueChanges`. Only flag RxJS when a signal primitive is clearly better — specifically: `BehaviorSubject` used as local component state (→ `signal()`), `combineLatest` feeding a template binding (→ `computed()`), `Subject.next()` used to sync two values (→ `linkedSignal()`). If the Observable handles genuinely streamy behavior, leave it alone.
+> Load: `references/angular-anti-patterns.md` section 2
+
+---
+
+**Agent 3 — Store Patterns** _(5+ agents)_
+
+> Read all `*.store.ts` and `*-store.ts` files in scope. Check against the 6-section anatomy: Dependencies → State → Resource → Selectors → Mutations → Private utils. Verify: cache-first loader pattern, optimistic update pattern, temp ID handling (real ID before cascade), `@Injectable()` vs `providedIn: 'root'` scoping, `resource()` / `rxResource()` usage.
+>
+> **Error handling in stores** — this is where most async operations live:
+> - Every `async` mutation method must have `try/catch` with state revert on error
+> - `catch (error: unknown)` — never `catch (e: any)` or empty `catch {}`
+> - Error narrowing via `isApiError()` or type guards — not raw `error.message`
+> - `firstValueFrom()` calls must be inside `try/catch`
+> - `resource()` / `httpResource()` consumers must check `.error()` or `.status()` in templates
+> - Zod `.parse()` in `httpResource({ parse })` is correct — but `.parse()` in other contexts needs error handling or `.safeParse()`
+> Load: `.claude/rules/03-frameworks-and-libraries/angular-store-pattern.md`, `references/angular-anti-patterns.md` section 18
+
+---
+
+**Agent 4 — Component Design** _(5+ agents)_
+
+> Read component files in scope. Check:
+> - `ChangeDetectionStrategy.OnPush` present
+> - File < 300 lines, functions < 30 lines
+> - Single responsibility (component coordinates UI — doesn't transform data). God component smell: ≥ 6 `inject()` calls in one class signals too many responsibilities
+> - `inject()` vs constructor DI, `input()` vs `@Input()`, `output()` vs `@Output()`
+> - `host: {}` vs `@HostBinding/@HostListener`, `viewChild()` vs `@ViewChild()`
+>
+> **Angular style guide checks** (from angular.dev/style-guide):
+> - `protected` on members only accessed from template (not `public`)
+> - `readonly` on `input()`, `output()`, `model()`, `viewChild()`, `viewChildren()`, `contentChild()`, `contentChildren()`
+> - Event handlers named for action, not event (`saveData()` not `handleClick()`, `onClick()`)
+> - Member order: injected deps → inputs → outputs → queries → computed → methods
+> - Lifecycle hooks implement interface (`implements OnInit`, not just `ngOnInit()` method)
+> - Empty lifecycle hooks = dead code, flag for removal
+> Load: `references/angular-clean-code.md` section 1, `references/angular-style-guide.md`
+
+---
+
+**Agent 5 — Template Quality** _(5+ agents)_
+
+> Read `.html` files and inline templates in scope. Check: `@if`/`@for`/`@switch` vs legacy directives, every `@for` has `track`, `@empty` blocks for lists, template expressions > 40 chars (should be `computed()`), unnecessary `<ng-container>` wrappers, nested `<div>` bloat (wrapper soup), `[ngClass]` → `[class.x]`, `[ngStyle]` → `[style.x]` or Tailwind.
+> Load: `references/angular-clean-code.md` section 4
+
+---
+
+**Agent 6 — TypeScript Quality** _(7+ agents)_
+
+> Check `.ts` files:
+> - `any` types → `unknown` + type guard
+> - `as Type` casts → type guard or generic
+> - `private` → `#` native private
+> - `JSON.parse(JSON.stringify())` → `structuredClone()`
+> - `.sort()`/`.reverse()` → `.toSorted()`/`.toReversed()`
+> - Manual `reduce` for grouping → `Object.groupBy()`
+> - Commented-out code → delete
+> - Magic numbers → named constants
+> - Dead imports, unused methods
+>
+> Load: `references/angular-anti-patterns.md` section 6
+
+---
+
+**Agent 7 — Styling** _(7+ agents)_
+
+> Read `.scss` files and inline styles. Check: `::ng-deep` → CSS custom properties, `!important` → specificity fix, `bg-[--var]` → `bg-(--var)` (Tailwind v4), `mat-button` → `matButton="filled"`, inline `style=""` → Tailwind/component styles, missing M3 token usage `var(--mat-sys-*)`.
+> Load: `references/angular-anti-patterns.md` section 7
+
+---
+
+**Agent 8 — AI Slop Detection** _(deep mode or `--slop`, 7+ agents)_
+
+> Read every file in scope looking for AI-generated code smells. Focus on: comments that restate code, over-engineered abstractions with a single consumer, defensive null checks on DI-injected or type-guaranteed values, verbose variable names (>25 chars), single-use helper functions, `try/catch` around non-throwing code, JSDoc that adds nothing beyond TypeScript types, unnecessary intermediate variables, wrapper `<div>` soup in templates.
+> Load: `references/ai-slop-detection.md`
+
+---
+
+**Agent 9 — ViewModel & Data Flow** _(deep mode or `--vm`, 10 agents)_
+
+> Trace data flow: API → Store → Component → Template. Check: raw API types in templates (should go through store `computed()`), transformation logic in components that belongs in store, store returning formatted strings (formatting is view concern — use pipes), duplicate `computed()` across components (should be shared store selector), god ViewModel objects (one big `computed()` returning everything), `ngOnInit` manually constructing ViewModels (breaks reactivity).
+> Load: `references/viewmodel-patterns.md`
+
+---
+
+**Agent 10 — Security, Performance & Code Health** _(10 agents)_
+
+> **Security & Performance**: `innerHTML` binding (XSS), `bypassSecurityTrust*`, `console.log` (use Logger), missing `@defer` opportunities for heavy below-fold components, eager imports from lazy-loaded features, `@for` without meaningful `track` expression.
+>
+> **Workaround / hack detection** — framework bypasses that indicate deeper issues:
+> - `setTimeout(0)` — working around change detection
+> - `detectChanges()` / `markForCheck()` in OnPush components — should not be needed with signals
+> - `@ts-ignore` / `@ts-expect-error` — hiding type errors
+> - `as any` — type escape hatch
+> - `eslint-disable` without justification comment
+> - `document.querySelector()` — use `viewChild()` + `ElementRef`
+> - `window.location` for navigation — use `Router`
+> - `zone.run()` / `NgZone` — not needed in zoneless Angular
+>
+> **Design smell detection**:
+> - Feature envy: method that mostly accesses another class's data — logic belongs elsewhere
+> - Primitive obsession: raw `string` IDs, amounts, dates where branded types would prevent misuse
+> - Inappropriate intimacy: component reaching into store's private state or deeply nested signal properties
+>
+> Load: `references/angular-anti-patterns.md` sections 8, 15, 16
+
+---
+
+## 8. Team Lead Consolidation
+
+After all specialists complete, launch a **team lead agent** (`code-reviewer` type):
+
+> You are a senior Angular architect. You have specialist reports from {N} agents analyzing `{scoped_files}`.
+>
+> Your job:
+> 1. **Merge** findings into one deduplicated list — remove exact duplicates across agents
+> 2. **Validate** — if a finding looks questionable, read the actual file to confirm or dismiss it
+> 3. **Resolve contradictions** — if two specialists disagree on the same code, investigate and decide
+> 4. **Cross-cutting observations** — look for issues no single specialist caught: inconsistent patterns across files, missing shared abstractions where 2+ files do the same transformation, naming inconsistencies within the scope
+> 5. **Prioritize** — sort by impact: Critical (bugs, security, architecture) → Important (patterns, signals) → Minor (naming, style)
+> 6. **Cap at 30** — report top 30 issues. If more exist, note the total.
+>
+> Output a markdown table:
+> `| # | File:Line | Issue | Category | Severity | Source |`
+>
+> Severity: Critical / Important / Minor
+> Every issue must be concrete and actionable — not vague ("could be improved").
+
+## 9. Present Results
+
+Display the team lead's consolidated issue table.
+
+**If `{auto_mode}`:** proceed to step-02 immediately.
+
+**Otherwise:** ask the user:
+- **Fix All** — apply all fixes
+- **Critical Only** — fix Critical + Important, skip Minor
+- **Review Details** — show detailed analysis per issue before deciding
+- **Cancel** — stop without changes
+
+**If `{save_mode}`:** write report to `01-scan.md`.
+
+---
+
+## Next Step
+
+After scan complete and user confirms → load `steps/step-02-apply.md`

--- a/.claude/skills/workflow-clean-code-angular/steps/step-02-apply.md
+++ b/.claude/skills/workflow-clean-code-angular/steps/step-02-apply.md
@@ -1,245 +1,144 @@
 ---
 name: step-02-apply
-description: Load Angular 21 documentation, generate recommendations, and apply clean code fixes
+description: Load documentation, apply fixes with parallel agents, team lead coherence check
 prev_step: steps/step-01-scan.md
 next_step: steps/step-03-verify.md
 ---
 
 # Step 2: APPLY
 
-## MANDATORY EXECUTION RULES (READ FIRST):
+Apply fixes from the consolidated issue list. Every change follows documented patterns and cites its source. After all fixes, the team lead verifies cross-file coherence.
 
-- 🛑 NEVER apply patterns without reading docs/references first
-- ✅ ALWAYS load relevant reference files before making changes
-- 📋 YOU ARE AN IMPLEMENTER following documented Angular 21 patterns
-- 💬 FOCUS on applying fixes from loaded docs with cited sources
-- 🚫 FORBIDDEN to invent patterns not documented in references or Angular MCP
-
-## EXECUTION PROTOCOLS:
-
-- 🎯 Load docs based on issue categories found in step-01
-- 💾 Track every fix with file:line and source citation
-- 📖 Complete all changes before step-03
-- 🚫 FORBIDDEN to modify files outside `{scoped_files}`
-
-## CONTEXT BOUNDARIES:
-
-- From step-01: `{scoped_files}`, `{issues}`, `{workspace_path}`, flags
-- Reference files in `references/` folder
-- Angular MCP tools for framework-specific docs
-- Project rules in `.claude/rules/` (auto-loaded by Claude Code)
-
-## YOUR TASK:
-
-Load Angular 21 documentation, generate prioritized recommendations, and apply clean code fixes with documented sources.
+Don't invent patterns — follow the loaded references. If no reference covers an issue, flag it rather than improvising.
 
 ---
 
-## EXECUTION SEQUENCE:
+## 1. Load Reference Files
 
-### 1. Load Reference Files
+Based on issue categories found in step-01:
 
 | Condition | Load |
 |-----------|------|
 | Always | `references/angular-clean-code.md` |
 | Always | `references/angular-anti-patterns.md` |
-| Architecture issues detected OR `--arch` | `references/angular-architecture.md` |
+| Always | `references/angular-style-guide.md` |
+| Architecture issues | `references/angular-architecture.md` |
+| AI Slop issues | `references/ai-slop-detection.md` |
+| ViewModel issues | `references/viewmodel-patterns.md` |
+| Store issues | `.claude/rules/03-frameworks-and-libraries/angular-store-pattern.md` |
 
-**CRITICAL: Actually READ the files with Read tool!**
+Read each relevant file with the Read tool.
 
-### 2. Load Angular MCP Documentation
+## 2. Load Angular MCP Documentation
 
-Based on issue categories from step-01, query Angular MCP:
+Query Angular MCP **only for categories with actual issues** — don't load docs for clean categories:
 
 | Issue Category | MCP Tool | Query |
 |----------------|----------|-------|
-| Signal misuse | `mcp__angular-cli__find_examples` | `query: "signal computed linkedSignal"`, `workspacePath` |
-| Legacy inputs/outputs | `mcp__angular-cli__find_examples` | `query: "signal input output"`, `workspacePath` |
-| Legacy control flow | `mcp__angular-cli__search_documentation` | `query: "control flow @if @for @switch"` |
-| Legacy DI | `mcp__angular-cli__find_examples` | `query: "inject function"`, `workspacePath` |
-| Store patterns | `mcp__angular-cli__find_examples` | `query: "signal store state management"`, `workspacePath` |
-| Material styling | `mcp__angular-cli__search_documentation` | `query: "Material theming design tokens"` |
-| OnPush missing | `mcp__angular-cli__find_examples` | `query: "OnPush change detection"`, `workspacePath` |
+| Signal misuse | `find_examples` | `"signal computed linkedSignal"` |
+| Legacy inputs/outputs | `find_examples` | `"signal input output"` |
+| Legacy control flow | `search_documentation` | `"control flow @if @for @switch"` |
+| Legacy DI | `find_examples` | `"inject function"` |
+| Store patterns | `find_examples` | `"signal store state management"` |
+| Material styling | `search_documentation` | `"Material theming design tokens"` |
 
-**Only query for categories that have actual issues.** Don't load docs for clean categories.
+## 3. Generate Fix Plan
 
-### 3. Generate Recommendations
-
-Based on issues + loaded docs, generate prioritized list:
+For each issue from the consolidated list, generate a concrete recommendation:
 
 ```markdown
-## Recommendations
-
-### 🔴 Critical (must fix)
-
-1. **Signal Misuse** — `budget.store.ts:45`
-   Replace `effect()` with `computed()` for derived state
-   📚 Source: `.claude/rules/frontend/signals.md`
-
-2. **Architecture Violation** — `budget-list.ts:3`
-   Cross-feature import from `feature/dashboard/`
-   📚 Source: `.claude/rules/00-architecture/angular-architecture.md`
-
-### 🟡 Improvements (should fix)
-
-3. **Legacy Input** — `budget-card.ts:12`
-   Replace `@Input()` with `input()`
-   📚 Source: angular.dev/guide/components/inputs
-
-4. **Legacy DI** — `budget.service.ts:8`
-   Replace `constructor(private ...)` with `inject()`
-   📚 Source: angular.dev/guide/di/dependency-injection
+### #{N} — {Issue Title}
+**File**: `file.ts:line`
+**Category**: {Category} | **Severity**: {level}
+**Current**: what's wrong (brief)
+**Fix**: what to change (concrete)
+**Source**: URL or rule file path
 ```
 
-### 4. Confirm Before Applying
+Group recommendations by file to minimize context switching.
 
-**If `{auto_mode}` = true:**
-→ Apply all recommendations
+## 4. Confirm
 
-**If `{auto_mode}` = false:**
-→ Display recommendations, then use AskUserQuestion:
+**If `{auto_mode}`:** proceed to apply.
 
-```yaml
-questions:
-  - header: "Apply"
-    question: "Apply these Angular clean code improvements?"
-    options:
-      - label: "Apply All (Recommended)"
-        description: "Apply all recommendations"
-      - label: "Critical Only"
-        description: "Only fix critical issues"
-      - label: "Review Details"
-        description: "Show before/after for each fix"
-    multiSelect: false
-```
+**Otherwise:** display the fix plan and ask:
+- **Apply All** — apply everything
+- **Critical Only** — skip Minor severity items
+- **Review Before/After** — show the planned diff for each fix before applying
 
-### 5. Apply Changes
+## 5. Apply Changes
 
-**If `{economy_mode}` = true:**
-→ Apply sequentially with Edit tool
+### Economy Mode (`-e`)
 
-**If `{economy_mode}` = false AND 4+ files to change:**
-→ Use parallel Snipper agents (one per file or group of related files)
+Apply sequentially with the Edit tool. One file at a time.
 
-**For each fix, apply the following patterns:**
+### Standard / Deep Mode (4+ files to change)
 
-#### Angular Anti-Pattern Fixes
+Launch parallel `Snipper` agents — one per file or group of related files.
 
-| Anti-Pattern | Fix | Source |
-|--------------|-----|--------|
-| `@Input()` | `input()` / `input.required()` | angular.dev/guide/components/inputs |
-| `@Output()` | `output()` | angular.dev/guide/components/outputs |
-| `@Input` + `@Output` (2-way) | `model()` | angular.dev/guide/signals/inputs#model-inputs |
-| `*ngIf`, `*ngFor` | `@if`, `@for` (with `track`) | angular.dev/guide/templates/control-flow |
-| `[ngClass]` | `[class.name]` binding | Project rule |
-| `constructor(private x)` | `readonly #x = inject(X)` | angular.dev/guide/di |
-| `ChangeDetectionStrategy.Default` | `ChangeDetectionStrategy.OnPush` | Angular best practices |
+Each agent gets:
+- The file(s) to modify
+- The specific fixes to apply (from the plan, with exact line numbers)
+- The reference patterns to follow
+- This constraint: **"Apply ONLY the listed fixes. Don't improve adjacent code, add comments, or refactor anything not in the plan."**
+- After applying fixes, run `npx tsc --noEmit --pretty {file}` on the modified file(s) to catch type errors early. If it fails, fix immediately before returning — don't pass broken code to the coherence check.
 
-#### Signal Pattern Fixes
+Group related fixes: if multiple issues affect the same file, one agent handles all of them.
 
-| Anti-Pattern | Fix | Source |
-|--------------|-----|--------|
-| `effect()` for derived state | `computed()` | `.claude/rules/frontend/signals.md` |
-| `effect()` to sync signals | `linkedSignal()` | angular.dev/guide/signals/linked-signal |
-| `signal.mutate(arr => arr.push(x))` | `signal.update(arr => [...arr, x])` | angular.dev/guide/signals |
-| Missing cleanup | `takeUntilDestroyed()` | angular.dev/ecosystem/rxjs-interop |
-| `BehaviorSubject` | `signal()` + `computed()` | Signal migration |
-| Public mutable signal | Private `#signal` + public `computed()` or `.asReadonly()` | Store pattern |
+### Fix Application Rules
 
-#### TypeScript Fixes
+Follow the patterns from loaded references exactly:
 
-| Anti-Pattern | Fix | Source |
-|--------------|-----|--------|
-| `private field` | `#field` | Project rule |
-| `any` type | `unknown` + type guard | `.claude/rules/shared/typescript.md` |
-| `as Type` | Type guard or generic | Same |
+- **Angular patterns**: `references/angular-clean-code.md` — `input()`, `output()`, `@if`/`@for`, `inject()`, `OnPush`, `host: {}`
+- **Style guide**: `references/angular-style-guide.md` — `protected` template members, `readonly` signals, handler naming, member order, lifecycle interfaces
+- **Architecture**: `references/angular-architecture.md` — move shared code to correct layer, fix import direction
+- **Store anatomy**: `.claude/rules/03-frameworks-and-libraries/angular-store-pattern.md` — 6-section structure, cache-first, resource usage
+- **AI Slop removal**: `references/ai-slop-detection.md` — delete unnecessary comments, inline single-use helpers, remove defensive theater
+- **ViewModel fixes**: `references/viewmodel-patterns.md` — move transformations to store `computed()`, remove template expressions
 
-#### Architecture Fixes
+Every change must trace to a documented pattern and cite its source.
 
-| Anti-Pattern | Fix | Source |
-|--------------|-----|--------|
-| Cross-feature import | Move shared code to `pattern/` or `core/` | Architecture doc |
-| `ui/` imports `core/` | Remove service dependency, use `input()` | Architecture doc |
-| `pattern/` imports `feature/` | Invert dependency | Architecture doc |
-| `feature/` imports `feature/` | Extract to `pattern/` or `core/` | Architecture doc |
+## 6. Team Lead Coherence Check
 
-#### Styling Fixes
+After all fixes are applied, launch the team lead agent (`code-reviewer` type):
 
-| Anti-Pattern | Fix | Source |
-|--------------|-----|--------|
-| `::ng-deep` | CSS custom properties / `var(--mat-sys-*)` | material.angular.dev/guide/theming |
-| `mat-button` (legacy) | `matButton="filled"` | material.angular.dev/components/button |
-| `bg-[--var]` | `bg-(--var)` | tailwindcss.com/docs/upgrade-guide |
+> You are a senior Angular architect reviewing changes just applied across multiple files.
+> Read every modified file.
+>
+> Check for:
+> 1. **Cross-file consistency** — do all modified files follow the same patterns? Same DI style, same signal patterns, same naming conventions?
+> 2. **Broken imports** — did any refactoring break import paths? Did moving code to `pattern/` update all consumers?
+> 3. **Incomplete migrations** — if `@Input()` → `input()` in a component, did callers update their templates too?
+> 4. **ViewModel coherence** — if store selectors changed, do component template bindings still match?
+> 5. **Side effects** — did any fix break a different concern? Did removing a "defensive" null check actually remove a needed guard?
+> 6. **Remaining slop** — after fixes, is there any leftover AI slop the specialists missed?
+>
+> If issues found: list them with `file:line` for immediate fix.
+> If everything is coherent: confirm "Changes are coherent."
 
-#### Naming Fixes
+Fix any issues the team lead identifies, then re-check if the fix was non-trivial.
 
-| Anti-Pattern | Fix | Source |
-|--------------|-----|--------|
-| `loading` (boolean) | `isLoading` | `.claude/rules/naming-conventions.md` |
-| `item` (array variable) | `items` | Same |
-
-### 6. Track Progress
+## 7. Track Progress
 
 ```markdown
 ## Changes Applied
 
-| # | File:Line | Change | Source |
-|---|-----------|--------|--------|
-| 1 | budget.store.ts:45 | `effect()` → `computed()` | signals.md |
-| 2 | budget-card.ts:12 | `@Input()` → `input()` | angular.dev |
-| 3 | budget.service.ts:8 | `constructor(private)` → `inject()` | angular.dev |
-```
+| # | File:Line | Change | Category | Source |
+|---|-----------|--------|----------|--------|
+| 1 | ... | ... | ... | ... |
 
-### 7. Summary
-
-```markdown
-## Apply Summary
-
+### Summary
 - **Files modified**: {N}
 - **Critical fixes**: {N}
-- **Improvements**: {N}
-- **Categories**: Signals ({N}), Angular ({N}), Architecture ({N}), TypeScript ({N}), Styling ({N})
+- **Important fixes**: {N}
+- **Minor fixes**: {N}
+- **Coherence check**: Passed / {issues fixed}
 ```
 
-**If `{save_mode}` = true:**
-→ Write to `.claude/output/clean-code-angular/{task_id}/02-apply.md`
+**If `{save_mode}`:** write to `02-apply.md`.
 
 ---
 
-## SUCCESS METRICS:
+## Next Step
 
-✅ Reference docs loaded and read
-✅ Angular MCP queried for relevant categories
-✅ Recommendations generated with sources
-✅ Changes applied following documented patterns
-✅ Every fix has a source citation
-✅ Progress tracked with file:line
-
-## FAILURE MODES:
-
-❌ Applying patterns without reading docs
-❌ Modifying files outside `{scoped_files}`
-❌ Fixes without source citations
-❌ Inventing patterns not from reference docs or Angular MCP
-❌ Not tracking progress
-
-## APPLY PROTOCOLS:
-
-- Follow patterns from docs exactly — no improvisation
-- Every fix must cite its source (URL or rule path)
-- Use `#field` not `private field` (project convention)
-- Use `inject()` not constructor injection
-- Use `input()` / `output()` not decorators
-- Use `@if` / `@for` not `*ngIf` / `*ngFor`
-- Always add `track` expression to `@for`
-- Always use `OnPush` change detection
-
----
-
-## NEXT STEP:
-
-After changes applied, load `./step-03-verify.md`
-
-<critical>
-Follow patterns from LOADED DOCS only! Every fix needs a source citation.
-</critical>
+After changes applied and coherence verified → load `steps/step-03-verify.md`

--- a/.claude/skills/workflow-clean-code-angular/steps/step-03-verify.md
+++ b/.claude/skills/workflow-clean-code-angular/steps/step-03-verify.md
@@ -1,42 +1,17 @@
 ---
 name: step-03-verify
-description: Verify quality passes and summarize all changes
+description: Quality gate, team lead craftsman review, commit
 prev_step: steps/step-02-apply.md
 next_step: null
 ---
 
 # Step 3: VERIFY
 
-## MANDATORY EXECUTION RULES (READ FIRST):
-
-- 🛑 NEVER complete with failing `pnpm quality`
-- ✅ ALWAYS run quality check before marking done
-- 📋 YOU ARE A VALIDATOR ensuring nothing is broken
-- 💬 FOCUS on verification and summary
-- 🚫 FORBIDDEN to skip any check
-
-## EXECUTION PROTOCOLS:
-
-- 🎯 Run all verification commands
-- 💾 Save summary if `{save_mode}` = true
-- 📖 Fix any errors before completing
-- 🚫 FORBIDDEN to mark complete if quality fails
-
-## CONTEXT BOUNDARIES:
-
-- From step-02: changes applied, files modified, progress table
-- Build/lint/test commands from CLAUDE.md
-- Package manager: pnpm (Pulpe convention)
-
-## YOUR TASK:
-
-Run quality checks, fix any errors introduced, and provide a final summary with all changes and sources.
+The final gate. Code must pass automated checks AND the team lead's craftsman review. If either fails, loop until both pass.
 
 ---
 
-## EXECUTION SEQUENCE:
-
-### 1. Run Quality Check
+## 1. Run Quality Check
 
 ```bash
 pnpm quality
@@ -44,127 +19,119 @@ pnpm quality
 
 This runs type-check + lint + format for all packages.
 
-**If errors:**
+If errors:
 1. Read the error output
-2. Fix the issue (likely in files we just modified)
+2. Fix the issue (likely in files just modified)
 3. Re-run `pnpm quality`
-4. **Loop until passes** (max 5 attempts)
+4. Loop until passes — max 5 attempts
 
-### 2. Run Tests (for scoped files)
+If still failing after 5 attempts: stop and ask the user. Something structural may need human judgment.
 
-If test files exist for the modified scope:
+## 2. Run Tests
+
+If test files exist for modified files:
 
 ```bash
 cd frontend && pnpm test -- path/to/file.spec.ts
 ```
 
-**If tests fail:**
-1. Read error
+If tests fail:
+1. Read the error
 2. Fix test or implementation
-3. Re-run
-4. **Loop until passes** (max 3 attempts)
+3. Re-run — max 3 attempts
 
-**If no tests exist:** Note in summary, don't create tests (out of scope for clean-code).
+If no tests exist for the scope: note it in the summary. Don't create tests — that's out of scope for this workflow.
 
-### 3. Generate Final Summary
+## 3. Team Lead Craftsman Review
+
+This is the gate that ensures the code reads like a senior wrote it. Launch the team lead (`code-reviewer` type):
+
+> You are a senior Angular developer doing a final quality review. The code has been cleaned up and passes automated checks. Now read every modified file one more time.
+>
+> For each file, evaluate these five dimensions:
+>
+> **1. Craftsmanship** — Does it read like a senior wrote it by hand? Is the code clear, minimal, and intentional? Would you be proud to ship this?
+>
+> **2. AI Slop** — Any remaining signs of AI generation? Unnecessary comments restating code, over-engineered abstractions, defensive checks for impossible scenarios, verbose names, single-use wrappers.
+>
+> **3. ViewModel Separation** — Do stores own data transformations via `computed()` selectors? Do components just bind to store signals? Are templates free of complex expressions (> 40 chars)? No duplicate derivations across files?
+>
+> **4. Pattern Consistency** — Does every store follow the 6-section anatomy? Every component use `OnPush`, `input()`, `inject()`? Same naming conventions throughout? No mixed old/new patterns in the same scope?
+>
+> **5. Dead Code** — Unused imports, unreachable branches, orphaned methods, commented-out code, empty lifecycle hooks.
+>
+> Rate each file: **CLEAN** / **MINOR ISSUES** / **NEEDS REWORK**
+>
+> For any file not rated CLEAN: describe exactly what's wrong and what to fix.
+
+If the team lead identifies issues:
+1. Fix them
+2. Re-run `pnpm quality` if code changed
+3. Re-run the craftsman review — max 2 review cycles
+
+The goal: every file in scope rated **CLEAN**.
+
+## 4. Generate Final Summary
 
 ```markdown
-## Angular Clean Code Complete
+## Angular Clean Code Audit Complete
 
 ### Verification
 | Check | Status |
 |-------|--------|
-| TypeScript | ✅ |
-| ESLint | ✅ |
-| Format | ✅ |
-| Tests | ✅ / ⚠️ No tests |
+| TypeScript | Pass / Fail |
+| ESLint | Pass / Fail |
+| Format | Pass / Fail |
+| Tests | Pass / No tests |
+| Craftsman Review | All CLEAN / See notes |
 
 ### Changes Applied
 | # | File:Line | Change | Category | Source |
 |---|-----------|--------|----------|--------|
-| 1 | budget.store.ts:45 | `effect()` → `computed()` | Signals | signals.md |
-| 2 | budget-card.ts:12 | `@Input()` → `input()` | Angular | angular.dev |
-| 3 | budget.service.ts:8 | constructor DI → `inject()` | DI | angular.dev |
 
-### Summary
-| Category | Critical | Improvements | Total |
-|----------|----------|--------------|-------|
-| Signals | 1 | 0 | 1 |
-| Angular | 0 | 2 | 2 |
-| Architecture | 1 | 0 | 1 |
-| TypeScript | 0 | 1 | 1 |
-| Styling | 0 | 1 | 1 |
-| **Total** | **2** | **4** | **6** |
+### Summary by Category
+| Category | Critical | Important | Minor | Total |
+|----------|----------|-----------|-------|-------|
+| Architecture | | | | |
+| Signals | | | | |
+| Store Patterns | | | | |
+| Components | | | | |
+| Templates | | | | |
+| TypeScript | | | | |
+| Styling | | | | |
+| AI Slop | | | | |
+| ViewModel | | | | |
+| Security | | | | |
+| **Total** | | | | |
 
 ### Files Modified: {N}
+### Craftsman Rating: ALL CLEAN / ATTENTION NEEDED
 ```
 
-**If `{save_mode}` = true:**
-→ Write to `.claude/output/clean-code-angular/{task_id}/03-verify.md`
+**If `{save_mode}`:** write to `03-verify.md`.
 
-### 4. Offer Commit
+## 5. Commit
 
-**If `{auto_mode}` = true:**
-→ Create commit automatically
+**If `{auto_mode}`:** commit automatically.
 
-**If `{auto_mode}` = false:**
-→ Use AskUserQuestion:
+**Otherwise:** ask:
+- **Commit** — commit with descriptive message
+- **Done** — finish without committing
+- **Review Changes** — show `git diff` before deciding
 
-```yaml
-questions:
-  - header: "Complete"
-    question: "Angular clean code complete. What next?"
-    options:
-      - label: "Commit (Recommended)"
-        description: "Commit all changes with descriptive message"
-      - label: "Done"
-        description: "Finish without committing"
-      - label: "Review Changes"
-        description: "Show git diff before committing"
-    multiSelect: false
-```
-
-**If commit:**
+Commit format:
 ```bash
-git add {modified_files}
+git add {specific_files}
 git commit -m "$(cat <<'EOF'
-refactor({scope}): apply Angular 21 clean code improvements
+refactor({scope}): apply Angular 21 clean code audit
 
-- {list of main changes}
+- {main changes grouped by category}
 EOF
 )"
 ```
 
-Use specific file adds (not `git add -A`).
-Use the actual scope name (e.g., `refactor(budget): ...`).
+Use specific file adds (not `git add -A`). Use the actual scope name in the conventional commit prefix.
 
 ---
 
-## SUCCESS METRICS:
-
-✅ `pnpm quality` passes (type-check + lint + format)
-✅ Tests pass (if they exist)
-✅ Final summary with all changes and sources
-✅ Commit created (if requested)
-
-## FAILURE MODES:
-
-❌ Completing with failing quality check
-❌ Skipping verification
-❌ Summary without source citations
-❌ Using `git add -A` instead of specific files
-
-## VERIFY PROTOCOLS:
-
-- Always run `pnpm quality` (project convention)
-- Fix errors in a loop, max 5 attempts
-- Every change in summary must have a source
-- Commit message follows conventional commits: `refactor({scope}): ...`
-
----
-
-## WORKFLOW COMPLETE
-
-<critical>
-NEVER complete if `pnpm quality` fails!
-</critical>
+## Workflow Complete

--- a/backend-nest/src/modules/budget-line/budget-line.service.spec.ts
+++ b/backend-nest/src/modules/budget-line/budget-line.service.spec.ts
@@ -306,6 +306,46 @@ describe('BudgetLineService', () => {
       ).rejects.toThrow(BusinessException);
     });
 
+    it('should persist checkedAt when provided', async () => {
+      const checkedDto: BudgetLineCreate = {
+        ...mockCreateDto,
+        checkedAt: '2026-03-10T10:00:00.000Z',
+      };
+      const checkedBudgetLineDb: BudgetLineRow = {
+        ...mockBudgetLineDb,
+        checked_at: '2026-03-10T10:00:00.000Z',
+      };
+
+      const queryBuilder = createMockQueryBuilder({
+        data: checkedBudgetLineDb,
+        error: null,
+      });
+      mockSupabase.from.mockReturnValue(queryBuilder);
+
+      const result = await service.create(
+        checkedDto,
+        mockUser,
+        getMockSupabaseClient(),
+      );
+
+      expect(result.success).toBe(true);
+      const insertCall = queryBuilder.insert.mock.calls[0][0];
+      expect(insertCall.checked_at).toBe('2026-03-10T10:00:00.000Z');
+    });
+
+    it('should default checkedAt to null when not provided', async () => {
+      const queryBuilder = createMockQueryBuilder({
+        data: mockBudgetLineDb,
+        error: null,
+      });
+      mockSupabase.from.mockReturnValue(queryBuilder);
+
+      await service.create(mockCreateDto, mockUser, getMockSupabaseClient());
+
+      const insertCall = queryBuilder.insert.mock.calls[0][0];
+      expect(insertCall.checked_at).toBeNull();
+    });
+
     it('should throw BusinessException on database error', async () => {
       mockSupabase.from.mockReturnValue(
         createMockQueryBuilder({

--- a/backend-nest/src/modules/budget-line/budget-line.service.ts
+++ b/backend-nest/src/modules/budget-line/budget-line.service.ts
@@ -200,6 +200,7 @@ export class BudgetLineService {
       kind: createBudgetLineDto.kind as Database['public']['Enums']['transaction_kind'],
       recurrence: createBudgetLineDto.recurrence,
       is_manually_adjusted: createBudgetLineDto.isManuallyAdjusted || false,
+      checked_at: createBudgetLineDto.checkedAt ?? null,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     };

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -23,7 +23,8 @@
     "no": "Non",
     "somethingWentWrong": "Quelque chose n'a pas fonctionné — réessaie",
     "formErrors": "Quelques champs à vérifier avant de continuer",
-    "networkError": "Erreur réseau — vérifie ta connexion"
+    "networkError": "Erreur réseau — vérifie ta connexion",
+    "viewAll": "Voir tout"
   },
   "navigation": {
     "dashboard": "Tableau de bord",
@@ -610,7 +611,13 @@
     "nextMonthTitle": "Mois prochain",
     "nextMonthEstimatedRollover": "Budget anticipé — report estimé :",
     "nextMonthNoBudget": "Pas encore de budget pour {{ month }}",
-    "nextMonthAnticipate": "Anticiper le mois prochain"
+    "nextMonthAnticipate": "Anticiper le mois prochain",
+    "uncheckedForecasts": {
+      "title": "Prévisions non pointées",
+      "count": "Sur le mois courant ({{ count }})",
+      "allCheckedMessage": "Tu as pointé toutes tes prévisions pour ce mois.",
+      "toggleAriaLabel": "Pointer {{ name }} — {{ amount }} CHF"
+    }
   },
   "completeProfile": {
     "loading": "Préparation de ton espace de liberté...",

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -395,6 +395,7 @@
     "amountMinError": "Le montant doit être supérieur à 0",
     "dateLabel": "Date",
     "dateOutOfBudgetPeriod": "La date doit être dans la période du budget",
+    "forecastCheckedToggle": "Pointer",
     "transactionCreateButton": "Créer",
     "transactionsDialogTitle": "Transactions — {{ name }}",
     "consumedLabel": "Consommé",
@@ -834,6 +835,7 @@
     "notesPlaceholder": "Ex: Alimentation, Transport",
     "notesOptional": "(optionnel)",
     "notesMaxLength": "La catégorie ne peut pas dépasser 50 caractères",
-    "formAriaLabel": "Formulaire de modification de transaction"
+    "formAriaLabel": "Formulaire de modification de transaction",
+    "checkedToggle": "Pointer"
   }
 }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
@@ -64,13 +64,13 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Consultation médecin',
         amount: 45.5,
         transactionDate: midMonth,
       });
 
-      component.submit();
+      component['submit']();
 
       expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -85,9 +85,9 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
     });
 
     it('should not dismiss when form is invalid', () => {
-      component.form.patchValue({ name: '', amount: null });
+      component['form'].patchValue({ name: '', amount: null });
 
-      component.submit();
+      component['submit']();
 
       expect(mockBottomSheetRef.dismiss).not.toHaveBeenCalled();
     });
@@ -98,13 +98,13 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: '  Courses  ',
         amount: 20,
         transactionDate: midMonth,
       });
 
-      component.submit();
+      component['submit']();
 
       expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'Courses' }),
@@ -117,13 +117,13 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Test',
         amount: 42.5,
         transactionDate: midMonth,
       });
 
-      component.submit();
+      component['submit']();
 
       expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
         expect.objectContaining({ amount: 42.5 }),
@@ -138,13 +138,13 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Test',
         amount: 10,
         transactionDate: midMonth,
       });
 
-      component.submit();
+      component['submit']();
 
       expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
         expect.objectContaining({ checkedAt: null }),
@@ -157,14 +157,14 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Test',
         amount: 10,
         transactionDate: midMonth,
         isChecked: true,
       });
 
-      component.submit();
+      component['submit']();
 
       const callArg = mockBottomSheetRef.dismiss.mock.calls[0][0];
       expect(callArg.checkedAt).toBeDefined();
@@ -175,7 +175,7 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
 
   describe('close', () => {
     it('should dismiss without data', () => {
-      component.close();
+      component['close']();
 
       expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith();
     });
@@ -183,50 +183,50 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
 
   describe('form validation', () => {
     it('should require name', () => {
-      component.form.get('name')?.setValue('');
+      component['form'].get('name')?.setValue('');
 
-      expect(component.form.get('name')?.hasError('required')).toBe(true);
+      expect(component['form'].get('name')?.hasError('required')).toBe(true);
     });
 
     it('should enforce max length on name', () => {
-      component.form.get('name')?.setValue('a'.repeat(101));
+      component['form'].get('name')?.setValue('a'.repeat(101));
 
-      expect(component.form.get('name')?.hasError('maxlength')).toBe(true);
+      expect(component['form'].get('name')?.hasError('maxlength')).toBe(true);
     });
 
     it('should require amount', () => {
-      component.form.get('amount')?.setValue(null);
+      component['form'].get('amount')?.setValue(null);
 
-      expect(component.form.get('amount')?.hasError('required')).toBe(true);
+      expect(component['form'].get('amount')?.hasError('required')).toBe(true);
     });
 
     it('should reject amount below 0.01', () => {
-      component.form.get('amount')?.setValue(0);
+      component['form'].get('amount')?.setValue(0);
 
-      expect(component.form.get('amount')?.hasError('min')).toBe(true);
+      expect(component['form'].get('amount')?.hasError('min')).toBe(true);
     });
 
     it('should reject negative amount', () => {
-      component.form.get('amount')?.setValue(-50);
+      component['form'].get('amount')?.setValue(-50);
 
-      expect(component.form.get('amount')?.hasError('min')).toBe(true);
+      expect(component['form'].get('amount')?.hasError('min')).toBe(true);
     });
 
     it('should require transaction date', () => {
-      component.form.get('transactionDate')?.setValue(null);
+      component['form'].get('transactionDate')?.setValue(null);
 
-      expect(component.form.get('transactionDate')?.hasError('required')).toBe(
-        true,
-      );
+      expect(
+        component['form'].get('transactionDate')?.hasError('required'),
+      ).toBe(true);
     });
   });
 
   describe('date constraints', () => {
     it('should set minDate and maxDate for current month budget', () => {
-      expect(component.minDate).toBeDefined();
-      expect(component.maxDate).toBeDefined();
-      expect(component.minDate!.getTime()).toBeLessThanOrEqual(
-        component.maxDate!.getTime(),
+      expect(component['minDate']).toBeDefined();
+      expect(component['maxDate']).toBeDefined();
+      expect(component['minDate']!.getTime()).toBeLessThanOrEqual(
+        component['maxDate']!.getTime(),
       );
     });
 
@@ -257,10 +257,10 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         CreateAllocatedTransactionBottomSheet,
       ).componentInstance;
 
-      expect(pastComponent.minDate).toBeDefined();
-      expect(pastComponent.maxDate).toBeDefined();
-      expect(pastComponent.minDate!.getMonth()).toBe(0); // January
-      expect(pastComponent.minDate!.getFullYear()).toBe(2020);
+      expect(pastComponent['minDate']).toBeDefined();
+      expect(pastComponent['maxDate']).toBeDefined();
+      expect(pastComponent['minDate']!.getMonth()).toBe(0); // January
+      expect(pastComponent['minDate']!.getFullYear()).toBe(2020);
     });
 
     it('should respect custom payDayOfMonth', async () => {
@@ -294,10 +294,10 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
         CreateAllocatedTransactionBottomSheet,
       ).componentInstance;
 
-      expect(customComponent.minDate).toBeDefined();
-      expect(customComponent.maxDate).toBeDefined();
-      expect(customComponent.minDate!.getDate()).toBe(25);
-      expect(customComponent.maxDate!.getDate()).toBe(24);
+      expect(customComponent['minDate']).toBeDefined();
+      expect(customComponent['maxDate']).toBeDefined();
+      expect(customComponent['minDate']!.getDate()).toBe(25);
+      expect(customComponent['maxDate']!.getDate()).toBe(24);
 
       vi.useRealTimers();
     });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.spec.ts
@@ -131,6 +131,48 @@ describe('CreateAllocatedTransactionBottomSheet', () => {
     });
   });
 
+  describe('checked toggle', () => {
+    it('should set checkedAt to null by default', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
+      component.form.patchValue({
+        name: 'Test',
+        amount: 10,
+        transactionDate: midMonth,
+      });
+
+      component.submit();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
+        expect.objectContaining({ checkedAt: null }),
+      );
+    });
+
+    it('should set checkedAt to ISO string when isChecked is true', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
+      component.form.patchValue({
+        name: 'Test',
+        amount: 10,
+        transactionDate: midMonth,
+        isChecked: true,
+      });
+
+      component.submit();
+
+      const callArg = mockBottomSheetRef.dismiss.mock.calls[0][0];
+      expect(callArg.checkedAt).toBeDefined();
+      expect(typeof callArg.checkedAt).toBe('string');
+      expect(() => new Date(callArg.checkedAt)).not.toThrow();
+    });
+  });
+
   describe('close', () => {
     it('should dismiss without data', () => {
       component.close();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -152,7 +152,10 @@ import {
           <span class="text-body-medium text-on-surface">{{
             'transactionForm.checkedToggle' | transloco
           }}</span>
-          <mat-slide-toggle formControlName="isChecked" />
+          <mat-slide-toggle
+            formControlName="isChecked"
+            [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
+          />
         </div>
       </form>
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { TranslocoPipe } from '@jsverse/transloco';
 import type { TransactionCreate } from 'pulpe-shared';
 import { formatLocalDate } from '@core/date/format-local-date';
@@ -26,6 +27,7 @@ import {
     MatButtonModule,
     MatIconModule,
     MatDatepickerModule,
+    MatSlideToggleModule,
     ReactiveFormsModule,
     TranslocoPipe,
   ],
@@ -145,6 +147,13 @@ import {
             }}</mat-error>
           }
         </mat-form-field>
+
+        <div class="flex items-center justify-between py-2 px-1">
+          <span class="text-body-medium text-on-surface">{{
+            'transactionForm.checkedToggle' | transloco
+          }}</span>
+          <mat-slide-toggle formControlName="isChecked" />
+        </div>
       </form>
 
       <!-- Action buttons -->
@@ -201,6 +210,7 @@ export class CreateAllocatedTransactionBottomSheet {
         createDateRangeValidator(this.minDate, this.maxDate),
       ],
     ],
+    isChecked: [false],
   });
 
   close(): void {
@@ -220,6 +230,7 @@ export class CreateAllocatedTransactionBottomSheet {
       kind: this.data.budgetLine.kind,
       transactionDate: formatLocalDate(formValue.transactionDate!),
       category: null,
+      checkedAt: formValue.isChecked ? new Date().toISOString() : null,
     };
 
     this.#bottomSheetRef.dismiss(transaction);

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-bottom-sheet.ts
@@ -184,7 +184,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CreateAllocatedTransactionBottomSheet {
-  readonly data = inject<CreateAllocatedTransactionDialogData>(
+  protected readonly data = inject<CreateAllocatedTransactionDialogData>(
     MAT_BOTTOM_SHEET_DATA,
   );
   readonly #bottomSheetRef = inject(
@@ -197,10 +197,10 @@ export class CreateAllocatedTransactionBottomSheet {
     this.data.budgetYear,
     this.data.payDayOfMonth,
   );
-  readonly minDate = this.#dateConstraints.minDate;
-  readonly maxDate = this.#dateConstraints.maxDate;
+  protected readonly minDate = this.#dateConstraints.minDate;
+  protected readonly maxDate = this.#dateConstraints.maxDate;
 
-  readonly form = this.#fb.group({
+  protected readonly form = this.#fb.group({
     name: ['', [Validators.required, Validators.maxLength(100)]],
     amount: [
       null as number | null,
@@ -216,11 +216,11 @@ export class CreateAllocatedTransactionBottomSheet {
     isChecked: [false],
   });
 
-  close(): void {
+  protected close(): void {
     this.#bottomSheetRef.dismiss();
   }
 
-  submit(): void {
+  protected submit(): void {
     if (this.form.invalid) return;
 
     const formValue = this.form.getRawValue();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.spec.ts
@@ -56,6 +56,128 @@ describe('CreateAllocatedTransactionDialog', () => {
     ).componentInstance;
   });
 
+  describe('submit', () => {
+    it('should close with transaction data when form is valid', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
+      component.form.patchValue({
+        name: 'Consultation médecin',
+        amount: 45.5,
+        transactionDate: midMonth,
+      });
+
+      component.submit();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(
+        expect.objectContaining({
+          budgetId: 'budget-456',
+          budgetLineId: 'bl-123',
+          name: 'Consultation médecin',
+          amount: 45.5,
+          kind: 'expense',
+          category: null,
+        }),
+      );
+    });
+
+    it('should not close when form is invalid', () => {
+      component.form.patchValue({ name: '', amount: null });
+
+      component.submit();
+
+      expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+
+    it('should trim whitespace from name', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
+      component.form.patchValue({
+        name: '  Courses  ',
+        amount: 20,
+        transactionDate: midMonth,
+      });
+
+      component.submit();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Courses' }),
+      );
+    });
+
+    it('should apply Math.abs on amount', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
+      component.form.patchValue({
+        name: 'Test',
+        amount: 42.5,
+        transactionDate: midMonth,
+      });
+
+      component.submit();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 42.5 }),
+      );
+    });
+  });
+
+  describe('cancel', () => {
+    it('should close without data', () => {
+      component.cancel();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('form validation', () => {
+    it('should require name', () => {
+      component.form.get('name')?.setValue('');
+
+      expect(component.form.get('name')?.hasError('required')).toBe(true);
+    });
+
+    it('should enforce max length on name', () => {
+      component.form.get('name')?.setValue('a'.repeat(101));
+
+      expect(component.form.get('name')?.hasError('maxlength')).toBe(true);
+    });
+
+    it('should require amount', () => {
+      component.form.get('amount')?.setValue(null);
+
+      expect(component.form.get('amount')?.hasError('required')).toBe(true);
+    });
+
+    it('should reject amount below 0.01', () => {
+      component.form.get('amount')?.setValue(0);
+
+      expect(component.form.get('amount')?.hasError('min')).toBe(true);
+    });
+
+    it('should reject negative amount', () => {
+      component.form.get('amount')?.setValue(-50);
+
+      expect(component.form.get('amount')?.hasError('min')).toBe(true);
+    });
+
+    it('should require transaction date', () => {
+      component.form.get('transactionDate')?.setValue(null);
+
+      expect(component.form.get('transactionDate')?.hasError('required')).toBe(
+        true,
+      );
+    });
+  });
+
   describe('checked toggle', () => {
     it('should set checkedAt to null by default', () => {
       const midMonth = new Date(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.spec.ts
@@ -63,13 +63,13 @@ describe('CreateAllocatedTransactionDialog', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Consultation médecin',
         amount: 45.5,
         transactionDate: midMonth,
       });
 
-      component.submit();
+      component['submit']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -84,9 +84,9 @@ describe('CreateAllocatedTransactionDialog', () => {
     });
 
     it('should not close when form is invalid', () => {
-      component.form.patchValue({ name: '', amount: null });
+      component['form'].patchValue({ name: '', amount: null });
 
-      component.submit();
+      component['submit']();
 
       expect(mockDialogRef.close).not.toHaveBeenCalled();
     });
@@ -97,13 +97,13 @@ describe('CreateAllocatedTransactionDialog', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: '  Courses  ',
         amount: 20,
         transactionDate: midMonth,
       });
 
-      component.submit();
+      component['submit']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'Courses' }),
@@ -116,13 +116,13 @@ describe('CreateAllocatedTransactionDialog', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Test',
         amount: 42.5,
         transactionDate: midMonth,
       });
 
-      component.submit();
+      component['submit']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith(
         expect.objectContaining({ amount: 42.5 }),
@@ -132,7 +132,7 @@ describe('CreateAllocatedTransactionDialog', () => {
 
   describe('cancel', () => {
     it('should close without data', () => {
-      component.cancel();
+      component['cancel']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith();
     });
@@ -140,41 +140,41 @@ describe('CreateAllocatedTransactionDialog', () => {
 
   describe('form validation', () => {
     it('should require name', () => {
-      component.form.get('name')?.setValue('');
+      component['form'].get('name')?.setValue('');
 
-      expect(component.form.get('name')?.hasError('required')).toBe(true);
+      expect(component['form'].get('name')?.hasError('required')).toBe(true);
     });
 
     it('should enforce max length on name', () => {
-      component.form.get('name')?.setValue('a'.repeat(101));
+      component['form'].get('name')?.setValue('a'.repeat(101));
 
-      expect(component.form.get('name')?.hasError('maxlength')).toBe(true);
+      expect(component['form'].get('name')?.hasError('maxlength')).toBe(true);
     });
 
     it('should require amount', () => {
-      component.form.get('amount')?.setValue(null);
+      component['form'].get('amount')?.setValue(null);
 
-      expect(component.form.get('amount')?.hasError('required')).toBe(true);
+      expect(component['form'].get('amount')?.hasError('required')).toBe(true);
     });
 
     it('should reject amount below 0.01', () => {
-      component.form.get('amount')?.setValue(0);
+      component['form'].get('amount')?.setValue(0);
 
-      expect(component.form.get('amount')?.hasError('min')).toBe(true);
+      expect(component['form'].get('amount')?.hasError('min')).toBe(true);
     });
 
     it('should reject negative amount', () => {
-      component.form.get('amount')?.setValue(-50);
+      component['form'].get('amount')?.setValue(-50);
 
-      expect(component.form.get('amount')?.hasError('min')).toBe(true);
+      expect(component['form'].get('amount')?.hasError('min')).toBe(true);
     });
 
     it('should require transaction date', () => {
-      component.form.get('transactionDate')?.setValue(null);
+      component['form'].get('transactionDate')?.setValue(null);
 
-      expect(component.form.get('transactionDate')?.hasError('required')).toBe(
-        true,
-      );
+      expect(
+        component['form'].get('transactionDate')?.hasError('required'),
+      ).toBe(true);
     });
   });
 
@@ -185,13 +185,13 @@ describe('CreateAllocatedTransactionDialog', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Test',
         amount: 10,
         transactionDate: midMonth,
       });
 
-      component.submit();
+      component['submit']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith(
         expect.objectContaining({ checkedAt: null }),
@@ -204,14 +204,14 @@ describe('CreateAllocatedTransactionDialog', () => {
         new Date().getMonth(),
         15,
       );
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Test',
         amount: 10,
         transactionDate: midMonth,
         isChecked: true,
       });
 
-      component.submit();
+      component['submit']();
 
       const callArg = mockDialogRef.close.mock.calls[0][0];
       expect(callArg.checkedAt).toBeDefined();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import {
+  CreateAllocatedTransactionDialog,
+  type CreateAllocatedTransactionDialogData,
+} from './create-allocated-transaction-dialog';
+
+const createDialogData = (
+  overrides: Partial<CreateAllocatedTransactionDialogData['budgetLine']> = {},
+): CreateAllocatedTransactionDialogData => ({
+  budgetLine: {
+    id: 'bl-123',
+    budgetId: 'budget-456',
+    name: 'Assurance maladie',
+    amount: 385,
+    kind: 'expense',
+    frequency: 'monthly',
+    savingsGoalId: null,
+    isRollover: false,
+    rolloverSourceBudgetId: undefined,
+    ...overrides,
+  } as CreateAllocatedTransactionDialogData['budgetLine'],
+  budgetMonth: new Date().getMonth() + 1,
+  budgetYear: new Date().getFullYear(),
+  payDayOfMonth: null,
+});
+
+describe('CreateAllocatedTransactionDialog', () => {
+  let component: CreateAllocatedTransactionDialog;
+  let mockDialogRef: { close: ReturnType<typeof vi.fn> };
+  let dialogData: CreateAllocatedTransactionDialogData;
+
+  beforeEach(async () => {
+    mockDialogRef = { close: vi.fn() };
+    dialogData = createDialogData();
+
+    await TestBed.configureTestingModule({
+      imports: [CreateAllocatedTransactionDialog],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideAnimationsAsync(),
+        provideNativeDateAdapter(),
+        ...provideTranslocoForTest(),
+        { provide: MAT_DIALOG_DATA, useValue: dialogData },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+      ],
+    }).compileComponents();
+
+    component = TestBed.createComponent(
+      CreateAllocatedTransactionDialog,
+    ).componentInstance;
+  });
+
+  describe('checked toggle', () => {
+    it('should set checkedAt to null by default', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
+      component.form.patchValue({
+        name: 'Test',
+        amount: 10,
+        transactionDate: midMonth,
+      });
+
+      component.submit();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(
+        expect.objectContaining({ checkedAt: null }),
+      );
+    });
+
+    it('should set checkedAt to ISO string when isChecked is true', () => {
+      const midMonth = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        15,
+      );
+      component.form.patchValue({
+        name: 'Test',
+        amount: 10,
+        transactionDate: midMonth,
+        isChecked: true,
+      });
+
+      component.submit();
+
+      const callArg = mockDialogRef.close.mock.calls[0][0];
+      expect(callArg.checkedAt).toBeDefined();
+      expect(typeof callArg.checkedAt).toBe('string');
+      expect(() => new Date(callArg.checkedAt)).not.toThrow();
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -163,7 +163,8 @@ export interface CreateAllocatedTransactionDialogData {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CreateAllocatedTransactionDialog {
-  readonly data = inject<CreateAllocatedTransactionDialogData>(MAT_DIALOG_DATA);
+  protected readonly data =
+    inject<CreateAllocatedTransactionDialogData>(MAT_DIALOG_DATA);
   readonly #dialogRef = inject(
     MatDialogRef<CreateAllocatedTransactionDialog, TransactionCreate>,
   );
@@ -174,10 +175,10 @@ export class CreateAllocatedTransactionDialog {
     this.data.budgetYear,
     this.data.payDayOfMonth,
   );
-  readonly minDate = this.#dateConstraints.minDate;
-  readonly maxDate = this.#dateConstraints.maxDate;
+  protected readonly minDate = this.#dateConstraints.minDate;
+  protected readonly maxDate = this.#dateConstraints.maxDate;
 
-  readonly form = this.#fb.group({
+  protected readonly form = this.#fb.group({
     name: ['', [Validators.required, Validators.maxLength(100)]],
     amount: [
       null as number | null,
@@ -193,11 +194,11 @@ export class CreateAllocatedTransactionDialog {
     isChecked: [false],
   });
 
-  cancel(): void {
+  protected cancel(): void {
     this.#dialogRef.close();
   }
 
-  submit(): void {
+  protected submit(): void {
     if (this.form.invalid) return;
 
     const formValue = this.form.getRawValue();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -206,7 +206,7 @@ export class CreateAllocatedTransactionDialog {
       budgetId: this.data.budgetLine.budgetId,
       budgetLineId: this.data.budgetLine.id,
       name: formValue.name!.trim(),
-      amount: formValue.amount!,
+      amount: Math.abs(formValue.amount!),
       kind: this.data.budgetLine.kind,
       transactionDate: formatLocalDate(formValue.transactionDate!),
       category: null,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -10,6 +10,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { type BudgetLine, type TransactionCreate } from 'pulpe-shared';
 import { formatLocalDate } from '@core/date/format-local-date';
@@ -34,6 +35,7 @@ export interface CreateAllocatedTransactionDialogData {
     MatButtonModule,
     MatIconModule,
     MatDatepickerModule,
+    MatSlideToggleModule,
     ReactiveFormsModule,
     TranslocoPipe,
   ],
@@ -130,6 +132,13 @@ export interface CreateAllocatedTransactionDialogData {
             }}</mat-error>
           }
         </mat-form-field>
+
+        <div class="flex items-center justify-between py-2 px-1">
+          <span class="text-body-medium text-on-surface">{{
+            'transactionForm.checkedToggle' | transloco
+          }}</span>
+          <mat-slide-toggle formControlName="isChecked" />
+        </div>
       </form>
     </mat-dialog-content>
 
@@ -178,6 +187,7 @@ export class CreateAllocatedTransactionDialog {
         createDateRangeValidator(this.minDate, this.maxDate),
       ],
     ],
+    isChecked: [false],
   });
 
   cancel(): void {
@@ -197,6 +207,7 @@ export class CreateAllocatedTransactionDialog {
       kind: this.data.budgetLine.kind,
       transactionDate: formatLocalDate(formValue.transactionDate!),
       category: null,
+      checkedAt: formValue.isChecked ? new Date().toISOString() : null,
     };
 
     this.#dialogRef.close(transaction);

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-allocated-transaction-dialog/create-allocated-transaction-dialog.ts
@@ -137,7 +137,10 @@ export interface CreateAllocatedTransactionDialogData {
           <span class="text-body-medium text-on-surface">{{
             'transactionForm.checkedToggle' | transloco
           }}</span>
-          <mat-slide-toggle formControlName="isChecked" />
+          <mat-slide-toggle
+            formControlName="isChecked"
+            [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
+          />
         </div>
       </form>
     </mat-dialog-content>

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import {
+  AddBudgetLineDialog,
+  type BudgetLineDialogData,
+} from './add-budget-line-dialog';
+
+describe('AddBudgetLineDialog', () => {
+  let component: AddBudgetLineDialog;
+  let mockDialogRef: { close: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    mockDialogRef = { close: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [AddBudgetLineDialog],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideAnimationsAsync(),
+        ...provideTranslocoForTest(),
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { budgetId: 'budget-123' } satisfies BudgetLineDialogData,
+        },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+      ],
+    }).compileComponents();
+
+    component = TestBed.createComponent(AddBudgetLineDialog).componentInstance;
+  });
+
+  describe('submit', () => {
+    it('should close with budget line data when form is valid', () => {
+      component.form.patchValue({
+        name: 'Loyer',
+        amount: 1200,
+        kind: 'expense',
+        recurrence: 'fixed',
+      });
+
+      component.handleSubmit();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(
+        expect.objectContaining({
+          budgetId: 'budget-123',
+          name: 'Loyer',
+          amount: 1200,
+          kind: 'expense',
+          recurrence: 'fixed',
+          isManuallyAdjusted: true,
+        }),
+      );
+    });
+
+    it('should not close when form is invalid', () => {
+      component.form.patchValue({ name: '', amount: null });
+
+      component.handleSubmit();
+
+      expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+
+    it('should trim whitespace from name', () => {
+      component.form.patchValue({
+        name: '  Assurance  ',
+        amount: 385,
+      });
+
+      component.handleSubmit();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Assurance' }),
+      );
+    });
+  });
+
+  describe('checked toggle', () => {
+    it('should set checkedAt to null by default', () => {
+      component.form.patchValue({ name: 'Test', amount: 10 });
+
+      component.handleSubmit();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(
+        expect.objectContaining({ checkedAt: null }),
+      );
+    });
+
+    it('should set checkedAt to ISO string when isChecked is true', () => {
+      component.form.patchValue({
+        name: 'Test',
+        amount: 10,
+        isChecked: true,
+      });
+
+      component.handleSubmit();
+
+      const callArg = mockDialogRef.close.mock.calls[0][0];
+      expect(callArg.checkedAt).toBeDefined();
+      expect(typeof callArg.checkedAt).toBe('string');
+      expect(() => new Date(callArg.checkedAt)).not.toThrow();
+    });
+  });
+
+  describe('cancel', () => {
+    it('should close without data', () => {
+      component.handleCancel();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.spec.ts
@@ -35,14 +35,14 @@ describe('AddBudgetLineDialog', () => {
 
   describe('submit', () => {
     it('should close with budget line data when form is valid', () => {
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Loyer',
         amount: 1200,
         kind: 'expense',
         recurrence: 'fixed',
       });
 
-      component.handleSubmit();
+      component['submit']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -57,20 +57,20 @@ describe('AddBudgetLineDialog', () => {
     });
 
     it('should not close when form is invalid', () => {
-      component.form.patchValue({ name: '', amount: null });
+      component['form'].patchValue({ name: '', amount: null });
 
-      component.handleSubmit();
+      component['submit']();
 
       expect(mockDialogRef.close).not.toHaveBeenCalled();
     });
 
     it('should trim whitespace from name', () => {
-      component.form.patchValue({
+      component['form'].patchValue({
         name: '  Assurance  ',
         amount: 385,
       });
 
-      component.handleSubmit();
+      component['submit']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'Assurance' }),
@@ -80,9 +80,9 @@ describe('AddBudgetLineDialog', () => {
 
   describe('checked toggle', () => {
     it('should set checkedAt to null by default', () => {
-      component.form.patchValue({ name: 'Test', amount: 10 });
+      component['form'].patchValue({ name: 'Test', amount: 10 });
 
-      component.handleSubmit();
+      component['submit']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith(
         expect.objectContaining({ checkedAt: null }),
@@ -90,13 +90,13 @@ describe('AddBudgetLineDialog', () => {
     });
 
     it('should set checkedAt to ISO string when isChecked is true', () => {
-      component.form.patchValue({
+      component['form'].patchValue({
         name: 'Test',
         amount: 10,
         isChecked: true,
       });
 
-      component.handleSubmit();
+      component['submit']();
 
       const callArg = mockDialogRef.close.mock.calls[0][0];
       expect(callArg.checkedAt).toBeDefined();
@@ -107,7 +107,7 @@ describe('AddBudgetLineDialog', () => {
 
   describe('cancel', () => {
     it('should close without data', () => {
-      component.handleCancel();
+      component['cancel']();
 
       expect(mockDialogRef.close).toHaveBeenCalledWith();
     });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import {
   type BudgetLineCreate,
@@ -32,6 +33,7 @@ export interface BudgetLineDialogData {
     MatSelectModule,
     MatButtonModule,
     MatIconModule,
+    MatSlideToggleModule,
     ReactiveFormsModule,
     TranslocoPipe,
     TransactionIconPipe,
@@ -95,6 +97,13 @@ export interface BudgetLineDialogData {
               </mat-option>
             </mat-select>
           </mat-form-field>
+
+          <div class="flex items-center justify-between py-2 px-1">
+            <span class="text-body-medium text-on-surface">{{
+              'budget.forecastCheckedToggle' | transloco
+            }}</span>
+            <mat-slide-toggle formControlName="isChecked" />
+          </div>
         </form>
       </div>
     </mat-dialog-content>
@@ -130,6 +139,7 @@ export class AddBudgetLineDialog {
     ],
     kind: ['expense' as TransactionKind, Validators.required],
     recurrence: ['one_off' as TransactionRecurrence],
+    isChecked: [false],
   });
 
   handleSubmit(): void {
@@ -142,6 +152,7 @@ export class AddBudgetLineDialog {
         kind: value.kind!,
         recurrence: value.recurrence!,
         isManuallyAdjusted: true,
+        checkedAt: value.isChecked ? new Date().toISOString() : undefined,
       };
       this.#dialogRef.close(budgetLine);
     }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.ts
@@ -102,7 +102,10 @@ export interface BudgetLineDialogData {
             <span class="text-body-medium text-on-surface">{{
               'budget.forecastCheckedToggle' | transloco
             }}</span>
-            <mat-slide-toggle formControlName="isChecked" />
+            <mat-slide-toggle
+              formControlName="isChecked"
+              [attr.aria-label]="'budget.forecastCheckedToggle' | transloco"
+            />
           </div>
         </form>
       </div>
@@ -152,7 +155,7 @@ export class AddBudgetLineDialog {
         kind: value.kind!,
         recurrence: value.recurrence!,
         isManuallyAdjusted: true,
-        checkedAt: value.isChecked ? new Date().toISOString() : undefined,
+        checkedAt: value.isChecked ? new Date().toISOString() : null,
       };
       this.#dialogRef.close(budgetLine);
     }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/create-budget-line/add-budget-line-dialog.ts
@@ -112,13 +112,13 @@ export interface BudgetLineDialogData {
     </mat-dialog-content>
 
     <mat-dialog-actions align="end">
-      <button matButton (click)="handleCancel()" data-testid="cancel-new-line">
+      <button matButton (click)="cancel()" data-testid="cancel-new-line">
         {{ 'common.cancel' | transloco }}
       </button>
       <button
         matButton="filled"
         color="primary"
-        (click)="handleSubmit()"
+        (click)="submit()"
         [disabled]="!form.valid"
         data-testid="add-new-line"
       >
@@ -134,7 +134,7 @@ export class AddBudgetLineDialog {
   readonly #data = inject<BudgetLineDialogData>(MAT_DIALOG_DATA);
   readonly #fb = inject(FormBuilder);
 
-  readonly form = this.#fb.group({
+  protected readonly form = this.#fb.group({
     name: ['', [Validators.required, Validators.minLength(1)]],
     amount: [
       null as number | null,
@@ -145,7 +145,7 @@ export class AddBudgetLineDialog {
     isChecked: [false],
   });
 
-  handleSubmit(): void {
+  protected submit(): void {
     if (this.form.valid) {
       const value = this.form.getRawValue();
       const budgetLine: BudgetLineCreate = {
@@ -161,7 +161,7 @@ export class AddBudgetLineDialog {
     }
   }
 
-  handleCancel(): void {
+  protected cancel(): void {
     this.#dialogRef.close();
   }
 }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -534,7 +534,6 @@ export class BudgetDetailsStore {
 
   /**
    * Create an allocated transaction with optimistic updates
-   * New transactions always start unchecked
    */
   async createAllocatedTransaction(
     transactionData: TransactionCreate,
@@ -568,7 +567,10 @@ export class BudgetDetailsStore {
 
     try {
       const response = await firstValueFrom(
-        this.#budgetApi.createTransaction$(transactionData),
+        this.#budgetApi.createTransaction$({
+          ...transactionData,
+          checkedAt: transactionData.checkedAt ?? null,
+        }),
       );
 
       this.#budgetDetailsResource.update((details) => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -554,7 +554,7 @@ export class BudgetDetailsStore {
       category: transactionData.category ?? null,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-      checkedAt: null,
+      checkedAt: transactionData.checkedAt ?? null,
     };
 
     this.#budgetDetailsResource.update((details) => {
@@ -568,10 +568,7 @@ export class BudgetDetailsStore {
 
     try {
       const response = await firstValueFrom(
-        this.#budgetApi.createTransaction$({
-          ...transactionData,
-          checkedAt: null,
-        }),
+        this.#budgetApi.createTransaction$(transactionData),
       );
 
       this.#budgetDetailsResource.update((details) => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import {
+  AddTransactionBottomSheet,
+  type TransactionFormData,
+} from './add-transaction-bottom-sheet';
+import { Subject } from 'rxjs';
+
+describe('AddTransactionBottomSheet', () => {
+  let component: AddTransactionBottomSheet;
+  let mockBottomSheetRef: {
+    dismiss: ReturnType<typeof vi.fn>;
+    afterOpened: ReturnType<typeof vi.fn>;
+  };
+  let afterOpened$: Subject<void>;
+
+  beforeEach(async () => {
+    afterOpened$ = new Subject<void>();
+    mockBottomSheetRef = {
+      dismiss: vi.fn(),
+      afterOpened: vi.fn().mockReturnValue(afterOpened$),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AddTransactionBottomSheet],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideAnimationsAsync(),
+        ...provideTranslocoForTest(),
+        { provide: MatBottomSheetRef, useValue: mockBottomSheetRef },
+      ],
+    }).compileComponents();
+
+    component = TestBed.createComponent(
+      AddTransactionBottomSheet,
+    ).componentInstance;
+  });
+
+  describe('submit', () => {
+    it('should dismiss with transaction data when form is valid', () => {
+      component['transactionForm'].patchValue({
+        name: 'Courses Migros',
+        amount: 45.5,
+        kind: 'expense',
+      });
+
+      component['onSubmit']();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Courses Migros',
+          amount: 45.5,
+          kind: 'expense',
+          category: null,
+        }),
+      );
+    });
+
+    it('should not dismiss when form is invalid', () => {
+      component['transactionForm'].patchValue({ name: '', amount: null });
+
+      component['onSubmit']();
+
+      expect(mockBottomSheetRef.dismiss).not.toHaveBeenCalled();
+    });
+
+    it('should apply Math.abs on amount', () => {
+      component['transactionForm'].patchValue({
+        name: 'Test',
+        amount: 42.5,
+        kind: 'expense',
+      });
+
+      component['onSubmit']();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 42.5 }),
+      );
+    });
+
+    it('should convert empty category to null', () => {
+      component['transactionForm'].patchValue({
+        name: 'Test',
+        amount: 10,
+        kind: 'expense',
+        category: '',
+      });
+
+      component['onSubmit']();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
+        expect.objectContaining({ category: null }),
+      );
+    });
+  });
+
+  describe('checked toggle', () => {
+    it('should set checkedAt to ISO string when isChecked is true (default)', () => {
+      component['transactionForm'].patchValue({
+        name: 'Test',
+        amount: 10,
+        kind: 'expense',
+      });
+
+      component['onSubmit']();
+
+      const callArg: TransactionFormData =
+        mockBottomSheetRef.dismiss.mock.calls[0][0];
+      expect(callArg.checkedAt).toBeDefined();
+      expect(typeof callArg.checkedAt).toBe('string');
+      expect(() => new Date(callArg.checkedAt!)).not.toThrow();
+    });
+
+    it('should set checkedAt to null when isChecked is false', () => {
+      component['transactionForm'].patchValue({
+        name: 'Test',
+        amount: 10,
+        kind: 'expense',
+        isChecked: false,
+      });
+
+      component['onSubmit']();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith(
+        expect.objectContaining({ checkedAt: null }),
+      );
+    });
+  });
+
+  describe('close', () => {
+    it('should dismiss without data', () => {
+      component['close']();
+
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('form validation', () => {
+    it('should require name', () => {
+      component['transactionForm'].get('name')?.setValue('');
+
+      expect(
+        component['transactionForm'].get('name')?.hasError('required'),
+      ).toBe(true);
+    });
+
+    it('should enforce max length on name', () => {
+      component['transactionForm'].get('name')?.setValue('a'.repeat(101));
+
+      expect(
+        component['transactionForm'].get('name')?.hasError('maxlength'),
+      ).toBe(true);
+    });
+
+    it('should require amount', () => {
+      component['transactionForm'].get('amount')?.setValue(null);
+
+      expect(
+        component['transactionForm'].get('amount')?.hasError('required'),
+      ).toBe(true);
+    });
+
+    it('should reject amount below 0.01', () => {
+      component['transactionForm'].get('amount')?.setValue(0);
+
+      expect(component['transactionForm'].get('amount')?.hasError('min')).toBe(
+        true,
+      );
+    });
+
+    it('should reject negative amount', () => {
+      component['transactionForm'].get('amount')?.setValue(-50);
+
+      expect(component['transactionForm'].get('amount')?.hasError('min')).toBe(
+        true,
+      );
+    });
+
+    it('should require kind', () => {
+      component['transactionForm'].get('kind')?.setValue(null);
+
+      expect(
+        component['transactionForm'].get('kind')?.hasError('required'),
+      ).toBe(true);
+    });
+  });
+
+  describe('predefined amounts', () => {
+    it('should patch form amount when selecting predefined amount', () => {
+      component['selectPredefinedAmount'](20);
+
+      expect(component['transactionForm'].get('amount')?.value).toBe(20);
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -1,5 +1,5 @@
 import {
-  type AfterViewInit,
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   type ElementRef,
@@ -25,7 +25,7 @@ import type { TransactionCreate } from 'pulpe-shared';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { TransactionLabelPipe } from '@pattern/transaction-display';
 
-type TransactionFormData = Pick<
+export type TransactionFormData = Pick<
   TransactionCreate,
   'name' | 'amount' | 'kind' | 'category' | 'checkedAt'
 >;
@@ -272,7 +272,7 @@ import { TransactionValidators } from '@core/transaction';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AddTransactionBottomSheet implements AfterViewInit {
+export class AddTransactionBottomSheet {
   readonly #fb = inject(FormBuilder);
   readonly #bottomSheetRef = inject(
     MatBottomSheetRef<AddTransactionBottomSheet>,
@@ -287,8 +287,8 @@ export class AddTransactionBottomSheet implements AfterViewInit {
   protected readonly predefinedAmounts = signal([10, 15, 20, 30]);
 
   // Reactive form with shared validators for consistency
-  readonly transactionForm: FormGroup<TransactionFormControls> = this.#fb.group(
-    {
+  protected readonly transactionForm: FormGroup<TransactionFormControls> =
+    this.#fb.group({
       name: new FormControl<string | null>(
         this.#transloco.translate('currentMonth.addTransactionDefaultName'),
         [...TransactionValidators.name],
@@ -304,14 +304,12 @@ export class AddTransactionBottomSheet implements AfterViewInit {
         ...TransactionValidators.category,
       ]),
       isChecked: new FormControl<boolean>(true, { nonNullable: true }),
-    },
-  );
+    });
 
-  ngAfterViewInit(): void {
-    // Auto-focus on amount field for immediate input
-    setTimeout(() => {
+  constructor() {
+    afterNextRender(() => {
       this.amountInput()?.nativeElement?.focus();
-    }, 200);
+    });
   }
 
   protected selectPredefinedAmount(amount: number): void {
@@ -326,16 +324,10 @@ export class AddTransactionBottomSheet implements AfterViewInit {
 
     const formValue = this.transactionForm.value;
 
-    // Explicit validation for required fields
-    if (!formValue.name || !formValue.amount || !formValue.kind) {
-      this.transactionForm.markAllAsTouched();
-      return;
-    }
-
     const transaction: TransactionFormData = {
-      name: formValue.name,
-      amount: Math.abs(formValue.amount),
-      kind: formValue.kind,
+      name: formValue.name!,
+      amount: Math.abs(formValue.amount!),
+      kind: formValue.kind!,
       category: formValue.category || null,
       checkedAt: formValue.isChecked ? new Date().toISOString() : null,
     };

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -303,7 +303,7 @@ export class AddTransactionBottomSheet implements AfterViewInit {
       category: new FormControl<string | null>('', [
         ...TransactionValidators.category,
       ]),
-      isChecked: new FormControl<boolean>(false, { nonNullable: true }),
+      isChecked: new FormControl<boolean>(true, { nonNullable: true }),
     },
   );
 

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -334,7 +334,7 @@ export class AddTransactionBottomSheet implements AfterViewInit {
 
     const transaction: TransactionFormData = {
       name: formValue.name,
-      amount: formValue.amount,
+      amount: Math.abs(formValue.amount),
       kind: formValue.kind,
       category: formValue.category || null,
       checkedAt: formValue.isChecked ? new Date().toISOString() : null,

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -36,7 +36,7 @@ interface TransactionFormControls {
   amount: FormControl<number | null>;
   kind: FormControl<'expense' | 'income' | 'saving' | null>;
   category: FormControl<string | null>;
-  isChecked: FormControl<boolean | null>;
+  isChecked: FormControl<boolean>;
 }
 
 import { TransactionValidators } from '@core/transaction';
@@ -241,7 +241,10 @@ import { TransactionValidators } from '@core/transaction';
           <span class="text-body-medium text-on-surface">{{
             'transactionForm.checkedToggle' | transloco
           }}</span>
-          <mat-slide-toggle formControlName="isChecked" />
+          <mat-slide-toggle
+            formControlName="isChecked"
+            [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
+          />
         </div>
       </form>
 
@@ -300,7 +303,7 @@ export class AddTransactionBottomSheet implements AfterViewInit {
       category: new FormControl<string | null>('', [
         ...TransactionValidators.category,
       ]),
-      isChecked: new FormControl<boolean | null>(false),
+      isChecked: new FormControl<boolean>(false, { nonNullable: true }),
     },
   );
 

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -20,13 +20,14 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import type { TransactionCreate } from 'pulpe-shared';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { TransactionLabelPipe } from '@pattern/transaction-display';
 
 type TransactionFormData = Pick<
   TransactionCreate,
-  'name' | 'amount' | 'kind' | 'category'
+  'name' | 'amount' | 'kind' | 'category' | 'checkedAt'
 >;
 
 // Define the form structure type
@@ -35,6 +36,7 @@ interface TransactionFormControls {
   amount: FormControl<number | null>;
   kind: FormControl<'expense' | 'income' | 'saving' | null>;
   category: FormControl<string | null>;
+  isChecked: FormControl<boolean | null>;
 }
 
 import { TransactionValidators } from '@core/transaction';
@@ -49,6 +51,7 @@ import { TransactionValidators } from '@core/transaction';
     MatInputModule,
     MatSelectModule,
     MatChipsModule,
+    MatSlideToggleModule,
     TranslocoPipe,
     TransactionLabelPipe,
   ],
@@ -233,6 +236,13 @@ import { TransactionValidators } from '@core/transaction';
           <mat-icon>event</mat-icon>
           <span>{{ 'currentMonth.addTransactionToday' | transloco }}</span>
         </div>
+
+        <div class="flex items-center justify-between py-2 px-1">
+          <span class="text-body-medium text-on-surface">{{
+            'transactionForm.checkedToggle' | transloco
+          }}</span>
+          <mat-slide-toggle formControlName="isChecked" />
+        </div>
       </form>
 
       <!-- Action Buttons -->
@@ -290,6 +300,7 @@ export class AddTransactionBottomSheet implements AfterViewInit {
       category: new FormControl<string | null>('', [
         ...TransactionValidators.category,
       ]),
+      isChecked: new FormControl<boolean | null>(false),
     },
   );
 
@@ -323,6 +334,7 @@ export class AddTransactionBottomSheet implements AfterViewInit {
       amount: formValue.amount,
       kind: formValue.kind,
       category: formValue.category || null,
+      checkedAt: formValue.isChecked ? new Date().toISOString() : null,
     };
 
     this.#bottomSheetRef.dismiss(transaction);

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -22,6 +22,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import type { TransactionCreate } from 'pulpe-shared';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { TransactionValidators } from '@core/transaction';
 import { TransactionLabelPipe } from '@pattern/transaction-display';
 
 export type TransactionFormData = Pick<
@@ -37,8 +38,6 @@ interface TransactionFormControls {
   category: FormControl<string | null>;
   isChecked: FormControl<boolean>;
 }
-
-import { TransactionValidators } from '@core/transaction';
 
 @Component({
   selector: 'pulpe-add-transaction-bottom-sheet',

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -1,5 +1,4 @@
 import {
-  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   type ElementRef,
@@ -307,7 +306,7 @@ export class AddTransactionBottomSheet {
     });
 
   constructor() {
-    afterNextRender(() => {
+    this.#bottomSheetRef.afterOpened().subscribe(() => {
       this.amountInput()?.nativeElement?.focus();
     });
   }

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.spec.ts
@@ -7,6 +7,7 @@ import type { BudgetLineConsumption } from '@core/budget/budget-line-consumption
 import { FinancialKindDirective } from '@ui/financial-kind';
 import { setTestInput } from '../../../testing/signal-test-utils';
 import { StubFinancialKindDirective } from '../../../testing/stub-directives';
+import { provideTranslocoForTest } from '../../../testing/transloco-testing';
 import { registerLocaleData } from '@angular/common';
 import localeDE from '@angular/common/locales/de-CH';
 
@@ -36,7 +37,10 @@ describe('DashboardUncheckedForecasts', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DashboardUncheckedForecasts],
-      providers: [provideZonelessChangeDetection()],
+      providers: [
+        provideZonelessChangeDetection(),
+        ...provideTranslocoForTest(),
+      ],
     })
       .overrideComponent(DashboardUncheckedForecasts, {
         remove: { imports: [FinancialKindDirective] },

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.spec.ts
@@ -80,31 +80,61 @@ describe('DashboardUncheckedForecasts', () => {
     expect(itemNames[0].nativeElement.textContent).toContain('Test Forecast');
   });
 
-  it('should emit toggleCheck when the row div is clicked', () => {
+  it('should emit toggleCheck only when the radio button is clicked', () => {
     setTestInput(component.forecasts, mockForecasts);
     fixture.detectChanges();
 
     let emittedId: string | undefined;
     component.toggleCheck.subscribe((id) => (emittedId = id));
 
-    const row = fixture.debugElement.query(By.css('[role="checkbox"]'));
-    row.nativeElement.click();
+    // Click the radio button
+    const radioButton = fixture.debugElement.query(
+      By.css('button[aria-label]'),
+    );
+    radioButton.nativeElement.click();
 
     expect(emittedId).toBe('1');
   });
 
-  it('should emit toggleCheck when mat-checkbox is clicked without double-firing', () => {
+  it('should not emit toggleCheck when the row text is clicked', () => {
     setTestInput(component.forecasts, mockForecasts);
     fixture.detectChanges();
 
-    const emittedIds: string[] = [];
-    component.toggleCheck.subscribe((id) => emittedIds.push(id));
+    let emitted = false;
+    component.toggleCheck.subscribe(() => (emitted = true));
 
-    const checkbox = fixture.debugElement.query(By.css('mat-checkbox'));
-    checkbox.nativeElement.querySelector('input')?.click();
+    const nameSpan = fixture.debugElement.query(
+      By.css('.text-body-medium.font-bold'),
+    );
+    nameSpan.nativeElement.click();
 
-    expect(emittedIds.length).toBe(1);
-    expect(emittedIds[0]).toBe('1');
+    expect(emitted).toBe(false);
+  });
+
+  it('should show radio_button_unchecked icon by default', () => {
+    setTestInput(component.forecasts, mockForecasts);
+    fixture.detectChanges();
+
+    const radioButton = fixture.debugElement.query(
+      By.css('button[aria-label]'),
+    );
+    const icon = radioButton.query(By.css('mat-icon'));
+    expect(icon.nativeElement.textContent.trim()).toBe(
+      'radio_button_unchecked',
+    );
+  });
+
+  it('should show check_circle icon with primary color when item is in checkingIds', () => {
+    setTestInput(component.forecasts, mockForecasts);
+    setTestInput(component.checkingIds, new Set(['1']));
+    fixture.detectChanges();
+
+    const radioButton = fixture.debugElement.query(
+      By.css('button[aria-label]'),
+    );
+    const icon = radioButton.query(By.css('mat-icon'));
+    expect(icon.nativeElement.textContent.trim()).toBe('check_circle');
+    expect(icon.nativeElement.classList.contains('text-primary')).toBe(true);
   });
 
   it('should display forecast amount when no consumptions provided', () => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
@@ -9,6 +9,7 @@ import { DecimalPipe } from '@angular/common';
 import { MatRipple } from '@angular/material/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { TranslocoPipe } from '@jsverse/transloco';
 import { FinancialKindDirective } from '@ui/financial-kind';
 import type { BudgetLineConsumption } from '@core/budget/budget-line-consumption';
 import type { BudgetLine } from 'pulpe-shared';
@@ -23,6 +24,7 @@ const MAX_VISIBLE_FORECASTS = 5;
     MatIconModule,
     DecimalPipe,
     FinancialKindDirective,
+    TranslocoPipe,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -68,7 +70,12 @@ const MAX_VISIBLE_FORECASTS = 5;
                   [matRippleCentered]="true"
                   (click)="toggleCheck.emit(forecast.id)"
                   [attr.aria-label]="
-                    'Pointer ' + forecast.name + ' — ' + displayAmount + ' CHF'
+                    ('currentMonth.forecastCheckedToggle' | transloco) +
+                    ' ' +
+                    forecast.name +
+                    ' — ' +
+                    displayAmount +
+                    ' CHF'
                   "
                 >
                   <mat-icon

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
@@ -70,7 +70,7 @@ const MAX_VISIBLE_FORECASTS = 5;
                   [matRippleCentered]="true"
                   (click)="toggleCheck.emit(forecast.id)"
                   [attr.aria-label]="
-                    ('currentMonth.forecastCheckedToggle' | transloco) +
+                    ('budget.forecastCheckedToggle' | transloco) +
                     ' ' +
                     forecast.name +
                     ' — ' +

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
@@ -40,17 +40,22 @@ const MAX_VISIBLE_FORECASTS = 5;
             <h2
               class="text-title-medium font-bold text-on-surface leading-tight"
             >
-              Prévisions non pointées
+              {{ 'currentMonth.uncheckedForecasts.title' | transloco }}
             </h2>
             <p
               class="text-body-small text-on-surface-variant font-medium mt-0.5"
             >
-              Sur le mois courant ({{ forecasts().length }})
+              {{
+                'currentMonth.uncheckedForecasts.count'
+                  | transloco: { count: forecasts().length }
+              }}
             </p>
           </div>
         </div>
         @if (hasMore()) {
-          <button matButton (click)="viewBudget.emit()">Voir tout</button>
+          <button matButton (click)="viewBudget.emit()">
+            {{ 'common.viewAll' | transloco }}
+          </button>
         }
       </div>
 
@@ -65,17 +70,14 @@ const MAX_VISIBLE_FORECASTS = 5;
                 class="relative overflow-hidden flex items-center gap-3 p-3 rounded-2xl hover:bg-on-surface/8 motion-safe:transition-colors"
               >
                 <button
-                  class="flex-shrink-0 flex items-center justify-center w-10 h-10 -m-2 rounded-full cursor-pointer"
+                  class="flex-shrink-0 flex items-center justify-center w-11 h-11 -m-2 rounded-full cursor-pointer"
                   matRipple
                   [matRippleCentered]="true"
                   (click)="toggleCheck.emit(forecast.id)"
                   [attr.aria-label]="
-                    ('budget.forecastCheckedToggle' | transloco) +
-                    ' ' +
-                    forecast.name +
-                    ' — ' +
-                    displayAmount +
-                    ' CHF'
+                    'currentMonth.uncheckedForecasts.toggleAriaLabel'
+                      | transloco
+                        : { name: forecast.name, amount: displayAmount }
                   "
                 >
                   <mat-icon
@@ -112,10 +114,12 @@ const MAX_VISIBLE_FORECASTS = 5;
               >
             </div>
             <h3 class="text-title-medium font-medium text-on-surface-variant">
-              Tout est à jour !
+              {{ 'dashboard.allUpToDate' | transloco }}
             </h3>
             <p class="text-body-medium text-on-surface-variant">
-              Tu as pointé toutes tes prévisions pour ce mois.
+              {{
+                'currentMonth.uncheckedForecasts.allCheckedMessage' | transloco
+              }}
             </p>
           </div>
         }

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
@@ -6,7 +6,6 @@ import {
   output,
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatRipple } from '@angular/material/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -20,7 +19,6 @@ const MAX_VISIBLE_FORECASTS = 5;
   selector: 'pulpe-dashboard-unchecked-forecasts',
   imports: [
     MatButtonModule,
-    MatCheckboxModule,
     MatRipple,
     MatIconModule,
     DecimalPipe,
@@ -60,36 +58,33 @@ const MAX_VISIBLE_FORECASTS = 5;
             @for (forecast of displayedForecasts(); track forecast.id) {
               @let displayAmount =
                 consumptions().get(forecast.id)?.remaining ?? forecast.amount;
+              @let isChecking = checkingIds().has(forecast.id);
               <div
-                class="relative overflow-hidden flex items-center justify-between p-3 rounded-2xl hover:bg-on-surface/8 motion-safe:transition-colors cursor-pointer"
-                matRipple
-                (click)="toggleCheck.emit(forecast.id)"
-                (keydown.enter)="toggleCheck.emit(forecast.id)"
-                (keydown.space)="
-                  toggleCheck.emit(forecast.id); $event.preventDefault()
-                "
-                tabindex="0"
-                role="checkbox"
-                [attr.aria-checked]="false"
-                [attr.aria-label]="
-                  forecast.name + ' — ' + displayAmount + ' CHF'
-                "
+                class="relative overflow-hidden flex items-center gap-3 p-3 rounded-2xl hover:bg-on-surface/8 motion-safe:transition-colors"
               >
-                <mat-checkbox
-                  [checked]="false"
-                  class="flex-1 min-w-0"
-                  color="primary"
-                  (click)="$event.stopPropagation()"
-                  (change)="toggleCheck.emit(forecast.id)"
+                <button
+                  class="flex-shrink-0 flex items-center justify-center w-10 h-10 -m-2 rounded-full cursor-pointer"
+                  matRipple
+                  [matRippleCentered]="true"
+                  (click)="toggleCheck.emit(forecast.id)"
+                  [attr.aria-label]="
+                    'Pointer ' + forecast.name + ' — ' + displayAmount + ' CHF'
+                  "
                 >
-                  <span
-                    class="text-body-medium font-bold text-on-surface truncate block ml-1 ph-no-capture"
+                  <mat-icon
+                    [class.text-primary]="isChecking"
+                    aria-hidden="true"
                   >
-                    {{ forecast.name }}
-                  </span>
-                </mat-checkbox>
+                    {{ isChecking ? 'check_circle' : 'radio_button_unchecked' }}
+                  </mat-icon>
+                </button>
                 <span
-                  class="text-label-large whitespace-nowrap ml-4 font-semibold tabular-nums ph-no-capture"
+                  class="text-body-medium font-bold text-on-surface truncate flex-1 min-w-0 ph-no-capture"
+                >
+                  {{ forecast.name }}
+                </span>
+                <span
+                  class="text-label-large whitespace-nowrap font-semibold tabular-nums ph-no-capture"
                   [pulpeFinancialKind]="forecast.kind"
                 >
                   {{ displayAmount | number: '1.2-2' : 'de-CH' }}
@@ -129,6 +124,7 @@ const MAX_VISIBLE_FORECASTS = 5;
 export class DashboardUncheckedForecasts {
   readonly forecasts = input.required<BudgetLine[]>();
   readonly consumptions = input(new Map<string, BudgetLineConsumption>());
+  readonly checkingIds = input(new Set<string>());
   readonly toggleCheck = output<string>();
   readonly viewBudget = output<void>();
 

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -28,10 +28,12 @@ import {
   ProductTourService,
   TOUR_START_DELAY,
 } from '@core/product-tour/product-tour.service';
-import { type TransactionCreate } from 'pulpe-shared';
 import { BaseLoading } from '@ui/loading';
 import { StateCard } from '@ui/state-card/state-card';
-import { AddTransactionBottomSheet } from './components/add-transaction-bottom-sheet';
+import {
+  AddTransactionBottomSheet,
+  type TransactionFormData,
+} from './components/add-transaction-bottom-sheet';
 import { DashboardError } from './components/dashboard-error';
 import { DashboardStore } from './services/dashboard-store';
 
@@ -42,11 +44,6 @@ import { DashboardFutureProjectionChart } from './components/dashboard-future-pr
 import { DashboardRecentTransactions } from './components/dashboard-recent-transactions';
 import { DashboardSavingsSummary } from './components/dashboard-savings-summary';
 import { DashboardNextMonth } from './components/dashboard-next-month';
-
-type TransactionFormData = Pick<
-  TransactionCreate,
-  'name' | 'amount' | 'kind' | 'category' | 'checkedAt'
->;
 
 @Component({
   selector: 'pulpe-dashboard',

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -45,7 +45,7 @@ import { DashboardNextMonth } from './components/dashboard-next-month';
 
 type TransactionFormData = Pick<
   TransactionCreate,
-  'name' | 'amount' | 'kind' | 'category'
+  'name' | 'amount' | 'kind' | 'category' | 'checkedAt'
 >;
 
 @Component({
@@ -377,6 +377,7 @@ export default class Dashboard {
         kind: transaction.kind,
         transactionDate: formatLocalDate(new Date()),
         category: transaction.category ?? null,
+        checkedAt: transaction.checkedAt ?? null,
       });
     } catch (error) {
       this.#logger.error('Error adding transaction:', error);

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -136,7 +136,8 @@ type TransactionFormData = Pick<
               class="order-1 lg:order-2"
               [forecasts]="store.uncheckedForecasts()"
               [consumptions]="store.consumptions()"
-              (toggleCheck)="toggleBudgetLineCheck($event)"
+              [checkingIds]="store.pendingChecks()"
+              (toggleCheck)="checkBudgetLine($event)"
               (viewBudget)="navigateToBudgetDetails()"
               data-testid="dashboard-block-forecasts"
             />
@@ -335,11 +336,11 @@ export default class Dashboard {
     this.#router.navigate(['/', ROUTES.BUDGET]);
   }
 
-  protected async toggleBudgetLineCheck(budgetLineId: string): Promise<void> {
+  protected async checkBudgetLine(budgetLineId: string): Promise<void> {
     try {
-      await this.store.toggleBudgetLineCheck(budgetLineId);
+      await this.store.checkBudgetLine(budgetLineId);
     } catch (error) {
-      this.#logger.error('Error toggling budget line check:', error);
+      this.#logger.error('Error checking budget line:', error);
       this.#snackBar.open(
         this.#transloco.translate('currentMonth.updateError'),
         this.#transloco.translate('currentMonth.close'),

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.spec.ts
@@ -338,11 +338,11 @@ describe('DashboardStore - Business Scenarios', () => {
     });
   });
 
-  describe('User can toggle budget line check', () => {
-    it('should optimistically set checkedAt when toggling unchecked line', async () => {
+  describe('User can check budget lines', () => {
+    it('should optimistically set checkedAt when checking unchecked line', async () => {
       const budget = createMockBudget();
       const line = createMockBudgetLine({
-        id: 'line-toggle',
+        id: 'line-check',
         checkedAt: null,
       });
 
@@ -363,43 +363,102 @@ describe('DashboardStore - Business Scenarios', () => {
         expect(store.budgetLines().length).toBe(1);
       });
 
-      await store.toggleBudgetLineCheck('line-toggle');
+      await store.checkBudgetLine('line-check');
 
-      // checkedAt should be set (not null anymore)
       expect(store.budgetLines()[0].checkedAt).not.toBeNull();
     });
 
-    it('should optimistically clear checkedAt when toggling checked line', async () => {
+    it('should be a no-op for already-checked items', async () => {
       const budget = createMockBudget();
       const line = createMockBudgetLine({
-        id: 'line-toggle',
+        id: 'line-already-checked',
         checkedAt: '2025-06-10T00:00:00Z',
+      });
+
+      const { store, budgetApi } = await setupWithBudgetAndWait(
+        budget,
+        [line],
+        [],
+      );
+
+      await store.checkBudgetLine('line-already-checked');
+
+      expect(budgetApi.toggleBudgetLineCheck$).not.toHaveBeenCalled();
+      expect(store.budgetLines()[0].checkedAt).toBe('2025-06-10T00:00:00Z');
+    });
+
+    it('should be a no-op for items already in pendingChecks (dedup)', async () => {
+      const budget = createMockBudget();
+      const line = createMockBudgetLine({
+        id: 'line-dedup',
+        checkedAt: null,
       });
 
       const mocks = createMocks();
       mocks.budgetApi.getDashboardData$.mockReturnValue(
         of({ budget, transactions: [], budgetLines: [line] }),
       );
-      mocks.budgetApi.toggleBudgetLineCheck$.mockReturnValue(
-        of({ success: true, data: { ...line, checkedAt: null } }),
-      );
+      // Never resolves — keeps the first call in-flight
+      mocks.budgetApi.toggleBudgetLineCheck$.mockReturnValue(NEVER);
       const { store } = setup(mocks);
 
       TestBed.tick();
       await vi.waitFor(() => {
-        expect(store.budgetLines()[0].checkedAt).toBe('2025-06-10T00:00:00Z');
+        expect(store.budgetLines().length).toBe(1);
       });
 
-      await store.toggleBudgetLineCheck('line-toggle');
+      // Fire first call (will stay pending)
+      store.checkBudgetLine('line-dedup');
 
-      expect(store.budgetLines()[0].checkedAt).toBeNull();
+      // Second call should be a no-op
+      await store.checkBudgetLine('line-dedup');
+
+      expect(mocks.budgetApi.toggleBudgetLineCheck$).toHaveBeenCalledTimes(1);
     });
 
-    it('should rollback on toggle API error', async () => {
+    it('should exclude pending items from uncheckedForecasts', async () => {
+      const budget = createMockBudget();
+      const lines = [
+        createMockBudgetLine({
+          id: 'line-a',
+          recurrence: 'fixed',
+          checkedAt: null,
+        }),
+        createMockBudgetLine({
+          id: 'line-b',
+          recurrence: 'one_off',
+          checkedAt: null,
+        }),
+      ];
+
+      const mocks = createMocks();
+      mocks.budgetApi.getDashboardData$.mockReturnValue(
+        of({ budget, transactions: [], budgetLines: lines }),
+      );
+      // Never resolves — keeps it pending
+      mocks.budgetApi.toggleBudgetLineCheck$.mockReturnValue(NEVER);
+      const { store } = setup(mocks);
+
+      TestBed.tick();
+      await vi.waitFor(() => {
+        expect(store.uncheckedForecasts().length).toBe(2);
+      });
+
+      // Check line-a — should disappear from uncheckedForecasts
+      store.checkBudgetLine('line-a');
+
+      await vi.waitFor(() => {
+        expect(store.uncheckedForecasts().length).toBe(1);
+        expect(store.uncheckedForecasts()[0].id).toBe('line-b');
+      });
+    });
+
+    it('should rollback on API error and remove from pendingChecks', async () => {
       const budget = createMockBudget();
       const line = createMockBudgetLine({
-        id: 'line-toggle',
+        id: 'line-fail',
         checkedAt: null,
+        recurrence: 'fixed',
       });
 
       const mocks = createMocks();
@@ -416,12 +475,57 @@ describe('DashboardStore - Business Scenarios', () => {
         expect(store.budgetLines().length).toBe(1);
       });
 
-      await expect(store.toggleBudgetLineCheck('line-toggle')).rejects.toThrow(
+      await expect(store.checkBudgetLine('line-fail')).rejects.toThrow(
         'Toggle failed',
       );
 
-      // Should rollback to null
+      // Should rollback checkedAt to null
       expect(store.budgetLines()[0].checkedAt).toBeNull();
+      // Should be removed from pendingChecks → reappear in uncheckedForecasts
+      expect(store.uncheckedForecasts().length).toBe(1);
+      expect(store.pendingChecks().size).toBe(0);
+    });
+
+    it('should handle two rapid calls for different items independently', async () => {
+      const budget = createMockBudget();
+      const lines = [
+        createMockBudgetLine({
+          id: 'line-x',
+          recurrence: 'fixed',
+          checkedAt: null,
+        }),
+        createMockBudgetLine({
+          id: 'line-y',
+          recurrence: 'one_off',
+          checkedAt: null,
+        }),
+      ];
+
+      const mocks = createMocks();
+      mocks.budgetApi.getDashboardData$.mockReturnValue(
+        of({ budget, transactions: [], budgetLines: lines }),
+      );
+      mocks.budgetApi.toggleBudgetLineCheck$.mockReturnValue(
+        of({ success: true }),
+      );
+      const { store } = setup(mocks);
+
+      TestBed.tick();
+      await vi.waitFor(() => {
+        expect(store.uncheckedForecasts().length).toBe(2);
+      });
+
+      // Fire both concurrently
+      await Promise.all([
+        store.checkBudgetLine('line-x'),
+        store.checkBudgetLine('line-y'),
+      ]);
+
+      expect(mocks.budgetApi.toggleBudgetLineCheck$).toHaveBeenCalledTimes(2);
+      expect(store.budgetLines()[0].checkedAt).not.toBeNull();
+      expect(store.budgetLines()[1].checkedAt).not.toBeNull();
+      // Items stay hidden via pendingChecks (cleaned up when resource reloads)
+      expect(store.uncheckedForecasts().length).toBe(0);
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
@@ -279,8 +279,8 @@ export class DashboardStore {
 
   // ── 5. Mutations ──
   refreshData(): void {
-    this.#pendingChecks.set(new Set());
     if (!this.#dashboardResource.isLoading()) {
+      this.#pendingChecks.set(new Set());
       this.#dashboardResource.reload();
     }
     if (!this.#historyResource.isLoading()) {

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
@@ -1,10 +1,12 @@
 import {
   computed,
+  effect,
   inject,
   Injectable,
   InjectionToken,
   resource,
   signal,
+  untracked,
 } from '@angular/core';
 import {
   BudgetApi,
@@ -278,9 +280,33 @@ export class DashboardStore {
   );
 
   // ── 5. Mutations ──
+  constructor() {
+    effect(() => {
+      const lines = this.budgetLines();
+      const pending = this.#pendingChecks();
+      if (pending.size === 0) return;
+
+      const confirmed = new Set(
+        [...pending].filter((id) => {
+          const line = lines.find((l) => l.id === id);
+          return line?.checkedAt !== null;
+        }),
+      );
+
+      if (confirmed.size > 0) {
+        untracked(() => {
+          this.#pendingChecks.update((s) => {
+            const next = new Set(s);
+            confirmed.forEach((id) => next.delete(id));
+            return next;
+          });
+        });
+      }
+    });
+  }
+
   refreshData(): void {
     if (!this.#dashboardResource.isLoading()) {
-      this.#pendingChecks.set(new Set());
       this.#dashboardResource.reload();
     }
     if (!this.#historyResource.isLoading()) {
@@ -311,10 +337,6 @@ export class DashboardStore {
       await firstValueFrom(
         this.#budgetApi.toggleBudgetLineCheck$(budgetLineId),
       );
-      // Item stays in pendingChecks until resource reloads with checkedAt !== null.
-      // Can't clean here — tap() already bumped version, resource is loading,
-      // and removing from pendingChecks would cause flicker (see PUL-84).
-      // Cleanup happens on refreshData() or store destruction.
     } catch (error) {
       this.#pendingChecks.update((s) => {
         const next = new Set(s);
@@ -331,17 +353,18 @@ export class DashboardStore {
     budgetLineId: string,
     checkedAt: string | null,
   ): void {
+    let patched: DashboardData | undefined;
     this.#dashboardResource.update((data) => {
       if (!data) return data;
-      return {
+      patched = {
         ...data,
         budgetLines: data.budgetLines.map((line) =>
           line.id === budgetLineId ? { ...line, checkedAt } : line,
         ),
       };
+      return patched;
     });
-    const current = this.#dashboardResource.value();
-    if (current) this.#syncDashboardCache(current);
+    if (patched) this.#syncDashboardCache(patched);
   }
 
   #syncDashboardCache(data: DashboardData): void {

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   InjectionToken,
   resource,
+  signal,
 } from '@angular/core';
 import {
   BudgetApi,
@@ -44,6 +45,9 @@ export class DashboardStore {
   readonly #invalidationService = inject(BudgetInvalidationService);
 
   // ── 2. State ──
+  readonly #pendingChecks = signal(new Set<string>());
+  readonly pendingChecks = this.#pendingChecks.asReadonly();
+
   readonly #currentDate = inject(DASHBOARD_NOW);
 
   readonly payDayOfMonth = this.#userSettingsApi.payDayOfMonth;
@@ -196,7 +200,8 @@ export class DashboardStore {
     this.budgetLines().filter(
       (line) =>
         (line.recurrence === 'fixed' || line.recurrence === 'one_off') &&
-        line.checkedAt === null,
+        line.checkedAt === null &&
+        !this.#pendingChecks().has(line.id),
     ),
   );
 
@@ -274,6 +279,7 @@ export class DashboardStore {
 
   // ── 5. Mutations ──
   refreshData(): void {
+    this.#pendingChecks.set(new Set());
     if (!this.#dashboardResource.isLoading()) {
       this.#dashboardResource.reload();
     }
@@ -292,40 +298,52 @@ export class DashboardStore {
     );
   }
 
-  async toggleBudgetLineCheck(budgetLineId: string): Promise<void> {
-    const originalData = this.#dashboardResource.value();
-    if (!originalData) return;
+  async checkBudgetLine(budgetLineId: string): Promise<void> {
+    if (this.#pendingChecks().has(budgetLineId)) return;
 
-    const budgetLine = originalData.budgetLines.find(
-      (line) => line.id === budgetLineId,
-    );
-    if (!budgetLine) return;
+    const budgetLine = this.budgetLines().find((l) => l.id === budgetLineId);
+    if (!budgetLine || budgetLine.checkedAt !== null) return;
 
-    const newCheckedAt =
-      budgetLine.checkedAt === null ? new Date().toISOString() : null;
-
-    const optimisticData = {
-      ...originalData,
-      budgetLines: originalData.budgetLines.map((line) =>
-        line.id === budgetLineId ? { ...line, checkedAt: newCheckedAt } : line,
-      ),
-    };
-
-    this.#dashboardResource.set(optimisticData);
-    this.#syncDashboardCache(optimisticData);
+    this.#pendingChecks.update((s) => new Set([...s, budgetLineId]));
+    this.#patchBudgetLineCheckedAt(budgetLineId, new Date().toISOString());
 
     try {
       await firstValueFrom(
         this.#budgetApi.toggleBudgetLineCheck$(budgetLineId),
       );
+      // Item stays in pendingChecks until resource reloads with checkedAt !== null.
+      // Can't clean here — tap() already bumped version, resource is loading,
+      // and removing from pendingChecks would cause flicker (see PUL-84).
+      // Cleanup happens on refreshData() or store destruction.
     } catch (error) {
-      this.#dashboardResource.set(originalData);
-      this.#syncDashboardCache(originalData);
+      this.#pendingChecks.update((s) => {
+        const next = new Set(s);
+        next.delete(budgetLineId);
+        return next;
+      });
+      this.#patchBudgetLineCheckedAt(budgetLineId, null);
       throw error;
     }
   }
 
   // ── 6. Private utils ──
+  #patchBudgetLineCheckedAt(
+    budgetLineId: string,
+    checkedAt: string | null,
+  ): void {
+    this.#dashboardResource.update((data) => {
+      if (!data) return data;
+      return {
+        ...data,
+        budgetLines: data.budgetLines.map((line) =>
+          line.id === budgetLineId ? { ...line, checkedAt } : line,
+        ),
+      };
+    });
+    const current = this.#dashboardResource.value();
+    if (current) this.#syncDashboardCache(current);
+  }
+
   #syncDashboardCache(data: DashboardData): void {
     const period = this.currentBudgetPeriod();
     const month = period.month.toString().padStart(2, '0');

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
@@ -10,6 +10,7 @@ struct AddAllocatedTransactionSheet: View {
     @State private var name = ""
     @State private var amount: Decimal?
     @State private var transactionDate = Date()
+    @State private var isChecked = false
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var isAmountFocused: Bool
@@ -39,6 +40,7 @@ struct AddAllocatedTransactionSheet: View {
             )
             descriptionField
             dateSelector
+            checkedToggle
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -83,6 +85,17 @@ struct AddAllocatedTransactionSheet: View {
         .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
     }
 
+    // MARK: - Checked Toggle
+
+    private var checkedToggle: some View {
+        Toggle("Pointer", isOn: $isChecked)
+            .font(PulpeTypography.bodyLarge)
+            .tint(budgetLine.kind.color)
+            .padding(DesignTokens.Spacing.lg)
+            .background(Color.inputBackgroundSoft)
+            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+    }
+
     // MARK: - Add Button
 
     private var addButton: some View {
@@ -110,7 +123,8 @@ struct AddAllocatedTransactionSheet: View {
             amount: amount,
             kind: budgetLine.kind,
             budgetLineId: budgetLine.id,
-            transactionDate: transactionDate
+            transactionDate: transactionDate,
+            checkedAt: isChecked ? Date() : nil
         )
 
         do {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionSheet.swift
@@ -40,7 +40,7 @@ struct AddAllocatedTransactionSheet: View {
             )
             descriptionField
             dateSelector
-            checkedToggle
+            CheckedToggle(isOn: $isChecked, tintColor: budgetLine.kind.color)
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -83,17 +83,6 @@ struct AddAllocatedTransactionSheet: View {
         .padding(DesignTokens.Spacing.lg)
         .background(Color.inputBackgroundSoft)
         .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
-    }
-
-    // MARK: - Checked Toggle
-
-    private var checkedToggle: some View {
-        Toggle("Pointer", isOn: $isChecked)
-            .font(PulpeTypography.bodyLarge)
-            .tint(budgetLine.kind.color)
-            .padding(DesignTokens.Spacing.lg)
-            .background(Color.inputBackgroundSoft)
-            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
     }
 
     // MARK: - Add Button

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -9,6 +9,7 @@ struct AddBudgetLineSheet: View {
     @State private var name = ""
     @State private var amount: Decimal?
     @State private var kind: TransactionKind = .expense
+    @State private var isChecked = false
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var isAmountFocused: Bool
@@ -32,6 +33,7 @@ struct AddBudgetLineSheet: View {
             QuickAmountChips(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused, color: kind.color)
                 .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
             descriptionField
+            checkedToggle
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -48,6 +50,17 @@ struct AddBudgetLineSheet: View {
     private var descriptionField: some View {
         TextField(kind.descriptionPlaceholder, text: $name)
             .font(PulpeTypography.bodyLarge)
+            .padding(DesignTokens.Spacing.lg)
+            .background(Color.inputBackgroundSoft)
+            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+    }
+
+    // MARK: - Checked Toggle
+
+    private var checkedToggle: some View {
+        Toggle("Pointer", isOn: $isChecked)
+            .font(PulpeTypography.bodyLarge)
+            .tint(kind.color)
             .padding(DesignTokens.Spacing.lg)
             .background(Color.inputBackgroundSoft)
             .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
@@ -79,7 +92,8 @@ struct AddBudgetLineSheet: View {
             name: name.trimmingCharacters(in: .whitespaces),
             amount: amount,
             kind: kind,
-            recurrence: .oneOff
+            recurrence: .oneOff,
+            checkedAt: isChecked ? Date() : nil
         )
 
         do {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -33,7 +33,7 @@ struct AddBudgetLineSheet: View {
             QuickAmountChips(amount: $amount, amountText: $amountText, isFocused: $isAmountFocused, color: kind.color)
                 .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
             descriptionField
-            checkedToggle
+            CheckedToggle(isOn: $isChecked, tintColor: kind.color)
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -50,17 +50,6 @@ struct AddBudgetLineSheet: View {
     private var descriptionField: some View {
         TextField(kind.descriptionPlaceholder, text: $name)
             .font(PulpeTypography.bodyLarge)
-            .padding(DesignTokens.Spacing.lg)
-            .background(Color.inputBackgroundSoft)
-            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
-    }
-
-    // MARK: - Checked Toggle
-
-    private var checkedToggle: some View {
-        Toggle("Pointer", isOn: $isChecked)
-            .font(PulpeTypography.bodyLarge)
-            .tint(kind.color)
             .padding(DesignTokens.Spacing.lg)
             .background(Color.inputBackgroundSoft)
             .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -51,7 +51,11 @@ struct AddTransactionSheet: View {
                 .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
             descriptionField
             dateSelector
-            checkedToggle
+            CheckedToggle(isOn: $isChecked, tintColor: kind.color)
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.md)
+                        .strokeBorder(Color.outlineVariant.opacity(0.5), lineWidth: 1)
+                )
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -106,17 +110,6 @@ struct AddTransactionSheet: View {
                     .strokeBorder(Color.outlineVariant.opacity(0.5), lineWidth: 1)
             )
         }
-    }
-
-    // MARK: - Checked Toggle
-
-    private var checkedToggle: some View {
-        Toggle("Pointer", isOn: $isChecked)
-            .font(PulpeTypography.bodyLarge)
-            .tint(kind.color)
-            .padding(DesignTokens.Spacing.lg)
-            .background(Color.inputBackgroundSoft)
-            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
     }
 
     // MARK: - Add Button

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -52,10 +52,6 @@ struct AddTransactionSheet: View {
             descriptionField
             dateSelector
             CheckedToggle(isOn: $isChecked, tintColor: kind.color)
-                .overlay(
-                    RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.md)
-                        .strokeBorder(Color.outlineVariant.opacity(0.5), lineWidth: 1)
-                )
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -11,7 +11,7 @@ struct AddTransactionSheet: View {
     @State private var amount: Decimal?
     @State private var kind: TransactionKind = .expense
     @State private var transactionDate = Date()
-    @State private var isChecked = false
+    @State private var isChecked = true
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var isAmountFocused: Bool

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -11,6 +11,7 @@ struct AddTransactionSheet: View {
     @State private var amount: Decimal?
     @State private var kind: TransactionKind = .expense
     @State private var transactionDate = Date()
+    @State private var isChecked = false
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var isAmountFocused: Bool
@@ -50,6 +51,7 @@ struct AddTransactionSheet: View {
                 .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
             descriptionField
             dateSelector
+            checkedToggle
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -106,6 +108,17 @@ struct AddTransactionSheet: View {
         }
     }
 
+    // MARK: - Checked Toggle
+
+    private var checkedToggle: some View {
+        Toggle("Pointer", isOn: $isChecked)
+            .font(PulpeTypography.bodyLarge)
+            .tint(kind.color)
+            .padding(DesignTokens.Spacing.lg)
+            .background(Color.inputBackgroundSoft)
+            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+    }
+
     // MARK: - Add Button
 
     private var addButton: some View {
@@ -140,7 +153,8 @@ struct AddTransactionSheet: View {
             name: name.trimmingCharacters(in: .whitespaces),
             amount: amount,
             kind: kind,
-            transactionDate: transactionDate
+            transactionDate: transactionDate,
+            checkedAt: isChecked ? Date() : nil
         )
 
         do {

--- a/ios/Pulpe/Shared/Components/CheckedToggle.swift
+++ b/ios/Pulpe/Shared/Components/CheckedToggle.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct CheckedToggle: View {
+    @Binding var isOn: Bool
+    let tintColor: Color
+
+    var body: some View {
+        Toggle("Pointer", isOn: $isOn)
+            .font(PulpeTypography.bodyLarge)
+            .tint(tintColor)
+            .padding(DesignTokens.Spacing.lg)
+            .background(Color.inputBackgroundSoft)
+            .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.md))
+            .accessibilityLabel("Marquer comme pointé")
+    }
+}

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -211,7 +211,7 @@ export const budgetLineCreateSchema = z.object({
   kind: transactionKindSchema,
   recurrence: transactionRecurrenceSchema,
   isManuallyAdjusted: z.boolean().default(false),
-  checkedAt: z.iso.datetime().nullable().optional(),
+  checkedAt: z.iso.datetime({ offset: true }).nullable().optional(),
 });
 export type BudgetLineCreate = z.infer<typeof budgetLineCreateSchema>;
 


### PR DESCRIPTION
## Summary

• Add "Pointer" toggle to all budget/transaction creation forms (Angular + iOS)
• Frontend: Budget line, allocated transaction (desktop/mobile), free transaction forms
• iOS: AddBudgetLineSheet, AddAllocatedTransactionSheet, AddTransactionSheet
• Store fix: Stop forcing `checkedAt: null` on allocated transactions
• i18n: Add French labels for toggle

## Type

feat (PUL-84)