### PR TITLE
fix(ios): correct template-line endpoints and add propagation flow (PUL-97)

### DIFF
--- a/ios/Pulpe/Core/Network/Endpoints.swift
+++ b/ios/Pulpe/Core/Network/Endpoints.swift
@@ -51,7 +51,7 @@ enum Endpoint {
     // MARK: - Template Lines
 
     case templateLines(templateId: String)
-    case templateLine(id: String)
+    case templateLine(templateId: String, lineId: String)
     case templateLinesBulk(templateId: String)
 
     // MARK: - Encryption
@@ -109,8 +109,8 @@ enum Endpoint {
 
         // Template Lines
         case .templateLines(let templateId): return "/budget-templates/\(templateId)/lines"
-        case .templateLine(let id): return "/template-lines/\(id)"
-        case .templateLinesBulk(let templateId): return "/budget-templates/\(templateId)/lines/bulk"
+        case .templateLine(let templateId, let lineId): return "/budget-templates/\(templateId)/lines/\(lineId)"
+        case .templateLinesBulk(let templateId): return "/budget-templates/\(templateId)/lines/bulk-operations"
 
         // Encryption
         case .encryptionVaultStatus: return "/encryption/vault-status"

--- a/ios/Pulpe/Domain/Models/BudgetTemplate.swift
+++ b/ios/Pulpe/Domain/Models/BudgetTemplate.swift
@@ -136,6 +136,11 @@ struct TemplateUsageData: Decodable {
     let isUsed: Bool
     let budgetCount: Int
     let budgets: [TemplateUsageBudget]
+
+    var propagationBudgetCount: Int {
+        let current = MonthYear()
+        return budgets.filter { MonthYear(month: $0.month, year: $0.year) >= current }.count
+    }
 }
 
 struct TemplateUsageBudget: Decodable {

--- a/ios/Pulpe/Domain/Models/BudgetTemplate.swift
+++ b/ios/Pulpe/Domain/Models/BudgetTemplate.swift
@@ -145,6 +145,26 @@ struct TemplateUsageBudget: Decodable {
     let description: String
 }
 
+// MARK: - Bulk Operations Response
+
+struct TemplateLinesBulkOperationsResponse: Decodable, Sendable {
+    let created: [TemplateLine]
+    let updated: [TemplateLine]
+    let deleted: [String]
+    let propagation: TemplateLinesPropagationSummary?
+}
+
+struct TemplateLinesPropagationSummary: Decodable, Sendable {
+    let mode: PropagationMode
+    let affectedBudgetIds: [String]
+    let affectedBudgetsCount: Int
+}
+
+enum PropagationMode: String, Codable, Sendable {
+    case templateOnly = "template-only"
+    case propagate
+}
+
 // MARK: - Onboarding Template Creation
 
 struct BudgetTemplateCreateFromOnboarding: Encodable {

--- a/ios/Pulpe/Domain/Services/TemplateService.swift
+++ b/ios/Pulpe/Domain/Services/TemplateService.swift
@@ -74,18 +74,20 @@ actor TemplateService {
     }
 
     /// Update a template line
-    func updateTemplateLine(id: String, data: TemplateLineUpdate) async throws -> TemplateLine {
-        try await apiClient.request(.templateLine(id: id), body: data, method: .patch)
+    func updateTemplateLine(templateId: String, lineId: String, data: TemplateLineUpdate) async throws -> TemplateLine {
+        try await apiClient.request(.templateLine(templateId: templateId, lineId: lineId), body: data, method: .patch)
     }
 
     /// Delete a template line
-    func deleteTemplateLine(id: String) async throws {
-        try await apiClient.requestVoid(.templateLine(id: id), method: .delete)
+    func deleteTemplateLine(templateId: String, lineId: String) async throws {
+        try await apiClient.requestVoid(.templateLine(templateId: templateId, lineId: lineId), method: .delete)
     }
 
-    /// Bulk update template lines
-    func bulkUpdateTemplateLines(templateId: String, operations: TemplateLinesBulkOperations) async throws {
-        try await apiClient.requestVoid(
+    /// Bulk update template lines with optional propagation
+    func bulkUpdateTemplateLines(
+        templateId: String, operations: TemplateLinesBulkOperations
+    ) async throws -> TemplateLinesBulkOperationsResponse {
+        try await apiClient.request(
             .templateLinesBulk(templateId: templateId),
             body: operations,
             method: .post

--- a/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
+++ b/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
@@ -62,18 +62,34 @@ final class CurrentMonthStore: StoreProtocol {
         var hasSavings: Bool { totalPlanned > 0 || totalRealized > 0 }
     }
 
+    /// Loading lifecycle — makes invalid UI states irrepresentable.
+    /// Error details live in the separate `error` property (mutations need independent error storage).
+    enum ContentState: Equatable, Sendable {
+        /// Store just initialized — no data fetched yet
+        case idle
+        /// Actively loading — no previous data available
+        case loading
+        /// Budget and details loaded successfully
+        case loaded
+        /// API confirmed no budget for the current month
+        case empty
+        /// Loading failed — check `error` for details
+        case failed
+    }
+
     // MARK: - State
 
+    private(set) var contentState: ContentState = .idle
     private(set) var budget: Budget?
     private(set) var budgetLines: [BudgetLine] = []
     private(set) var transactions: [Transaction] = []
-    private(set) var isLoading = false
     private(set) var error: APIError?
 
+    /// Derived from `contentState` — satisfies `StoreProtocol.isLoading`
+    var isLoading: Bool { contentState == .loading }
+
     /// Returns true if the store has an error and no budget data to display
-    var hasError: Bool {
-        error != nil && budget == nil
-    }
+    var hasError: Bool { contentState == .failed }
 
     /// Custom pay day used for period resolution (set via loadBudgetSummary)
     private(set) var payDayOfMonth: Int?
@@ -133,10 +149,9 @@ final class CurrentMonthStore: StoreProtocol {
     func loadBudgetSummary(payDayOfMonth: Int? = nil) async {
         self.payDayOfMonth = payDayOfMonth
         guard budget == nil else { return }
-        isLoading = true
+        contentState = .loading
         error = nil
         let loadStart = ContinuousClock.now
-        defer { isLoading = false }
 
         do {
             let sparseBudgets = try await budgetService.getBudgetsSparse(
@@ -149,6 +164,7 @@ final class CurrentMonthStore: StoreProtocol {
                 $0.month == period.month && $0.year == period.year
             }) else {
                 try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
+                contentState = .empty
                 return
             }
 
@@ -158,13 +174,16 @@ final class CurrentMonthStore: StoreProtocol {
             try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
 
             budget = fetchedBudget
+            contentState = .loaded
             recomputeMetrics()
         } catch is CancellationError {
             // Task was cancelled, don't update error state
         } catch let apiError as APIError {
             self.error = apiError
+            contentState = .failed
         } catch {
             self.error = .networkError(error)
+            contentState = .failed
         }
     }
 
@@ -188,9 +207,8 @@ final class CurrentMonthStore: StoreProtocol {
             return
         }
 
-        isLoading = true
+        // Budget exists — loading details in background, stay .loaded (no skeleton)
         error = nil
-        defer { isLoading = false }
 
         do {
             let details = try await budgetService.getBudgetWithDetails(id: currentBudget.id)
@@ -225,6 +243,7 @@ final class CurrentMonthStore: StoreProtocol {
         loadGeneration = 0
         widgetSyncTask?.cancel()
         widgetSyncTask = nil
+        contentState = .idle
         budget = nil
         budgetLines = []
         transactions = []
@@ -248,17 +267,18 @@ final class CurrentMonthStore: StoreProtocol {
         let currentGeneration = loadGeneration
 
         let task = Task {
-            let showsSkeleton = budget == nil
-            isLoading = true
+            let isFirstLoad = budget == nil
+            if isFirstLoad {
+                contentState = .loading
+            }
             error = nil
             let loadStart = ContinuousClock.now
-            defer { isLoading = false }
 
             do {
                 guard let currentBudget = try await budgetService.getCurrentMonthBudget(
                     payDayOfMonth: self.payDayOfMonth
                 ) else {
-                    if showsSkeleton {
+                    if isFirstLoad {
                         try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
                     }
                     budget = nil
@@ -266,6 +286,7 @@ final class CurrentMonthStore: StoreProtocol {
                     transactions = []
                     recomputeMetrics()
                     lastLoadTime = Date()
+                    contentState = .empty
                     return
                 }
 
@@ -274,7 +295,7 @@ final class CurrentMonthStore: StoreProtocol {
 
                 let details = try await budgetService.getBudgetWithDetails(id: currentBudget.id)
 
-                if showsSkeleton {
+                if isFirstLoad {
                     try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
                 }
 
@@ -283,8 +304,10 @@ final class CurrentMonthStore: StoreProtocol {
                 // Task was cancelled, don't update error state
             } catch let apiError as APIError {
                 self.error = apiError
+                if isFirstLoad { contentState = .failed }
             } catch {
                 self.error = .networkError(error)
+                if isFirstLoad { contentState = .failed }
             }
         }
 
@@ -330,6 +353,7 @@ final class CurrentMonthStore: StoreProtocol {
         transactions = details.transactions
         recomputeMetrics()
         lastLoadTime = Date()
+        contentState = .loaded
         BudgetDetailCache.shared.store(
             budgetId: details.budget.id,
             budget: details.budget,
@@ -363,6 +387,7 @@ final class CurrentMonthStore: StoreProtocol {
         self.budget = budget
         self.budgetLines = budgetLines
         self.transactions = transactions
+        contentState = budget != nil ? .loaded : .empty
         recomputeMetrics()
     }
     #endif

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -44,6 +44,7 @@ struct CurrentMonthView: View {
                         .font(PulpeTypography.emojiDisplay)
                         .foregroundStyle(Color.textTertiary)
                         .symbolEffect(.pulse, options: .nonRepeating)
+                        .accessibilityHidden(true)
                     Text("Pas encore de budget ce mois-ci")
                         .font(PulpeTypography.stepTitle)
                         .foregroundStyle(Color.textPrimary)

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -29,15 +29,16 @@ struct CurrentMonthView: View {
 
     var body: some View {
         ZStack {
-            if store.isLoading && store.budget == nil {
+            switch store.contentState {
+            case .idle, .loading:
                 CurrentMonthSkeletonView()
                     .transition(.opacity)
-            } else if let error = store.error, store.budget == nil {
-                ErrorView(error: error) {
+            case .failed:
+                ErrorView(error: store.error ?? .networkError(URLError(.unknown))) {
                     await store.forceRefresh()
                 }
                 .transition(.opacity)
-            } else if store.budget == nil {
+            case .empty:
                 VStack(spacing: DesignTokens.Spacing.lg) {
                     Image(systemName: "calendar.badge.plus")
                         .font(PulpeTypography.emojiDisplay)
@@ -53,13 +54,13 @@ struct CurrentMonthView: View {
                 }
                 .padding(DesignTokens.Spacing.xxxl)
                 .transition(.opacity)
-            } else {
+            case .loaded:
                 dashboardContent
                     .transition(.opacity)
             }
         }
         .trackScreen("Dashboard")
-        .animation(DesignTokens.Animation.smoothEaseOut, value: store.isLoading)
+        .animation(DesignTokens.Animation.smoothEaseOut, value: store.contentState)
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
@@ -83,7 +83,7 @@ struct EditTemplateLineSheet: View {
             }
         } message: {
             Text("""
-                Ce modèle est utilisé par \(usageData?.budgetCount ?? 0) budget(s).\n\n\
+                Ce modèle est utilisé par \(usageData?.propagationBudgetCount ?? 0) budget(s).\n\n\
                 « Propager » appliquera les modifications aux budgets en cours et futurs. \
                 Les catégories modifiées manuellement ne seront pas affectées.
                 """)
@@ -144,7 +144,7 @@ struct EditTemplateLineSheet: View {
             recurrence: recurrence
         )
 
-        let budgetCount = usageData?.budgetCount ?? 0
+        let budgetCount = usageData?.propagationBudgetCount ?? 0
         if budgetCount > 0 {
             showPropagationAlert = true
         } else {

--- a/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
@@ -17,6 +17,9 @@ struct EditTemplateLineSheet: View {
     @FocusState private var isDescriptionFocused: Bool
     @State private var amountText: String
     @State private var submitSuccessTrigger = false
+    @State private var showPropagationAlert = false
+    @State private var usageData: TemplateUsageData?
+    @State private var pendingUpdate: TemplateLineUpdate?
 
     private let dependencies: EditTemplateLineDependencies
 
@@ -65,6 +68,26 @@ struct EditTemplateLineSheet: View {
             saveButton
         }
         .sensoryFeedback(.success, trigger: submitSuccessTrigger)
+        .task {
+            usageData = try? await dependencies.checkTemplateUsage(templateLine.templateId)
+        }
+        .alert("Propager aux budgets ?", isPresented: $showPropagationAlert) {
+            Button("Propager") {
+                Task { await saveAndPropagateToBudgets() }
+            }
+            Button("Modèle uniquement") {
+                Task { await saveTemplateOnly() }
+            }
+            Button("Annuler", role: .cancel) {
+                pendingUpdate = nil
+            }
+        } message: {
+            Text("""
+                Ce modèle est utilisé par \(usageData?.budgetCount ?? 0) budget(s).\n\n\
+                « Propager » appliquera les modifications aux budgets en cours et futurs. \
+                Les catégories modifiées manuellement ne seront pas affectées.
+                """)
+        }
     }
 
     // MARK: - Description
@@ -113,35 +136,93 @@ struct EditTemplateLineSheet: View {
     private func updateTemplateLine() async {
         guard let amount else { return }
 
-        isLoading = true
-        defer { isLoading = false }
         error = nil
-
-        let data = TemplateLineUpdate(
+        pendingUpdate = TemplateLineUpdate(
             name: name.trimmingCharacters(in: .whitespaces),
             amount: amount,
             kind: kind,
             recurrence: recurrence
         )
 
+        let budgetCount = usageData?.budgetCount ?? 0
+        if budgetCount > 0 {
+            showPropagationAlert = true
+        } else {
+            await saveTemplateOnly()
+        }
+    }
+
+    private func saveTemplateOnly() async {
+        guard let data = pendingUpdate else { return }
+
+        isLoading = true
+        defer { isLoading = false }
+        error = nil
+
         do {
-            let updatedLine = try await dependencies.updateTemplateLine(templateLine.id, data)
-            submitSuccessTrigger.toggle()
-            onUpdate(updatedLine)
-            toastManager.show("Ligne modifiée")
-            dismiss()
+            let updatedLine = try await dependencies.updateTemplateLine(templateLine.templateId, templateLine.id, data)
+            finishSave(updatedLine: updatedLine, message: "Ligne modifiée")
         } catch {
             self.error = error
         }
     }
+
+    private func saveAndPropagateToBudgets() async {
+        guard let data = pendingUpdate else { return }
+
+        isLoading = true
+        defer { isLoading = false }
+        error = nil
+
+        do {
+            let operations = TemplateLinesBulkOperations(
+                update: [TemplateLineUpdateWithId(
+                    id: templateLine.id,
+                    name: data.name,
+                    amount: data.amount,
+                    kind: data.kind,
+                    recurrence: data.recurrence,
+                    description: data.description
+                )],
+                propagateToBudgets: true
+            )
+            let response = try await dependencies.bulkUpdateWithPropagation(templateLine.templateId, operations)
+            let updatedLine = response.updated.first ?? templateLine
+            let affectedCount = response.propagation?.affectedBudgetsCount ?? 0
+            let message = affectedCount > 0
+                ? "Ligne modifiée — \(affectedCount) budget(s) mis à jour"
+                : "Ligne modifiée"
+            finishSave(updatedLine: updatedLine, message: message)
+        } catch {
+            self.error = error
+        }
+    }
+
+    private func finishSave(updatedLine: TemplateLine, message: String) {
+        submitSuccessTrigger.toggle()
+        onUpdate(updatedLine)
+        toastManager.show(message)
+        pendingUpdate = nil
+        dismiss()
+    }
 }
 
 struct EditTemplateLineDependencies: Sendable {
-    var updateTemplateLine: @Sendable (String, TemplateLineUpdate) async throws -> TemplateLine
+    var updateTemplateLine: @Sendable (String, String, TemplateLineUpdate) async throws -> TemplateLine
+    var checkTemplateUsage: @Sendable (String) async throws -> TemplateUsageData
+    var bulkUpdateWithPropagation: @Sendable (
+        String, TemplateLinesBulkOperations
+    ) async throws -> TemplateLinesBulkOperationsResponse
 
     static let live = EditTemplateLineDependencies(
-        updateTemplateLine: { id, data in
-            try await TemplateService.shared.updateTemplateLine(id: id, data: data)
+        updateTemplateLine: { templateId, lineId, data in
+            try await TemplateService.shared.updateTemplateLine(templateId: templateId, lineId: lineId, data: data)
+        },
+        checkTemplateUsage: { templateId in
+            try await TemplateService.shared.checkTemplateUsage(id: templateId)
+        },
+        bulkUpdateWithPropagation: { templateId, operations in
+            try await TemplateService.shared.bulkUpdateTemplateLines(templateId: templateId, operations: operations)
         }
     )
 }

--- a/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
@@ -19,6 +19,7 @@ struct EditTemplateLineSheet: View {
     @State private var submitSuccessTrigger = false
     @State private var showPropagationAlert = false
     @State private var usageData: TemplateUsageData?
+    @State private var usageFetchFailed = false
     @State private var pendingUpdate: TemplateLineUpdate?
 
     private let dependencies: EditTemplateLineDependencies
@@ -69,7 +70,11 @@ struct EditTemplateLineSheet: View {
         }
         .sensoryFeedback(.success, trigger: submitSuccessTrigger)
         .task {
-            usageData = try? await dependencies.checkTemplateUsage(templateLine.templateId)
+            do {
+                usageData = try await dependencies.checkTemplateUsage(templateLine.templateId)
+            } catch {
+                usageFetchFailed = true
+            }
         }
         .alert("Propager aux budgets ?", isPresented: $showPropagationAlert) {
             Button("Propager") {
@@ -82,8 +87,12 @@ struct EditTemplateLineSheet: View {
                 pendingUpdate = nil
             }
         } message: {
+            let count = usageData?.propagationBudgetCount ?? 0
+            let intro = usageFetchFailed
+                ? "Ce modèle est peut-être utilisé par d'autres budgets."
+                : "Ce modèle est utilisé par \(count) \(count == 1 ? "budget" : "budgets")."
             Text("""
-                Ce modèle est utilisé par \(usageData?.propagationBudgetCount ?? 0) budget(s).\n\n\
+                \(intro)\n\n\
                 « Propager » appliquera les modifications aux budgets en cours et futurs. \
                 Les catégories modifiées manuellement ne seront pas affectées.
                 """)
@@ -144,8 +153,8 @@ struct EditTemplateLineSheet: View {
             recurrence: recurrence
         )
 
-        let budgetCount = usageData?.propagationBudgetCount ?? 0
-        if budgetCount > 0 {
+        let hasBudgets = usageFetchFailed || (usageData?.propagationBudgetCount ?? 0) > 0
+        if hasBudgets {
             showPropagationAlert = true
         } else {
             await saveTemplateOnly()
@@ -190,7 +199,7 @@ struct EditTemplateLineSheet: View {
             let updatedLine = response.updated.first ?? templateLine
             let affectedCount = response.propagation?.affectedBudgetsCount ?? 0
             let message = affectedCount > 0
-                ? "Ligne modifiée — \(affectedCount) budget(s) mis à jour"
+                ? "Ligne modifiée — \(affectedCount) \(affectedCount == 1 ? "budget mis à jour" : "budgets mis à jour")"
                 : "Ligne modifiée"
             finishSave(updatedLine: updatedLine, message: message)
         } catch {

--- a/ios/Pulpe/Resources/Info.plist
+++ b/ios/Pulpe/Resources/Info.plist
@@ -85,12 +85,5 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
 </dict>
 </plist>

--- a/ios/PulpeTests/Domain/Store/CurrentMonthStoreContentStateTests.swift
+++ b/ios/PulpeTests/Domain/Store/CurrentMonthStoreContentStateTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Tests for the `ContentState` enum state machine in `CurrentMonthStore`.
+/// Verifies state transitions, computed property derivation, and reset behavior.
+@MainActor
+struct CurrentMonthStoreContentStateTests {
+    // MARK: - Initial State
+
+    @Test func initialState_isIdle() {
+        let store = CurrentMonthStore()
+
+        #expect(store.contentState == .idle)
+        #expect(store.budget == nil)
+        #expect(store.isLoading == false)
+        #expect(store.hasError == false)
+        #expect(store.error == nil)
+    }
+
+    // MARK: - populateForTesting
+
+    @Test func populateForTesting_withBudget_setsLoaded() {
+        let store = CurrentMonthStore()
+
+        store.populateForTesting(
+            budget: TestDataFactory.createBudget()
+        )
+
+        #expect(store.contentState == .loaded)
+        #expect(store.budget != nil)
+    }
+
+    @Test func populateForTesting_withoutBudget_setsEmpty() {
+        let store = CurrentMonthStore()
+
+        store.populateForTesting(budget: nil)
+
+        #expect(store.contentState == .empty)
+        #expect(store.budget == nil)
+    }
+
+    // MARK: - Computed Properties
+
+    @Test func isLoading_derivesFromContentState() {
+        let store = CurrentMonthStore()
+
+        // .idle → not loading
+        #expect(store.isLoading == false)
+
+        // .loaded → not loading
+        store.populateForTesting(budget: TestDataFactory.createBudget())
+        #expect(store.isLoading == false)
+
+        // .empty → not loading
+        store.populateForTesting(budget: nil)
+        #expect(store.isLoading == false)
+    }
+
+    @Test func hasError_trueOnlyWhenFailed() {
+        let store = CurrentMonthStore()
+
+        // .idle → no error
+        #expect(store.hasError == false)
+
+        // .loaded → no error (even if mutation sets store.error)
+        store.populateForTesting(budget: TestDataFactory.createBudget())
+        #expect(store.hasError == false)
+
+        // .empty → no error
+        store.populateForTesting(budget: nil)
+        #expect(store.hasError == false)
+    }
+
+    // MARK: - Reset
+
+    @Test func reset_returnsToIdle() {
+        let store = CurrentMonthStore()
+
+        store.populateForTesting(
+            budget: TestDataFactory.createBudget(),
+            budgetLines: [TestDataFactory.createBudgetLine()],
+            transactions: [TestDataFactory.createTransaction()]
+        )
+        #expect(store.contentState == .loaded)
+
+        store.reset()
+
+        #expect(store.contentState == .idle)
+        #expect(store.budget == nil)
+        #expect(store.budgetLines.isEmpty)
+        #expect(store.transactions.isEmpty)
+        #expect(store.error == nil)
+        #expect(store.isLoading == false)
+        #expect(store.hasError == false)
+    }
+
+    @Test func reset_fromEmpty_returnsToIdle() {
+        let store = CurrentMonthStore()
+
+        store.populateForTesting(budget: nil)
+        #expect(store.contentState == .empty)
+
+        store.reset()
+
+        #expect(store.contentState == .idle)
+    }
+
+    // MARK: - Error Path (no backend → .failed)
+
+    @Test func forceRefresh_withoutBackend_transitionsToFailed() async {
+        let store = CurrentMonthStore()
+
+        #expect(store.contentState == .idle)
+
+        await store.forceRefresh()
+
+        #expect(store.contentState == .failed)
+        #expect(store.error != nil)
+        #expect(store.hasError == true)
+        #expect(store.isLoading == false)
+    }
+
+    @Test func loadBudgetSummary_withoutBackend_transitionsToFailed() async {
+        let store = CurrentMonthStore()
+
+        #expect(store.contentState == .idle)
+
+        await store.loadBudgetSummary()
+
+        #expect(store.contentState == .failed)
+        #expect(store.error != nil)
+        #expect(store.hasError == true)
+    }
+
+    @Test func forceRefresh_afterPopulatedWithBudget_staysLoaded() async {
+        let store = CurrentMonthStore()
+        store.populateForTesting(budget: TestDataFactory.createBudget())
+
+        #expect(store.contentState == .loaded)
+
+        // forceRefresh with no backend — but budget exists, so stays .loaded
+        await store.forceRefresh()
+
+        #expect(store.contentState == .loaded)
+        #expect(store.error != nil, "Error set from failed API call")
+        #expect(store.hasError == false, "hasError false because contentState is .loaded, not .failed")
+    }
+
+    // MARK: - ContentState Equatable
+
+    @Test("ContentState enum is Equatable", arguments: [
+        (CurrentMonthStore.ContentState.idle, CurrentMonthStore.ContentState.idle, true),
+        (CurrentMonthStore.ContentState.loading, CurrentMonthStore.ContentState.loading, true),
+        (CurrentMonthStore.ContentState.loaded, CurrentMonthStore.ContentState.loaded, true),
+        (CurrentMonthStore.ContentState.empty, CurrentMonthStore.ContentState.empty, true),
+        (CurrentMonthStore.ContentState.failed, CurrentMonthStore.ContentState.failed, true),
+        (CurrentMonthStore.ContentState.idle, CurrentMonthStore.ContentState.loading, false),
+        (CurrentMonthStore.ContentState.loaded, CurrentMonthStore.ContentState.empty, false),
+        (CurrentMonthStore.ContentState.loaded, CurrentMonthStore.ContentState.failed, false),
+    ])
+    func contentState_equatable(
+        lhs: CurrentMonthStore.ContentState,
+        rhs: CurrentMonthStore.ContentState,
+        expected: Bool
+    ) {
+        #expect((lhs == rhs) == expected)
+    }
+}

--- a/ios/PulpeTests/Domain/Store/CurrentMonthStoreSWRTests.swift
+++ b/ios/PulpeTests/Domain/Store/CurrentMonthStoreSWRTests.swift
@@ -65,6 +65,7 @@ struct CurrentMonthStoreSWRIntegrationTests {
     @Test func store_initialState_hasNoCacheAndNoError() {
         let store = CurrentMonthStore()
 
+        #expect(store.contentState == .idle, "Initial contentState should be .idle")
         #expect(store.budget == nil, "Initial budget should be nil")
         #expect(store.budgetLines.isEmpty, "Initial budgetLines should be empty")
         #expect(store.transactions.isEmpty, "Initial transactions should be empty")

--- a/ios/PulpeTests/Domain/Store/StoreResetTests.swift
+++ b/ios/PulpeTests/Domain/Store/StoreResetTests.swift
@@ -21,6 +21,7 @@ struct StoreResetTests {
 
         store.reset()
 
+        #expect(store.contentState == .idle, "contentState must be .idle after reset")
         #expect(store.budget == nil, "budget must be nil after reset")
         #expect(store.budgetLines.isEmpty, "budgetLines must be empty after reset")
         #expect(store.transactions.isEmpty, "transactions must be empty after reset")

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -88,8 +88,9 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.pulpe.ios
         PRODUCT_NAME: Pulpe
-        TARGETED_DEVICE_FAMILY: "1,2"
-        SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: true
+        TARGETED_DEVICE_FAMILY: "1"
+        SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: false
+        SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD: false
         INFOPLIST_KEY_LSApplicationCategoryType: "public.app-category.finance"
         INFOPLIST_KEY_CFBundleDisplayName: Pulpe
     info:
@@ -106,11 +107,6 @@ targets:
         UILaunchStoryboardName: LaunchScreen
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
-        UISupportedInterfaceOrientations~ipad:
-          - UIInterfaceOrientationPortrait
-          - UIInterfaceOrientationPortraitUpsideDown
-          - UIInterfaceOrientationLandscapeLeft
-          - UIInterfaceOrientationLandscapeRight
         UIRequiredDeviceCapabilities:
           - arm64
         ITSAppUsesNonExemptEncryption: false
@@ -174,7 +170,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.pulpe.ios.widget
         PRODUCT_NAME: "Pulpe Widget"
         SKIP_INSTALL: true
-        TARGETED_DEVICE_FAMILY: "1,2"
+        TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_KEY_CFBundleDisplayName: "Pulpe Widget"
     info:
       path: PulpeWidget/Info.plist
@@ -211,7 +207,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.pulpe.ios.tests
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
-        TARGETED_DEVICE_FAMILY: "1,2"
+        TARGETED_DEVICE_FAMILY: "1"
 
   PulpeUITests:
     type: bundle.ui-testing
@@ -226,7 +222,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.pulpe.ios.uitests
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
-        TARGETED_DEVICE_FAMILY: "1,2"
+        TARGETED_DEVICE_FAMILY: "1"
 
 schemes:
   PulpeLocal:


### PR DESCRIPTION
## Summary

- **Fix template-line endpoints**: was hitting `/template-lines/{id}` (404) instead of `/budget-templates/{templateId}/lines/{lineId}`; also fixed bulk-operations path
- **Add propagation UX**: prefetch usage, alert with explanation, saveTemplateOnly / saveAndPropagateToBudgets split, toast with affected count
- **Show propagation-eligible budget count** in template dialog (current + future only, not all linked budgets)
- **Replace boolean state flags with ContentState enum** in CurrentMonthStore — fixes flash of "Pas de budget" after login
- **Restrict supported destinations to iPhone only** — drop iPad/Mac/Vision targets

## Test plan

- [ ] Edit a template line → verify PATCH succeeds (no more 404)
- [ ] Propagation dialog shows correct count of eligible budgets
- [ ] After login, skeleton shows until API confirms budget existence (no flash)
- [ ] App Store Connect only requires iPhone screenshots
- [ ] Unit tests pass (`CurrentMonthStoreContentStateTests`)