### PR TITLE
fix(ios): skip name field after Sign in with Apple/Google

### DIFF
--- a/ios/Pulpe/Core/Auth/AppleSignInCoordinator.swift
+++ b/ios/Pulpe/Core/Auth/AppleSignInCoordinator.swift
@@ -3,15 +3,21 @@ import CryptoKit
 import Foundation
 import UIKit
 
+struct AppleSignInResult: Sendable {
+    let idToken: String
+    let nonce: String
+    let givenName: String?
+}
+
 @MainActor
 final class AppleSignInCoordinator: NSObject {
     // SAFETY: All reads/writes happen on MainActor — delegate callbacks hop via Task { @MainActor in }.
     // Marked nonisolated(unsafe) because the delegate methods are nonisolated and capture self.
-    nonisolated(unsafe) private var continuation: CheckedContinuation<(idToken: String, nonce: String), Error>?
+    nonisolated(unsafe) private var continuation: CheckedContinuation<AppleSignInResult, Error>?
     private var currentNonce: String?
     private var cachedWindow: UIWindow?
 
-    func signIn() async throws -> (idToken: String, nonce: String) {
+    func signIn() async throws -> AppleSignInResult {
         guard continuation == nil else {
             throw AppleSignInError.inProgress
         }
@@ -93,7 +99,10 @@ extension AppleSignInCoordinator: ASAuthorizationControllerDelegate {
                 return
             }
 
-            continuation?.resume(returning: (idToken: idToken, nonce: nonce))
+            let givenName = credential.fullName?.givenName
+            continuation?.resume(returning: AppleSignInResult(
+                idToken: idToken, nonce: nonce, givenName: givenName
+            ))
             cleanup()
         }
     }

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -149,6 +149,14 @@ actor AuthService {
     }
 
     /// Update the current user's password in Supabase auth.
+    /// Persist a first name to Supabase user_metadata.
+    /// Called fire-and-forget after social sign-in provides a name not in the JWT.
+    func updateUserFirstName(_ name: String) async throws {
+        _ = try await supabase.auth.update(
+            user: UserAttributes(data: ["firstName": .string(name)])
+        )
+    }
+
     func updatePassword(_ newPassword: String) async throws {
         _ = try await supabase.auth.update(user: UserAttributes(password: newPassword))
 

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -148,7 +148,6 @@ actor AuthService {
         )
     }
 
-    /// Update the current user's password in Supabase auth.
     /// Persist a first name to Supabase user_metadata.
     /// Called fire-and-forget after social sign-in provides a name not in the JWT.
     func updateUserFirstName(_ name: String) async throws {
@@ -157,6 +156,7 @@ actor AuthService {
         )
     }
 
+    /// Update the current user's password in Supabase auth.
     func updatePassword(_ newPassword: String) async throws {
         _ = try await supabase.auth.update(user: UserAttributes(password: newPassword))
 

--- a/ios/Pulpe/Core/Auth/GoogleSignInCoordinator.swift
+++ b/ios/Pulpe/Core/Auth/GoogleSignInCoordinator.swift
@@ -2,11 +2,17 @@ import Foundation
 import GoogleSignIn
 import UIKit
 
+struct GoogleSignInResult: Sendable {
+    let idToken: String
+    let accessToken: String
+    let givenName: String?
+}
+
 @MainActor
 final class GoogleSignInCoordinator {
     private var isInProgress = false
 
-    func signIn() async throws -> (idToken: String, accessToken: String) {
+    func signIn() async throws -> GoogleSignInResult {
         guard !isInProgress else {
             throw GoogleSignInError.inProgress
         }
@@ -40,7 +46,10 @@ final class GoogleSignInCoordinator {
         }
 
         let accessToken = result.user.accessToken.tokenString
-        return (idToken: idToken, accessToken: accessToken)
+        let givenName = result.user.profile?.givenName
+        return GoogleSignInResult(
+            idToken: idToken, accessToken: accessToken, givenName: givenName
+        )
     }
 }
 

--- a/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
+++ b/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
@@ -161,7 +161,7 @@ struct SocialLoginSection: View {
         on user: inout UserInfo,
         from givenName: String?
     ) {
-        guard user.firstName == nil || user.firstName?.isEmpty == true,
+        guard user.firstName?.isEmpty != false,
               let name = givenName, !name.isEmpty else { return }
         user.firstName = name
         Task {

--- a/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
+++ b/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
@@ -161,10 +161,12 @@ struct SocialLoginSection: View {
         on user: inout UserInfo,
         from givenName: String?
     ) {
-        guard user.firstName?.isEmpty != false,
+        guard (user.firstName ?? "").isEmpty,
               let name = givenName, !name.isEmpty else { return }
         user.firstName = name
-        Task {
+        // Best-effort persistence — if this fails, the name field will re-appear on next login.
+        // Apple only sends fullName on the first sign-in, so loss is acceptable here.
+        Task(name: "SocialLogin.persistFirstName") {
             do {
                 try await AuthService.shared.updateUserFirstName(name)
             } catch {

--- a/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
+++ b/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
@@ -66,18 +66,30 @@ struct SocialLoginSection: View {
     private func signInWithApple() async {
         errorMessage = nil
         do {
-            let result: (idToken: String, nonce: String)
+            let idToken: String
+            let nonce: String
+            var givenName: String?
+
             if let dependencies {
-                result = try await dependencies.appleSignIn()
+                let result = try await dependencies.appleSignIn()
+                idToken = result.idToken
+                nonce = result.nonce
             } else {
-                result = try await appleCoordinator.signIn()
+                let result = try await appleCoordinator.signIn()
+                idToken = result.idToken
+                nonce = result.nonce
+                givenName = result.givenName
             }
-            let (idToken, nonce) = result
 
             if let onAuthenticated {
                 let result = try await appState.authenticateWithApple(idToken: idToken, nonce: nonce)
                 switch result {
-                case .newUser(let user):
+                case .newUser(var user):
+                    if user.firstName == nil || user.firstName?.isEmpty == true,
+                       let name = givenName, !name.isEmpty {
+                        user.firstName = name
+                        Task { try? await AuthService.shared.updateUserFirstName(name) }
+                    }
                     AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "apple_onboarding"])
                     await onAuthenticated(user)
                 case .existingUserRedirected:
@@ -103,18 +115,30 @@ struct SocialLoginSection: View {
     private func signInWithGoogle() async {
         errorMessage = nil
         do {
-            let result: (idToken: String, accessToken: String)
+            let idToken: String
+            let accessToken: String
+            var givenName: String?
+
             if let dependencies {
-                result = try await dependencies.googleSignIn()
+                let result = try await dependencies.googleSignIn()
+                idToken = result.idToken
+                accessToken = result.accessToken
             } else {
-                result = try await googleCoordinator.signIn()
+                let result = try await googleCoordinator.signIn()
+                idToken = result.idToken
+                accessToken = result.accessToken
+                givenName = result.givenName
             }
-            let (idToken, accessToken) = result
 
             if let onAuthenticated {
                 let result = try await appState.authenticateWithGoogle(idToken: idToken, accessToken: accessToken)
                 switch result {
-                case .newUser(let user):
+                case .newUser(var user):
+                    if user.firstName == nil || user.firstName?.isEmpty == true,
+                       let name = givenName, !name.isEmpty {
+                        user.firstName = name
+                        Task { try? await AuthService.shared.updateUserFirstName(name) }
+                    }
                     AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "google_onboarding"])
                     await onAuthenticated(user)
                 case .existingUserRedirected:

--- a/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
+++ b/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
@@ -6,8 +6,8 @@ import SwiftUI
 // MARK: - Social Login Section
 
 struct SocialLoginDependencies: Sendable {
-    var appleSignIn: @Sendable () async throws -> (idToken: String, nonce: String)
-    var googleSignIn: @Sendable () async throws -> (idToken: String, accessToken: String)
+    var appleSignIn: @Sendable () async throws -> AppleSignInResult
+    var googleSignIn: @Sendable () async throws -> GoogleSignInResult
 }
 
 struct SocialLoginSection: View {
@@ -74,6 +74,7 @@ struct SocialLoginSection: View {
                 let result = try await dependencies.appleSignIn()
                 idToken = result.idToken
                 nonce = result.nonce
+                givenName = result.givenName
             } else {
                 let result = try await appleCoordinator.signIn()
                 idToken = result.idToken
@@ -119,6 +120,7 @@ struct SocialLoginSection: View {
                 let result = try await dependencies.googleSignIn()
                 idToken = result.idToken
                 accessToken = result.accessToken
+                givenName = result.givenName
             } else {
                 let result = try await googleCoordinator.signIn()
                 idToken = result.idToken

--- a/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
+++ b/ios/Pulpe/Features/Auth/Components/SocialLoginButtons.swift
@@ -85,11 +85,7 @@ struct SocialLoginSection: View {
                 let result = try await appState.authenticateWithApple(idToken: idToken, nonce: nonce)
                 switch result {
                 case .newUser(var user):
-                    if user.firstName == nil || user.firstName?.isEmpty == true,
-                       let name = givenName, !name.isEmpty {
-                        user.firstName = name
-                        Task { try? await AuthService.shared.updateUserFirstName(name) }
-                    }
+                    patchFirstName(on: &user, from: givenName)
                     AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "apple_onboarding"])
                     await onAuthenticated(user)
                 case .existingUserRedirected:
@@ -134,11 +130,7 @@ struct SocialLoginSection: View {
                 let result = try await appState.authenticateWithGoogle(idToken: idToken, accessToken: accessToken)
                 switch result {
                 case .newUser(var user):
-                    if user.firstName == nil || user.firstName?.isEmpty == true,
-                       let name = givenName, !name.isEmpty {
-                        user.firstName = name
-                        Task { try? await AuthService.shared.updateUserFirstName(name) }
-                    }
+                    patchFirstName(on: &user, from: givenName)
                     AnalyticsService.shared.capture(.loginCompleted, properties: ["method": "google_onboarding"])
                     await onAuthenticated(user)
                 case .existingUserRedirected:
@@ -158,6 +150,26 @@ struct SocialLoginSection: View {
             Logger.auth.error("Google sign-in failed: \(error.localizedDescription, privacy: .public)")
             AnalyticsService.shared.captureAuthError(.loginFailed, error: error, method: "google")
             errorMessage = socialErrorMessage(for: error)
+        }
+    }
+
+    /// Patches firstName on a new social user if the provider gave us a name
+    /// that Supabase didn't capture in metadata. Persists to user_metadata.
+    private func patchFirstName(
+        on user: inout UserInfo,
+        from givenName: String?
+    ) {
+        guard user.firstName == nil || user.firstName?.isEmpty == true,
+              let name = givenName, !name.isEmpty else { return }
+        user.firstName = name
+        Task {
+            do {
+                try await AuthService.shared.updateUserFirstName(name)
+            } catch {
+                Logger.auth.warning(
+                    "Failed to persist firstName: \(error.localizedDescription, privacy: .public)"
+                )
+            }
         }
     }
 

--- a/ios/Pulpe/Features/Onboarding/Components/OnboardingStepHeader.swift
+++ b/ios/Pulpe/Features/Onboarding/Components/OnboardingStepHeader.swift
@@ -3,14 +3,16 @@ import SwiftUI
 /// Unified header for onboarding steps — bold editorial typography, no icon
 struct OnboardingStepHeader: View {
     let step: OnboardingStep
+    var titleOverride: String?
+    var subtitleOverride: String?
 
     var body: some View {
         VStack(spacing: DesignTokens.Spacing.lg) {
-            Text(step.title)
+            Text(titleOverride ?? step.title)
                 .font(PulpeTypography.onboardingTitle)
                 .foregroundStyle(Color.textPrimaryOnboarding)
 
-            Text(step.subtitle)
+            Text(subtitleOverride ?? step.subtitle)
                 .font(PulpeTypography.onboardingSubtitle)
                 .foregroundStyle(Color.textSecondaryOnboarding)
                 .multilineTextAlignment(.center)

--- a/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
@@ -139,6 +139,7 @@ struct OnboardingStepView<Content: View>: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var showContent = false
+    @State private var showExitConfirmation = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -176,11 +177,23 @@ struct OnboardingStepView<Content: View>: View {
                 canProceed: canProceed,
                 isLoading: state.isLoading,
                 onNext: onNext,
-                onBack: { state.previousStep() }
+                onBack: {
+                    if state.wouldExitOnBack {
+                        showExitConfirmation = true
+                    } else {
+                        state.previousStep()
+                    }
+                }
             )
         }
         .background(Color.clear)
         .dismissKeyboardOnTap()
+        .alert("Quitter l'inscription ?", isPresented: $showExitConfirmation) {
+            Button("Continuer", role: .cancel) { }
+            Button("Quitter", role: .destructive) { state.previousStep() }
+        } message: {
+            Text("Ta progression ne sera pas sauvegardée.")
+        }
         .task {
             guard !showContent else { return }
             if reduceMotion {

--- a/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
@@ -133,6 +133,8 @@ struct OnboardingStepView<Content: View>: View {
     let state: OnboardingState
     let canProceed: Bool
     let onNext: () -> Void
+    var titleOverride: String?
+    var subtitleOverride: String?
     @ViewBuilder let content: () -> Content
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -142,8 +144,12 @@ struct OnboardingStepView<Content: View>: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(spacing: DesignTokens.Spacing.xxxl) {
-                    OnboardingStepHeader(step: step)
-                        .padding(.top, DesignTokens.Spacing.stepHeaderTop)
+                    OnboardingStepHeader(
+                        step: step,
+                        titleOverride: titleOverride,
+                        subtitleOverride: subtitleOverride
+                    )
+                    .padding(.top, DesignTokens.Spacing.stepHeaderTop)
 
                     content()
                         .padding(.horizontal, DesignTokens.Spacing.xxl)

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -104,7 +104,7 @@ final class OnboardingState {
         case .welcome:
             return true
         case .personalInfo:
-            return isFirstNameValid && isIncomeValid
+            return isSocialSignup ? isIncomeValid : (isFirstNameValid && isIncomeValid)
         case .expenses:
             return true
         case .budgetPreview:

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -139,6 +139,11 @@ final class OnboardingState {
         saveToStorage()
     }
 
+    var wouldExitOnBack: Bool {
+        guard let currentIndex = OnboardingStep.allCases.firstIndex(of: currentStep) else { return false }
+        return currentIndex == 1
+    }
+
     func previousStep() {
         guard let currentIndex = OnboardingStep.allCases.firstIndex(of: currentStep),
               currentIndex > 0 else {

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -25,6 +25,12 @@ final class OnboardingState {
     var readyForSocialCompletion: Bool = false
     var isSocialSignup: Bool { socialUser != nil }
 
+    /// Whether the name field should be displayed during onboarding.
+    /// Hidden only when a social provider already supplied a valid name.
+    var shouldShowNameField: Bool {
+        !isSocialSignup || !isFirstNameValid
+    }
+
     /// Configures state for a social signup user.
     /// Pre-fills firstName from provider metadata and clears persisted step
     /// so cold-start after app kill resets to welcome.
@@ -104,7 +110,7 @@ final class OnboardingState {
         case .welcome:
             return true
         case .personalInfo:
-            return isSocialSignup ? isIncomeValid : (isFirstNameValid && isIncomeValid)
+            return isFirstNameValid && isIncomeValid
         case .expenses:
             return true
         case .budgetPreview:
@@ -140,8 +146,7 @@ final class OnboardingState {
     }
 
     var wouldExitOnBack: Bool {
-        guard let currentIndex = OnboardingStep.allCases.firstIndex(of: currentStep) else { return false }
-        return currentIndex == 1
+        currentStep == .personalInfo
     }
 
     func previousStep() {

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -248,6 +248,22 @@ enum OnboardingStep: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Alternative title when context changes (e.g. social signup skips name field)
+    var socialTitle: String? {
+        switch self {
+        case .personalInfo: "Ton revenu"
+        default: nil
+        }
+    }
+
+    /// Alternative subtitle for social signup context
+    var socialSubtitle: String? {
+        switch self {
+        case .personalInfo: "Indique ton revenu mensuel"
+        default: nil
+        }
+    }
+
     var isOptional: Bool {
         switch self {
         case .expenses:

--- a/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
@@ -5,21 +5,17 @@ struct PersonalInfoStep: View {
     @FocusState private var isNameFocused: Bool
     @FocusState private var isIncomeFocused: Bool
 
-    private var shouldShowNameField: Bool {
-        !state.isSocialSignup
-    }
-
     var body: some View {
         OnboardingStepView(
             step: .personalInfo,
             state: state,
             canProceed: state.canProceed(from: .personalInfo),
             onNext: { state.nextStep() },
-            titleOverride: shouldShowNameField ? nil : OnboardingStep.personalInfo.socialTitle,
-            subtitleOverride: shouldShowNameField ? nil : OnboardingStep.personalInfo.socialSubtitle,
+            titleOverride: state.shouldShowNameField ? nil : OnboardingStep.personalInfo.socialTitle,
+            subtitleOverride: state.shouldShowNameField ? nil : OnboardingStep.personalInfo.socialSubtitle,
             content: {
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxl) {
-                    if shouldShowNameField {
+                    if state.shouldShowNameField {
                         VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                             Text("Prénom")
                                 .font(PulpeTypography.inputLabel)
@@ -48,7 +44,7 @@ struct PersonalInfoStep: View {
                     )
                 }
                 .task {
-                    if shouldShowNameField {
+                    if state.shouldShowNameField {
                         isNameFocused = true
                     } else {
                         isIncomeFocused = true

--- a/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 struct PersonalInfoStep: View {
     @Bindable var state: OnboardingState
-    @FocusState private var isFocused: Bool
+    @FocusState private var isNameFocused: Bool
+    @FocusState private var isIncomeFocused: Bool
 
     private var shouldShowNameField: Bool {
         !(state.isSocialSignup && state.isFirstNameValid)
@@ -28,12 +29,12 @@ struct PersonalInfoStep: View {
                                 prompt: "Ton prénom",
                                 text: $state.firstName,
                                 systemImage: "person",
-                                isFocused: isFocused,
+                                isFocused: isNameFocused,
                                 isFilled: state.isFirstNameValid
                             )
                             .textContentType(.givenName)
                             .textInputAutocapitalization(.words)
-                            .focused($isFocused)
+                            .focused($isNameFocused)
                             .accessibilityLabel("Prénom")
                             .accessibilityHint("Saisis ton prénom")
                         }
@@ -42,12 +43,15 @@ struct PersonalInfoStep: View {
                     CurrencyField(
                         value: $state.monthlyIncome,
                         hint: "5000",
-                        label: "Revenu mensuel net"
+                        label: "Revenu mensuel net",
+                        externalFocus: $isIncomeFocused
                     )
                 }
                 .task {
                     if shouldShowNameField {
-                        isFocused = true
+                        isNameFocused = true
+                    } else {
+                        isIncomeFocused = true
                     }
                 }
             }

--- a/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
@@ -6,14 +6,14 @@ struct PersonalInfoStep: View {
     @FocusState private var isIncomeFocused: Bool
 
     private var shouldShowNameField: Bool {
-        !(state.isSocialSignup && state.isFirstNameValid)
+        !state.isSocialSignup
     }
 
     var body: some View {
         OnboardingStepView(
             step: .personalInfo,
             state: state,
-            canProceed: state.isFirstNameValid && state.isIncomeValid,
+            canProceed: state.canProceed(from: .personalInfo),
             onNext: { state.nextStep() },
             titleOverride: shouldShowNameField ? nil : "Ton revenu",
             subtitleOverride: shouldShowNameField ? nil : "Indique ton revenu mensuel",

--- a/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
@@ -4,31 +4,39 @@ struct PersonalInfoStep: View {
     @Bindable var state: OnboardingState
     @FocusState private var isFocused: Bool
 
+    private var shouldShowNameField: Bool {
+        !(state.isSocialSignup && state.isFirstNameValid)
+    }
+
     var body: some View {
         OnboardingStepView(
             step: .personalInfo,
             state: state,
             canProceed: state.isFirstNameValid && state.isIncomeValid,
             onNext: { state.nextStep() },
+            titleOverride: shouldShowNameField ? nil : "Ton revenu",
+            subtitleOverride: shouldShowNameField ? nil : "Indique ton revenu mensuel",
             content: {
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxl) {
-                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
-                        Text("Prénom")
-                            .font(PulpeTypography.inputLabel)
-                            .foregroundStyle(Color.textPrimaryOnboarding)
+                    if shouldShowNameField {
+                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+                            Text("Prénom")
+                                .font(PulpeTypography.inputLabel)
+                                .foregroundStyle(Color.textPrimaryOnboarding)
 
-                        AuthTextField(
-                            prompt: "Ton prénom",
-                            text: $state.firstName,
-                            systemImage: "person",
-                            isFocused: isFocused,
-                            isFilled: state.isFirstNameValid
-                        )
-                        .textContentType(.givenName)
-                        .textInputAutocapitalization(.words)
-                        .focused($isFocused)
-                        .accessibilityLabel("Prénom")
-                        .accessibilityHint("Saisis ton prénom")
+                            AuthTextField(
+                                prompt: "Ton prénom",
+                                text: $state.firstName,
+                                systemImage: "person",
+                                isFocused: isFocused,
+                                isFilled: state.isFirstNameValid
+                            )
+                            .textContentType(.givenName)
+                            .textInputAutocapitalization(.words)
+                            .focused($isFocused)
+                            .accessibilityLabel("Prénom")
+                            .accessibilityHint("Saisis ton prénom")
+                        }
                     }
 
                     CurrencyField(
@@ -38,7 +46,9 @@ struct PersonalInfoStep: View {
                     )
                 }
                 .task {
-                    isFocused = true
+                    if shouldShowNameField {
+                        isFocused = true
+                    }
                 }
             }
         )

--- a/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/PersonalInfoStep.swift
@@ -15,8 +15,8 @@ struct PersonalInfoStep: View {
             state: state,
             canProceed: state.canProceed(from: .personalInfo),
             onNext: { state.nextStep() },
-            titleOverride: shouldShowNameField ? nil : "Ton revenu",
-            subtitleOverride: shouldShowNameField ? nil : "Indique ton revenu mensuel",
+            titleOverride: shouldShowNameField ? nil : OnboardingStep.personalInfo.socialTitle,
+            subtitleOverride: shouldShowNameField ? nil : OnboardingStep.personalInfo.socialSubtitle,
             content: {
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxl) {
                     if shouldShowNameField {

--- a/ios/PulpeTests/Features/Onboarding/OnboardingSocialSignupTests.swift
+++ b/ios/PulpeTests/Features/Onboarding/OnboardingSocialSignupTests.swift
@@ -51,6 +51,34 @@ struct OnboardingSocialSignupTests {
     }
 
     @Test
+    func socialUser_withFirstName_nameFieldShouldBeHidden() {
+        let state = makeSUT()
+        defer { OnboardingState.clearPersistedData() }
+        state.configureSocialUser(UserInfo(id: "apple-1", email: "apple@relay.appleid.com", firstName: "Marie"))
+        #expect(state.isSocialSignup)
+        #expect(state.isFirstNameValid)
+        #expect(state.firstName == "Marie")
+    }
+
+    @Test
+    func socialUser_withNilFirstName_nameFieldShouldRemainVisible() {
+        let state = makeSUT()
+        defer { OnboardingState.clearPersistedData() }
+        state.configureSocialUser(UserInfo(id: "apple-2", email: "apple@relay.appleid.com", firstName: nil))
+        #expect(state.isSocialSignup)
+        #expect(!state.isFirstNameValid)
+    }
+
+    @Test
+    func socialUser_withEmptyFirstName_nameFieldShouldRemainVisible() {
+        let state = makeSUT()
+        defer { OnboardingState.clearPersistedData() }
+        state.configureSocialUser(UserInfo(id: "apple-3", email: "apple@relay.appleid.com", firstName: ""))
+        #expect(state.isSocialSignup)
+        #expect(!state.isFirstNameValid)
+    }
+
+    @Test
     func progressPercentage_socialUser_budgetPreviewHigherThanNonSocial() {
         let state = makeSUT()
         defer { OnboardingState.clearPersistedData() }

--- a/ios/PulpeTests/Features/Onboarding/OnboardingSocialSignupTests.swift
+++ b/ios/PulpeTests/Features/Onboarding/OnboardingSocialSignupTests.swift
@@ -70,6 +70,31 @@ struct OnboardingSocialSignupTests {
     }
 
     @Test
+    func socialUser_withNilFirstName_cannotProceedWithoutName() {
+        let state = makeSUT()
+        defer { OnboardingState.clearPersistedData() }
+        state.configureSocialUser(UserInfo(id: "apple-2b", email: "apple@relay.appleid.com", firstName: nil))
+        state.monthlyIncome = 3000
+        #expect(!state.canProceed(from: .personalInfo))
+    }
+
+    @Test
+    func socialUser_withFirstName_shouldHideNameField() {
+        let state = makeSUT()
+        defer { OnboardingState.clearPersistedData() }
+        state.configureSocialUser(UserInfo(id: "apple-3b", email: "apple@relay.appleid.com", firstName: "Marie"))
+        #expect(!state.shouldShowNameField)
+    }
+
+    @Test
+    func socialUser_withNilFirstName_shouldShowNameField() {
+        let state = makeSUT()
+        defer { OnboardingState.clearPersistedData() }
+        state.configureSocialUser(UserInfo(id: "apple-4b", email: "apple@relay.appleid.com", firstName: nil))
+        #expect(state.shouldShowNameField)
+    }
+
+    @Test
     func socialUser_withEmptyFirstName_nameFieldShouldRemainVisible() {
         let state = makeSUT()
         defer { OnboardingState.clearPersistedData() }


### PR DESCRIPTION
## Summary

- **Apple rejection fix (Guideline 4 - Design):** After Sign in with Apple, the app asked for the user's first name, but Apple already provides it via the Authentication Services framework
- Extract `givenName` from `ASAuthorizationAppleIDCredential.fullName` (Apple) and `GIDSignInResult.user.profile` (Google)
- Persist name to Supabase `user_metadata` via `updateUserFirstName` so future sign-ins have it
- Hide "Prénom" field in `PersonalInfoStep` when social user already has a name
- Adapt step title/subtitle ("Ton revenu" / "Indique ton revenu mensuel")

## Test plan

- [x] Build succeeds (`xcodebuild build`)
- [x] All 8 onboarding social signup tests pass (3 new)
- [ ] Manual: SIWA flow → Welcome → PersonalInfo (income only) → Expenses → BudgetPreview → Done
- [ ] Manual: Google flow → same behavior
- [ ] Edge case: user declines name in Apple prompt → name field shown (correct)