### PR TITLE
feat(PUL-91): verify recovery key from settings (API, web, iOS)

### DIFF
--- a/backend-nest/src/modules/encryption/dto/encryption-swagger.dto.ts
+++ b/backend-nest/src/modules/encryption/dto/encryption-swagger.dto.ts
@@ -2,6 +2,7 @@ import { createZodDto } from 'nestjs-zod';
 import {
   encryptionValidateKeyRequestSchema,
   encryptionRecoverRequestSchema,
+  encryptionVerifyRecoveryKeyRequestSchema,
   encryptionChangePinRequestSchema,
   encryptionVaultStatusResponseSchema,
   encryptionSaltResponseSchema,
@@ -16,6 +17,9 @@ export class EncryptionValidateKeyRequestDto extends createZodDto(
 ) {}
 export class EncryptionRecoverRequestDto extends createZodDto(
   encryptionRecoverRequestSchema,
+) {}
+export class EncryptionVerifyRecoveryKeyRequestDto extends createZodDto(
+  encryptionVerifyRecoveryKeyRequestSchema,
 ) {}
 export class EncryptionChangePinRequestDto extends createZodDto(
   encryptionChangePinRequestSchema,

--- a/backend-nest/src/modules/encryption/encryption.controller.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.spec.ts
@@ -14,6 +14,7 @@ const createMockEncryptionService = (overrides?: {
   createRecoveryKey?: ReturnType<typeof mock>;
   regenerateRecoveryKey?: ReturnType<typeof mock>;
   recoverWithKey?: ReturnType<typeof mock>;
+  verifyRecoveryKey?: ReturnType<typeof mock>;
   reEncryptAllUserData?: ReturnType<typeof mock>;
   changePinRekey?: ReturnType<typeof mock>;
 }) => ({
@@ -41,6 +42,8 @@ const createMockEncryptionService = (overrides?: {
     overrides?.regenerateRecoveryKey ??
     mock(() => Promise.resolve({ formatted: 'XXXX-YYYY-ZZZZ-5678' })),
   recoverWithKey: overrides?.recoverWithKey ?? mock(() => Promise.resolve()),
+  verifyRecoveryKey:
+    overrides?.verifyRecoveryKey ?? mock(() => Promise.resolve()),
   reEncryptAllUserData:
     overrides?.reEncryptAllUserData ?? mock(() => Promise.resolve()),
   changePinRekey:
@@ -543,6 +546,23 @@ describe('EncryptionController', () => {
         expect(error).toBe(originalError);
         expect(error.message).toBe('DB connection lost');
       }
+    });
+  });
+
+  describe('verifyRecoveryKey', () => {
+    it('should call encryption service with user id and recovery key', async () => {
+      const user = createMockUser();
+      const body = { recoveryKey: 'ABCD-EFGH-IJKL-MNOP-QRST-UVWX-YZ23-4567' };
+
+      const { controller, mockEncryptionService } = setupController();
+
+      await controller.verifyRecoveryKey(user, body);
+
+      expect(mockEncryptionService.verifyRecoveryKey).toHaveBeenCalledTimes(1);
+      expect(mockEncryptionService.verifyRecoveryKey).toHaveBeenCalledWith(
+        user.id,
+        body.recoveryKey,
+      );
     });
   });
 

--- a/backend-nest/src/modules/encryption/encryption.controller.ts
+++ b/backend-nest/src/modules/encryption/encryption.controller.ts
@@ -34,6 +34,7 @@ import { EncryptionService } from './encryption.service';
 import {
   EncryptionValidateKeyRequestDto,
   EncryptionRecoverRequestDto,
+  EncryptionVerifyRecoveryKeyRequestDto,
   EncryptionChangePinRequestDto,
   EncryptionVaultStatusResponseDto,
   EncryptionSaltResponseDto,
@@ -237,6 +238,30 @@ export class EncryptionController {
     );
 
     return { success: true };
+  }
+
+  @SkipClientKey()
+  @Post('verify-recovery-key')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  // Read-only unwrap — same ceiling as validate-key so users can retry after typos
+  // (unlike /recover which re-encrypts all data and stays at 5/hour)
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Verify recovery key matches stored wrapped DEK (read-only)',
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'Recovery key is valid',
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid recovery key or no recovery key configured',
+    type: ErrorResponseDto,
+  })
+  async verifyRecoveryKey(
+    @User() user: AuthenticatedUser,
+    @Body() body: EncryptionVerifyRecoveryKeyRequestDto,
+  ): Promise<void> {
+    await this.encryptionService.verifyRecoveryKey(user.id, body.recoveryKey);
   }
 
   /**

--- a/backend-nest/src/modules/encryption/encryption.http.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.http.spec.ts
@@ -67,6 +67,7 @@ function createMockEncryptionService() {
     regenerateRecoveryKey: mock(() =>
       Promise.resolve({ formatted: 'AAAA-BBBB-CCCC-5678' }),
     ),
+    verifyRecoveryKey: mock(() => Promise.resolve()),
     ensureUserDEK: mock(() => Promise.resolve(Buffer.alloc(32))),
     getUserDEK: mock(() => Promise.resolve(Buffer.alloc(32))),
     generateKeyCheck: mock(() => 'mock-key-check'),
@@ -367,6 +368,43 @@ describe('Encryption HTTP pipeline', () => {
         .expect(400);
 
       expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+  });
+
+  describe('POST /api/v1/encryption/verify-recovery-key', () => {
+    it('returns 204 when verification succeeds', async () => {
+      await request(app.getHttpServer())
+        .post('/api/v1/encryption/verify-recovery-key')
+        .send({
+          recoveryKey:
+            'AAAA-BBBB-CCCC-DDDD-EEEE-FFFF-GGGG-HHHH-IIII-JJJJ-KKKK-LLLL-MMMM',
+        })
+        .expect(204);
+
+      expect(mockService.verifyRecoveryKey.mock.calls.length).toBe(1);
+    });
+
+    it('returns 400 Zod error when recoveryKey is missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/verify-recovery-key')
+        .send({})
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_ZOD_VALIDATION_FAILED');
+    });
+
+    it('returns 400 ERR_RECOVERY_KEY_INVALID when service rejects', async () => {
+      mockService.verifyRecoveryKey.mockImplementation(() => {
+        throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/encryption/verify-recovery-key')
+        .send({ recoveryKey: 'WRONG-KEY0-WRONG-KEY0-WRONG-KEY0-WRONG-KEY0' })
+        .expect(400);
+
+      expect(res.body.code).toBe('ERR_RECOVERY_KEY_INVALID');
+      mockService.verifyRecoveryKey.mockImplementation(() => Promise.resolve());
     });
   });
 

--- a/backend-nest/src/modules/encryption/encryption.service.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.spec.ts
@@ -1583,6 +1583,97 @@ describe('EncryptionService', () => {
     });
   });
 
+  describe('verifyRecoveryKey', () => {
+    beforeEach(() => {
+      service = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        mockRepository as any,
+      );
+    });
+
+    it('should resolve when recovery key unwraps wrapped_dek', async () => {
+      const dek = randomBytes(32);
+      const { raw, formatted } = service.generateRecoveryKey();
+      const wrapped = service.wrapDEK(dek, raw);
+      raw.fill(0);
+
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: randomBytes(16).toString('hex'),
+          kdf_iterations: 600000,
+          wrapped_dek: wrapped,
+          key_check: null,
+        }),
+      );
+      const repo = createMockRepository({ findByUserId });
+      const svc = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
+
+      await svc.verifyRecoveryKey(TEST_USER_ID, formatted);
+    });
+
+    it('should throw RECOVERY_KEY_NOT_CONFIGURED when wrapped_dek is null', async () => {
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: randomBytes(16).toString('hex'),
+          kdf_iterations: 600000,
+          wrapped_dek: null,
+          key_check: null,
+        }),
+      );
+      const repo = createMockRepository({ findByUserId });
+      const svc = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
+
+      try {
+        await svc.verifyRecoveryKey(TEST_USER_ID, 'AAAA-BBBB');
+        expect.unreachable('Should have thrown');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect(error.code).toBe(
+          ERROR_DEFINITIONS.RECOVERY_KEY_NOT_CONFIGURED.code,
+        );
+      }
+    });
+
+    it('should throw RECOVERY_KEY_INVALID for wrong recovery key', async () => {
+      const dek = randomBytes(32);
+      const { formatted: wrongFormatted } = service.generateRecoveryKey();
+      const { raw: actualWrapKey } = service.generateRecoveryKey();
+      const wrapped = service.wrapDEK(dek, actualWrapKey);
+      actualWrapKey.fill(0);
+      const findByUserId = mock(() =>
+        Promise.resolve({
+          salt: randomBytes(16).toString('hex'),
+          kdf_iterations: 600000,
+          wrapped_dek: wrapped,
+          key_check: null,
+        }),
+      );
+      const repo = createMockRepository({ findByUserId });
+      const svc = new EncryptionService(
+        createMockLogger() as any,
+        mockConfigService as any,
+        repo as any,
+      );
+
+      try {
+        await svc.verifyRecoveryKey(TEST_USER_ID, wrongFormatted);
+        expect.unreachable('Should have thrown');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect(error.code).toBe(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID.code);
+      }
+    });
+  });
+
   describe('recoverWithKey', () => {
     beforeEach(() => {
       service = new EncryptionService(

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -402,12 +402,18 @@ export class EncryptionService {
     if (!row?.wrapped_dek) {
       throw new BusinessException(
         ERROR_DEFINITIONS.RECOVERY_KEY_NOT_CONFIGURED,
+        undefined,
+        { userId, operation: 'verify_recovery_key.not_configured' },
       );
     }
 
     const trimmedKey = recoveryKeyFormatted.trim();
     if (!trimmedKey) {
-      throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+      throw new BusinessException(
+        ERROR_DEFINITIONS.RECOVERY_KEY_INVALID,
+        undefined,
+        { userId, operation: 'verify_recovery_key.empty_key' },
+      );
     }
 
     let recoveryKey: Buffer | null = null;
@@ -416,15 +422,27 @@ export class EncryptionService {
       try {
         recoveryKey = decodeBase32(trimmedKey.replace(/-/g, ''));
       } catch {
-        throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+        throw new BusinessException(
+          ERROR_DEFINITIONS.RECOVERY_KEY_INVALID,
+          undefined,
+          { userId, operation: 'verify_recovery_key.decode_failed' },
+        );
       }
       if (recoveryKey.length !== KEY_LENGTH) {
-        throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+        throw new BusinessException(
+          ERROR_DEFINITIONS.RECOVERY_KEY_INVALID,
+          undefined,
+          { userId, operation: 'verify_recovery_key.invalid_length' },
+        );
       }
       try {
         dek = this.unwrapDEK(row.wrapped_dek, recoveryKey);
       } catch {
-        throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+        throw new BusinessException(
+          ERROR_DEFINITIONS.RECOVERY_KEY_INVALID,
+          undefined,
+          { userId, operation: 'verify_recovery_key.unwrap_failed' },
+        );
       }
     } finally {
       recoveryKey?.fill(0);

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -421,11 +421,12 @@ export class EncryptionService {
     try {
       try {
         recoveryKey = decodeBase32(trimmedKey.replace(/-/g, ''));
-      } catch {
+      } catch (error) {
         throw new BusinessException(
           ERROR_DEFINITIONS.RECOVERY_KEY_INVALID,
           undefined,
           { userId, operation: 'verify_recovery_key.decode_failed' },
+          { cause: error },
         );
       }
       if (recoveryKey.length !== KEY_LENGTH) {
@@ -437,11 +438,12 @@ export class EncryptionService {
       }
       try {
         dek = this.unwrapDEK(row.wrapped_dek, recoveryKey);
-      } catch {
+      } catch (error) {
         throw new BusinessException(
           ERROR_DEFINITIONS.RECOVERY_KEY_INVALID,
           undefined,
           { userId, operation: 'verify_recovery_key.unwrap_failed' },
+          { cause: error },
         );
       }
     } finally {

--- a/backend-nest/src/modules/encryption/encryption.service.ts
+++ b/backend-nest/src/modules/encryption/encryption.service.ts
@@ -394,6 +394,44 @@ export class EncryptionService {
     }
   }
 
+  async verifyRecoveryKey(
+    userId: string,
+    recoveryKeyFormatted: string,
+  ): Promise<void> {
+    const row = await this.#repository.findByUserId(userId);
+    if (!row?.wrapped_dek) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.RECOVERY_KEY_NOT_CONFIGURED,
+      );
+    }
+
+    const trimmedKey = recoveryKeyFormatted.trim();
+    if (!trimmedKey) {
+      throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+    }
+
+    let recoveryKey: Buffer | null = null;
+    let dek: Buffer | null = null;
+    try {
+      try {
+        recoveryKey = decodeBase32(trimmedKey.replace(/-/g, ''));
+      } catch {
+        throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+      }
+      if (recoveryKey.length !== KEY_LENGTH) {
+        throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+      }
+      try {
+        dek = this.unwrapDEK(row.wrapped_dek, recoveryKey);
+      } catch {
+        throw new BusinessException(ERROR_DEFINITIONS.RECOVERY_KEY_INVALID);
+      }
+    } finally {
+      recoveryKey?.fill(0);
+      dek?.fill(0);
+    }
+  }
+
   async changePinRekey(
     userId: string,
     oldClientKey: Buffer,

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -230,6 +230,11 @@
     "changePassword": "Modifier",
     "recoveryKey": "Clé de récupération",
     "recoveryKeyDescription": "Indispensable si tu oublies ton code PIN.",
+    "verifyRecoveryKeyTitle": "Vérifier la clé de récupération",
+    "verifyRecoveryKeyHint": "Tu peux vérifier qu'une clé notée correspond bien à ton compte, sans rien modifier.",
+    "verifyRecoveryKeyLabel": "Saisis ta clé (avec ou sans tirets)",
+    "verifyRecoveryKeySubmit": "Vérifier",
+    "verifyRecoveryKeySuccess": "Cette clé est valide pour ton compte.",
     "regenerateKey": "Régénérer",
     "newRecoveryKeySaved": "Nouvelle clé de récupération enregistrée",
     "generateKeyError": "La génération de la clé a échoué — réessaie plus tard",
@@ -817,7 +822,10 @@
     "profileUpdateFailed": "La mise à jour du profil a échoué — réessaie",
     "validationFailed": "Les données envoyées ne sont pas valides",
     "unauthorized": "Tu dois te connecter pour continuer",
-    "forbidden": "Tu n'as pas accès à cette ressource"
+    "forbidden": "Tu n'as pas accès à cette ressource",
+    "rateLimited": "Trop de tentatives — patiente une minute avant de réessayer",
+    "recoveryKeyInvalid": "Cette clé ne correspond pas — vérifie ta saisie",
+    "recoveryKeyNotConfigured": "Aucune clé de récupération n'est enregistrée — génère-en une avec « Régénérer »"
   },
   "logout": {
     "inProgress": "Déconnexion...",

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -234,6 +234,7 @@
     "verifyRecoveryKeyHint": "Tu peux vérifier qu'une clé notée correspond bien à ton compte, sans rien modifier.",
     "verifyRecoveryKeyLabel": "Saisis ta clé (avec ou sans tirets)",
     "verifyRecoveryKeySubmit": "Vérifier",
+    "verifyRecoveryKeyAction": "Vérifier",
     "verifyRecoveryKeySuccess": "Cette clé est valide pour ton compte.",
     "regenerateKey": "Régénérer",
     "newRecoveryKeySaved": "Nouvelle clé de récupération enregistrée",

--- a/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.ts
@@ -4,9 +4,12 @@ import type {
 } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { catchError, throwError } from 'rxjs';
+import { isExpectedBusinessHttpError } from '@core/api/http-expected-business-noise';
 import { PostHogService, sanitizeUrl, sanitizeRecord } from '@core/analytics';
 import { Logger } from '../logging/logger';
 import { ApplicationConfiguration } from '../config/application-configuration';
+
+export { isExpectedBusinessHttpError as shouldSkipPostHogHttpCapture };
 
 /**
  * HTTP error interceptor for PostHog error tracking.
@@ -48,6 +51,10 @@ function captureHttpError(
   applicationConfiguration: ApplicationConfiguration,
 ): void {
   if (AUTH_HANDLED_STATUSES.has(error.status)) {
+    return;
+  }
+
+  if (isExpectedBusinessHttpError(error)) {
     return;
   }
 

--- a/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.ts
@@ -9,8 +9,6 @@ import { PostHogService, sanitizeUrl, sanitizeRecord } from '@core/analytics';
 import { Logger } from '../logging/logger';
 import { ApplicationConfiguration } from '../config/application-configuration';
 
-export { isExpectedBusinessHttpError as shouldSkipPostHogHttpCapture };
-
 /**
  * HTTP error interceptor for PostHog error tracking.
  * Leverages PostHog's built-in data sanitization for security.

--- a/frontend/projects/webapp/src/app/core/api/api-error-localizer.spec.ts
+++ b/frontend/projects/webapp/src/app/core/api/api-error-localizer.spec.ts
@@ -69,6 +69,18 @@ describe('ApiErrorLocalizer', () => {
     );
   });
 
+  it('should localize HTTP 429 before error code mapping', () => {
+    const rateLimited = new ApiError(
+      'Too Many Requests',
+      'HTTP_429',
+      429,
+      null,
+    );
+    expect(service.localizeApiError(rateLimited)).toBe(
+      'Trop de tentatives — patiente une minute avant de réessayer',
+    );
+  });
+
   it('should return generic message for unknown error codes', () => {
     const error = new ApiError('Unknown', 'ERR_UNKNOWN_CODE', 500, null);
     expect(service.localizeApiError(error)).toBe(

--- a/frontend/projects/webapp/src/app/core/api/api-error-localizer.ts
+++ b/frontend/projects/webapp/src/app/core/api/api-error-localizer.ts
@@ -31,6 +31,9 @@ const CODE_KEY_MAP = {
   [API_ERROR_CODES.USER_PROFILE_UPDATE_FAILED]: 'apiError.profileUpdateFailed',
   [API_ERROR_CODES.VALIDATION_FAILED]: 'apiError.validationFailed',
   [API_ERROR_CODES.AUTH_UNAUTHORIZED]: 'apiError.unauthorized',
+  [API_ERROR_CODES.RECOVERY_KEY_INVALID]: 'apiError.recoveryKeyInvalid',
+  [API_ERROR_CODES.RECOVERY_KEY_NOT_CONFIGURED]:
+    'apiError.recoveryKeyNotConfigured',
 } as const satisfies Partial<Record<ApiErrorCode, string>>;
 
 @Injectable({ providedIn: 'root' })
@@ -38,6 +41,9 @@ export class ApiErrorLocalizer {
   readonly #transloco = inject(TranslocoService);
 
   localizeApiError(error: ApiError): string {
+    if (error.status === 429) {
+      return this.#transloco.translate('apiError.rateLimited');
+    }
     if (error.code && error.code in CODE_KEY_MAP) {
       const key = CODE_KEY_MAP[error.code as keyof typeof CODE_KEY_MAP];
       return this.#transloco.translate(key);

--- a/frontend/projects/webapp/src/app/core/api/http-expected-business-noise.spec.ts
+++ b/frontend/projects/webapp/src/app/core/api/http-expected-business-noise.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { HttpErrorResponse } from '@angular/common/http';
+import { API_ERROR_CODES } from 'pulpe-shared';
+import { ApiError } from './api-error';
+import {
+  isExpectedBusinessApiError,
+  isExpectedBusinessHttpError,
+} from './http-expected-business-noise';
+
+describe('isExpectedBusinessHttpError', () => {
+  it('returns true for HTTP 429', () => {
+    const error = new HttpErrorResponse({
+      status: 429,
+      statusText: 'Too Many Requests',
+    });
+    expect(isExpectedBusinessHttpError(error)).toBe(true);
+  });
+
+  it('returns true for 400 with ERR_RECOVERY_KEY_INVALID', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { code: API_ERROR_CODES.RECOVERY_KEY_INVALID },
+    });
+    expect(isExpectedBusinessHttpError(error)).toBe(true);
+  });
+
+  it('returns true for 400 with ERR_ENCRYPTION_KEY_CHECK_FAILED', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { code: API_ERROR_CODES.ENCRYPTION_KEY_CHECK_FAILED },
+    });
+    expect(isExpectedBusinessHttpError(error)).toBe(true);
+  });
+
+  it('returns false for 400 with unrelated business code', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { code: 'ERR_BUDGET_NOT_FOUND' },
+    });
+    expect(isExpectedBusinessHttpError(error)).toBe(false);
+  });
+
+  it('returns false for 500', () => {
+    const error = new HttpErrorResponse({
+      status: 500,
+      error: { code: API_ERROR_CODES.RECOVERY_KEY_INVALID },
+    });
+    expect(isExpectedBusinessHttpError(error)).toBe(false);
+  });
+});
+
+describe('isExpectedBusinessApiError', () => {
+  it('returns false for non-ApiError', () => {
+    expect(isExpectedBusinessApiError(new Error('x'))).toBe(false);
+  });
+
+  it('returns true for 429 ApiError', () => {
+    const error = new ApiError('x', 'CODE', 429, undefined);
+    expect(isExpectedBusinessApiError(error)).toBe(true);
+  });
+
+  it('returns true for 400 with recovery key invalid', () => {
+    const error = new ApiError(
+      'x',
+      API_ERROR_CODES.RECOVERY_KEY_INVALID,
+      400,
+      undefined,
+    );
+    expect(isExpectedBusinessApiError(error)).toBe(true);
+  });
+});

--- a/frontend/projects/webapp/src/app/core/api/http-expected-business-noise.ts
+++ b/frontend/projects/webapp/src/app/core/api/http-expected-business-noise.ts
@@ -1,0 +1,44 @@
+import type { HttpErrorResponse } from '@angular/common/http';
+import { API_ERROR_CODES } from 'pulpe-shared';
+import { isApiError } from './api-error';
+
+const EXPECTED_BUSINESS_ERROR_CODES: ReadonlySet<string> = new Set([
+  API_ERROR_CODES.RECOVERY_KEY_INVALID,
+  API_ERROR_CODES.RECOVERY_KEY_NOT_CONFIGURED,
+  API_ERROR_CODES.ENCRYPTION_KEY_CHECK_FAILED,
+]);
+
+function matchesExpectedBusinessNoise(
+  status: number,
+  code: string | undefined,
+): boolean {
+  if (status === 429) {
+    return true;
+  }
+  if (status !== 400) {
+    return false;
+  }
+  return typeof code === 'string' && EXPECTED_BUSINESS_ERROR_CODES.has(code);
+}
+
+function readErrorBodyCode(body: unknown): string | undefined {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return undefined;
+  }
+  const raw = (body as Record<string, unknown>)['code'];
+  return typeof raw === 'string' ? raw : undefined;
+}
+
+export function isExpectedBusinessHttpError(error: HttpErrorResponse): boolean {
+  return matchesExpectedBusinessNoise(
+    error.status,
+    readErrorBodyCode(error.error),
+  );
+}
+
+export function isExpectedBusinessApiError(error: unknown): boolean {
+  if (!isApiError(error)) {
+    return false;
+  }
+  return matchesExpectedBusinessNoise(error.status, error.code);
+}

--- a/frontend/projects/webapp/src/app/core/encryption/encryption-api.ts
+++ b/frontend/projects/webapp/src/app/core/encryption/encryption-api.ts
@@ -32,6 +32,12 @@ export class EncryptionApi {
     });
   }
 
+  verifyRecoveryKey$(recoveryKey: string): Observable<void> {
+    return this.#api.postVoid$('/encryption/verify-recovery-key', {
+      recoveryKey,
+    });
+  }
+
   setupRecoveryKey$(): Observable<EncryptionSetupRecoveryResponse> {
     return this.#api.post$(
       '/encryption/setup-recovery',

--- a/frontend/projects/webapp/src/app/feature/settings/components/verify-recovery-key-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/components/verify-recovery-key-dialog.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of, throwError } from 'rxjs';
+import { ApiError } from '@core/api/api-error';
+import { ApiErrorLocalizer } from '@core/api/api-error-localizer';
+import { EncryptionApi } from '@core/encryption';
+import { Logger } from '@core/logging/logger';
+import { API_ERROR_CODES } from 'pulpe-shared';
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import { VerifyRecoveryKeyDialog } from './verify-recovery-key-dialog';
+
+describe('VerifyRecoveryKeyDialog', () => {
+  let component: VerifyRecoveryKeyDialog;
+  let mockDialogRef: { close: Mock };
+  let mockEncryptionApi: { verifyRecoveryKey$: Mock };
+  let mockSnackBar: { open: Mock };
+  let mockLogger: { error: Mock };
+
+  beforeEach(() => {
+    mockDialogRef = { close: vi.fn() };
+    mockEncryptionApi = {
+      verifyRecoveryKey$: vi.fn(),
+    };
+    mockSnackBar = {
+      open: vi.fn(),
+    };
+    mockLogger = {
+      error: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...provideTranslocoForTest(),
+        VerifyRecoveryKeyDialog,
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: EncryptionApi, useValue: mockEncryptionApi },
+        { provide: MatSnackBar, useValue: mockSnackBar },
+        { provide: Logger, useValue: mockLogger },
+        ApiErrorLocalizer,
+      ],
+    });
+
+    component = TestBed.inject(VerifyRecoveryKeyDialog);
+  });
+
+  it('should have invalid form when empty', () => {
+    expect(component['verifyRecoveryForm'].valid).toBe(false);
+  });
+
+  it('should close dialog and show snackbar on success', async () => {
+    mockEncryptionApi.verifyRecoveryKey$.mockReturnValue(of(undefined));
+    component['verifyRecoveryForm'].patchValue({
+      recoveryKey: 'AAAA-BBBB-CCCC-DDDD',
+    });
+
+    await component['verifyRecoveryKey']();
+
+    expect(mockSnackBar.open).toHaveBeenCalled();
+    expect(mockDialogRef.close).toHaveBeenCalledWith(true);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('should set error message when key is invalid', async () => {
+    const apiError = new ApiError(
+      'invalid',
+      API_ERROR_CODES.RECOVERY_KEY_INVALID,
+      400,
+      undefined,
+    );
+    mockEncryptionApi.verifyRecoveryKey$.mockReturnValue(
+      throwError(() => apiError),
+    );
+    component['verifyRecoveryForm'].patchValue({
+      recoveryKey: 'AAAA-BBBB-CCCC-DDDD',
+    });
+
+    await component['verifyRecoveryKey']();
+
+    expect(component['errorMessage']()).toBeTruthy();
+    expect(mockDialogRef.close).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/settings/components/verify-recovery-key-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/components/verify-recovery-key-dialog.ts
@@ -1,0 +1,175 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { firstValueFrom } from 'rxjs';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { ApiErrorLocalizer } from '@core/api/api-error-localizer';
+import { isApiError } from '@core/api/api-error';
+import { isExpectedBusinessApiError } from '@core/api/http-expected-business-noise';
+import { EncryptionApi } from '@core/encryption';
+import { Logger } from '@core/logging/logger';
+import {
+  formatRecoveryKeyInput,
+  recoveryKeyValidators,
+} from '@core/validators';
+import { ErrorAlert } from '@ui/error-alert';
+
+@Component({
+  selector: 'pulpe-verify-recovery-key-dialog',
+  imports: [
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    ErrorAlert,
+    TranslocoPipe,
+  ],
+  template: `
+    <h2 mat-dialog-title>
+      {{ 'settings.verifyRecoveryKeyTitle' | transloco }}
+    </h2>
+
+    <mat-dialog-content>
+      <p class="text-body-small text-on-surface-variant leading-relaxed mb-4">
+        {{ 'settings.verifyRecoveryKeyHint' | transloco }}
+      </p>
+
+      <pulpe-error-alert
+        [message]="errorMessage()"
+        data-testid="verify-recovery-key-dialog-error"
+      />
+
+      <form [formGroup]="verifyRecoveryForm" (ngSubmit)="verifyRecoveryKey()">
+        <mat-form-field
+          appearance="outline"
+          class="w-full"
+          subscriptSizing="dynamic"
+        >
+          <mat-label>{{
+            'settings.verifyRecoveryKeyLabel' | transloco
+          }}</mat-label>
+          <input
+            matInput
+            formControlName="recoveryKey"
+            data-testid="verify-recovery-key-dialog-input"
+            autocomplete="off"
+            spellcheck="false"
+            (input)="formatRecoveryKeyAsUserTypes($event)"
+          />
+          @if (verifyRecoveryForm.controls.recoveryKey.hasError('pattern')) {
+            <mat-error>{{
+              'auth.recoverVaultCode.recoveryKeyInvalidFormat' | transloco
+            }}</mat-error>
+          } @else if (
+            verifyRecoveryForm.controls.recoveryKey.hasError('required')
+          ) {
+            <mat-error>{{
+              'auth.recoverVaultCode.recoveryKeyRequired' | transloco
+            }}</mat-error>
+          }
+        </mat-form-field>
+      </form>
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      <button
+        matButton
+        mat-dialog-close
+        data-testid="verify-recovery-key-dialog-cancel"
+      >
+        {{ 'common.cancel' | transloco }}
+      </button>
+      <button
+        matButton="filled"
+        color="primary"
+        data-testid="verify-recovery-key-dialog-submit"
+        type="button"
+        [disabled]="verifyRecoveryForm.invalid || isVerifyingRecoveryKey()"
+        (click)="verifyRecoveryKey()"
+      >
+        <span class="flex items-center justify-center">
+          @if (isVerifyingRecoveryKey()) {
+            <mat-spinner diameter="20" class="mr-2" />
+          }
+          {{ 'settings.verifyRecoveryKeySubmit' | transloco }}
+        </span>
+      </button>
+    </mat-dialog-actions>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VerifyRecoveryKeyDialog {
+  readonly #logger = inject(Logger);
+  readonly #dialogRef = inject(MatDialogRef<VerifyRecoveryKeyDialog>);
+  readonly #encryptionApi = inject(EncryptionApi);
+  readonly #apiErrorLocalizer = inject(ApiErrorLocalizer);
+  readonly #transloco = inject(TranslocoService);
+  readonly #snackBar = inject(MatSnackBar);
+
+  protected readonly verifyRecoveryForm = new FormGroup({
+    recoveryKey: new FormControl('', {
+      nonNullable: true,
+      validators: recoveryKeyValidators,
+    }),
+  });
+  protected readonly isVerifyingRecoveryKey = signal(false);
+  protected readonly errorMessage = signal('');
+
+  protected formatRecoveryKeyAsUserTypes(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const formatted = formatRecoveryKeyInput(input.value);
+    if (formatted !== input.value) {
+      this.verifyRecoveryForm.controls.recoveryKey.setValue(formatted, {
+        emitEvent: false,
+      });
+      input.value = formatted;
+    }
+  }
+
+  protected async verifyRecoveryKey(): Promise<void> {
+    if (this.isVerifyingRecoveryKey() || !this.verifyRecoveryForm.valid) {
+      return;
+    }
+
+    this.errorMessage.set('');
+    this.isVerifyingRecoveryKey.set(true);
+
+    const { recoveryKey } = this.verifyRecoveryForm.getRawValue();
+
+    try {
+      await firstValueFrom(this.#encryptionApi.verifyRecoveryKey$(recoveryKey));
+      this.#snackBar.open(
+        this.#transloco.translate('settings.verifyRecoveryKeySuccess'),
+        'OK',
+        {
+          duration: 4000,
+          horizontalPosition: 'center',
+          verticalPosition: 'bottom',
+        },
+      );
+      this.#dialogRef.close(true);
+    } catch (error) {
+      const message = isApiError(error)
+        ? this.#apiErrorLocalizer.localizeApiError(error)
+        : this.#transloco.translate('apiError.generic');
+      this.errorMessage.set(message);
+      if (!isExpectedBusinessApiError(error)) {
+        this.#logger.error('Recovery key verification failed', error);
+      }
+    } finally {
+      this.isVerifyingRecoveryKey.set(false);
+    }
+  }
+}

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.spec.ts
@@ -86,7 +86,10 @@ describe('SettingsPage', () => {
         { provide: AuthStateService, useValue: mockAuthState },
         {
           provide: EncryptionApi,
-          useValue: { regenerateRecoveryKey$: vi.fn() },
+          useValue: {
+            regenerateRecoveryKey$: vi.fn(),
+            verifyRecoveryKey$: vi.fn().mockReturnValue(of(undefined)),
+          },
         },
         { provide: DemoModeService, useValue: { isDemoMode: signal(false) } },
       ],

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
@@ -40,6 +40,7 @@ import { ChangePasswordDialog } from './components/change-password-dialog';
 import { ChangePinDialog } from './components/change-pin-dialog';
 import { DeleteAccountDialog } from './components/delete-account-dialog';
 import { RegenerateRecoveryKeyDialog } from './components/regenerate-recovery-key-dialog';
+import { VerifyRecoveryKeyDialog } from './components/verify-recovery-key-dialog';
 
 @Component({
   selector: 'pulpe-settings-page',
@@ -217,8 +218,10 @@ import { RegenerateRecoveryKeyDialog } from './components/regenerate-recovery-ke
             </div>
 
             <!-- Clé de récupération -->
-            <div class="flex items-center justify-between gap-6">
-              <div class="space-y-1">
+            <div
+              class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6"
+            >
+              <div class="space-y-1 min-w-0">
                 <h3 class="text-title-small">
                   {{ 'settings.recoveryKey' | transloco }}
                 </h3>
@@ -226,19 +229,28 @@ import { RegenerateRecoveryKeyDialog } from './components/regenerate-recovery-ke
                   {{ 'settings.recoveryKeyDescription' | transloco }}
                 </p>
               </div>
-              <button
-                matButton="outlined"
-                data-testid="generate-recovery-key-button"
-                [disabled]="isGeneratingRecoveryKey()"
-                (click)="onRegenerateRecoveryKey()"
-              >
-                <span class="flex items-center justify-center">
-                  @if (isGeneratingRecoveryKey()) {
-                    <mat-spinner diameter="20" class="mr-2" />
-                  }
-                  {{ 'settings.regenerateKey' | transloco }}
-                </span>
-              </button>
+              <div class="flex flex-wrap gap-3 items-center shrink-0">
+                <button
+                  matButton="outlined"
+                  data-testid="generate-recovery-key-button"
+                  [disabled]="isGeneratingRecoveryKey()"
+                  (click)="onRegenerateRecoveryKey()"
+                >
+                  <span class="flex items-center justify-center">
+                    @if (isGeneratingRecoveryKey()) {
+                      <mat-spinner diameter="20" class="mr-2" />
+                    }
+                    {{ 'settings.regenerateKey' | transloco }}
+                  </span>
+                </button>
+                <button
+                  matButton="outlined"
+                  data-testid="verify-recovery-key-button"
+                  (click)="onVerifyRecoveryKey()"
+                >
+                  {{ 'settings.verifyRecoveryKeySubmit' | transloco }}
+                </button>
+              </div>
             </div>
           </div>
         </section>
@@ -417,6 +429,10 @@ export default class SettingsPage {
         verticalPosition: 'bottom',
       },
     );
+  }
+
+  onVerifyRecoveryKey(): void {
+    this.#dialog.open(VerifyRecoveryKeyDialog, { width: '480px' });
   }
 
   async onRegenerateRecoveryKey(): Promise<void> {

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
@@ -248,7 +248,7 @@ import { VerifyRecoveryKeyDialog } from './components/verify-recovery-key-dialog
                   data-testid="verify-recovery-key-button"
                   (click)="onVerifyRecoveryKey()"
                 >
-                  {{ 'settings.verifyRecoveryKeySubmit' | transloco }}
+                  {{ 'settings.verifyRecoveryKeyAction' | transloco }}
                 </button>
               </div>
             </div>

--- a/ios/Pulpe/Core/Encryption/EncryptionAPI.swift
+++ b/ios/Pulpe/Core/Encryption/EncryptionAPI.swift
@@ -74,6 +74,10 @@ struct RecoverRequest: Codable, Sendable {
     let newClientKey: String
 }
 
+struct VerifyRecoveryKeyRequest: Codable, Sendable {
+    let recoveryKey: String
+}
+
 struct ChangePinRequest: Codable, Sendable {
     let oldClientKey: String
     let newClientKey: String
@@ -120,6 +124,13 @@ actor EncryptionAPI {
     func regenerateRecoveryKey() async throws -> String {
         let response: RecoveryKeyResponse = try await apiClient.request(.encryptionRegenerateRecovery)
         return response.recoveryKey
+    }
+
+    /// Verify recovery key matches wrapped DEK (read-only)
+    func verifyRecoveryKey(_ recoveryKey: String) async throws {
+        let trimmed = recoveryKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = VerifyRecoveryKeyRequest(recoveryKey: trimmed)
+        try await apiClient.requestVoid(.encryptionVerifyRecoveryKey, body: body)
     }
 
     /// Recover encryption using recovery key and a new clientKey

--- a/ios/Pulpe/Core/Encryption/RecoveryKeyFormatter.swift
+++ b/ios/Pulpe/Core/Encryption/RecoveryKeyFormatter.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public struct RecoveryKeyFormatter {
+    public static let strippedKeyCharacterCount = 52
+
     /// Formats a raw string into groups of 4 characters separated by dashes.
     /// Example: "ABCDEFGH" -> "ABCD-EFGH"
     public static func format(_ input: String) -> String {

--- a/ios/Pulpe/Core/Network/APIError.swift
+++ b/ios/Pulpe/Core/Network/APIError.swift
@@ -26,6 +26,7 @@ enum APIError: LocalizedError {
     case maintenance
     case clientKeyInvalid
     case recoveryKeyInvalid
+    case recoveryKeyNotConfigured
 
     var errorDescription: String? {
         switch self {
@@ -73,6 +74,8 @@ enum APIError: LocalizedError {
             return "Ton code d'accès a été modifié — saisis ton nouveau code"
         case .recoveryKeyInvalid:
             return "Clé de récupération invalide — vérifie que tu as bien copié la clé"
+        case .recoveryKeyNotConfigured:
+            return "Aucune clé de secours n'est enregistrée — génère-en une depuis « Clé de secours »."
         }
     }
 
@@ -89,6 +92,7 @@ enum APIError: LocalizedError {
         "MAINTENANCE": .maintenance,
         "ERR_ENCRYPTION_KEY_CHECK_FAILED": .clientKeyInvalid,
         "ERR_RECOVERY_KEY_INVALID": .recoveryKeyInvalid,
+        "ERR_RECOVERY_KEY_NOT_CONFIGURED": .recoveryKeyNotConfigured,
     ]
 
     /// Create APIError from server error code

--- a/ios/Pulpe/Core/Network/APIError.swift
+++ b/ios/Pulpe/Core/Network/APIError.swift
@@ -39,7 +39,7 @@ enum APIError: LocalizedError {
         case .forbidden:
             return "Tu n'as pas accès à cette ressource"
         case .notFound:
-            return "Cette page n'existe plus ou a été déplacée"
+            return "Ressource introuvable — réessaie ou mets l'app à jour"
         case .conflict(let message):
             return message
         case .validationError(let details):

--- a/ios/Pulpe/Core/Network/Endpoints.swift
+++ b/ios/Pulpe/Core/Network/Endpoints.swift
@@ -62,6 +62,7 @@ enum Endpoint {
     case encryptionSetupRecovery
     case encryptionRegenerateRecovery
     case encryptionRecover
+    case encryptionVerifyRecoveryKey
     case encryptionChangePin
 
     // MARK: - Path
@@ -118,6 +119,7 @@ enum Endpoint {
         case .encryptionSetupRecovery: return "/encryption/setup-recovery"
         case .encryptionRegenerateRecovery: return "/encryption/regenerate-recovery"
         case .encryptionRecover: return "/encryption/recover"
+        case .encryptionVerifyRecoveryKey: return "/encryption/verify-recovery-key"
         case .encryptionChangePin: return "/encryption/change-pin"
         }
     }
@@ -130,7 +132,7 @@ enum Endpoint {
              .templateLines, .templateFromOnboarding, .templateLinesBulk,
              .budgetLineToggle, .budgetLineResetFromTemplate, .transactionToggle,
              .encryptionValidateKey, .encryptionSetupRecovery, .encryptionRegenerateRecovery, .encryptionRecover,
-             .encryptionChangePin:
+             .encryptionVerifyRecoveryKey, .encryptionChangePin:
             return .post
 
         case .validateSession, .userProfile, .budget, .budgetDetails, .budgetsExport,

--- a/ios/Pulpe/Features/Account/SecuritySettingsView.swift
+++ b/ios/Pulpe/Features/Account/SecuritySettingsView.swift
@@ -150,7 +150,9 @@ struct SecuritySettingsView: View {
             }
         }
         .sheet(isPresented: $showVerifyRecoveryKey) {
-            VerifyRecoveryKeySheet()
+            VerifyRecoveryKeySheet {
+                appState.toastManager.show("Cette clé est valide pour ton compte.", type: .success)
+            }
         }
         .overlay {
             if securityViewModel.isRegenerating {

--- a/ios/Pulpe/Features/Account/SecuritySettingsView.swift
+++ b/ios/Pulpe/Features/Account/SecuritySettingsView.swift
@@ -8,6 +8,7 @@ struct SecuritySettingsView: View {
     @State private var showChangePin = false
     @State private var showChangePassword = false
     @State private var showDeleteConfirmation = false
+    @State private var showVerifyRecoveryKey = false
     @State private var securityViewModel = AccountSecurityViewModel()
 
     private let canUseBiometrics = BiometricService.shared.canUseBiometrics()
@@ -28,6 +29,10 @@ struct SecuritySettingsView: View {
                     securityViewModel.showConfirmPassword = true
                 }
                 .disabled(securityViewModel.isRegenerating)
+
+                chevronRow("Vérifier ma clé de récupération", detail: "Tester") {
+                    showVerifyRecoveryKey = true
+                }
             }
 
             if canUseBiometrics {
@@ -143,6 +148,9 @@ struct SecuritySettingsView: View {
                     securityViewModel.showRecoveryKeySheet = false
                 }
             }
+        }
+        .sheet(isPresented: $showVerifyRecoveryKey) {
+            VerifyRecoveryKeySheet()
         }
         .overlay {
             if securityViewModel.isRegenerating {

--- a/ios/Pulpe/Features/Account/SecuritySettingsView.swift
+++ b/ios/Pulpe/Features/Account/SecuritySettingsView.swift
@@ -30,7 +30,7 @@ struct SecuritySettingsView: View {
                 }
                 .disabled(securityViewModel.isRegenerating)
 
-                chevronRow("Vérifier ma clé de récupération", detail: "Tester") {
+                chevronRow("Vérifier ma clé de récupération", detail: "Vérifier") {
                     showVerifyRecoveryKey = true
                 }
             }

--- a/ios/Pulpe/Features/Account/VerifyRecoveryKeySheet.swift
+++ b/ios/Pulpe/Features/Account/VerifyRecoveryKeySheet.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct VerifyRecoveryKeySheet: View {
-    @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
+    let onSuccess: () -> Void
     @State private var recoveryKey = ""
     @State private var isVerifying = false
     @State private var errorMessage: String?
@@ -31,7 +31,10 @@ struct VerifyRecoveryKeySheet: View {
                 focusBinding: $isKeyFieldFocused
             )
             .onChange(of: recoveryKey) { _, newValue in
-                let stripped = RecoveryKeyFormatter.strip(newValue)
+                let stripped = String(
+                    RecoveryKeyFormatter.strip(newValue)
+                        .prefix(RecoveryKeyFormatter.strippedKeyCharacterCount)
+                )
                 let formatted = RecoveryKeyFormatter.format(stripped)
                 if formatted != newValue {
                     recoveryKey = formatted
@@ -76,8 +79,8 @@ struct VerifyRecoveryKeySheet: View {
         do {
             try await EncryptionAPI.shared.verifyRecoveryKey(stripped)
             submitSuccessTrigger.toggle()
-            appState.toastManager.show("Cette clé est valide pour ton compte.", type: .success)
             dismiss()
+            onSuccess()
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -87,6 +90,6 @@ struct VerifyRecoveryKeySheet: View {
 }
 
 #Preview {
-    VerifyRecoveryKeySheet()
+    VerifyRecoveryKeySheet(onSuccess: {})
         .environment(AppState())
 }

--- a/ios/Pulpe/Features/Account/VerifyRecoveryKeySheet.swift
+++ b/ios/Pulpe/Features/Account/VerifyRecoveryKeySheet.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct VerifyRecoveryKeySheet: View {
+    @State private var recoveryKey = ""
+    @State private var isVerifying = false
+    @State private var resultMessage: String?
+    @State private var isSuccess = false
+    @FocusState private var isKeyFieldFocused: Bool
+
+    var body: some View {
+        SheetFormContainer(
+            title: "Vérifier ma clé",
+            isLoading: isVerifying,
+            autoFocus: $isKeyFieldFocused
+        ) {
+            Text(
+                "Saisis ta clé telle que tu l'as notée (tirets optionnels). " +
+                    "Elle sert uniquement à cette vérification et n'est pas enregistrée."
+            )
+            .font(PulpeTypography.bodyMedium)
+            .foregroundStyle(Color.textSecondaryOnboarding)
+            .multilineTextAlignment(.center)
+
+            FormTextField(
+                hint: "XXXX-XXXX-…",
+                text: $recoveryKey,
+                label: "Clé de récupération",
+                accessibilityLabel: "Clé de récupération",
+                focusBinding: $isKeyFieldFocused
+            )
+            .onChange(of: recoveryKey) { _, newValue in
+                let stripped = RecoveryKeyFormatter.strip(newValue)
+                let formatted = RecoveryKeyFormatter.format(stripped)
+                if formatted != newValue {
+                    recoveryKey = formatted
+                }
+            }
+
+            if let resultMessage {
+                Text(resultMessage)
+                    .font(PulpeTypography.labelMedium)
+                    .foregroundStyle(isSuccess ? Color.primary : Color.errorPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Button {
+                Task { await verify() }
+            } label: {
+                if isVerifying {
+                    ProgressView()
+                        .tint(.white)
+                        .accessibilityLabel("Vérification en cours")
+                } else {
+                    Text("Vérifier")
+                }
+            }
+            .primaryButtonStyle(
+                isEnabled: canSubmit
+            )
+            .disabled(!canSubmit)
+        }
+    }
+
+    private var canSubmit: Bool {
+        let trimmed = recoveryKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && !isVerifying &&
+            !RecoveryKeyFormatter.containsInvalidCharacters(recoveryKey)
+    }
+
+    private func verify() async {
+        isVerifying = true
+        resultMessage = nil
+        let trimmed = recoveryKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            isVerifying = false
+            return
+        }
+
+        do {
+            try await EncryptionAPI.shared.verifyRecoveryKey(trimmed)
+            isSuccess = true
+            resultMessage = "Cette clé est valide pour ton compte."
+        } catch let error as APIError {
+            isSuccess = false
+            resultMessage = error.localizedDescription
+        } catch {
+            isSuccess = false
+            resultMessage = error.localizedDescription
+        }
+
+        isVerifying = false
+    }
+}
+
+#Preview {
+    VerifyRecoveryKeySheet()
+}

--- a/ios/Pulpe/Features/Account/VerifyRecoveryKeySheet.swift
+++ b/ios/Pulpe/Features/Account/VerifyRecoveryKeySheet.swift
@@ -17,7 +17,7 @@ struct VerifyRecoveryKeySheet: View {
                 "Saisis ta clé telle que tu l'as notée (tirets optionnels). " +
                     "Elle sert uniquement à cette vérification et n'est pas enregistrée."
             )
-            .font(PulpeTypography.bodyMedium)
+            .font(PulpeTypography.bodyLarge)
             .foregroundStyle(Color.textSecondaryOnboarding)
             .multilineTextAlignment(.center)
 

--- a/ios/Pulpe/Features/Account/VerifyRecoveryKeySheet.swift
+++ b/ios/Pulpe/Features/Account/VerifyRecoveryKeySheet.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
 struct VerifyRecoveryKeySheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
     @State private var recoveryKey = ""
     @State private var isVerifying = false
-    @State private var resultMessage: String?
-    @State private var isSuccess = false
+    @State private var errorMessage: String?
+    @State private var submitSuccessTrigger = false
     @FocusState private var isKeyFieldFocused: Bool
 
     var body: some View {
@@ -36,11 +38,8 @@ struct VerifyRecoveryKeySheet: View {
                 }
             }
 
-            if let resultMessage {
-                Text(resultMessage)
-                    .font(PulpeTypography.labelMedium)
-                    .foregroundStyle(isSuccess ? Color.primary : Color.errorPrimary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            if let errorMessage {
+                ErrorBanner(message: errorMessage)
             }
 
             Button {
@@ -54,38 +53,33 @@ struct VerifyRecoveryKeySheet: View {
                     Text("Vérifier")
                 }
             }
-            .primaryButtonStyle(
-                isEnabled: canSubmit
-            )
+            .primaryButtonStyle(isEnabled: canSubmit)
             .disabled(!canSubmit)
         }
+        .sensoryFeedback(.success, trigger: submitSuccessTrigger)
     }
 
     private var canSubmit: Bool {
-        let trimmed = recoveryKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        return !trimmed.isEmpty && !isVerifying &&
-            !RecoveryKeyFormatter.containsInvalidCharacters(recoveryKey)
+        let stripped = RecoveryKeyFormatter.strip(recoveryKey)
+        return stripped.count == RecoveryKeyFormatter.strippedKeyCharacterCount && !isVerifying
     }
 
     private func verify() async {
         isVerifying = true
-        resultMessage = nil
-        let trimmed = recoveryKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
+        errorMessage = nil
+        let stripped = RecoveryKeyFormatter.strip(recoveryKey)
+        guard stripped.count == RecoveryKeyFormatter.strippedKeyCharacterCount else {
             isVerifying = false
             return
         }
 
         do {
-            try await EncryptionAPI.shared.verifyRecoveryKey(trimmed)
-            isSuccess = true
-            resultMessage = "Cette clé est valide pour ton compte."
-        } catch let error as APIError {
-            isSuccess = false
-            resultMessage = error.localizedDescription
+            try await EncryptionAPI.shared.verifyRecoveryKey(stripped)
+            submitSuccessTrigger.toggle()
+            appState.toastManager.show("Cette clé est valide pour ton compte.", type: .success)
+            dismiss()
         } catch {
-            isSuccess = false
-            resultMessage = error.localizedDescription
+            errorMessage = error.localizedDescription
         }
 
         isVerifying = false
@@ -94,4 +88,5 @@ struct VerifyRecoveryKeySheet: View {
 
 #Preview {
     VerifyRecoveryKeySheet()
+        .environment(AppState())
 }

--- a/ios/Pulpe/Features/Auth/Pin/PinRecoveryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinRecoveryView.swift
@@ -236,7 +236,9 @@ final class PinRecoveryViewModel {
 
     let pinLength = PinConstants.length
 
-    var isRecoveryKeyValid: Bool { RecoveryKeyFormatter.strip(recoveryKey).count == 52 }
+    var isRecoveryKeyValid: Bool {
+        RecoveryKeyFormatter.strip(recoveryKey).count == RecoveryKeyFormatter.strippedKeyCharacterCount
+    }
     var canConfirm: Bool { digits.count == pinLength && !isProcessing }
 
     // MARK: - Private

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -115,6 +115,7 @@ export {
   // Encryption schemas — requests
   encryptionValidateKeyRequestSchema,
   encryptionRecoverRequestSchema,
+  encryptionVerifyRecoveryKeyRequestSchema,
   encryptionChangePinRequestSchema,
   // Encryption schemas — responses
   encryptionVaultStatusResponseSchema,
@@ -260,6 +261,7 @@ export type {
   // Encryption types — requests
   EncryptionValidateKeyRequest,
   EncryptionRecoverRequest,
+  EncryptionVerifyRecoveryKeyRequest,
   EncryptionChangePinRequest,
   // Encryption types — responses
   EncryptionVaultStatusResponse,

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -955,6 +955,14 @@ export type EncryptionRecoverRequest = z.infer<
   typeof encryptionRecoverRequestSchema
 >;
 
+/** POST /verify-recovery-key — read-only unwrap check */
+export const encryptionVerifyRecoveryKeyRequestSchema = z.object({
+  recoveryKey: z.string().min(1).max(512),
+});
+export type EncryptionVerifyRecoveryKeyRequest = z.infer<
+  typeof encryptionVerifyRecoveryKeyRequestSchema
+>;
+
 /** POST /change-pin — old + new hex-encoded client keys */
 export const encryptionChangePinRequestSchema = z.object({
   oldClientKey: hexKey64,

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "angular-architecture": {
       "source": "neogenz/skills",
       "sourceType": "github",
-      "computedHash": "d1169a26af4c5d9ac281ed6f4dfc18b83fd66ccf58aa95574e117248e41bd5cc"
+      "computedHash": "eca36e379b3e99a6a4f02258f22366ff1115fb2b3b7e5090981a386a23480d2a"
     },
     "angular-component": {
       "source": "analogjs/angular-skills",


### PR DESCRIPTION
## Summary

• POST `/encryption/verify-recovery-key` + shared Zod schema
• Web: verify dialog next to regenerate, i18n, `http-expected-business-noise` for PostHog/logger
• iOS: `VerifyRecoveryKeySheet`, API errors + endpoint
• Backend: encryption service + tests, Swagger DTO

## Type

feat

Made with [Cursor](https://cursor.com)