### PR TITLE
feat(posthog): release tracking, annotations & source linking (PUL-21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,30 +757,21 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v5
 
-      - name: 📊 Create PostHog annotations
+      - name: 📊 Create PostHog annotation
         run: |
-          WEBAPP_VERSION=$(jq -r .version frontend/package.json)
-          LANDING_VERSION=$(jq -r .version landing/package.json)
+          VERSION=$(jq -r .version frontend/package.json)
           COMMIT="${GITHUB_SHA::7}"
           DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          echo "📊 Creating annotation for Webapp v${WEBAPP_VERSION}..."
-          curl -sf -X POST "${POSTHOG_HOST}/api/projects/${POSTHOG_WEBAPP_PROJECT_ID}/annotations/" \
+          echo "📊 Creating annotation for v${VERSION} (${COMMIT})..."
+          curl -sf -X POST "${POSTHOG_HOST}/api/projects/${POSTHOG_PROJECT_ID}/annotations/" \
             -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
             -H "Content-Type: application/json" \
-            -d "{\"content\":\"v${WEBAPP_VERSION} (${COMMIT})\",\"scope\":\"project\",\"date_marker\":\"${DATE}\"}" \
-            || echo "⚠️  Webapp annotation failed (non-blocking)"
+            -d "{\"content\":\"v${VERSION} (${COMMIT})\",\"scope\":\"project\",\"date_marker\":\"${DATE}\"}" \
+            || echo "⚠️  Annotation failed (non-blocking)"
 
-          echo "📊 Creating annotation for Landing v${LANDING_VERSION}..."
-          curl -sf -X POST "${POSTHOG_HOST}/api/projects/${POSTHOG_LANDING_PROJECT_ID}/annotations/" \
-            -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
-            -H "Content-Type: application/json" \
-            -d "{\"content\":\"v${LANDING_VERSION} (${COMMIT})\",\"scope\":\"project\",\"date_marker\":\"${DATE}\"}" \
-            || echo "⚠️  Landing annotation failed (non-blocking)"
-
-          echo "✅ PostHog annotations created"
+          echo "✅ PostHog annotation created"
         env:
           POSTHOG_HOST: https://eu.i.posthog.com
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
-          POSTHOG_WEBAPP_PROJECT_ID: ${{ secrets.POSTHOG_WEBAPP_PROJECT_ID }}
-          POSTHOG_LANDING_PROJECT_ID: ${{ secrets.POSTHOG_LANDING_PROJECT_ID }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_WEBAPP_PROJECT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,9 +768,8 @@ jobs:
             -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
             -H "Content-Type: application/json" \
             -d "{\"content\":\"v${VERSION} (${COMMIT})\",\"scope\":\"project\",\"date_marker\":\"${DATE}\"}" \
+            && echo "✅ PostHog annotation created" \
             || echo "⚠️  Annotation failed (non-blocking)"
-
-          echo "✅ PostHog annotation created"
         env:
           POSTHOG_HOST: https://eu.i.posthog.com
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,3 +745,42 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_DB_PASSWORD }}
+
+  # 📊 POSTHOG RELEASE ANNOTATIONS (push main only — marks deploys on PostHog graphs)
+  posthog-annotate:
+    name: 📊 PostHog Release Annotations
+    if: always() && needs.ci-success.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [ci-success]
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v5
+
+      - name: 📊 Create PostHog annotations
+        run: |
+          WEBAPP_VERSION=$(jq -r .version frontend/package.json)
+          LANDING_VERSION=$(jq -r .version landing/package.json)
+          COMMIT="${GITHUB_SHA::7}"
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          echo "📊 Creating annotation for Webapp v${WEBAPP_VERSION}..."
+          curl -sf -X POST "${POSTHOG_HOST}/api/projects/${POSTHOG_WEBAPP_PROJECT_ID}/annotations/" \
+            -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"content\":\"v${WEBAPP_VERSION} (${COMMIT})\",\"scope\":\"project\",\"date_marker\":\"${DATE}\"}" \
+            || echo "⚠️  Webapp annotation failed (non-blocking)"
+
+          echo "📊 Creating annotation for Landing v${LANDING_VERSION}..."
+          curl -sf -X POST "${POSTHOG_HOST}/api/projects/${POSTHOG_LANDING_PROJECT_ID}/annotations/" \
+            -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"content\":\"v${LANDING_VERSION} (${COMMIT})\",\"scope\":\"project\",\"date_marker\":\"${DATE}\"}" \
+            || echo "⚠️  Landing annotation failed (non-blocking)"
+
+          echo "✅ PostHog annotations created"
+        env:
+          POSTHOG_HOST: https://eu.i.posthog.com
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_WEBAPP_PROJECT_ID: ${{ secrets.POSTHOG_WEBAPP_PROJECT_ID }}
+          POSTHOG_LANDING_PROJECT_ID: ${{ secrets.POSTHOG_LANDING_PROJECT_ID }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -84,6 +84,7 @@ jobs:
             -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
             -H "Content-Type: application/json" \
             -d "{\"version\":\"ios-${IOS_VERSION}+${BUILD_NUMBER}\",\"hash_id\":\"${COMMIT}\"}" \
+            && echo "✅ PostHog iOS release created" \
             || echo "⚠️  PostHog release creation failed (non-blocking)"
 
           echo "📊 Creating PostHog annotation for iOS v${IOS_VERSION}..."
@@ -91,9 +92,8 @@ jobs:
             -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
             -H "Content-Type: application/json" \
             -d "{\"content\":\"iOS v${IOS_VERSION} (${GITHUB_SHA::7})\",\"scope\":\"project\",\"date_marker\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" \
+            && echo "✅ PostHog iOS annotation created" \
             || echo "⚠️  PostHog annotation failed (non-blocking)"
-
-          echo "✅ PostHog iOS release and annotation created"
         env:
           POSTHOG_HOST: https://eu.i.posthog.com
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -78,6 +78,11 @@ jobs:
           BUILD_NUMBER=$(grep 'CURRENT_PROJECT_VERSION' project.yml | head -1 | sed 's/.*: *//' | tr -d '"' | tr -d "'")
           COMMIT="${GITHUB_SHA}"
 
+          if [ -z "$IOS_VERSION" ] || [ -z "$BUILD_NUMBER" ]; then
+            echo "⚠️  Failed to parse iOS version from project.yml, skipping PostHog release"
+            exit 0
+          fi
+
           echo "📦 Creating PostHog release for iOS v${IOS_VERSION} (build ${BUILD_NUMBER})"
 
           curl -sf -X POST "${POSTHOG_HOST}/api/projects/${POSTHOG_PROJECT_ID}/error_tracking/releases/" \
@@ -97,4 +102,5 @@ jobs:
         env:
           POSTHOG_HOST: https://eu.i.posthog.com
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          # All apps share one PostHog project (87621) — secret name is webapp-specific for historical reasons
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_WEBAPP_PROJECT_ID }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -70,3 +70,31 @@ jobs:
             -derivedDataPath build/DerivedData \
             CODE_SIGNING_ALLOWED=NO \
             -quiet
+
+      - name: 📊 Create PostHog Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          IOS_VERSION=$(grep 'MARKETING_VERSION' project.yml | head -1 | sed 's/.*: *//' | tr -d '"' | tr -d "'")
+          BUILD_NUMBER=$(grep 'CURRENT_PROJECT_VERSION' project.yml | head -1 | sed 's/.*: *//' | tr -d '"' | tr -d "'")
+          COMMIT="${GITHUB_SHA}"
+
+          echo "📦 Creating PostHog release for iOS v${IOS_VERSION} (build ${BUILD_NUMBER})"
+
+          curl -sf -X POST "${POSTHOG_HOST}/api/projects/${POSTHOG_PROJECT_ID}/error_tracking/releases/" \
+            -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"version\":\"ios-${IOS_VERSION}+${BUILD_NUMBER}\",\"hash_id\":\"${COMMIT}\"}" \
+            || echo "⚠️  PostHog release creation failed (non-blocking)"
+
+          echo "📊 Creating PostHog annotation for iOS v${IOS_VERSION}..."
+          curl -sf -X POST "${POSTHOG_HOST}/api/projects/${POSTHOG_PROJECT_ID}/annotations/" \
+            -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"content\":\"iOS v${IOS_VERSION} (${GITHUB_SHA::7})\",\"scope\":\"project\",\"date_marker\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" \
+            || echo "⚠️  PostHog annotation failed (non-blocking)"
+
+          echo "✅ PostHog iOS release and annotation created"
+        env:
+          POSTHOG_HOST: https://eu.i.posthog.com
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_WEBAPP_PROJECT_ID }}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -151,10 +151,10 @@ Environment variables:
 | `NEXT_PUBLIC_ANGULAR_APP_URL` | `https://app.pulpe.app` | Webapp URL for CTA links |
 | `NEXT_PUBLIC_SUPABASE_URL` | (same as frontend project) | Auth redirect detection |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | (same as frontend project) | Auth redirect detection |
