### PR TITLE
fix(ios): fix PIN dots pulse animation and skeleton layout leak

### DIFF
--- a/ios/Pulpe/Core/Network/APIError.swift
+++ b/ios/Pulpe/Core/Network/APIError.swift
@@ -79,6 +79,15 @@ enum APIError: LocalizedError {
         }
     }
 
+    /// URLSession cancellation (Code=-999) is thrown as NSError, not Swift CancellationError.
+    var isCancellation: Bool {
+        if case .networkError(let inner) = self {
+            let nsError = inner as NSError
+            return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+        }
+        return false
+    }
+
     private static let codeMapping: [String: APIError] = [
         "ERR_BUDGET_ALREADY_EXISTS": .budgetAlreadyExists,
         "ERR_TEMPLATE_NOT_FOUND": .templateNotFound,
@@ -106,5 +115,19 @@ enum APIError: LocalizedError {
         }
 
         return .serverError(message: message ?? code)
+    }
+}
+
+extension NSError {
+    var isURLCancellation: Bool {
+        domain == NSURLErrorDomain && code == NSURLErrorCancelled
+    }
+}
+
+extension Error {
+    /// Returns true for Swift CancellationError OR URLSession cancellation (Code=-999).
+    var isCancellationOrURLCancellation: Bool {
+        self is CancellationError || (self as? APIError)?.isCancellation == true ||
+            (self as NSError).isURLCancellation
     }
 }

--- a/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
+++ b/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
@@ -216,8 +216,8 @@ final class CurrentMonthStore: StoreProtocol {
         }
 
         guard let currentBudget = budget else {
-            // Initial load is PulpeApp.task's job — don't compete
-            guard contentState != .idle && contentState != .loading else { return }
+            // No budget loaded — skip if already loading, otherwise trigger a full load
+            guard contentState != .loading else { return }
             await forceRefresh()
             return
         }

--- a/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
+++ b/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
@@ -142,10 +142,10 @@ final class CurrentMonthStore: StoreProtocol {
         self.widgetSyncService = widgetSyncService
     }
 
-    // MARK: - Smart Loading (StoreProtocol)
+    // MARK: - Loading
 
