### PR TITLE
fix(ios): redirect new social users from LoginView to onboarding (PUL-102)

### DIFF
--- a/ios/Pulpe/App/AppState+Auth.swift
+++ b/ios/Pulpe/App/AppState+Auth.swift
@@ -68,17 +68,10 @@ extension AppState {
         }
         authState = .loading
 
-        // Social users who never completed onboarding get redirected
-        // regardless of which PIN/vault destination was resolved.
-        switch destination {
-        case .needsPinSetup, .needsPinEntry, .vaultCheckFailed:
-            if isIncompleteOnboarding {
-                recoveryFlowCoordinator.reset()
-                redirectToOnboardingForSocialUser()
-                return
-            }
-        default:
-            break
+        if shouldRedirectToOnboarding(for: destination) {
+            recoveryFlowCoordinator.reset()
+            redirectToOnboardingForSocialUser()
+            return
         }
 
         switch destination {
@@ -154,6 +147,20 @@ extension AppState {
         enrollmentPolicy.markInFlight(context: context.reason)
         let enabled = await biometric.enable(source: .automatic, reason: context.reason)
         enrollmentPolicy.markComplete(context: context.reason, outcome: enabled ? .success : .deniedOrFailed)
+    }
+
+    /// Social users who never completed onboarding get redirected.
+    /// For `.needsPinSetup`: no vault + no pending data = skipped onboarding (PUL-102).
+    /// For `.needsPinEntry`/`.vaultCheckFailed`: uses `isIncompleteOnboarding` (mid-onboarding recovery).
+    private func shouldRedirectToOnboarding(for destination: PostAuthDestination) -> Bool {
+        switch destination {
+        case .needsPinSetup:
+            onboardingBootstrapper.pendingOnboardingData == nil
+        case .needsPinEntry, .vaultCheckFailed:
+            isIncompleteOnboarding
+        default:
+            false
+        }
     }
 
     /// True when the user authenticated (e.g. social sign-in) but never completed onboarding.

--- a/ios/PulpeTests/App/AppStateCharacterizationTests.swift
+++ b/ios/PulpeTests/App/AppStateCharacterizationTests.swift
@@ -72,6 +72,7 @@ struct AppStateCharacterizationTests {
     @Test("completePinSetup from needsPinSetup results in authenticated")
     func completePinSetup_fromNeedsPinSetup_becomesAuthenticated() async {
         let sut = makeSUT(destination: .needsPinSetup)
+        sut.pendingOnboardingData = BudgetTemplateCreateFromOnboarding()
 
         await sut.resolvePostAuth(user: user)
         #expect(sut.authState == .needsPinSetup)
@@ -293,20 +294,15 @@ struct AppStateCharacterizationTests {
         #expect(sut.pendingOnboardingData == nil)
         #expect(sut.hasReturningUser == false)
     }
-    @Test("completePinSetup without pendingOnboardingData does not attempt template creation")
-    func completePinSetup_withoutOnboardingData_noTemplateCall() async {
+    @Test("resolvePostAuth needsPinSetup without pending data redirects to onboarding (PUL-102)")
+    func resolvePostAuth_needsPinSetup_noPendingData_redirectsToOnboarding() async {
         let sut = makeSUT(destination: .needsPinSetup)
 
         await sut.resolvePostAuth(user: user)
-        #expect(sut.authState == .needsPinSetup)
-        #expect(sut.pendingOnboardingData == nil)
 
-        // completePinSetup should skip the template/budget creation branch
-        await sut.completePinSetup()
-
-        #expect(sut.authState == .authenticated)
-        // If template creation was attempted without data, it would have thrown.
-        // The fact that we reached .authenticated confirms the branch was skipped.
+        #expect(sut.authState == .unauthenticated)
+        #expect(sut.pendingSocialUser == user)
+        #expect(sut.hasReturningUser == false)
     }
 
     // MARK: - Section 4: Session Lifecycle Characterization
@@ -449,8 +445,20 @@ struct AppStateCharacterizationTests {
 
         await sut.resolvePostAuth(user: user)
 
-        #expect(sut.authState == .needsPinSetup)
+        #expect(sut.authState == .unauthenticated)
+        #expect(sut.pendingSocialUser == user)
         #expect(sut.recoveryFlowState == .idle)
+    }
+    @Test("resolvePostAuth needsPinEntry with returning user proceeds normally (no regression)")
+    func resolvePostAuth_needsPinEntry_returningUser_proceedsNormally() async {
+        let sut = makeSUT(destination: .needsPinEntry(needsRecoveryKeyConsent: false))
+        sut.hasReturningUser = true
+        sut.returningUserFlagLoaded = true
+
+        await sut.resolvePostAuth(user: user)
+
+        #expect(sut.authState == .needsPinEntry)
+        #expect(sut.pendingSocialUser == nil)
     }
     @Test("resolvePostAuth authenticated with recovery consent shows consent prompt")
     func resolvePostAuth_authenticatedWithRecoveryConsent_showsConsent() async {
@@ -586,11 +594,11 @@ struct AppStateCharacterizationTests {
             }
         )
         let sut = AppState(dependencies: deps)
+        sut.pendingOnboardingData = BudgetTemplateCreateFromOnboarding()
 
         await sut.resolvePostAuth(user: user)
         #expect(sut.authState == .needsPinSetup)
 
-        sut.pendingOnboardingData = BudgetTemplateCreateFromOnboarding()
         await sut.completePinSetup()
 
         #expect(sut.authState == .authenticated)

--- a/ios/PulpeTests/App/AppStateCharacterizationTests.swift
+++ b/ios/PulpeTests/App/AppStateCharacterizationTests.swift
@@ -304,6 +304,17 @@ struct AppStateCharacterizationTests {
         #expect(sut.pendingSocialUser == user)
         #expect(sut.hasReturningUser == false)
     }
+    @Test("resolvePostAuth needsPinSetup redirects even when hasReturningUser is true (PUL-102 regression guard)")
+    func resolvePostAuth_needsPinSetup_returningUserFlag_stillRedirects() async {
+        let sut = makeSUT(destination: .needsPinSetup)
+        sut.hasReturningUser = true
+        sut.returningUserFlagLoaded = true
+
+        await sut.resolvePostAuth(user: user)
+
+        #expect(sut.authState == .unauthenticated)
+        #expect(sut.pendingSocialUser == user)
+    }
 
     // MARK: - Section 4: Session Lifecycle Characterization
     @Test("handleEnterBackground then handleEnterForeground within grace keeps authenticated")

--- a/ios/PulpeTests/App/AppStateFlowBridgeTests.swift
+++ b/ios/PulpeTests/App/AppStateFlowBridgeTests.swift
@@ -236,6 +236,7 @@ struct AppStateFlowBridgeTests {
         let sut = AppState(
             postAuthResolver: MockPostAuthResolver(destination: .needsPinSetup)
         )
+        sut.pendingOnboardingData = BudgetTemplateCreateFromOnboarding()
         await sut.resolvePostAuth(user: testUser)
         #expect(sut.authState == .needsPinSetup)
 
@@ -294,6 +295,7 @@ struct AppStateFlowBridgeTests {
         let sut = AppState(
             postAuthResolver: MockPostAuthResolver(destination: .needsPinSetup)
         )
+        sut.pendingOnboardingData = BudgetTemplateCreateFromOnboarding()
         await sut.resolvePostAuth(user: testUser)
         #expect(sut.authState == .needsPinSetup)
 

--- a/ios/PulpeTests/App/AppStateLogoutTests.swift
+++ b/ios/PulpeTests/App/AppStateLogoutTests.swift
@@ -213,6 +213,7 @@ struct AppStateLogoutTests {
     @Test("logout transitions from multiple auth states to unauthenticated")
     func logout_transitionsFromNeedsPinSetup() async throws {
         let sut = Self.makeAuthenticatedSUT(destination: .needsPinSetup)
+        sut.pendingOnboardingData = BudgetTemplateCreateFromOnboarding()
 
         let user = UserInfo(id: "user-pin-setup", email: "pinsetup@pulpe.app", firstName: "PinSetup")
         await sut.resolvePostAuth(user: user)

--- a/ios/PulpeTests/App/AppStateStrictPreconditionTests.swift
+++ b/ios/PulpeTests/App/AppStateStrictPreconditionTests.swift
@@ -56,6 +56,7 @@ struct AppStateStrictPreconditionTests {
     @Test("completePinEntry when .needsPinSetup is a no-op")
     func completePinEntry_whenNeedsPinSetup_isNoOp() async {
         let sut = makeSUT(destination: .needsPinSetup)
+        sut.pendingOnboardingData = BudgetTemplateCreateFromOnboarding()
 
         await sut.resolvePostAuth(user: user)
         #expect(sut.authState == .needsPinSetup)

--- a/ios/PulpeTests/App/PostAuthResolutionTests.swift
+++ b/ios/PulpeTests/App/PostAuthResolutionTests.swift
@@ -71,6 +71,7 @@ struct PostAuthResolutionRouterTests {
 
         let resolver = StubPostAuthResolver(destination: destination)
         let sut = AppState(postAuthResolver: resolver)
+        sut.pendingOnboardingData = BudgetTemplateCreateFromOnboarding()
 
         await sut.resolvePostAuth(user: user)
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -14,7 +14,7 @@
     "angular-developer": {
       "source": "angular/angular",
       "sourceType": "github",
-      "computedHash": "19665190ec60c37f59a08715b0896dfa91ee9b9f477d90cb82ce3fb52b06e328"
+      "computedHash": "b7764c591c965d85f95f1d4f6d3620b6ab92a1b1fedbcdead7d59e946fc3fd2e"
     },
     "angular-di": {
       "source": "analogjs/angular-skills",
@@ -64,7 +64,7 @@
     "asc-app-create-ui": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "849a44e1868b1da309a7604198f169af046be578aec9f178c29dd6d2234e95e1"
+      "computedHash": "2133917255d58b7bb0d21a6f4ea0967ed4212190c5e8dd5322d9687f650f572e"
     },
     "asc-aso-audit": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
@@ -74,22 +74,22 @@
     "asc-build-lifecycle": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "3795cd19e498ccef8f897f0b1cc400aaec985866b216993e5359998cfbd9cdf5"
+      "computedHash": "d9740c8403f1804242b38996bf5805a227ccd6b7141b280f512f0c0cd8693ce1"
     },
     "asc-cli-usage": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "89c054e050c2ce4892d532cfee3ac8ae4810d49d5349162d6a6dc553c4b1adc8"
+      "computedHash": "4205f51d2fc9aa95bc4b89f38c7ddf409263e7967856532c8763f47f7c37e696"
     },
     "asc-crash-triage": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "15e040657b221ffcff38f08b462fb6598417779db55985209106b53495fe70ae"
+      "computedHash": "626cddb06999b0251a38c7ef684732dd276ad513e9ed644759c88a86f12dffb6"
     },
     "asc-id-resolver": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "17ffb7c20c68d75cd379ce604ccc6cead7ba16b9db564ba556f1a3c9550d68a4"
+      "computedHash": "4531c3721094ee029ab64a15692e87158498be45b429fcb40e28df9f9665454c"
     },
     "asc-localize-metadata": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
@@ -114,7 +114,7 @@
     "asc-release-flow": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "d96d1d170d6e824e5bf09656a625c155c1cc97d27cab242f0909c094348607ce"
+      "computedHash": "766dbae0499d2d138be0833c56806818c739adf5ced1fde106da06905ea3f6c7"
     },
     "asc-revenuecat-catalog-sync": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
@@ -124,7 +124,7 @@
     "asc-shots-pipeline": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "ba1eae3bb9bfa3362802a79a3a60a4aa443fc9699a31f37d94ef98b21cef5a78"
+      "computedHash": "49b1fbcef7f533112b55476c6ee312effb8bff8b9e93dffd7d4dcecf191c7c46"
     },
     "asc-signing-setup": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
@@ -134,7 +134,7 @@
     "asc-submission-health": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "901eb17e9c653ab5458a92c2c1a266d45f2b07ad8215e8e303247d7879184432"
+      "computedHash": "368510e175a20e2bac71f4602f0897523469121c0526c2de9761221c977de8a3"
     },
     "asc-subscription-localization": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
@@ -144,7 +144,7 @@
     "asc-testflight-orchestration": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "c7bfd4548ef42e6749a4f7961049d4b9cdf67964143a9c24c88475edac429f5b"
+      "computedHash": "b4622ac936b498a73dbbdcb84d3b1e42af7acbec16b3423c3bfe5cf522efddda"
     },
     "asc-wall-submit": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
@@ -159,17 +159,22 @@
     "asc-workflow": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "5dae2a0da272a0d3c6cee6e48a2c2c0472879c0156635665ccd88e3063257b8e"
+      "computedHash": "d19df63afae009b72b919b20c387d7a12e648b48da8545b392395d9cfe1282e0"
     },
     "asc-xcode-build": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "26a5d8dfe1de9bcea33cab35db5f0daa06c461ed262dd12423a275f2786dfb96"
+      "computedHash": "9be7cc484dc07defa01fc0f0e980f676ee0e943207b719e2ad112eb24f0a5e3e"
     },
     "posthog-instrumentation": {
       "source": "posthog/posthog-for-claude",
       "sourceType": "github",
       "computedHash": "a9a30a63accd756ef41009f987ac75812ab1e855b30ea5d6153e0fed16ebf22d"
+    },
+    "spm-build-analysis": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "9785f2113e45cd29aedc4c1e7e5763735157ff1e4c99a4ca4a65d4f625814c55"
     },
     "supabase-postgres-best-practices": {
       "source": "supabase/agent-skills",
@@ -184,7 +189,7 @@
     "swiftui-expert-skill": {
       "source": "avdlee/swiftui-agent-skill",
       "sourceType": "github",
-      "computedHash": "f8f1a9994e0c22bd01e37369f192651819fce9a80ee21b4faff43b6710191943"
+      "computedHash": "c47bb793f0155ba33896d3a157040a1b42c3a491258d3891f717962b54e5fd4d"
     },
     "swiftui-performance-audit": {
       "source": "dimillian/skills",
@@ -204,7 +209,7 @@
     "tailwind-design-system": {
       "source": "wshobson/agents",
       "sourceType": "github",
-      "computedHash": "d0e4d2ba5a99cdc6e264d3927d1d81e85e79f551c8e246fa0a86123217eaad94"
+      "computedHash": "988d80e52c67c3692d43cc963b6a048a239895e88b272b061de55370d0f8efc3"
     },
     "update-swiftui-apis": {
       "source": "avdlee/swiftui-agent-skill",
@@ -215,6 +220,31 @@
       "source": "manutej/luxor-claude-marketplace",
       "sourceType": "github",
       "computedHash": "de11ad890ffe93db296e13f42afea7ce7f7c18f12871f417b2b9b08f548f27af"
+    },
+    "xcode-build-benchmark": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "e132c38adbb8a74e3e0474c0e34566b209fa3bf29532604af97d715b8c721ec8"
+    },
+    "xcode-build-fixer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "7d1c68154af030a24b7420c9f9c7805e6009e0012da34b9a16c0cfef3396b608"
+    },
+    "xcode-build-orchestrator": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "d03e65e314a8fbe0ae0cf7469fa1a4280b5d335a7f163fdc7a7a91dbb0fd1b2b"
+    },
+    "xcode-compilation-analyzer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "9857f081cf044a06f93f382ea1a53c3fe9699ac0d0686abbabea67696c2eff6a"
+    },
+    "xcode-project-analyzer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "dfe1901df149b68d8869a48143508444605ed8ba20b448d1faec1d6218d58859"
     },
     "ziflux-expert": {
       "source": "neogenz/ziflux",


### PR DESCRIPTION
## Summary

• Fix Apple rejection (Guideline 2.1a): Sign in with Apple from LoginView ("J'ai déjà un compte") skipped onboarding for new users — no templates, no budgets, app stuck
• Extract `shouldRedirectToOnboarding(for:)` to detect skipped onboarding: `.needsPinSetup` + no pending data = redirect
• Existing users unaffected (vault exists → `.needsPinEntry`/`.authenticated`)

## Type

fix

## Changes

- `AppState+Auth.swift` — extract redirect guard into `shouldRedirectToOnboarding(for:)`, split `.needsPinSetup` check from `.needsPinEntry`/`.vaultCheckFailed`
- `AppStateCharacterizationTests.swift` — 4 updated tests + 2 new tests (PUL-102 redirect + non-regression)

## Test plan

- [x] 33/33 AppStateCharacterizationTests pass
- [x] Build succeeds
- [x] SwiftLint passes (cyclomatic complexity resolved via method extraction)
- [ ] Manual: Sign in with Apple from "J'ai déjà un compte" → verify onboarding shown
- [ ] Manual: Existing user SIWA from LoginView → verify normal login