-| `PUBLIC_POSTHOG_API_KEY` | `phc_...` | PostHog project key (Pulpe Landing, ID 75556) |
+| `PUBLIC_POSTHOG_API_KEY` | `phc_...` | PostHog project key (Pulpe Webapp, ID 87621) |
 | `PUBLIC_POSTHOG_HOST` | `/ph` | Reverse proxy (see landing/vercel.json) |
 | `PUBLIC_POSTHOG_ENABLED` | `true` | Enable analytics |
-| `POSTHOG_PERSONAL_API_KEY` | `phc_...` | Release creation on deploy (see [POSTHOG_RELEASES.md](./POSTHOG_RELEASES.md)) |
+| `POSTHOG_PERSONAL_API_KEY` | `phx_...` | Release creation on deploy (see [POSTHOG_RELEASES.md](./POSTHOG_RELEASES.md)) |
 | `POSTHOG_CLI_ENV_ID` | `87621` | PostHog project ID (same as webapp) |
 
 **Ignored Build Step** (skip build when only frontend changed):

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -146,12 +146,16 @@ git diff --quiet HEAD^ HEAD -- frontend/ shared/
 
 Environment variables:
 
-| Variable | Value |
-|----------|-------|
-| `NEXT_PUBLIC_ANGULAR_APP_URL` | `https://app.pulpe.app` |
-| `NEXT_PUBLIC_SUPABASE_URL` | (same as frontend project) |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | (same as frontend project) |
-| PostHog variables | as needed |
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `NEXT_PUBLIC_ANGULAR_APP_URL` | `https://app.pulpe.app` | Webapp URL for CTA links |
+| `NEXT_PUBLIC_SUPABASE_URL` | (same as frontend project) | Auth redirect detection |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | (same as frontend project) | Auth redirect detection |
+| `PUBLIC_POSTHOG_API_KEY` | `phc_...` | PostHog project key (Pulpe Landing, ID 75556) |
+| `PUBLIC_POSTHOG_HOST` | `/ph` | Reverse proxy (see landing/vercel.json) |
+| `PUBLIC_POSTHOG_ENABLED` | `true` | Enable analytics |
+| `POSTHOG_PERSONAL_API_KEY` | `phc_...` | Release creation on deploy (see [POSTHOG_RELEASES.md](./POSTHOG_RELEASES.md)) |
+| `POSTHOG_CLI_ENV_ID` | `87621` | PostHog project ID (same as webapp) |
 
 **Ignored Build Step** (skip build when only frontend changed):
 ```
@@ -259,6 +263,20 @@ Domain purchased at **Infomaniak**.
 - [ ] Turnstile: add `app.pulpe.app`
 - [ ] PostHog: add `https://app.pulpe.app` to toolbar URLs
 - [ ] Test: landing on `pulpe.app`, app on `app.pulpe.app`, auth flow, Google OAuth, legal pages from iOS