-    /// Lightweight loading: only fetches budget summary via GET /budgets
-    /// Use this at app startup to quickly enable the "+" button
+    /// Primary startup loader — called once by PulpeApp.task after auth.
+    /// Resolves the current budget period, loads budget + details in one pass.
     func loadBudgetSummary(payDayOfMonth: Int? = nil) async {
         self.payDayOfMonth = payDayOfMonth
 
@@ -186,14 +186,12 @@ final class CurrentMonthStore: StoreProtocol {
 
             try Task.checkCancellation()
 
-            let fetchedBudget = try await budgetService.getBudget(id: match.id)
+            let details = try await budgetService.getBudgetWithDetails(id: match.id)
             try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
 
-            budget = fetchedBudget
-            contentState = .loaded
-            recomputeMetrics()
-        } catch is CancellationError {
-            // Task was cancelled, don't update error state
+            applyDetails(details)
+        } catch where error.isCancellationOrURLCancellation {
+            // Task or URLSession cancellation — silently absorb
         } catch let apiError as APIError {
             self.error = apiError
             contentState = .failed
@@ -218,7 +216,8 @@ final class CurrentMonthStore: StoreProtocol {
         }
 
         guard let currentBudget = budget else {
-            // No budget summary loaded yet, load everything
+            // Initial load is PulpeApp.task's job — don't compete
+            guard contentState != .idle && contentState != .loading else { return }
             await forceRefresh()
             return
         }
@@ -229,8 +228,8 @@ final class CurrentMonthStore: StoreProtocol {
         do {
             let details = try await budgetService.getBudgetWithDetails(id: currentBudget.id)
             applyDetails(details)
-        } catch is CancellationError {
-            // Task was cancelled, don't update error state
+        } catch where error.isCancellationOrURLCancellation {
+            // Task or URLSession cancellation — silently absorb
         } catch let apiError as APIError {
             self.error = apiError
         } catch {
@@ -250,6 +249,7 @@ final class CurrentMonthStore: StoreProtocol {
 
     func loadIfNeeded() async {
         guard !isCacheValid else { return }
+        guard contentState != .loading else { return }
         await forceRefresh()
     }
 
@@ -273,6 +273,13 @@ final class CurrentMonthStore: StoreProtocol {
         cachedSavingsSummary = nil
         error = nil
         BudgetDetailCache.shared.invalidateAll()
+    }
+
+    /// Clears stale error state before a new load cycle — prevents brief error flash on view (re-)entry
+    func prepareForReload() {
+        guard contentState == .failed else { return }
+        contentState = .idle
+        error = nil
     }
 
     func forceRefresh() async {
@@ -316,8 +323,8 @@ final class CurrentMonthStore: StoreProtocol {
                 }
 
                 applyDetails(details)
-            } catch is CancellationError {
-                // Task was cancelled, don't update error state
+            } catch where error.isCancellationOrURLCancellation {
+                // Task or URLSession cancellation — silently absorb
             } catch let apiError as APIError {
                 self.error = apiError
                 if isFirstLoad { contentState = .failed }

--- a/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
+++ b/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
@@ -191,12 +191,9 @@ final class CurrentMonthStore: StoreProtocol {
 
             applyDetails(details)
         } catch where error.isCancellationOrURLCancellation {
-            // Task or URLSession cancellation — silently absorb
-        } catch let apiError as APIError {
-            self.error = apiError
-            contentState = .failed
+            if contentState == .loading { contentState = .idle }
         } catch {
-            self.error = .networkError(error)
+            self.error = (error as? APIError) ?? .networkError(error)
             contentState = .failed
         }
     }
@@ -229,11 +226,9 @@ final class CurrentMonthStore: StoreProtocol {
             let details = try await budgetService.getBudgetWithDetails(id: currentBudget.id)
             applyDetails(details)
         } catch where error.isCancellationOrURLCancellation {
-            // Task or URLSession cancellation — silently absorb
-        } catch let apiError as APIError {
-            self.error = apiError
+            // silently absorb
         } catch {
-            self.error = .networkError(error)
+            self.error = (error as? APIError) ?? .networkError(error)
         }
     }
 
@@ -283,60 +278,53 @@ final class CurrentMonthStore: StoreProtocol {
     }
 
     func forceRefresh() async {
-        // Cancel any existing load task to avoid duplicate requests
         loadTask?.cancel()
-
         loadGeneration += 1
         let currentGeneration = loadGeneration
-
-        let task = Task {
-            let isFirstLoad = budget == nil
-            if isFirstLoad {
-                contentState = .loading
-            }
-            error = nil
-            let loadStart = ContinuousClock.now
-
-            do {
-                guard let currentBudget = try await budgetService.getCurrentMonthBudget(
-                    payDayOfMonth: self.payDayOfMonth
-                ) else {
-                    if isFirstLoad {
-                        try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
-                    }
-                    budget = nil
-                    budgetLines = []
-                    transactions = []
-                    recomputeMetrics()
-                    lastLoadTime = Date()
-                    contentState = .empty
-                    return
-                }
-
-                // Check for cancellation before expensive network call
-                try Task.checkCancellation()
-
-                let details = try await budgetService.getBudgetWithDetails(id: currentBudget.id)
-
-                if isFirstLoad {
-                    try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
-                }
-
-                applyDetails(details)
-            } catch where error.isCancellationOrURLCancellation {
-                // Task or URLSession cancellation — silently absorb
-            } catch let apiError as APIError {
-                self.error = apiError
-                if isFirstLoad { contentState = .failed }
-            } catch {
-                self.error = .networkError(error)
-                if isFirstLoad { contentState = .failed }
-            }
-        }
-
+        let task = Task { await performRefresh() }
         loadTask = task
         await task.value
         if loadGeneration == currentGeneration { loadTask = nil }
+    }
+
+    private func performRefresh() async {
+        let isFirstLoad = budget == nil
+        if isFirstLoad {
+            contentState = .loading
+        }
+        error = nil
+        let loadStart = ContinuousClock.now
+
+        do {
+            guard let currentBudget = try await budgetService.getCurrentMonthBudget(
+                payDayOfMonth: self.payDayOfMonth
+            ) else {
+                if isFirstLoad {
+                    try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
+                }
+                budget = nil
+                budgetLines = []
+                transactions = []
+                recomputeMetrics()
+                lastLoadTime = Date()
+                contentState = .empty
+                return
+            }
+
+            try Task.checkCancellation()
+            let details = try await budgetService.getBudgetWithDetails(id: currentBudget.id)
+
+            if isFirstLoad {
+                try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
+            }
+
+            applyDetails(details)
+        } catch where error.isCancellationOrURLCancellation {
+            if contentState == .loading { contentState = .idle }
+        } catch {
+            self.error = (error as? APIError) ?? .networkError(error)
+            if isFirstLoad { contentState = .failed }
+        }
     }
 
     // MARK: - Widget Sync

--- a/ios/Pulpe/Features/Auth/Pin/Components/PinDotsView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/Components/PinDotsView.swift
@@ -7,6 +7,7 @@ struct PinDotsView: View {
     var isValidating: Bool = false
 
     @State private var shakeOffset: CGFloat = 0
+    @State private var pulseScale: CGFloat = 1.0
 
     var body: some View {
         HStack(spacing: DesignTokens.Spacing.lg) {
@@ -16,18 +17,25 @@ struct PinDotsView: View {
                     .fill(dotColor(at: index))
                     .frame(width: DesignTokens.Numpad.dotSize, height: DesignTokens.Numpad.dotSize)
                     .scaleEffect(isFilled ? 1.0 : 0.7)
-                    .phaseAnimator(
-                        isValidating && isFilled ? [false, true] : [false]
-                    ) { content, pulsing in
-                        content.scaleEffect(pulsing ? 0.7 : 1.0)
-                    } animation: { _ in
-                        .easeInOut(duration: DesignTokens.Animation.pulseDuration)
-                    }
-                    .animation(.spring(response: 0.2, dampingFraction: 0.7), value: enteredCount)
+                    .animation(.spring(response: 0.2, dampingFraction: 0.7), value: isFilled)
+                    .scaleEffect(isValidating && isFilled ? pulseScale : 1.0)
             }
         }
         .offset(x: shakeOffset)
         .accessibilityHidden(true)
+        .onChange(of: isValidating) { _, validating in
+            if validating {
+                let pulse = Animation.easeInOut(duration: DesignTokens.Animation.pulseDuration)
+                    .repeatForever(autoreverses: true)
+                withAnimation(pulse) {
+                    pulseScale = 0.7
+                }
+            } else {
+                withAnimation(.spring(response: 0.2, dampingFraction: 0.7)) {
+                    pulseScale = 1.0
+                }
+            }
+        }
         .onChange(of: isError) { _, newValue in
             guard newValue else { return }
             withAnimation(.easeInOut(duration: 0.08).repeatCount(5, autoreverses: true)) {

--- a/ios/Pulpe/Features/Auth/Pin/Components/PinDotsView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/Components/PinDotsView.swift
@@ -8,6 +8,7 @@ struct PinDotsView: View {
 
     @State private var shakeOffset: CGFloat = 0
     @State private var pulseScale: CGFloat = 1.0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         HStack(spacing: DesignTokens.Spacing.lg) {
@@ -24,10 +25,9 @@ struct PinDotsView: View {
         .offset(x: shakeOffset)
         .accessibilityHidden(true)
         .onChange(of: isValidating) { _, validating in
+            guard !reduceMotion else { return }
             if validating {
-                let pulse = Animation.easeInOut(duration: DesignTokens.Animation.pulseDuration)
-                    .repeatForever(autoreverses: true)
-                withAnimation(pulse) {
+                withAnimation(DesignTokens.Animation.pulse) {
                     pulseScale = 0.7
                 }
             } else {
@@ -38,6 +38,7 @@ struct PinDotsView: View {
         }
         .onChange(of: isError) { _, newValue in
             guard newValue else { return }
+            guard !reduceMotion else { return }
             withAnimation(.easeInOut(duration: 0.08).repeatCount(5, autoreverses: true)) {
                 shakeOffset = 10
             } completion: {

--- a/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
@@ -193,7 +193,8 @@ final class PinEntryViewModel {
                 clientKeyManager: clientKeyManager
             )
 
-            // Ensure at least one full pulse cycle is visible
+            // Ensure at least one full pulse cycle is visible.
+            // try?: PIN already verified — don't block auth if task is cancelled.
             let elapsed = ContinuousClock.now - validationStart
             let minimumPulseTime: Duration = .seconds(DesignTokens.Animation.pulseDuration)
             if elapsed < minimumPulseTime {

--- a/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
@@ -195,7 +195,7 @@ final class PinEntryViewModel {
 
             // Ensure at least one full pulse cycle is visible
             let elapsed = ContinuousClock.now - validationStart
-            let minimumPulseTime: Duration = .milliseconds(600)
+            let minimumPulseTime: Duration = .seconds(DesignTokens.Animation.pulseDuration)
             if elapsed < minimumPulseTime {
                 try? await Task.sleep(for: minimumPulseTime - elapsed)
             }

--- a/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/PinEntryView.swift
@@ -182,6 +182,7 @@ final class PinEntryViewModel {
     private func validatePin() async {
         defer { isValidating = false }
 
+        let validationStart = ContinuousClock.now
         let pin = digits.map(String.init).joined()
 
         do {
@@ -192,7 +193,13 @@ final class PinEntryViewModel {
                 clientKeyManager: clientKeyManager
             )
 
-            digits = []
+            // Ensure at least one full pulse cycle is visible
+            let elapsed = ContinuousClock.now - validationStart
+            let minimumPulseTime: Duration = .milliseconds(600)
+            if elapsed < minimumPulseTime {
+                try? await Task.sleep(for: minimumPulseTime - elapsed)
+            }
+
             hapticSuccess.toggle()
             AnalyticsService.shared.capture(.pinEntered)
             authenticated = true

--- a/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
@@ -371,16 +371,13 @@ struct BudgetLineRow: View {
     }
 
     private var progressBar: some View {
-        GeometryReader { geo in
-            ZStack(alignment: .leading) {
-                Rectangle()
-                    .fill(Color.progressTrack)
+        ZStack {
+            Rectangle()
+                .fill(Color.progressTrack)
 
-                Rectangle()
-                    .fill(consumptionColor)
-                    .frame(width: geo.size.width * CGFloat(min(consumption.percentage / 100, 1)))
-                    .animation(DesignTokens.Animation.gentleSpring, value: consumption.percentage)
-            }
+            ProgressBarShape(progress: CGFloat(min(consumption.percentage / 100, 1)))
+                .fill(consumptionColor)
+                .animation(DesignTokens.Animation.gentleSpring, value: consumption.percentage)
         }
         .frame(height: DesignTokens.ProgressBar.height)
         .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.progressBar))

--- a/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/BudgetSection.swift
@@ -370,21 +370,20 @@ struct BudgetLineRow: View {
         .opacity(line.isVirtualRollover ? 0.6 : 1)
     }
 
-    @State private var barWidth: CGFloat = 0
-
     private var progressBar: some View {
-        ZStack(alignment: .leading) {
-            Rectangle()
-                .fill(Color.progressTrack)
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .fill(Color.progressTrack)
 
-            Rectangle()
-                .fill(consumptionColor)
-                .frame(width: barWidth * CGFloat(min(consumption.percentage / 100, 1)))
-                .animation(DesignTokens.Animation.gentleSpring, value: consumption.percentage)
+                Rectangle()
+                    .fill(consumptionColor)
+                    .frame(width: geo.size.width * CGFloat(min(consumption.percentage / 100, 1)))
+                    .animation(DesignTokens.Animation.gentleSpring, value: consumption.percentage)
+            }
         }
         .frame(height: DesignTokens.ProgressBar.height)
         .clipShape(.rect(cornerRadius: DesignTokens.CornerRadius.progressBar))
-        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { barWidth = $0 }
     }
 
     private func handleLongPress() {

--- a/ios/Pulpe/Features/CurrentMonth/Components/HeroBalanceCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/HeroBalanceCard.swift
@@ -276,7 +276,7 @@ struct HeroBalanceCard: View {
                 .fill(.white.opacity(0.2))
 
             ProgressBarShape(progress: fillPercentage)
-                .fill(.white)
+                .fill(Color.white)
                 .animation(DesignTokens.Animation.smoothEaseInOut, value: fillPercentage)
         }
         .frame(height: DesignTokens.ProgressBar.heroHeight)

--- a/ios/Pulpe/Features/CurrentMonth/Components/HeroBalanceCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/HeroBalanceCard.swift
@@ -270,20 +270,19 @@ struct HeroBalanceCard: View {
 
     // MARK: - Progress Bar with Pace Indicator
 
-    @State private var barWidth: CGFloat = 0
-
     private var progressBar: some View {
-        ZStack(alignment: .leading) {
-            Capsule()
-                .fill(.white.opacity(0.2))
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(.white.opacity(0.2))
 
-            Capsule()
-                .fill(.white)
-                .frame(width: barWidth * fillPercentage)
-                .animation(DesignTokens.Animation.smoothEaseInOut, value: fillPercentage)
+                Capsule()
+                    .fill(.white)
+                    .frame(width: geo.size.width * fillPercentage)
+                    .animation(DesignTokens.Animation.smoothEaseInOut, value: fillPercentage)
+            }
         }
         .frame(height: DesignTokens.ProgressBar.heroHeight)
-        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { barWidth = $0 }
     }
 
     // MARK: - Card Background

--- a/ios/Pulpe/Features/CurrentMonth/Components/HeroBalanceCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/HeroBalanceCard.swift
@@ -271,16 +271,13 @@ struct HeroBalanceCard: View {
     // MARK: - Progress Bar with Pace Indicator
 
     private var progressBar: some View {
-        GeometryReader { geo in
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(.white.opacity(0.2))
+        ZStack {
+            Capsule()
+                .fill(.white.opacity(0.2))
 
-                Capsule()
-                    .fill(.white)
-                    .frame(width: geo.size.width * fillPercentage)
-                    .animation(DesignTokens.Animation.smoothEaseInOut, value: fillPercentage)
-            }
+            ProgressBarShape(progress: fillPercentage)
+                .fill(.white)
+                .animation(DesignTokens.Animation.smoothEaseInOut, value: fillPercentage)
         }
         .frame(height: DesignTokens.ProgressBar.heroHeight)
     }

--- a/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
@@ -10,7 +10,6 @@ struct LinkedTransactionsSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.amountsHidden) private var amountsHidden
-    @State private var progressBarWidth: CGFloat = 0
 
     private var consumption: BudgetFormulas.Consumption {
         BudgetFormulas.calculateConsumption(for: budgetLine, transactions: transactions)
@@ -143,16 +142,17 @@ struct LinkedTransactionsSheet: View {
                     .foregroundStyle(progressColor)
             }
 
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(Color.progressTrack)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.progressTrack)
 
-                Capsule()
-                    .fill(progressColor)
-                    .frame(width: progressBarWidth * CGFloat(min(consumption.percentage / 100, 1)))
+                    Capsule()
+                        .fill(progressColor)
+                        .frame(width: geo.size.width * CGFloat(min(consumption.percentage / 100, 1)))
+                }
             }
             .frame(height: DesignTokens.ProgressBar.thickHeight)
-            .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { progressBarWidth = $0 }
         }
         .padding(DesignTokens.Spacing.lg)
         .pulpeCardBackground()

--- a/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/LinkedTransactionsSheet.swift
@@ -142,15 +142,12 @@ struct LinkedTransactionsSheet: View {
                     .foregroundStyle(progressColor)
             }
 
-            GeometryReader { geo in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.progressTrack)
+            ZStack {
+                Capsule()
+                    .fill(Color.progressTrack)
 
-                    Capsule()
-                        .fill(progressColor)
-                        .frame(width: geo.size.width * CGFloat(min(consumption.percentage / 100, 1)))
-                }
+                ProgressBarShape(progress: CGFloat(min(consumption.percentage / 100, 1)))
+                    .fill(progressColor)
             }
             .frame(height: DesignTokens.ProgressBar.thickHeight)
         }

--- a/ios/Pulpe/Features/CurrentMonth/Components/SavingsSummaryCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/SavingsSummaryCard.swift
@@ -62,16 +62,13 @@ struct SavingsSummaryCard: View {
             }
 
             // Progress bar
-            GeometryReader { geo in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.progressTrack)
+            ZStack {
+                Capsule()
+                    .fill(Color.progressTrack)
 
-                    Capsule()
-                        .fill(Color.financialSavings)
-                        .frame(width: geo.size.width * CGFloat(max(0, min(summary.progressPercentage / 100, 1))))
-                        .animation(DesignTokens.Animation.gentleSpring, value: summary.progressPercentage)
-                }
+                ProgressBarShape(progress: CGFloat(max(0, min(summary.progressPercentage / 100, 1))))
+                    .fill(Color.financialSavings)
+                    .animation(DesignTokens.Animation.gentleSpring, value: summary.progressPercentage)
             }
             .frame(height: DesignTokens.ProgressBar.thickHeight)
 

--- a/ios/Pulpe/Features/CurrentMonth/Components/SavingsSummaryCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/SavingsSummaryCard.swift
@@ -5,7 +5,6 @@ struct SavingsSummaryCard: View {
     let summary: CurrentMonthStore.SavingsSummary
 
     @Environment(\.amountsHidden) private var amountsHidden
-    @State private var barWidth: CGFloat = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
@@ -63,17 +62,18 @@ struct SavingsSummaryCard: View {
             }
 
             // Progress bar
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(Color.progressTrack)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.progressTrack)
 
-                Capsule()
-                    .fill(Color.financialSavings)
-                    .frame(width: barWidth * CGFloat(max(0, min(summary.progressPercentage / 100, 1))))
-                    .animation(DesignTokens.Animation.gentleSpring, value: summary.progressPercentage)
+                    Capsule()
+                        .fill(Color.financialSavings)
+                        .frame(width: geo.size.width * CGFloat(max(0, min(summary.progressPercentage / 100, 1))))
+                        .animation(DesignTokens.Animation.gentleSpring, value: summary.progressPercentage)
+                }
             }
             .frame(height: DesignTokens.ProgressBar.thickHeight)
-            .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { barWidth = $0 }
 
             // Checked count subtitle
             Text("\(summary.checkedCount) sur \(summary.totalCount) pointées")

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -18,6 +18,15 @@ struct CurrentMonthView: View {
     @State private var hasAppeared = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    private var animationPhase: Int {
+        switch store.contentState {
+        case .idle, .loading: 0
+        case .failed: 1
+        case .empty: 2
+        case .loaded: 3
+        }
+    }
+
     private var timeElapsedPercentage: Double {
         guard let budget = store.budget else { return 0 }
         return BudgetPeriodCalculator.timeElapsedPercentage(
@@ -61,7 +70,7 @@ struct CurrentMonthView: View {
             }
         }
         .trackScreen("Dashboard")
-        .animation(DesignTokens.Animation.smoothEaseOut, value: store.contentState)
+        .animation(DesignTokens.Animation.smoothEaseOut, value: animationPhase)
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -92,6 +101,7 @@ struct CurrentMonthView: View {
             }
         }
         .task {
+            store.prepareForReload()
             // Ensure settings (payDay) are loaded before budget loading,
             // critical when user has PIN lock (settings aren't loaded at startup)
             await userSettingsStore.loadIfNeeded()

--- a/ios/Pulpe/Shared/Components/ProgressBarShape.swift
+++ b/ios/Pulpe/Shared/Components/ProgressBarShape.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Animatable progress bar shape — fills proportionally from the leading edge.
+/// Uses `path(in:)` to read the available rect directly (no GeometryReader or @State needed).
+struct ProgressBarShape: Shape {
+    var progress: CGFloat
+
+    var animatableData: CGFloat {
+        get { progress }
+        set { progress = newValue }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let clampedProgress = min(max(progress, 0), 1)
+        let fillWidth = rect.width * clampedProgress
+        guard fillWidth > 0 else { return Path() }
+        let cornerRadius = rect.height / 2
+        return Path(
+            roundedRect: CGRect(x: 0, y: 0, width: fillWidth, height: rect.height),
+            cornerRadius: cornerRadius
+        )
+    }
+}

--- a/ios/Pulpe/Shared/Components/RealizedBalanceSheet.swift
+++ b/ios/Pulpe/Shared/Components/RealizedBalanceSheet.swift
@@ -325,8 +325,6 @@ private struct CategoryRow: View {
     let realized: Decimal
     let planned: Decimal
 
-    @State private var barWidth: CGFloat = 0
-
     private var percentage: Double {
         guard planned > 0 else { return 0 }
         return min(Double(truncating: NSDecimalNumber(decimal: realized / planned)), 1.0)
@@ -365,17 +363,18 @@ private struct CategoryRow: View {
 
                 // Progress bar + percentage
                 HStack(spacing: DesignTokens.Spacing.sm) {
-                    ZStack(alignment: .leading) {
-                        Capsule()
-                            .fill(Color.progressTrack)
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            Capsule()
+                                .fill(Color.progressTrack)
 
-                        Capsule()
-                            .fill(kind.color)
-                            .frame(width: barWidth * CGFloat(percentage))
-                            .animation(DesignTokens.Animation.gentleSpring, value: percentage)
+                            Capsule()
+                                .fill(kind.color)
+                                .frame(width: geo.size.width * CGFloat(percentage))
+                                .animation(DesignTokens.Animation.gentleSpring, value: percentage)
+                        }
                     }
                     .frame(height: DesignTokens.ProgressBar.thickHeight)
-                    .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { barWidth = $0 }
 
                     Text(percentageText)
                         .font(PulpeTypography.progressUnit)

--- a/ios/Pulpe/Shared/Components/RealizedBalanceSheet.swift
+++ b/ios/Pulpe/Shared/Components/RealizedBalanceSheet.swift
@@ -363,16 +363,13 @@ private struct CategoryRow: View {
 
                 // Progress bar + percentage
                 HStack(spacing: DesignTokens.Spacing.sm) {
-                    GeometryReader { geo in
-                        ZStack(alignment: .leading) {
-                            Capsule()
-                                .fill(Color.progressTrack)
+                    ZStack {
+                        Capsule()
+                            .fill(Color.progressTrack)
 
-                            Capsule()
-                                .fill(kind.color)
-                                .frame(width: geo.size.width * CGFloat(percentage))
-                                .animation(DesignTokens.Animation.gentleSpring, value: percentage)
-                        }
+                        ProgressBarShape(progress: CGFloat(percentage))
+                            .fill(kind.color)
+                            .animation(DesignTokens.Animation.gentleSpring, value: percentage)
                     }
                     .frame(height: DesignTokens.ProgressBar.thickHeight)
 

--- a/ios/Pulpe/Shared/Extensions/View+Extensions.swift
+++ b/ios/Pulpe/Shared/Extensions/View+Extensions.swift
@@ -323,13 +323,11 @@ private struct ShimmerModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .opacity(isAnimating ? 0.4 : 1.0)
             .animation(
-                reduceMotion
-                    ? nil
-                    : .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
-                value: isAnimating
-            )
+                reduceMotion ? nil : .easeInOut(duration: 1.0).repeatForever(autoreverses: true)
+            ) {
+                $0.opacity(isAnimating ? 0.4 : 1.0)
+            }
             .onAppear {
                 guard !reduceMotion else { return }
                 isAnimating = true


### PR DESCRIPTION
## Summary

- **PIN dots pulse broken**: `phaseAnimator` with dynamic phases array didn't reliably restart its animation cycle. Replaced with `@State pulseScale` driven by `withAnimation(.repeatForever)`, using two separate `.scaleEffect` modifiers with sandwiched `.animation(.spring, value: isFilled)` to isolate fill from pulse animation.
- **Skeleton layout bounce**: `ShimmerModifier` used `.animation(.repeatForever, value:)` which captured layout changes (containerRelativeFrame, NavigationStack setup) on first appear. Switched to iOS 17+ scoped animation syntax `.animation(.curve) { $0.opacity(...) }` which guarantees only opacity is animated.
- **Pulse barely visible**: Added minimum 600ms display time before transitioning (ContinuousClock pattern, consistent with existing `ensureMinimumSkeletonTime`).

## Test plan

- [x] Build succeeds (`xcodebuild build`)
- [x] 21/21 PIN entry unit tests pass
- [ ] Enter PIN → dots pulse visibly for ~600ms → smooth transition to dashboard
- [ ] Dashboard skeleton appears fullscreen instantly (no unfolding/sliding)
- [ ] FaceID dialog → skeleton stays static
- [ ] Wrong PIN → dots shake + error message → no regression
- [ ] Skeleton shimmer works on BudgetListView, TemplateListView (all use `.shimmering()`)
- [ ] Reduce Motion ON → no shimmer animation