### PR TITLE
fix(ios): persist clientKey on rekey partial failure (PUL-89)

### DIFF
--- a/ios/Pulpe/Core/Network/APIError.swift
+++ b/ios/Pulpe/Core/Network/APIError.swift
@@ -27,6 +27,7 @@ enum APIError: LocalizedError {
     case clientKeyInvalid
     case recoveryKeyInvalid
     case recoveryKeyNotConfigured
+    case rekeyPartialFailure
 
     var errorDescription: String? {
         switch self {
@@ -76,6 +77,8 @@ enum APIError: LocalizedError {
             return "Clé de récupération invalide — vérifie que tu as bien copié la clé"
         case .recoveryKeyNotConfigured:
             return "Aucune clé de secours n'est enregistrée — génère-en une depuis « Clé de secours »."
+        case .rekeyPartialFailure:
+            return "Le changement de PIN a réussi mais la clé de secours n'a pas pu être mise à jour"
         }
     }
 
@@ -102,6 +105,7 @@ enum APIError: LocalizedError {
         "ERR_ENCRYPTION_KEY_CHECK_FAILED": .clientKeyInvalid,
         "ERR_RECOVERY_KEY_INVALID": .recoveryKeyInvalid,
         "ERR_RECOVERY_KEY_NOT_CONFIGURED": .recoveryKeyNotConfigured,
+        "ERR_ENCRYPTION_REKEY_PARTIAL_FAILURE": .rekeyPartialFailure,
     ]
 
     /// Create APIError from server error code

--- a/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
@@ -289,20 +289,12 @@ final class ChangePinViewModel {
                 newClientKeyHex: result.clientKeyHex
             )
 
-            await clientKeyManager.store(result.clientKeyHex, enableBiometric: biometricEnabled)
-            self.oldClientKeyHex = nil
-            self.cachedSalt = nil
-            hapticSuccess.toggle()
-            AnalyticsService.shared.capture(.pinChanged)
+            await completeChangePin(clientKeyHex: result.clientKeyHex)
             recoveryKey = response.recoveryKey
         } catch let error as APIError {
             if case .rekeyPartialFailure = error, let newKey = newClientKeyHex {
                 Self.logger.warning("Rekey partial failure: persisting new key")
-                await clientKeyManager.store(newKey, enableBiometric: biometricEnabled)
-                self.oldClientKeyHex = nil
-                self.cachedSalt = nil
-                hapticSuccess.toggle()
-                AnalyticsService.shared.capture(.pinChanged)
+                await completeChangePin(clientKeyHex: newKey)
                 completedWithoutRecovery = true
             } else {
                 step = .enterNewPin
@@ -317,6 +309,16 @@ final class ChangePinViewModel {
             step = .enterNewPin
             showError("Erreur inattendue, réessaie")
         }
+    }
+
+    // MARK: - Completion
+
+    private func completeChangePin(clientKeyHex: String) async {
+        await clientKeyManager.store(clientKeyHex, enableBiometric: biometricEnabled)
+        oldClientKeyHex = nil
+        cachedSalt = nil
+        hapticSuccess.toggle()
+        AnalyticsService.shared.capture(.pinChanged)
     }
 
     // MARK: - Error Handling

--- a/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
@@ -32,6 +32,9 @@ struct ChangePinView: View {
                     onSuccess()
                 }
             }
+            .onChange(of: viewModel.completedWithoutRecovery) { _, completed in
+                if completed { onSuccess() }
+            }
     }
 
     // MARK: - Content