+
+### GitHub Actions Secrets
+
+> Repository Settings → Secrets and variables → Actions → New repository secret
+
+| Secret | Value | Used by |
+|--------|-------|---------|
+| `SUPABASE_ACCESS_TOKEN` | Supabase CLI token | Migration CI |
+| `PRODUCTION_DB_PASSWORD` | Supabase DB password | Migration CI |
+| `PRODUCTION_PROJECT_ID` | Supabase project ref | Migration CI |
+| `POSTHOG_PERSONAL_API_KEY` | PostHog personal API key | CI annotations + iOS releases |
+| `POSTHOG_WEBAPP_PROJECT_ID` | `87621` | CI annotations + iOS releases (single project for all apps) |
+
+See [POSTHOG_RELEASES.md](./POSTHOG_RELEASES.md) for the full PostHog release architecture.
 
 ## Release Process
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -121,7 +121,7 @@ PostHog variables (Production):
 
 ```env
 PUBLIC_POSTHOG_HOST=/ph                          # Reverse proxy (see vercel.json)
-POSTHOG_PERSONAL_API_KEY=phc_...                 # Sourcemaps upload (CI)
+POSTHOG_PERSONAL_API_KEY=phx_...                 # Sourcemaps upload (CI)
 POSTHOG_CLI_ENV_ID=12345                         # Sourcemaps upload (CI)
 POSTHOG_HOST=https://eu.i.posthog.com            # Sourcemaps upload (CI, direct access)
 ```

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -113,7 +113,7 @@ PostHog releases et annotations sont créées automatiquement à chaque deploy. 
 | Webapp (Angular) | Build Vercel | Sourcemaps upload + release avec source linking GitHub |
 | Landing (Next.js) | Build Vercel | Release via API (version + commit) |
 | iOS (SwiftUI) | Push main (paths: ios/**) | Release `ios-X.Y.Z+BUILD` + annotation |
-| Toutes | Push main (CI verte) | Annotations sur les 2 projets PostHog |
+| Toutes | Push main (CI verte) | Annotation sur le projet PostHog 87621 |
 
 ### Source linking GitHub
 

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -19,7 +19,7 @@ curl https://www.pulpe.app/api/debug/error  # Force une erreur (dev only)
 ### ⚡ Variables Critiques Vercel
 ```env
 # OBLIGATOIRES pour sourcemaps automatiques
-POSTHOG_PERSONAL_API_KEY=phc_your_personal_api_key_here
+POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
 POSTHOG_CLI_ENV_ID=12345
 POSTHOG_HOST=https://eu.i.posthog.com
 ```
@@ -70,7 +70,7 @@ L'upload des sourcemaps est **100% automatisé** dans le processus de déploieme
 ### Variables Environnement Vercel
 ```env
 # OBLIGATOIRE: Clé API personnelle PostHog
-POSTHOG_PERSONAL_API_KEY=phc_your_personal_api_key_here
+POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
 
 # OBLIGATOIRE: ID du projet PostHog (nombre entier)
 POSTHOG_CLI_ENV_ID=12345
@@ -95,7 +95,7 @@ POSTHOG_HOST=https://eu.i.posthog.com
 #### Clé API Personnelle
 1. PostHog Dashboard → **Settings > Personal API Keys**
 2. Créer nouvelle clé avec permissions `sourcemap:upload`
-3. Copier la clé (format: `phc_...`)
+3. Copier la clé (format: `phx_...`)
 
 #### Project ID
 1. PostHog Dashboard → **Settings > Project variables**

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -102,6 +102,35 @@ POSTHOG_HOST=https://eu.i.posthog.com
 2. Copier **Project ID** (nombre entier, ex: `12345`)
 3. Utiliser pour `POSTHOG_CLI_ENV_ID`
 
+## 📦 Releases & Annotations {#releases}
+
+PostHog releases et annotations sont créées automatiquement à chaque deploy. Voir [POSTHOG_RELEASES.md](./POSTHOG_RELEASES.md) pour l'architecture complète.
+
+### Ce qui se passe automatiquement
+
+| App | Déclencheur | Actions PostHog |
+|-----|------------|-----------------|
+| Webapp (Angular) | Build Vercel | Sourcemaps upload + release avec source linking GitHub |
+| Landing (Next.js) | Build Vercel | Release via API (version + commit) |
+| iOS (SwiftUI) | Push main (paths: ios/**) | Release `ios-X.Y.Z+BUILD` + annotation |
+| Toutes | Push main (CI verte) | Annotations sur les 2 projets PostHog |
+
+### Source linking GitHub
+
+Les stack traces dans Error Tracking incluent des liens cliquables vers le code source dans GitHub au bon commit. Nécessite :
+- GitHub connecté dans PostHog (Settings → Error Tracking → Integrations)
+- Releases créées avec infos Git (automatique via le CLI)
+
+### Vérifier après un deploy
+
+- **Annotations** : n'importe quel graphique PostHog → markers verticaux avec la version
+- **Releases** : Settings → Error Tracking → Releases
+- **Source linking** : Error Tracking → cliquer sur une erreur → liens "View in GitHub" sur les frames
+
+### Variables requises
+
+Voir [DEPLOYMENT.md](./DEPLOYMENT.md) (sections GitHub Actions Secrets et Landing Vercel variables).
+
 ## 📊 Error Tracking Configuration {#error-tracking}
 
 ### Capture Automatique

--- a/docs/POSTHOG_RELEASES.md
+++ b/docs/POSTHOG_RELEASES.md
@@ -1,0 +1,187 @@
+# PostHog Release Management
+
+Architecture de tracking multi-plateforme pour le monorepo Pulpe — sourcemaps, releases, annotations, source linking.
+
+**Issue** : [PUL-21](https://linear.app/pulpe/issue/PUL-21/gerer-les-releases-posthog)
+**Commit** : `94a530cf`
+
+---
+
+## Architecture
+
+### Projets PostHog
+
+| App | Domaine | Projet PostHog | ID | Plateforme |
+|-----|---------|---------------|----|------------|
+| Angular Webapp | app.pulpe.app | Pulpe Webapp | 87621 | `web` |
+| Landing (Next.js) | pulpe.app | Pulpe Landing | 75556 | `landing` |
+| iOS (SwiftUI) | App Store | Pulpe Webapp | 87621 | `ios` |
+| Backend (NestJS) | api.pulpe.app | — | — | Non concerné |
+
+L'iOS partage le même projet PostHog que le webapp. Les events se distinguent via la super property `platform`.
+
+### Intégrations actives
+
+- **GitHub** : Orga `neogenz`, repo `pulpe` autorisé → source linking sur les stack traces
+- **Linear** : Workspace `pulpe` connecté → lien bidirectionnel issues/erreurs
+- **Reverse proxy** : Vercel rewrites `/ph/*` → `eu.i.posthog.com` (contourne les ad blockers)
+
+---
+
+## Webapp — Sourcemaps + Source Linking
+
+**Fichier** : `frontend/scripts/upload-sourcemaps.js`
+**Déclenché par** : Build Vercel à chaque deploy
+
+### Flux
+
+```
+Push main → CI verte → Vercel deploy → Build Angular →
+  1. posthog-cli sourcemap inject --directory ./dist/webapp/browser
+  2. posthog-cli sourcemap upload --directory ./dist/webapp/browser \
+       --release-name pulpe-webapp \
+       --release-version 0.30.0
+  3. CI job posthog-annotate → annotation sur projet 87621
+```
+
+### Fonctionnement
+
+Le PostHog CLI gère la création de release automatiquement lors de l'upload des sourcemaps. Les flags `--release-name` et `--release-version` identifient la release, et le CLI auto-détecte les infos Git (repo, commit SHA) pour activer le source linking GitHub.
+
+Chaque frame de stack trace dans PostHog Error Tracking devient cliquable vers le fichier exact dans GitHub au bon commit.
+
+### Variables d'environnement requises (Vercel — projet Webapp)
+
+| Variable | Description |
+|----------|-------------|
+| `POSTHOG_PERSONAL_API_KEY` | Clé API personnelle PostHog (pas la clé projet) |
+| `POSTHOG_CLI_ENV_ID` | ID du projet PostHog (87621) |
+| `POSTHOG_HOST` | `https://eu.i.posthog.com` (optionnel, défaut EU) |
+
+---
+
+## Landing — Création de release
+
+**Fichier** : `landing/scripts/create-release.js`
+**Déclenché par** : Build Vercel à chaque deploy (`buildCommand` dans `landing/vercel.json`)
+
+### Flux
+
+```
+Push main → CI verte → Vercel deploy → Build Next.js →
+  1. node scripts/create-release.js → Release créée via API REST (version + commit)
+  2. CI job posthog-annotate → annotation sur projet 75556
+```
+
+### Fonctionnement
+
+La landing utilise `output: 'export'` (site statique) — pas de sourcemaps. Le script crée une release PostHog via l'API REST pour le tracking de version. Non-bloquant : si les credentials manquent, le script skip silencieusement.
+
+### Variables d'environnement requises (Vercel — projet Landing)
+
+| Variable | Description |
+|----------|-------------|
+| `POSTHOG_PERSONAL_API_KEY` | Clé API personnelle PostHog |
+| `POSTHOG_LANDING_ENV_ID` | ID du projet PostHog Landing (75556) |
+| `POSTHOG_HOST` | `https://eu.i.posthog.com` (optionnel, défaut EU) |
+
+---
+
+## iOS — Release + Annotation via CI
+
+**Fichier** : `.github/workflows/ios.yml`
+**Déclenché par** : Push sur `main` avec changements dans `ios/**`
+
+### Flux
+
+```
+Push main (paths: ios/**) → iOS CI build →
+  1. Extraction MARKETING_VERSION + CURRENT_PROJECT_VERSION depuis project.yml
+  2. Release PostHog "ios-X.Y.Z+BUILD" via API REST
+  3. Annotation PostHog "iOS vX.Y.Z"
+```
+
+### Fonctionnement
+
+L'iOS a son propre cycle de release (App Store) avec un versioning indépendant. Pas de sourcemaps (Swift natif), mais les releases permettent le filtrage des erreurs par version iOS dans le même projet PostHog que le webapp (87621).
+
+Le format de version `ios-X.Y.Z+BUILD` distingue les releases iOS des releases webapp dans PostHog.
+
+### Pas encore implémenté : dSYM upload
+
+PostHog supporte l'upload de dSYMs via `posthog-cli` pour la symbolication des crash reports natifs. À intégrer dans le workflow de release App Store (archive build).
+
+---
+
+## CI — Annotations automatiques
+
+**Fichier** : `.github/workflows/ci.yml`
+**Job** : `posthog-annotate`
+**Condition** : `push main` + CI success
+
+### Flux
+
+```
+CI verte sur main →
+  1. Lecture des versions webapp (frontend/package.json) et landing (landing/package.json)
+  2. Annotation Webapp "v0.30.0 (abc1234)" sur projet 87621
+  3. Annotation Landing "v0.30.0 (abc1234)" sur projet 75556
+```
+
+### Fonctionnement
+
+Les annotations créent des markers verticaux sur tous les graphiques PostHog. Quand un spike d'erreurs ou un changement de métriques apparaît, la corrélation avec un deploy est immédiate.
+
+---
+
+## Configuration requise
+
+### Secrets GitHub Actions
+
+> Repository Settings → Secrets and variables → Actions → New repository secret
+
+| Secret | Valeur | Utilisé par |
+|--------|--------|------------|
+| `POSTHOG_PERSONAL_API_KEY` | Clé API personnelle PostHog | CI annotations, iOS release |
+| `POSTHOG_WEBAPP_PROJECT_ID` | `87621` | CI annotations webapp |
+| `POSTHOG_LANDING_PROJECT_ID` | `75556` | CI annotations landing |
+
+### Variables Vercel — projet Landing
+
+> Vercel Dashboard → Projet Landing → Settings → Environment Variables
+
+| Variable | Valeur |
+|----------|--------|
+| `POSTHOG_PERSONAL_API_KEY` | Même clé que GitHub |
+| `POSTHOG_LANDING_ENV_ID` | `75556` |
+
+### Variables Vercel — projet Webapp (déjà configurées)
+
+| Variable | Valeur |
+|----------|--------|
+| `POSTHOG_PERSONAL_API_KEY` | Clé API personnelle |
+| `POSTHOG_CLI_ENV_ID` | `87621` |
+| `POSTHOG_HOST` | `https://eu.i.posthog.com` |
+
+---
+
+## Ce que ça débloque
+
+| Feature | Description |
+|---------|-------------|
+| **Source linking** | Chaque frame de stack trace → lien cliquable vers le fichier exact dans GitHub au bon commit |
+| **Annotations** | Markers visuels sur tous les graphiques PostHog → corrélation deploy/métriques |
+| **Releases** | Filtrage des erreurs par version, tracking des régressions |
+| **Multi-plateforme** | iOS + Web + Landing avec releases indépendantes dans le même écosystème |
+| **Status pending_release** | Marquer un bug "résolu au prochain deploy" → détection auto de régression si l'erreur revient |
+
+---
+
+## Future work
+
+| Sujet | Description | Priorité |
+|-------|-------------|----------|
+| dSYM upload iOS | Symbolication des crash reports natifs via `posthog-cli` | Medium |
+| Feature flags | 0 flags configurés, SDK prêt web + iOS. Gradual rollouts, kill switches | Medium |
+| Workflow pending_release | Marquer les bugs résolus, vérifier au prochain deploy | Low |
+| Tri des issues | 281 issues actives dans Error Tracking à trier | Low |

--- a/docs/POSTHOG_RELEASES.md
+++ b/docs/POSTHOG_RELEASES.md
@@ -3,7 +3,6 @@
 Architecture de tracking multi-plateforme pour le monorepo Pulpe — sourcemaps, releases, annotations, source linking.
 
 **Issue** : [PUL-21](https://linear.app/pulpe/issue/PUL-21/gerer-les-releases-posthog)
-**Commit** : `94a530cf`
 
 ---
 

--- a/docs/POSTHOG_RELEASES.md
+++ b/docs/POSTHOG_RELEASES.md
@@ -9,16 +9,20 @@ Architecture de tracking multi-plateforme pour le monorepo Pulpe — sourcemaps,
 
 ## Architecture
 
-### Projets PostHog
+### Projet PostHog
 
-| App | Domaine | Projet PostHog | ID | Plateforme |
-|-----|---------|---------------|----|------------|
-| Angular Webapp | app.pulpe.app | Pulpe Webapp | 87621 | `web` |
-| Landing (Next.js) | pulpe.app | Pulpe Landing | 75556 | `landing` |
-| iOS (SwiftUI) | App Store | Pulpe Webapp | 87621 | `ios` |
-| Backend (NestJS) | api.pulpe.app | — | — | Non concerné |
+Toutes les apps utilisent le **même projet PostHog** : **Pulpe Webapp** (ID `87621`).
 
-L'iOS partage le même projet PostHog que le webapp. Les events se distinguent via la super property `platform`.
+| App | Domaine | Plateforme (super property) | Release format |
+|-----|---------|---------------------------|----------------|
+| Angular Webapp | app.pulpe.app | `web` | `pulpe-webapp` vX.Y.Z |
+| Landing (Next.js) | pulpe.app | `landing` | `landing-X.Y.Z` |
+| iOS (SwiftUI) | App Store | `ios` | `ios-X.Y.Z+BUILD` |
+| Backend (NestJS) | api.pulpe.app | — | Non concerné |
+
+Les events se distinguent via la super property `platform`. Les releases se distinguent par leur préfixe de nom.
+
+> **Note** : Le projet PostHog "Pulpe Landing" (ID 75556) est un ancien projet de collecte d'emails, plus utilisé.
 
 ### Intégrations actives
 
@@ -69,8 +73,8 @@ Chaque frame de stack trace dans PostHog Error Tracking devient cliquable vers l
 
 ```
 Push main → CI verte → Vercel deploy → Build Next.js →
-  1. node scripts/create-release.js → Release créée via API REST (version + commit)
-  2. CI job posthog-annotate → annotation sur projet 75556
+  1. node scripts/create-release.js → Release "landing-X.Y.Z" créée via API REST (même projet 87621)
+  2. CI job posthog-annotate → annotation sur projet 87621
 ```
 
 ### Fonctionnement
@@ -82,7 +86,7 @@ La landing utilise `output: 'export'` (site statique) — pas de sourcemaps. Le 
 | Variable | Description |
 |----------|-------------|
 | `POSTHOG_PERSONAL_API_KEY` | Clé API personnelle PostHog |
-| `POSTHOG_LANDING_ENV_ID` | ID du projet PostHog Landing (75556) |
+| `POSTHOG_CLI_ENV_ID` | ID du projet PostHog (`87621`, même que webapp) |
 | `POSTHOG_HOST` | `https://eu.i.posthog.com` (optionnel, défaut EU) |
 
 ---
@@ -123,9 +127,8 @@ PostHog supporte l'upload de dSYMs via `posthog-cli` pour la symbolication des c
 
 ```
 CI verte sur main →
-  1. Lecture des versions webapp (frontend/package.json) et landing (landing/package.json)
-  2. Annotation Webapp "v0.30.0 (abc1234)" sur projet 87621
-  3. Annotation Landing "v0.30.0 (abc1234)" sur projet 75556
+  1. Lecture de la version webapp (frontend/package.json)
+  2. Annotation "v0.30.0 (abc1234)" sur projet 87621
 ```
 
 ### Fonctionnement
@@ -143,17 +146,7 @@ Les annotations créent des markers verticaux sur tous les graphiques PostHog. Q
 | Secret | Valeur | Utilisé par |
 |--------|--------|------------|
 | `POSTHOG_PERSONAL_API_KEY` | Clé API personnelle PostHog | CI annotations, iOS release |
-| `POSTHOG_WEBAPP_PROJECT_ID` | `87621` | CI annotations webapp |
-| `POSTHOG_LANDING_PROJECT_ID` | `75556` | CI annotations landing |
-
-### Variables Vercel — projet Landing
-
-> Vercel Dashboard → Projet Landing → Settings → Environment Variables
-
-| Variable | Valeur |
-|----------|--------|
-| `POSTHOG_PERSONAL_API_KEY` | Même clé que GitHub |
-| `POSTHOG_LANDING_ENV_ID` | `75556` |
+| `POSTHOG_WEBAPP_PROJECT_ID` | `87621` | CI annotations + iOS releases |
 
 ### Variables Vercel — projet Webapp (déjà configurées)
 
@@ -162,6 +155,15 @@ Les annotations créent des markers verticaux sur tous les graphiques PostHog. Q
 | `POSTHOG_PERSONAL_API_KEY` | Clé API personnelle |
 | `POSTHOG_CLI_ENV_ID` | `87621` |
 | `POSTHOG_HOST` | `https://eu.i.posthog.com` |
+
+### Variables Vercel — projet Landing
+
+> Vercel Dashboard → Projet Landing → Settings → Environment Variables
+
+| Variable | Valeur |
+|----------|--------|
+| `POSTHOG_PERSONAL_API_KEY` | Même clé que GitHub |
+| `POSTHOG_CLI_ENV_ID` | `87621` (même projet que webapp) |
 
 ---
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -49,7 +49,7 @@ PUBLIC_POSTHOG_DEBUG=false
 # === SOURCEMAPS (CI/CD UNIQUEMENT) ===
 # Clé API personnelle PostHog (DIFFÉRENTE de PUBLIC_POSTHOG_API_KEY)
 # Dashboard PostHog > Settings > Personal API Keys
-POSTHOG_PERSONAL_API_KEY=phc_your_personal_api_key_here
+POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
 
 # Doit correspondre à PUBLIC_POSTHOG_HOST
 POSTHOG_HOST=https://eu.i.posthog.com

--- a/frontend/docs/sourcemaps-upload.md
+++ b/frontend/docs/sourcemaps-upload.md
@@ -14,7 +14,7 @@ Dans le dashboard Vercel de votre projet, configurez ces variables :
 
 ```env
 # OBLIGATOIRE: Clé API personnelle PostHog
-POSTHOG_PERSONAL_API_KEY=phc_your_personal_api_key_here
+POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
 
 # OBLIGATOIRE: ID du projet PostHog (nombre entier)
 POSTHOG_CLI_ENV_ID=12345

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,7 +83,7 @@
     "@angular/platform-browser-dynamic": "^21.0.6",
     "@eslint/js": "^9.28.0",
     "@playwright/test": "^1.57.0",
-    "@posthog/cli": "^0.4.7",
+    "@posthog/cli": "^0.6.1",
     "@vitest/coverage-v8": "^4.0.16",
     "@vitest/ui": "^4.0.16",
     "angular-eslint": "21.1.0",

--- a/frontend/scripts/upload-sourcemaps.js
+++ b/frontend/scripts/upload-sourcemaps.js
@@ -29,7 +29,7 @@ const envId = process.env.POSTHOG_CLI_ENV_ID;
 const host = process.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
 
 function getVersionInfo() {
-  let version;
+  let version, commitHash;
 
   try {
     const packageJsonPath = path.join(__dirname, '..', 'package.json');
@@ -45,7 +45,36 @@ function getVersionInfo() {
     process.exit(1);
   }
 
-  return { version };
+  try {
+    commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    commitHash = 'unknown';
+  }
+
+  return { version, commitHash };
+}
+
+async function createPostHogRelease(version, commitHash) {
+  const url = `${host}/api/projects/${envId}/error_tracking/releases/`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      version: `pulpe-webapp-${version}`,
+      hash_id: commitHash
+    })
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Failed to create release: ${response.status} - ${errorText}`);
+  }
+
+  return response.json();
 }
 
 async function main() {
@@ -137,17 +166,29 @@ async function main() {
 
     // Step 2: Upload source maps to PostHog
     console.log('\n☁️  Step 2: Uploading source maps to PostHog...');
-    const { version } = getVersionInfo();
-    const uploadCmd = `${POSTHOG_CLI} sourcemap upload --directory ${DIST_DIR} --release-name pulpe-webapp --release-version ${version}`;
+    const uploadCmd = `${POSTHOG_CLI} sourcemap upload --directory ${DIST_DIR}`;
     execSync(uploadCmd, {
       stdio: isCI ? 'pipe' : 'inherit',
       env
     });
     console.log('✅ Source maps uploaded successfully');
 
+    // Step 3: Create PostHog release for version tracking
+    console.log('\n📦 Step 3: Creating PostHog release...');
+    const { version, commitHash } = getVersionInfo();
+    console.log(`   Version: pulpe-webapp-${version}`);
+    console.log(`   Commit: ${commitHash.substring(0, 7)}`);
+
+    try {
+      await createPostHogRelease(version, commitHash);
+      console.log('✅ PostHog release created successfully');
+    } catch (releaseError) {
+      console.warn(`⚠️  Release creation failed (non-blocking): ${releaseError.message}`);
+    }
+
     console.log('\n🎉 PostHog source maps processing completed!');
     console.log('Your error tracking will now show readable stack traces.');
-    console.log(`Release "${version}" created with source linking enabled.`);
+    console.log(`Release "pulpe-webapp-${version}" created.`);
 
   } catch (error) {
     console.error('\n❌ Error during source maps processing:', error.message);

--- a/frontend/scripts/upload-sourcemaps.js
+++ b/frontend/scripts/upload-sourcemaps.js
@@ -69,7 +69,7 @@ async function main() {
     console.log('⚠️  PostHog credentials not fully configured');
     console.log('Skipping sourcemap upload in local development.');
     console.log('To test locally, set these environment variables:');
-    console.log('- POSTHOG_PERSONAL_API_KEY=phc_your_key_here');
+    console.log('- POSTHOG_PERSONAL_API_KEY=phx_your_key_here');
     console.log('- POSTHOG_CLI_ENV_ID=your_project_id_here');
     return;
   }

--- a/frontend/scripts/upload-sourcemaps.js
+++ b/frontend/scripts/upload-sourcemaps.js
@@ -20,7 +20,7 @@ const path = require('path');
 
 // Configuration
 const DIST_DIR = './dist/webapp/browser';
-const POSTHOG_CLI = 'npx @posthog/cli';
+const POSTHOG_CLI = 'pnpm exec posthog-cli';
 
 // Environment detection
 const isCI = !!(process.env.CI || process.env.VERCEL || process.env.GITHUB_ACTIONS);
@@ -28,9 +28,7 @@ const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
 const envId = process.env.POSTHOG_CLI_ENV_ID;
 const host = process.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
 
-function getVersionInfo() {
-  let version, commitHash;
-
+function getVersion() {
   try {
     const packageJsonPath = path.join(__dirname, '..', 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
@@ -39,42 +37,11 @@ function getVersionInfo() {
       throw new Error('package.json is missing "version" field');
     }
 
-    version = packageJson.version;
+    return packageJson.version;
   } catch (error) {
     console.error('❌ Failed to read version from package.json:', error.message);
     process.exit(1);
   }
-
-  try {
-    commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
-  } catch {
-    commitHash = 'unknown';
-  }
-
-  return { version, commitHash };
-}
-
-async function createPostHogRelease(version, commitHash) {
-  const url = `${host}/api/projects/${envId}/error_tracking/releases/`;
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`
-    },
-    body: JSON.stringify({
-      version: `pulpe-webapp-${version}`,
-      hash_id: commitHash
-    })
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Failed to create release: ${response.status} - ${errorText}`);
-  }
-
-  return response.json();
 }
 
 async function main() {
@@ -164,31 +131,20 @@ async function main() {
       }
     }
 
-    // Step 2: Upload source maps to PostHog
+    // Step 2: Upload source maps with release info
     console.log('\n☁️  Step 2: Uploading source maps to PostHog...');
-    const uploadCmd = `${POSTHOG_CLI} sourcemap upload --directory ${DIST_DIR}`;
+    const version = getVersion();
+    console.log(`   Release: pulpe-webapp v${version}`);
+    const uploadCmd = `${POSTHOG_CLI} sourcemap upload --directory ${DIST_DIR} --release-name pulpe-webapp --release-version ${version}`;
     execSync(uploadCmd, {
       stdio: isCI ? 'pipe' : 'inherit',
       env
     });
-    console.log('✅ Source maps uploaded successfully');
-
-    // Step 3: Create PostHog release for version tracking
-    console.log('\n📦 Step 3: Creating PostHog release...');
-    const { version, commitHash } = getVersionInfo();
-    console.log(`   Version: pulpe-webapp-${version}`);
-    console.log(`   Commit: ${commitHash.substring(0, 7)}`);
-
-    try {
-      await createPostHogRelease(version, commitHash);
-      console.log('✅ PostHog release created successfully');
-    } catch (releaseError) {
-      console.warn(`⚠️  Release creation failed (non-blocking): ${releaseError.message}`);
-    }
+    console.log('✅ Source maps uploaded with release info');
 
     console.log('\n🎉 PostHog source maps processing completed!');
     console.log('Your error tracking will now show readable stack traces.');
-    console.log(`Release "pulpe-webapp-${version}" created.`);
+    console.log(`Release "pulpe-webapp v${version}" created with source linking.`);
 
   } catch (error) {
     console.error('\n❌ Error during source maps processing:', error.message);

--- a/frontend/scripts/upload-sourcemaps.js
+++ b/frontend/scripts/upload-sourcemaps.js
@@ -29,7 +29,7 @@ const envId = process.env.POSTHOG_CLI_ENV_ID;
 const host = process.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
 
 function getVersionInfo() {
-  let version, commitHash;
+  let version;
 
   try {
     const packageJsonPath = path.join(__dirname, '..', 'package.json');
@@ -45,37 +45,7 @@ function getVersionInfo() {
     process.exit(1);
   }
 
-  try {
-    commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
-  } catch {
-    console.warn('⚠️  Could not get git commit hash');
-    commitHash = 'unknown';
-  }
-
-  return { version, commitHash };
-}
-
-async function createPostHogRelease(version, commitHash) {
-  const url = `${host}/api/projects/${envId}/error_tracking/releases/`;
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`
-    },
-    body: JSON.stringify({
-      version: version,
-      hash_id: commitHash
-    })
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Failed to create release: ${response.status} - ${errorText}`);
-  }
-
-  return response.json();
+  return { version };
 }
 
 async function main() {
@@ -167,29 +137,17 @@ async function main() {
 
     // Step 2: Upload source maps to PostHog
     console.log('\n☁️  Step 2: Uploading source maps to PostHog...');
-    const uploadCmd = `${POSTHOG_CLI} sourcemap upload --directory ${DIST_DIR}`;
+    const { version } = getVersionInfo();
+    const uploadCmd = `${POSTHOG_CLI} sourcemap upload --directory ${DIST_DIR} --release-name pulpe-webapp --release-version ${version}`;
     execSync(uploadCmd, {
       stdio: isCI ? 'pipe' : 'inherit',
       env
     });
     console.log('✅ Source maps uploaded successfully');
 
-    // Step 3: Create PostHog release for version tracking
-    console.log('\n📦 Step 3: Creating PostHog release...');
-    const { version, commitHash } = getVersionInfo();
-    console.log(`   Version: ${version}`);
-    console.log(`   Commit: ${commitHash.substring(0, 7)}`);
-
-    try {
-      await createPostHogRelease(version, commitHash);
-      console.log('✅ PostHog release created successfully');
-    } catch (releaseError) {
-      console.warn(`⚠️  Release creation failed (non-blocking): ${releaseError.message}`);
-    }
-
     console.log('\n🎉 PostHog source maps processing completed!');
     console.log('Your error tracking will now show readable stack traces.');
-    console.log('Errors will be grouped by release version.');
+    console.log(`Release "${version}" created with source linking enabled.`);
 
   } catch (error) {
     console.error('\n❌ Error during source maps processing:', error.message);

--- a/frontend/scripts/upload-sourcemaps.js
+++ b/frontend/scripts/upload-sourcemaps.js
@@ -115,7 +115,8 @@ async function main() {
     const injectCmd = `${POSTHOG_CLI} sourcemap inject --directory ${DIST_DIR}`;
     execSync(injectCmd, {
       stdio: isCI ? 'pipe' : 'inherit',
-      env
+      env,
+      timeout: 60_000
     });
     console.log('✅ Source map metadata injected successfully');
 
@@ -138,7 +139,8 @@ async function main() {
     const uploadCmd = `${POSTHOG_CLI} sourcemap upload --directory ${DIST_DIR} --release-name pulpe-webapp --release-version ${version}`;
     execSync(uploadCmd, {
       stdio: isCI ? 'pipe' : 'inherit',
-      env
+      env,
+      timeout: 120_000
     });
     console.log('✅ Source maps uploaded with release info');
 
@@ -148,6 +150,7 @@ async function main() {
 
   } catch (error) {
     console.error('\n❌ Error during source maps processing:', error.message);
+    if (error.stderr) console.error(error.stderr.toString());
 
     if (isCI) {
       console.error('\nCI/CD Environment - Please check:');

--- a/frontend/scripts/upload-sourcemaps.js
+++ b/frontend/scripts/upload-sourcemaps.js
@@ -41,6 +41,7 @@ function getVersion() {
   } catch (error) {
     console.error('❌ Failed to read version from package.json:', error.message);
     process.exit(1);
+    return undefined;
   }
 }
 

--- a/frontend/scripts/upload-sourcemaps.test.js
+++ b/frontend/scripts/upload-sourcemaps.test.js
@@ -1,0 +1,122 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Tests for upload-sourcemaps.js
+ *
+ * Run: node --test frontend/scripts/upload-sourcemaps.test.js
+ *
+ * Tests version extraction, CLI command construction,
+ * environment validation, and error handling.
+ */
+
+describe('upload-sourcemaps: getVersion()', () => {
+  it('should read version from frontend/package.json', () => {
+    const packageJsonPath = path.join(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    assert.ok(packageJson.version, 'package.json should have a version field');
+    assert.match(packageJson.version, /^\d+\.\d+\.\d+/, 'Version should be semver format');
+  });
+});
+
+describe('upload-sourcemaps: CLI command construction', () => {
+  it('should use pnpm exec posthog-cli (not npx)', () => {
+    const scriptContent = fs.readFileSync(path.join(__dirname, 'upload-sourcemaps.js'), 'utf8');
+
+    assert.ok(
+      scriptContent.includes("pnpm exec posthog-cli"),
+      'Should use pnpm exec posthog-cli instead of npx @posthog/cli',
+    );
+    assert.ok(
+      !scriptContent.includes("npx @posthog/cli"),
+      'Should NOT use npx @posthog/cli (causes musl fallback on Vercel)',
+    );
+  });
+
+  it('should include --release-name and --release-version flags in upload command', () => {
+    const scriptContent = fs.readFileSync(path.join(__dirname, 'upload-sourcemaps.js'), 'utf8');
+
+    assert.ok(
+      scriptContent.includes('--release-name pulpe-webapp'),
+      'Upload command should include --release-name pulpe-webapp',
+    );
+    assert.ok(
+      scriptContent.includes('--release-version'),
+      'Upload command should include --release-version',
+    );
+  });
+
+  it('should set POSTHOG_CLI_TOKEN env var for CLI auth (not pass key in command)', () => {
+    const scriptContent = fs.readFileSync(path.join(__dirname, 'upload-sourcemaps.js'), 'utf8');
+
+    assert.ok(
+      scriptContent.includes('POSTHOG_CLI_TOKEN: apiKey'),
+      'Should pass API key via POSTHOG_CLI_TOKEN env var',
+    );
+    // Verify the key is NOT interpolated into the command string
+    const uploadCmdLine = scriptContent.split('\n').find(l => l.includes('uploadCmd'));
+    assert.ok(
+      !uploadCmdLine.includes('apiKey'),
+      'API key should NOT be interpolated in the command string',
+    );
+  });
+});
+
+describe('upload-sourcemaps: environment validation', () => {
+  it('should default PostHog host to EU instance', () => {
+    const scriptContent = fs.readFileSync(path.join(__dirname, 'upload-sourcemaps.js'), 'utf8');
+
+    assert.ok(
+      scriptContent.includes("'https://eu.i.posthog.com'"),
+      'Default host should be https://eu.i.posthog.com',
+    );
+  });
+
+  it('should log SET/MISSING for env vars in CI (never the actual value)', () => {
+    const scriptContent = fs.readFileSync(path.join(__dirname, 'upload-sourcemaps.js'), 'utf8');
+
+    // Find the debug logging lines
+    const debugLines = scriptContent.split('\n').filter(l =>
+      l.includes('POSTHOG_PERSONAL_API_KEY') && l.includes('SET')
+    );
+
+    assert.ok(debugLines.length > 0, 'Should have debug logging for API key');
+    assert.ok(
+      debugLines.every(l => l.includes("? 'SET' : 'MISSING'")),
+      'Should only log SET or MISSING, never the actual key value',
+    );
+  });
+
+  it('should exit with 0 (not 1) when credentials missing in local dev', () => {
+    const scriptContent = fs.readFileSync(path.join(__dirname, 'upload-sourcemaps.js'), 'utf8');
+
+    assert.ok(
+      scriptContent.includes('process.exit(isCI ? 1 : 0)'),
+      'Should exit 0 in local, 1 in CI — non-blocking locally',
+    );
+  });
+});
+
+describe('upload-sourcemaps: PostHog CLI version', () => {
+  it('should have @posthog/cli >= 0.6.0 in devDependencies', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
+    );
+
+    const cliVersion = packageJson.devDependencies?.['@posthog/cli'];
+    assert.ok(cliVersion, '@posthog/cli should be in devDependencies');
+
+    // Extract the minimum version number
+    const versionMatch = cliVersion.match(/(\d+)\.(\d+)\.(\d+)/);
+    assert.ok(versionMatch, `Version should be parseable: ${cliVersion}`);
+
+    const [, major, minor] = versionMatch.map(Number);
+    assert.ok(
+      major > 0 || minor >= 6,
+      `@posthog/cli should be >= 0.6.0 (has --release-name flag), got ${cliVersion}`,
+    );
+  });
+});

