### PR TITLE
fix(pul-92): prevent 429 rate limiting on dashboard refresh

### DIFF
--- a/backend-nest/src/modules/encryption/encryption.controller.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.ts
@@ -97,7 +97,7 @@ export class EncryptionController {
   @SkipClientKey()
   @Post('validate-key')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({ summary: 'Verify that a client key can decrypt user data' })
   @ApiResponse({
     status: 204,

--- a/backend-nest/src/modules/encryption/encryption.rate-limit.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.rate-limit.spec.ts
@@ -65,15 +65,15 @@ const runAttempts = async (
 };
 
 describe('EncryptionController Rate Limiting', () => {
-  it('throttles validate-key after 5 attempts per minute', async () => {
+  it('throttles validate-key after 30 attempts per minute', async () => {
     const guard = await createGuard();
     const handler = EncryptionController.prototype.validateKey;
 
-    await runAttempts(guard, handler, 5);
+    await runAttempts(guard, handler, 30);
 
     try {
       await guard.canActivate(createContext(handler) as any);
-      expect.unreachable('Expected throttling exception after 5 attempts');
+      expect.unreachable('Expected throttling exception after 30 attempts');
     } catch (error) {
       expect(error).toBeInstanceOf(ThrottlerException);
     }

--- a/frontend/projects/webapp/src/app/core/encryption/client-key.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/client-key.service.spec.ts
@@ -36,6 +36,8 @@ describe('ClientKeyService', () => {
       remove: vi.fn(),
     };
 
+    mockedIsValidClientKeyHex.mockReturnValue(true);
+
     TestBed.configureTestingModule({
       providers: [
         ClientKeyService,
@@ -65,7 +67,6 @@ describe('ClientKeyService', () => {
     it('should restore key from sessionStorage first', () => {
       const storedKey = 'deadbeef1234567890abcdef';
       mockStorageService.getString.mockReturnValueOnce(storedKey);
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
 
@@ -78,7 +79,6 @@ describe('ClientKeyService', () => {
 
     it('should need server validation when restored from sessionStorage (multi-tab stale key)', () => {
       mockStorageService.getString.mockReturnValueOnce('session-key');
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
 
@@ -92,7 +92,6 @@ describe('ClientKeyService', () => {
       mockStorageService.get.mockReturnValueOnce(
         new Date('2026-01-15T11:57:00Z').getTime(),
       );
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
 
@@ -107,7 +106,6 @@ describe('ClientKeyService', () => {
       mockStorageService.get.mockReturnValueOnce(
         new Date('2026-01-15T11:50:00Z').getTime(),
       );
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
 
@@ -119,7 +117,6 @@ describe('ClientKeyService', () => {
       const storedKey = 'deadbeef1234567890abcdef';
       mockStorageService.getString.mockReturnValueOnce(null);
       mockStorageService.getString.mockReturnValueOnce(storedKey);
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
 
@@ -139,7 +136,6 @@ describe('ClientKeyService', () => {
     it('should need server validation when restored from localStorage', () => {
       mockStorageService.getString.mockReturnValueOnce(null);
       mockStorageService.getString.mockReturnValueOnce('local-key');
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
 
@@ -161,7 +157,6 @@ describe('ClientKeyService', () => {
     it('should clear needsServerValidation flag', () => {
       mockStorageService.getString.mockReturnValueOnce(null);
       mockStorageService.getString.mockReturnValueOnce('local-key');
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
       expect(service.needsServerValidation()).toBe(true);
@@ -229,8 +224,6 @@ describe('ClientKeyService', () => {
 
   describe('setDirectKey()', () => {
     it('should store in sessionStorage by default', () => {
-      mockedIsValidClientKeyHex.mockReturnValue(true);
-
       service.setDirectKey('valid-key-hex');
 
       expect(mockStorageService.setString).toHaveBeenCalledWith(
@@ -245,16 +238,12 @@ describe('ClientKeyService', () => {
     });
 
     it('should not need server validation (key was just validated by caller)', () => {
-      mockedIsValidClientKeyHex.mockReturnValue(true);
-
       service.setDirectKey('valid-key-hex');
 
       expect(service.needsServerValidation()).toBe(false);
     });
 
     it('should store in localStorage when useLocalStorage=true', () => {
-      mockedIsValidClientKeyHex.mockReturnValue(true);
-
       service.setDirectKey('valid-key-hex', true);
 
       expect(mockStorageService.setString).toHaveBeenCalledWith(
@@ -298,7 +287,6 @@ describe('ClientKeyService', () => {
     it('should reset needsServerValidation flag', () => {
       mockStorageService.getString.mockReturnValueOnce(null);
       mockStorageService.getString.mockReturnValueOnce('local-key');
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
       expect(service.needsServerValidation()).toBe(true);
@@ -331,7 +319,6 @@ describe('ClientKeyService', () => {
     it('should reset needsServerValidation flag', () => {
       mockStorageService.getString.mockReturnValueOnce(null);
       mockStorageService.getString.mockReturnValueOnce('local-key');
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
       expect(service.needsServerValidation()).toBe(true);
@@ -357,7 +344,6 @@ describe('ClientKeyService', () => {
       mockStorageService.getString
         .mockReturnValueOnce(sessionKey)
         .mockReturnValueOnce(localKey);
-      mockedIsValidClientKeyHex.mockReturnValue(true);
 
       service.initialize();
 
@@ -369,9 +355,7 @@ describe('ClientKeyService', () => {
       mockStorageService.getString
         .mockReturnValueOnce('invalid-session-key')
         .mockReturnValueOnce(localKey);
-      mockedIsValidClientKeyHex
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true);
+      mockedIsValidClientKeyHex.mockReturnValueOnce(false);
 
       service.initialize();
 
@@ -380,6 +364,18 @@ describe('ClientKeyService', () => {
   });
 
   describe('deriveAndStore() - error paths', () => {
+    it('should throw for invalid derived key', async () => {
+      mockedDeriveClientKey.mockResolvedValue('bad-key');
+      mockedIsValidClientKeyHex.mockReturnValue(false);
+
+      await expect(
+        service.deriveAndStore('password', 'salt', 100000),
+      ).rejects.toThrow('Invalid client key hex');
+
+      expect(service.clientKeyHex()).toBeNull();
+      expect(mockStorageService.setString).not.toHaveBeenCalled();
+    });
+
     it('should not persist key when deriveClientKey rejects', async () => {
       mockedDeriveClientKey.mockRejectedValue(new Error('Derivation failed'));
 
@@ -422,7 +418,6 @@ describe('ClientKeyService', () => {
 
   describe('setDirectKey() - storage failure', () => {
     it('should not persist to storage when setString silently fails', () => {
-      mockedIsValidClientKeyHex.mockReturnValue(true);
       const storedValues = new Map<string, string>();
 
       // setString silently does nothing (simulates storage quota exceeded)

--- a/frontend/projects/webapp/src/app/core/encryption/client-key.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/client-key.service.spec.ts
@@ -22,6 +22,8 @@ describe('ClientKeyService', () => {
   let mockStorageService: {
     getString: Mock;
     setString: Mock;
+    get: Mock;
+    set: Mock;
     remove: Mock;
   };
 
@@ -29,6 +31,8 @@ describe('ClientKeyService', () => {
     mockStorageService = {
       getString: vi.fn(),
       setString: vi.fn(),
+      get: vi.fn().mockReturnValue(null),
+      set: vi.fn(),
       remove: vi.fn(),
     };
 
@@ -79,6 +83,36 @@ describe('ClientKeyService', () => {
       service.initialize();
 
       expect(service.needsServerValidation()).toBe(true);
+    });
+
+    it('should skip server validation when validation cache is fresh', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-15T12:00:00Z'));
+      mockStorageService.getString.mockReturnValueOnce('session-key');
+      mockStorageService.get.mockReturnValueOnce(
+        new Date('2026-01-15T11:57:00Z').getTime(),
+      );
+      mockedIsValidClientKeyHex.mockReturnValue(true);
+
+      service.initialize();
+
+      expect(service.needsServerValidation()).toBe(false);
+      vi.useRealTimers();
+    });
+
+    it('should require server validation when validation cache is expired', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-15T12:00:00Z'));
+      mockStorageService.getString.mockReturnValueOnce('session-key');
+      mockStorageService.get.mockReturnValueOnce(
+        new Date('2026-01-15T11:50:00Z').getTime(),
+      );
+      mockedIsValidClientKeyHex.mockReturnValue(true);
+
+      service.initialize();
+
+      expect(service.needsServerValidation()).toBe(true);
+      vi.useRealTimers();
     });
 
     it('should fallback to localStorage when sessionStorage is empty', () => {
@@ -134,6 +168,16 @@ describe('ClientKeyService', () => {
 
       service.markValidated();
       expect(service.needsServerValidation()).toBe(false);
+    });
+
+    it('should persist validation timestamp to sessionStorage', () => {
+      service.markValidated();
+
+      expect(mockStorageService.set).toHaveBeenCalledWith(
+        STORAGE_KEYS.VAULT_KEY_VALIDATED_AT,
+        expect.any(Number),
+        'session',
+      );
     });
   });
 
@@ -294,6 +338,15 @@ describe('ClientKeyService', () => {
 
       service.clearPreservingDeviceTrust();
       expect(service.needsServerValidation()).toBe(false);
+    });
+
+    it('should clear validation cache from sessionStorage', () => {
+      service.clearPreservingDeviceTrust();
+
+      expect(mockStorageService.remove).toHaveBeenCalledWith(
+        STORAGE_KEYS.VAULT_KEY_VALIDATED_AT,
+        'session',
+      );
     });
   });
 

--- a/frontend/projects/webapp/src/app/core/encryption/client-key.service.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/client-key.service.ts
@@ -58,16 +58,11 @@ export class ClientKeyService {
     useLocalStorage = false,
   ): Promise<void> {
     const keyHex = await deriveClientKey(password, saltHex, iterations);
-    this.#clientKeyHex.set(keyHex);
-    this.#persist(keyHex, useLocalStorage);
+    this.#setAndPersist(keyHex, useLocalStorage);
   }
 
   setDirectKey(keyHex: string, useLocalStorage = false): void {
-    if (!isValidClientKeyHex(keyHex)) {
-      throw new Error('Invalid client key hex');
-    }
-    this.#clientKeyHex.set(keyHex);
-    this.#persist(keyHex, useLocalStorage);
+    this.#setAndPersist(keyHex, useLocalStorage);
   }
 
   clearPreservingDeviceTrust(): void {
@@ -80,6 +75,14 @@ export class ClientKeyService {
   clear(): void {
     this.clearPreservingDeviceTrust();
     this.#storage.remove(STORAGE_KEYS.VAULT_CLIENT_KEY_LOCAL, 'local');
+  }
+
+  #setAndPersist(keyHex: string, useLocalStorage: boolean): void {
+    if (!isValidClientKeyHex(keyHex)) {
+      throw new Error('Invalid client key hex');
+    }
+    this.#clientKeyHex.set(keyHex);
+    this.#persist(keyHex, useLocalStorage);
   }
 
   #isValidationCacheValid(): boolean {

--- a/frontend/projects/webapp/src/app/core/encryption/client-key.service.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/client-key.service.ts
@@ -4,6 +4,8 @@ import { deriveClientKey, isValidClientKeyHex } from './crypto.utils';
 import { STORAGE_KEYS } from '../storage/storage-keys';
 import { StorageService } from '../storage/storage.service';
 
+// 5 min: balance between UX (skip redundant server calls across navigations)
+// and security (limits the window where an unverified key grants access).
 const VALIDATION_CACHE_DURATION_MS = 5 * 60 * 1000;
 
 @Injectable({

--- a/frontend/projects/webapp/src/app/core/encryption/client-key.service.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/client-key.service.ts
@@ -4,6 +4,8 @@ import { deriveClientKey, isValidClientKeyHex } from './crypto.utils';
 import { STORAGE_KEYS } from '../storage/storage-keys';
 import { StorageService } from '../storage/storage.service';
 
+const VALIDATION_CACHE_DURATION_MS = 5 * 60 * 1000;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -25,7 +27,7 @@ export class ClientKeyService {
     );
     if (sessionKey && isValidClientKeyHex(sessionKey)) {
       this.#clientKeyHex.set(sessionKey);
-      this.#needsServerValidation.set(true);
+      this.#needsServerValidation.set(!this.#isValidationCacheValid());
       return;
     }
 
@@ -36,12 +38,17 @@ export class ClientKeyService {
     );
     if (localKey && isValidClientKeyHex(localKey)) {
       this.#clientKeyHex.set(localKey);
-      this.#needsServerValidation.set(true);
+      this.#needsServerValidation.set(!this.#isValidationCacheValid());
     }
   }
 
   markValidated(): void {
     this.#needsServerValidation.set(false);
+    this.#storage.set<number>(
+      STORAGE_KEYS.VAULT_KEY_VALIDATED_AT,
+      Date.now(),
+      'session',
+    );
   }
 
   async deriveAndStore(
@@ -67,11 +74,21 @@ export class ClientKeyService {
     this.#clientKeyHex.set(null);
     this.#needsServerValidation.set(false);
     this.#storage.remove(STORAGE_KEYS.VAULT_CLIENT_KEY_SESSION, 'session');
+    this.#storage.remove(STORAGE_KEYS.VAULT_KEY_VALIDATED_AT, 'session');
   }
 
   clear(): void {
     this.clearPreservingDeviceTrust();
     this.#storage.remove(STORAGE_KEYS.VAULT_CLIENT_KEY_LOCAL, 'local');
+  }
+
+  #isValidationCacheValid(): boolean {
+    const validatedAt = this.#storage.get<number>(
+      STORAGE_KEYS.VAULT_KEY_VALIDATED_AT,
+      'session',
+    );
+    if (validatedAt === null) return false;
+    return Date.now() - validatedAt < VALIDATION_CACHE_DURATION_MS;
   }
 
   #persist(keyHex: string, useLocalStorage: boolean): void {

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.spec.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.spec.ts
@@ -276,7 +276,7 @@ describe('encryptionSetupGuard', () => {
 
       expect(result).toBe(true);
       expect(mockClientKeyService.clear).not.toHaveBeenCalled();
-      expect(mockClientKeyService.markValidated).not.toHaveBeenCalled();
+      expect(mockClientKeyService.markValidated).toHaveBeenCalled();
     });
 
     it('should skip validation when needsServerValidation is false (sessionStorage key)', async () => {

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.spec.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.spec.ts
@@ -276,7 +276,7 @@ describe('encryptionSetupGuard', () => {
 
       expect(result).toBe(true);
       expect(mockClientKeyService.clear).not.toHaveBeenCalled();
-      expect(mockClientKeyService.markValidated).toHaveBeenCalled();
+      expect(mockClientKeyService.markValidated).not.toHaveBeenCalled();
     });
 
     it('should skip validation when needsServerValidation is false (sessionStorage key)', async () => {

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.spec.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.spec.ts
@@ -13,6 +13,7 @@ import { ClientKeyService } from './client-key.service';
 import { EncryptionApi } from './encryption-api';
 import { AuthStateService } from '@core/auth/auth-state.service';
 import { DemoModeService } from '@core/demo/demo-mode.service';
+import { ApiError } from '@core/api/api-error';
 import { ROUTES } from '@core/routing/routes-constants';
 
 const dummyRoute = {} as ActivatedRouteSnapshot;
@@ -262,6 +263,20 @@ describe('encryptionSetupGuard', () => {
         '/',
         ROUTES.ENTER_VAULT_CODE,
       ]);
+    });
+
+    it('should allow access without clearing key on rate limit (429)', async () => {
+      mockEncryptionApi.validateKey$.mockReturnValue(
+        throwError(
+          () => new ApiError('Too Many Requests', undefined, 429, undefined),
+        ),
+      );
+
+      const result = await resolveGuard();
+
+      expect(result).toBe(true);
+      expect(mockClientKeyService.clear).not.toHaveBeenCalled();
+      expect(mockClientKeyService.markValidated).not.toHaveBeenCalled();
     });
 
     it('should skip validation when needsServerValidation is false (sessionStorage key)', async () => {

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
@@ -8,6 +8,7 @@ import { ClientKeyService } from './client-key.service';
 import { EncryptionApi } from './encryption-api';
 import { AuthStateService } from '@core/auth/auth-state.service';
 import { DemoModeService } from '@core/demo/demo-mode.service';
+import type { ApiError } from '@core/api/api-error';
 import { ROUTES } from '@core/routing/routes-constants';
 
 export const encryptionSetupGuard: CanActivateFn = () => {
@@ -62,7 +63,10 @@ export const encryptionSetupGuard: CanActivateFn = () => {
         clientKeyService.markValidated();
         return true as const;
       }),
-      catchError(() => {
+      catchError((error: ApiError) => {
+        if (error.status === 429) {
+          return of(true as const);
+        }
         clientKeyService.clear();
         return of(router.createUrlTree(['/', ROUTES.ENTER_VAULT_CODE]));
       }),

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
@@ -65,7 +65,6 @@ export const encryptionSetupGuard: CanActivateFn = () => {
       }),
       catchError((error: unknown) => {
         if (isApiError(error) && error.status === 429) {
-          clientKeyService.markValidated();
           return of(true as const);
         }
         clientKeyService.clear();

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
@@ -65,6 +65,7 @@ export const encryptionSetupGuard: CanActivateFn = () => {
       }),
       catchError((error: unknown) => {
         if (isApiError(error) && error.status === 429) {
+          clientKeyService.markValidated();
           return of(true as const);
         }
         clientKeyService.clear();

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
@@ -8,7 +8,7 @@ import { ClientKeyService } from './client-key.service';
 import { EncryptionApi } from './encryption-api';
 import { AuthStateService } from '@core/auth/auth-state.service';
 import { DemoModeService } from '@core/demo/demo-mode.service';
-import type { ApiError } from '@core/api/api-error';
+import { isApiError } from '@core/api/api-error';
 import { ROUTES } from '@core/routing/routes-constants';
 
 export const encryptionSetupGuard: CanActivateFn = () => {
@@ -63,8 +63,8 @@ export const encryptionSetupGuard: CanActivateFn = () => {
         clientKeyService.markValidated();
         return true as const;
       }),
-      catchError((error: ApiError) => {
-        if (error.status === 429) {
+      catchError((error: unknown) => {
+        if (isApiError(error) && error.status === 429) {
           return of(true as const);
         }
         clientKeyService.clear();

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-setup.guard.ts
@@ -65,6 +65,10 @@ export const encryptionSetupGuard: CanActivateFn = () => {
       }),
       catchError((error: unknown) => {
         if (isApiError(error) && error.status === 429) {
+          // Optimistic passthrough: don't block the user, but don't fake validation.
+          // Cache is NOT written — needsServerValidation stays true. On the next
+          // full page load, the guard will re-attempt. This is safe: 429 responses
+          // are cheap, and validation will succeed once the rate-limit window clears.
           return of(true as const);
         }
         clientKeyService.clear();

--- a/frontend/projects/webapp/src/app/core/storage/storage-keys.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage-keys.ts
@@ -22,6 +22,9 @@ export const STORAGE_KEYS = {
   VAULT_CLIENT_KEY_SESSION: 'pulpe-vault-client-key-session',
   VAULT_CLIENT_KEY_LOCAL: 'pulpe-vault-client-key-local',
 
+  // Vault key validation cache (sessionStorage)
+  VAULT_KEY_VALIDATED_AT: 'pulpe-vault-key-validated-at',
+
   // What's New dismissal
   WHATS_NEW_DISMISSED: 'pulpe-whats-new-dismissed',
 

--- a/frontend/projects/webapp/src/app/core/storage/storage-schemas.ts
+++ b/frontend/projects/webapp/src/app/core/storage/storage-schemas.ts
@@ -60,6 +60,14 @@ export const STORAGE_SCHEMAS = {
     storageType: 'local',
   },
 
+  // Vault key validation cache — timestamp of last server validation (session-scoped)
+  [STORAGE_KEYS.VAULT_KEY_VALIDATED_AT]: {
+    version: 1,
+    schema: z.number().int().positive(),
+    scope: 'user',
+    storageType: 'session',
+  },
+
   // What's New - tracks last dismissed version (device-level, preserved across sessions)
   [STORAGE_KEYS.WHATS_NEW_DISMISSED]: {
     version: 1,


### PR DESCRIPTION
## Summary

Fixes [PUL-92](https://linear.app/pulpe/issue/PUL-92): 5 rapid dashboard refreshes trigger 429 errors because `validate-key` has a 5 req/min limit, and the guard clears the vault key on any error — including rate limits.

- **Backend**: Raise `validate-key` throttle from 5 to 30 req/min (DoS protection, not crypto — AES-256 brute-force is physically impossible)
- **Frontend**: Cache validation timestamp in sessionStorage (5min TTL) so subsequent refreshes skip the server call
- **Frontend**: On 429, let users through (optimistic) instead of clearing their key and forcing re-entry
- **Frontend**: Clear validation cache on `clearPreservingDeviceTrust()` to prevent stale sessions after logout

## Test plan

- [x] Backend rate-limit test updated (30 attempts)
- [x] Guard 429 passthrough test with proper `ApiError` mock
- [x] Validation cache: fresh cache skips validation, expired cache triggers it
- [x] `markValidated()` persists timestamp to sessionStorage
- [x] `clearPreservingDeviceTrust()` clears validation cache
- [x] All 1657 tests pass, `pnpm quality` clean
- [ ] Manual: deploy to preview, refresh dashboard 10x rapidly → no 429