### PR TITLE
feat(ios): add CTA buttons for budget and template creation

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetList/CreateBudgetView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/CreateBudgetView.swift
@@ -70,7 +70,7 @@ struct CreateBudgetView: View {
         .standardSheetPresentation()
         .sheet(isPresented: $showCreateTemplate) {
             CreateTemplateView { _ in
-                Task { await viewModel.loadTemplates() }
+                Task(name: "CreateBudget.reloadTemplates") { await viewModel.loadTemplates() }
             }
         }
     }

--- a/ios/Pulpe/Features/Budgets/BudgetList/CreateBudgetView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/CreateBudgetView.swift
@@ -8,6 +8,7 @@ struct CreateBudgetView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel: CreateBudgetViewModel
     @State private var hasAppeared = false
+    @State private var showCreateTemplate = false
 
     init(month: Int, year: Int, onCreate: @escaping (Budget) -> Void) {
         self.month = month
@@ -67,6 +68,11 @@ struct CreateBudgetView: View {
             }
         }
         .standardSheetPresentation()
+        .sheet(isPresented: $showCreateTemplate) {
+            CreateTemplateView { _ in
+                Task { await viewModel.loadTemplates() }
+            }
+        }
     }
 
     // MARK: - Create Button
@@ -187,13 +193,20 @@ struct CreateBudgetView: View {
                 .font(PulpeTypography.subheadline)
                 .foregroundStyle(Color.textSecondary)
 
-            Text("Crée d'abord un modèle dans l'onglet Modèles")
+            Text("Crée-en un pour préparer ton budget")
                 .font(PulpeTypography.detailLabel)
                 .foregroundStyle(Color.textTertiary)
                 .multilineTextAlignment(.center)
+
+            Button("Créer un modèle") {
+                showCreateTemplate = true
+            }
+            .primaryButtonStyle()
+            .padding(.top, DesignTokens.Spacing.sm)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, DesignTokens.Spacing.xxxl)
+        .padding(.horizontal, DesignTokens.Spacing.lg)
         .pulpeCardBackground(cornerRadius: DesignTokens.CornerRadius.md)
     }
 

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -12,8 +12,10 @@ private enum SheetDestination: Identifiable {
 struct CurrentMonthView: View {
     @Environment(AppState.self) private var appState
     @Environment(CurrentMonthStore.self) private var store
+    @Environment(BudgetListStore.self) private var budgetListStore
     @Environment(UserSettingsStore.self) private var userSettingsStore
     @State private var activeSheet: SheetDestination?
+    @State private var showCreateBudget = false
     @State private var navigateToBudget = false
     @State private var hasAppeared = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -61,6 +63,10 @@ struct CurrentMonthView: View {
                         .font(PulpeTypography.bodyLarge)
                         .foregroundStyle(Color.textTertiary)
                         .multilineTextAlignment(.center)
+                    Button("Créer un budget") {
+                        showCreateBudget = true
+                    }
+                    .primaryButtonStyle()
                 }
                 .padding(DesignTokens.Spacing.xxxl)
                 .transition(.opacity)
@@ -98,6 +104,19 @@ struct CurrentMonthView: View {
                 )
             case .account:
                 AccountView()
+            }
+        }
+        .sheet(isPresented: $showCreateBudget) {
+            if let nextMonth = budgetListStore.nextAvailableMonth {
+                CreateBudgetView(
+                    month: nextMonth.month,
+                    year: nextMonth.year
+                ) { _ in
+                    store.invalidateCache()
+                    Task {
+                        await store.loadDetailsIfNeeded()
+                    }
+                }
             }
         }
         .task {

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -66,7 +66,8 @@ struct CurrentMonthView: View {
                     Button("Créer un budget") {
                         showCreateBudget = true
                     }
-                    .primaryButtonStyle()
+                    .disabled(budgetListStore.nextAvailableMonth == nil)
+                    .primaryButtonStyle(isEnabled: budgetListStore.nextAvailableMonth != nil)
                 }
                 .padding(DesignTokens.Spacing.xxxl)
                 .transition(.opacity)
@@ -111,7 +112,8 @@ struct CurrentMonthView: View {
                 CreateBudgetView(
                     month: nextMonth.month,
                     year: nextMonth.year
-                ) { _ in
+                ) { budget in
+                    budgetListStore.addBudget(budget)
                     store.invalidateCache()
                     Task {
                         await store.loadDetailsIfNeeded()

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -5,6 +5,7 @@ private enum SheetDestination: Identifiable {
     case addTransaction
     case realizedBalance
     case account
+    case createBudget
 
     var id: Self { self }
 }
@@ -15,7 +16,6 @@ struct CurrentMonthView: View {
     @Environment(BudgetListStore.self) private var budgetListStore
     @Environment(UserSettingsStore.self) private var userSettingsStore
     @State private var activeSheet: SheetDestination?
-    @State private var showCreateBudget = false
     @State private var navigateToBudget = false
     @State private var hasAppeared = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -63,11 +63,12 @@ struct CurrentMonthView: View {
                         .font(PulpeTypography.bodyLarge)
                         .foregroundStyle(Color.textTertiary)
                         .multilineTextAlignment(.center)
+                    let canCreateBudget = budgetListStore.nextAvailableMonth != nil
                     Button("Créer un budget") {
-                        showCreateBudget = true
+                        activeSheet = .createBudget
                     }
-                    .disabled(budgetListStore.nextAvailableMonth == nil)
-                    .primaryButtonStyle(isEnabled: budgetListStore.nextAvailableMonth != nil)
+                    .disabled(!canCreateBudget)
+                    .primaryButtonStyle(isEnabled: canCreateBudget)
                 }
                 .padding(DesignTokens.Spacing.xxxl)
                 .transition(.opacity)
@@ -105,18 +106,17 @@ struct CurrentMonthView: View {
                 )
             case .account:
                 AccountView()
-            }
-        }
-        .sheet(isPresented: $showCreateBudget) {
-            if let nextMonth = budgetListStore.nextAvailableMonth {
-                CreateBudgetView(
-                    month: nextMonth.month,
-                    year: nextMonth.year
-                ) { budget in
-                    budgetListStore.addBudget(budget)
-                    store.invalidateCache()
-                    Task {
-                        await store.loadDetailsIfNeeded()
+            case .createBudget:
+                if let nextMonth = budgetListStore.nextAvailableMonth {
+                    CreateBudgetView(
+                        month: nextMonth.month,
+                        year: nextMonth.year
+                    ) { budget in
+                        budgetListStore.addBudget(budget)
+                        store.invalidateCache()
+                        Task {
+                            await store.loadDetailsIfNeeded()
+                        }
                     }
                 }
             }

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -29,6 +29,10 @@ struct CurrentMonthView: View {
         }
     }
 
+    private var canCreateBudget: Bool {
+        budgetListStore.nextAvailableMonth != nil
+    }
+
     private var timeElapsedPercentage: Double {
         guard let budget = store.budget else { return 0 }
         return BudgetPeriodCalculator.timeElapsedPercentage(
@@ -63,7 +67,6 @@ struct CurrentMonthView: View {
                         .font(PulpeTypography.bodyLarge)
                         .foregroundStyle(Color.textTertiary)
                         .multilineTextAlignment(.center)
-                    let canCreateBudget = budgetListStore.nextAvailableMonth != nil
                     Button("Créer un budget") {
                         activeSheet = .createBudget
                     }


### PR DESCRIPTION
## Summary

• Add "Créer un budget" CTA button in home empty state (CurrentMonthView)
• Add "Créer un modèle" CTA button in budget creation sheet when no templates exist
• Both follow existing empty state pattern (icon → title → subtitle → primary CTA)
• Audited against Practical UI rules (copywriting, button hierarchy, spacing)

## Type

feat