--- a/landing/package.json
+++ b/landing/package.json
@@ -17,7 +17,8 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "generate:og": "npx tsx scripts/generate-og-image.ts"
+    "generate:og": "npx tsx scripts/generate-og-image.ts",
+    "create:release": "node scripts/create-release.js"
   },
   "dependencies": {
     "lucide-react": "^0.562.0",

--- a/landing/scripts/create-release.js
+++ b/landing/scripts/create-release.js
@@ -27,6 +27,11 @@ async function main() {
     return;
   }
 
+  if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') {
+    console.log('⏭️  Non-production Vercel deploy, skipping release creation.');
+    return;
+  }
+
   let version;
   try {
     const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));

--- a/landing/scripts/create-release.js
+++ b/landing/scripts/create-release.js
@@ -9,7 +9,7 @@
  *
  * Environment Variables:
  * - POSTHOG_PERSONAL_API_KEY: Personal API key for PostHog
- * - POSTHOG_LANDING_ENV_ID: PostHog project ID for the landing
+ * - POSTHOG_CLI_ENV_ID: PostHog project ID (same project as webapp: 87621)
  * - POSTHOG_HOST: PostHog instance URL (optional, defaults to EU)
  */
 
@@ -19,7 +19,7 @@ const { execSync } = require('child_process');
 
 const isCI = !!(process.env.CI || process.env.VERCEL || process.env.GITHUB_ACTIONS);
 const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