@@ -142,6 +145,7 @@ final class ChangePinViewModel {
     private(set) var hapticSuccess = false
     private(set) var hapticError = false
     private(set) var recoveryKey: String?
+    private(set) var completedWithoutRecovery = false
 
     let pinLength = PinConstants.length
 
@@ -262,6 +266,8 @@ final class ChangePinViewModel {
         step = .processing
         defer { isProcessing = false }
 
+        var newClientKeyHex: String?
+
         do {
             let result = try await PinValidation.derive(
                 pin: pinString,
@@ -276,6 +282,8 @@ final class ChangePinViewModel {
                 return
             }
 
+            newClientKeyHex = result.clientKeyHex
+
             let response = try await encryptionAPI.changePin(
                 oldClientKeyHex: oldClientKeyHex,
                 newClientKeyHex: result.clientKeyHex
@@ -288,8 +296,17 @@ final class ChangePinViewModel {
             AnalyticsService.shared.capture(.pinChanged)
             recoveryKey = response.recoveryKey
         } catch let error as APIError {
-            step = .enterNewPin
-            handleAPIError(error)
+            if case .rekeyPartialFailure = error, let newKey = newClientKeyHex {
+                await clientKeyManager.store(newKey, enableBiometric: biometricEnabled)
+                self.oldClientKeyHex = nil
+                self.cachedSalt = nil
+                hapticSuccess.toggle()
+                AnalyticsService.shared.capture(.pinChanged)
+                completedWithoutRecovery = true
+            } else {
+                step = .enterNewPin
+                handleAPIError(error)
+            }
         } catch let error as CryptoServiceError {
             step = .enterNewPin
             handleCryptoError(error)

--- a/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
+++ b/ios/Pulpe/Features/Auth/Pin/ChangePinView.swift
@@ -297,6 +297,7 @@ final class ChangePinViewModel {
             recoveryKey = response.recoveryKey
         } catch let error as APIError {
             if case .rekeyPartialFailure = error, let newKey = newClientKeyHex {
+                Self.logger.warning("Rekey partial failure: persisting new key")
                 await clientKeyManager.store(newKey, enableBiometric: biometricEnabled)
                 self.oldClientKeyHex = nil
                 self.cachedSalt = nil

--- a/ios/PulpeTests/App/AppStateFlowBridgeTests.swift
+++ b/ios/PulpeTests/App/AppStateFlowBridgeTests.swift
@@ -242,7 +242,7 @@ struct AppStateFlowBridgeTests {
 
         sut.send(.pinSetupCompleted)
 
-        await waitForCondition(timeout: .milliseconds(500), "pin setup must complete") {
+        await waitForCondition("pin setup must complete") {
             sut.authState == .authenticated
         }
     }

--- a/ios/PulpeTests/Features/Auth/ChangePinViewModelTests.swift
+++ b/ios/PulpeTests/Features/Auth/ChangePinViewModelTests.swift
@@ -242,6 +242,22 @@ struct ChangePinFlowTests {
         #expect(result.sut.step == .enterOldPin, "Should stay on enterOldPin — no auto-confirm")
         #expect(result.sut.digits.count == 4)
     }
+
+    // MARK: - Partial Rekey Failure
+
+    @Test("partial rekey failure persists new key and signals completion")
+    func rekeyPartialFailure_persistsNewKeyAndSignalsCompletion() async {
+        let result = makeFlowSUT(changePinError: .rekeyPartialFailure)
+
+        await advanceToNewPinStep(result.sut)
+        await enterNewPinAndConfirm(result.sut)
+
+        #expect(result.sut.completedWithoutRecovery == true)
+        #expect(result.sut.recoveryKey == nil)
+        #expect(await result.storage.lastStoredKey == ChangePinConstants.newKey)
+        #expect(await result.storage.storeCallCount == 2) // validate + change
+        #expect(result.sut.step == .processing) // not reset to enterNewPin
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## Summary

• Handle `ERR_ENCRYPTION_REKEY_PARTIAL_FAILURE` in iOS PIN change flow
• Add `rekeyPartialFailure` case to `APIError` enum with code mapping
• Persist new clientKey and dismiss gracefully on partial failure (prevents user lockout)
• Add test verifying key persistence and completion signal

## Type

fix

## Closes

PUL-89