### PR TITLE
PUL-95: Prefetch budget list after onboarding + multi-platform improvements

### DIFF
--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
@@ -20,6 +20,7 @@ describe('ProfileSetupService', () => {
   let mockPostHogService: { enableTracking: ReturnType<typeof vi.fn> };
   let mockLogger: {
     info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
     error: ReturnType<typeof vi.fn>;
   };
 
@@ -58,6 +59,7 @@ describe('ProfileSetupService', () => {
 
     mockLogger = {
       info: vi.fn(),
+      warn: vi.fn(),
       error: vi.fn(),
     };
 

--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
@@ -14,6 +14,7 @@ describe('ProfileSetupService', () => {
   let mockApiClient: { post$: ReturnType<typeof vi.fn> };
   let mockBudgetApi: {
     createBudget$: ReturnType<typeof vi.fn>;
+    getAllBudgets$: ReturnType<typeof vi.fn>;
     cache: unknown;
   };
   let mockPostHogService: { enableTracking: ReturnType<typeof vi.fn> };
@@ -35,7 +36,20 @@ describe('ProfileSetupService', () => {
       createBudget$: vi
         .fn()
         .mockReturnValue(of({ budget: { id: 'budget-123' } })),
-      cache: { invalidate: vi.fn(), set: vi.fn(), clear: vi.fn() },
+      getAllBudgets$: vi
+        .fn()
+        .mockReturnValue(of([{ id: 'budget-123', remaining: 500 }])),
+      cache: {
+        invalidate: vi.fn(),
+        prefetch: vi
+          .fn()
+          .mockImplementation(
+            async (_key: string[], fn: () => Promise<unknown>) => {
+              await fn();
+            },
+          ),
+        clear: vi.fn(),
+      },
     };
 
     mockPostHogService = {
@@ -137,7 +151,7 @@ describe('ProfileSetupService', () => {
       );
     });
 
-    it('should set optimistic list cache with created budget', async () => {
+    it('should prefetch full budget list after create to align list amounts', async () => {
       const result = await service.createInitialBudget({
         firstName: 'Test',
         monthlyIncome: 3000,
@@ -145,8 +159,14 @@ describe('ProfileSetupService', () => {
 
       expect(result.success).toBe(true);
       expect(
-        (mockBudgetApi.cache as { set: ReturnType<typeof vi.fn> }).set,
-      ).toHaveBeenCalledWith(['budget', 'list'], [{ id: 'budget-123' }]);
+        (mockBudgetApi.cache as { invalidate: ReturnType<typeof vi.fn> })
+          .invalidate,
+      ).toHaveBeenCalledWith(['budget']);
+      expect(mockBudgetApi.getAllBudgets$).toHaveBeenCalled();
+      expect(
+        (mockBudgetApi.cache as { prefetch: ReturnType<typeof vi.fn> })
+          .prefetch,
+      ).toHaveBeenCalledWith(['budget', 'list'], expect.any(Function));
     });
 
     it('should handle year boundary and use period year in description', async () => {

--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.ts
@@ -73,11 +73,18 @@ export class ProfileSetupService {
         description: `Budget initial de ${profileData.firstName} pour ${year}`,
       };
 
-      const { budget } = await firstValueFrom(
-        this.#budgetApi.createBudget$(budgetRequest),
-      );
+      await firstValueFrom(this.#budgetApi.createBudget$(budgetRequest));
       this.#budgetApi.cache.invalidate(['budget']);
-      this.#budgetApi.cache.set(['budget', 'list'], [budget]);
+      await this.#budgetApi.cache
+        .prefetch(['budget', 'list'], () =>
+          firstValueFrom(this.#budgetApi.getAllBudgets$()),
+        )
+        .catch((error: unknown) => {
+          this.#logger.warn(
+            '[ProfileSetupService] Failed to prefetch budget list after onboarding',
+            error,
+          );
+        });
 
       // 3. Enable PostHog tracking (user has accepted terms)
       this.#postHogService.enableTracking();


### PR DESCRIPTION
## Summary

• **Frontend**: Prefetch full budget list after onboarding (PUL-95) — replaces incomplete cache entry with complete list via `invalidate(['budget'])` + `prefetch(['budget', 'list'], ...)`
• **iOS**: Accessibility improvements, typography tokens, form handling, keyboard toolbar for decimal pad
• **Backend**: Fix circular dependency in budget-list-store; invalidate server cache after template propagation
• **Test**: Add warn mock to Logger for error path coverage in profile-setup service
• **Chore**: Sync architecture rules to Cursor format, update skills

## Details

### Frontend (PUL-95)
- After `createBudget$()` succeeds, invalidate the `budget` cache prefix
- Prefetch full budget list with `getAllBudgets$()` to ensure list shows correct amounts
- `.catch()` handler gracefully degrades if prefetch fails; user keeps `success: true` after successful creation

### iOS
- Dynamic Type scaling for accessibility
- Updated design tokens (typography, spacing, colors)
- Form text field improvements
- Keyboard toolbar for PIN/currency inputs
- Privacy label corrections

### Backend
- Break circular dependency: budget-list-store now independent of budget-template-store
- Invalidate server cache after template propagation to ensure consistency

### Test
- Add missing `warn` mock to Logger test double (for prefetch error path)

## Type

feat + fix (cross-platform improvements)