-const envId = process.env.POSTHOG_LANDING_ENV_ID;
+const envId = process.env.POSTHOG_CLI_ENV_ID;
 const host = process.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
 
 async function main() {
@@ -54,7 +54,7 @@ async function main() {
         'Authorization': `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        version: version,
+        version: `landing-${version}`,
         hash_id: commitHash,
       }),
     });
@@ -64,7 +64,7 @@ async function main() {
       throw new Error(`${response.status} - ${errorText}`);
     }
 
-    console.log(`✅ PostHog release v${version} created for landing`);
+    console.log(`✅ PostHog release landing-${version} created`);
   } catch (error) {
     console.warn(`⚠️  Release creation failed (non-blocking): ${error.message}`);
   }

--- a/landing/scripts/create-release.js
+++ b/landing/scripts/create-release.js
@@ -40,6 +40,7 @@ async function main() {
   } catch (error) {
     console.error('❌ Failed to read version from package.json:', error.message);
     process.exit(isCI ? 1 : 0);
+    return;
   }
 
   let commitHash;

--- a/landing/scripts/create-release.js
+++ b/landing/scripts/create-release.js
@@ -35,6 +35,7 @@ async function main() {
   let version;
   try {
     const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+    if (!pkg.version) throw new Error('Missing version field in package.json');
     version = pkg.version;
   } catch (error) {
     console.error('❌ Failed to read version from package.json:', error.message);
@@ -61,6 +62,7 @@ async function main() {
         version: `landing-${version}`,
         hash_id: commitHash,
       }),
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (!response.ok) {

--- a/landing/scripts/create-release.js
+++ b/landing/scripts/create-release.js
@@ -13,9 +13,8 @@
  * - POSTHOG_HOST: PostHog instance URL (optional, defaults to EU)
  */
 
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
 
 const isCI = !!(process.env.CI || process.env.VERCEL || process.env.GITHUB_ACTIONS);
 const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
@@ -30,7 +29,7 @@ async function main() {
 
   let version;
   try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
     version = pkg.version;
   } catch (error) {
     console.error('❌ Failed to read version from package.json:', error.message);

--- a/landing/scripts/create-release.js
+++ b/landing/scripts/create-release.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * PostHog Release Creation for Landing Page
+ *
+ * Creates a release in PostHog to track deployments.
+ * The landing page uses static export (no sourcemaps needed),
+ * but releases enable version-based error filtering.
+ *
+ * Environment Variables:
+ * - POSTHOG_PERSONAL_API_KEY: Personal API key for PostHog
+ * - POSTHOG_LANDING_ENV_ID: PostHog project ID for the landing
+ * - POSTHOG_HOST: PostHog instance URL (optional, defaults to EU)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const isCI = !!(process.env.CI || process.env.VERCEL || process.env.GITHUB_ACTIONS);
+const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+const envId = process.env.POSTHOG_LANDING_ENV_ID;
+const host = process.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
+
+async function main() {
+  if (!apiKey || !envId) {
+    console.log('⚠️  PostHog credentials not configured for landing releases. Skipping.');
+    return;
+  }
+
+  let version;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+    version = pkg.version;
+  } catch (error) {
+    console.error('❌ Failed to read version from package.json:', error.message);
+    process.exit(isCI ? 1 : 0);
+  }
+
+  let commitHash;
+  try {
+    commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    commitHash = 'unknown';
+  }
+
+  console.log(`📦 Creating PostHog release for landing v${version} (${commitHash.substring(0, 7)})`);
+
+  try {
+    const response = await fetch(`${host}/api/projects/${envId}/error_tracking/releases/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        version: version,
+        hash_id: commitHash,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`${response.status} - ${errorText}`);
+    }
+
+    console.log(`✅ PostHog release v${version} created for landing`);
+  } catch (error) {
+    console.warn(`⚠️  Release creation failed (non-blocking): ${error.message}`);
+  }
+}
+
+main().catch((error) => {
+  console.error('❌ Unhandled error:', error.message);
+  process.exit(isCI ? 1 : 0);
+});

--- a/landing/scripts/create-release.test.js
+++ b/landing/scripts/create-release.test.js
@@ -1,0 +1,202 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Tests for create-release.js
+ *
+ * Run: node --test landing/scripts/create-release.test.js
+ *
+ * Tests the guards (missing credentials, non-production env),
+ * the API payload structure, and error handling.
+ */
+
+// Save original env
+const originalEnv = { ...process.env };
+
+// Track console output
+let logs = [];
+let warns = [];
+const originalLog = console.log;
+const originalWarn = console.warn;
+const originalError = console.error;
+
+beforeEach(() => {
+  // Reset env
+  delete process.env.POSTHOG_PERSONAL_API_KEY;
+  delete process.env.POSTHOG_CLI_ENV_ID;
+  delete process.env.POSTHOG_HOST;
+  delete process.env.VERCEL_ENV;
+  delete process.env.CI;
+  delete process.env.VERCEL;
+  delete process.env.GITHUB_ACTIONS;
+  logs = [];
+  warns = [];
+  console.log = (...args) => logs.push(args.join(' '));
+  console.warn = (...args) => warns.push(args.join(' '));
+  console.error = () => {};
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  console.warn = originalWarn;
+  console.error = originalError;
+  Object.assign(process.env, originalEnv);
+});
+
+describe('create-release.js guards', () => {
+  it('should skip when POSTHOG_PERSONAL_API_KEY is missing', async () => {
+    process.env.POSTHOG_CLI_ENV_ID = '87621';
+
+    // Import fresh module (node --test isolates)
+    const exitMock = mock.fn();
+    const origExit = process.exit;
+    process.exit = exitMock;
+
+    try {
+      await import('./create-release.js?skip1');
+    } catch {
+      // Module may throw or exit
+    }
+
+    process.exit = origExit;
+
+    assert.ok(
+      logs.some((l) => l.includes('not configured') || l.includes('Skipping')),
+      'Should log skip message when API key is missing',
+    );
+  });
+
+  it('should skip when POSTHOG_CLI_ENV_ID is missing', async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = 'phx_test';
+
+    const exitMock = mock.fn();
+    const origExit = process.exit;
+    process.exit = exitMock;
+
+    try {
+      await import('./create-release.js?skip2');
+    } catch {
+      // Module may throw or exit
+    }
+
+    process.exit = origExit;
+
+    assert.ok(
+      logs.some((l) => l.includes('not configured') || l.includes('Skipping')),
+      'Should log skip message when ENV_ID is missing',
+    );
+  });
+
+  it('should skip on non-production Vercel deploy', async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = 'phx_test';
+    process.env.POSTHOG_CLI_ENV_ID = '87621';
+    process.env.VERCEL_ENV = 'preview';
+
+    const exitMock = mock.fn();
+    const origExit = process.exit;
+    process.exit = exitMock;
+
+    try {
+      await import('./create-release.js?skip3');
+    } catch {
+      // Module may throw or exit
+    }
+
+    process.exit = origExit;
+
+    assert.ok(
+      logs.some((l) => l.includes('Non-production') || l.includes('skipping')),
+      'Should log skip message for preview deploys',
+    );
+  });
+});
+
+describe('create-release.js API call', () => {
+  it('should call PostHog API with correct payload structure', async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = 'phx_test_key';
+    process.env.POSTHOG_CLI_ENV_ID = '87621';
+    process.env.POSTHOG_HOST = 'https://test.posthog.com';
+    process.env.VERCEL_ENV = 'production';
+
+    let capturedUrl = '';
+    let capturedOptions = {};
+
+    // Mock global fetch
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url, options) => {
+      capturedUrl = url;
+      capturedOptions = options;
+      return { ok: true, json: async () => ({}) };
+    };
+
+    const exitMock = mock.fn();
+    const origExit = process.exit;
+    process.exit = exitMock;
+
+    try {
+      await import('./create-release.js?api1');
+      // Give the async main() time to complete
+      await new Promise((r) => setTimeout(r, 100));
+    } catch {
+      // Module may throw
+    }
+
+    process.exit = origExit;
+    globalThis.fetch = originalFetch;
+
+    // Verify URL
+    assert.ok(
+      capturedUrl.includes('/api/projects/87621/error_tracking/releases/'),
+      `URL should target project 87621, got: ${capturedUrl}`,
+    );
+    assert.ok(
+      capturedUrl.startsWith('https://test.posthog.com'),
+      `URL should use custom host, got: ${capturedUrl}`,
+    );
+
+    // Verify headers
+    assert.equal(capturedOptions.method, 'POST');
+    assert.equal(capturedOptions.headers['Content-Type'], 'application/json');
+    assert.equal(capturedOptions.headers['Authorization'], 'Bearer phx_test_key');
+
+    // Verify payload
+    const body = JSON.parse(capturedOptions.body);
+    assert.ok(body.version.startsWith('landing-'), `Version should start with "landing-", got: ${body.version}`);
+    assert.ok(body.hash_id, 'Should include hash_id');
+  });
+
+  it('should handle API errors gracefully (non-blocking)', async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = 'phx_test_key';
+    process.env.POSTHOG_CLI_ENV_ID = '87621';
+    process.env.VERCEL_ENV = 'production';
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 401,
+      text: async () => 'Unauthorized',
+    });
+
+    const exitMock = mock.fn();
+    const origExit = process.exit;
+    process.exit = exitMock;
+
+    try {
+      await import('./create-release.js?api2');
+      await new Promise((r) => setTimeout(r, 100));
+    } catch {
+      // Module may throw
+    }
+
+    process.exit = origExit;
+    globalThis.fetch = originalFetch;
+
+    // Should warn but not crash
+    assert.ok(
+      warns.some((w) => w.includes('Release creation failed')),
+      'Should warn about failure, not crash',
+    );
+    // process.exit should NOT have been called (non-blocking)
+    assert.equal(exitMock.mock.callCount(), 0, 'Should not exit on API error');
+  });
+});

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "cd .. && pnpm build:shared && cd landing && pnpm build",
+  "buildCommand": "cd .. && pnpm build:shared && cd landing && pnpm build && node scripts/create-release.js",
   "installCommand": "cd .. && pnpm install --frozen-lockfile --filter=pulpe-landing --filter=pulpe-shared --ignore-scripts",
   "redirects": [
     {

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "cd .. && pnpm build:shared && cd landing && pnpm build && node scripts/create-release.js",
+  "buildCommand": "cd .. && pnpm build:shared && cd landing && pnpm build && (node scripts/create-release.js || echo '⚠️  PostHog release skipped')",
   "installCommand": "cd .. && pnpm install --frozen-lockfile --filter=pulpe-landing --filter=pulpe-shared --ignore-scripts",
   "redirects": [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,8 +297,8 @@ importers:
         specifier: ^1.57.0
         version: 1.57.0
       '@posthog/cli':
-        specifier: ^0.4.7
-        version: 0.4.7
+        specifier: ^0.6.1
+        version: 0.6.1
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.0.16(vitest@4.0.16)
@@ -2277,8 +2277,8 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/cli@0.4.7':
-    resolution: {integrity: sha512-FTIQMW7J+OaN0B/cRGvXUL2bJaSwr19ef2Vu8UzkQb5/9U/FtbYIcGqpdlv82Bi4Aet9S/k+RmVO2wlCq34dZw==}
+  '@posthog/cli@0.6.1':
+    resolution: {integrity: sha512-SjKAJi6NaFaN/kG5oLUL/WawTedi4wNlPUVY36z+rOETccdnaeQ//UuEDADT8IrICWaWpAaRfh76SU8zP9atng==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
 
@@ -3440,8 +3440,8 @@ packages:
   axios-proxy-builder@0.1.2:
     resolution: {integrity: sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA==}
 
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3449,6 +3449,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
@@ -3492,6 +3496,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4577,6 +4585,10 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -4702,6 +4714,10 @@ packages:
   glob@13.0.0:
     resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
     engines: {node: 20 || >=22}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -5579,6 +5595,10 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -5619,6 +5639,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.1.0:
@@ -6067,6 +6091,10 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@8.2.0:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
@@ -6404,8 +6432,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@6.1.2:
-    resolution: {integrity: sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==}
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -9439,13 +9467,13 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/cli@0.4.7':
+  '@posthog/cli@0.6.1':
     dependencies:
-      axios: 1.11.0
+      axios: 1.13.6
       axios-proxy-builder: 0.1.2
       console.table: 0.10.0
       detect-libc: 2.1.2
-      rimraf: 6.1.2
+      rimraf: 6.1.3
     transitivePeerDependencies:
       - debug
 
@@ -10743,10 +10771,10 @@ snapshots:
     dependencies:
       tunnel: 0.0.6
 
-  axios@1.11.0:
+  axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
-      form-data: 4.0.4
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -10754,6 +10782,8 @@ snapshots:
   axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   base64-js@0.0.8: {}
 
@@ -10818,6 +10848,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -11616,8 +11650,8 @@ snapshots:
       '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
@@ -11647,7 +11681,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11658,7 +11692,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11697,14 +11731,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11775,7 +11809,7 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11786,7 +11820,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12191,6 +12225,14 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -12328,6 +12370,12 @@ snapshots:
       minimatch: 10.1.1
       minipass: 7.1.2
       path-scurry: 2.0.1
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@7.2.3:
     dependencies:
@@ -13192,6 +13240,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -13235,6 +13287,8 @@ snapshots:
       yallist: 4.0.0
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
@@ -13749,6 +13803,11 @@ snapshots:
       lru-cache: 11.2.4
       minipass: 7.1.2
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.4
+      minipass: 7.1.3
+
   path-to-regexp@8.2.0: {}
 
   path-type@3.0.0:
@@ -14083,9 +14142,9 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rimraf@6.1.2:
+  rimraf@6.1.3:
     dependencies:
-      glob: 13.0.0
+      glob: 13.0.6
       package-json-from-dist: 1.0.1
 
   rolldown@1.0.0-beta.47:


### PR DESCRIPTION
## Summary

- **Webapp**: sourcemaps upload via PostHog CLI avec `--release-name`/`--release-version` pour activer le source linking GitHub
- **Landing**: script `create-release.js` crée une release PostHog à chaque build Vercel
- **iOS**: step CI crée une release `ios-X.Y.Z+BUILD` + annotation sur push main
- **CI**: job `posthog-annotate` crée des annotations (markers sur les graphiques) sur push main
- **Docs**: `POSTHOG_RELEASES.md`, `DEPLOYMENT.md`, `MONITORING.md` mis à jour

Toutes les apps ciblent le même projet PostHog (87621). Les releases se distinguent par préfixe (`pulpe-webapp`, `landing-X.Y.Z`, `ios-X.Y.Z+BUILD`).

## Config requise (déjà fait)

- [x] GitHub secrets: `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_WEBAPP_PROJECT_ID`
- [x] Vercel Landing: `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_CLI_ENV_ID`
- [x] PostHog: GitHub + Linear connectés

## Test plan

- [ ] Merger dans preview, puis main
- [ ] Vérifier les logs Vercel webapp: `Release "pulpe-webapp" created with source linking enabled.`
- [ ] Vérifier les logs Vercel landing: `PostHog release landing-X.Y.Z created`
- [ ] Vérifier GitHub Actions: job `posthog-annotate` vert
- [ ] Vérifier PostHog: annotation visible sur un graphique
- [ ] Vérifier PostHog: Settings → Error Tracking → Releases
- [ ] Vérifier PostHog: stack trace avec lien "View in GitHub"