### PR TITLE
fix(ios): show correct biometric modality on Touch ID / Optic ID devices (PUL-116)

### DIFF
--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -285,7 +285,7 @@ actor AuthService {
             return nil
         }
 
-        // Single Face ID prompt via pre-authenticated LAContext
+        // Single biometric prompt via pre-authenticated LAContext
         // SAFETY: LAContext is not Sendable but nonisolated(unsafe) is correct here because:
         // 1. The context is created, evaluated, and consumed entirely within this function scope.
         // 2. It is never shared with another task or stored beyond this call.
@@ -294,7 +294,7 @@ actor AuthService {
         do {
             try await context.evaluatePolicy(
                 .deviceOwnerAuthenticationWithBiometrics,
-                localizedReason: "Se connecter avec Face ID"
+                localizedReason: "Se connecter avec \(BiometricService.shared.biometryDisplayName)"
             )
         } catch let error as LAError where error.code == .userCancel {
             throw KeychainError.userCanceled

--- a/ios/Pulpe/Core/Auth/BiometricService.swift
+++ b/ios/Pulpe/Core/Auth/BiometricService.swift
@@ -30,6 +30,21 @@ final class BiometricService: Sendable {
         }
     }
 
+    var biometrySFSymbolName: String {
+        switch biometryType {
+        case .faceID:
+            return "faceid"
+        case .touchID:
+            return "touchid"
+        case .opticID:
+            return "opticid"
+        case .none:
+            return "lock.shield"
+        @unknown default:
+            return "lock.shield"
+        }
+    }
+
     // MARK: - Methods
 
     func canUseBiometrics() -> Bool {

--- a/ios/Pulpe/Features/Auth/LoginView.swift
+++ b/ios/Pulpe/Features/Auth/LoginView.swift
@@ -10,6 +10,9 @@ struct LoginView: View {
     @FocusState private var focusedField: Field?
     @State private var submitSuccessTrigger = false
 
+    private let biometryDisplayName = BiometricService.shared.biometryDisplayName
+    private let biometrySymbolName = BiometricService.shared.biometrySFSymbolName
+
     var isPresented: Binding<Bool>?
     var onBiometric: (() -> Void)?
 
@@ -123,7 +126,7 @@ extension LoginView {
                 appState.biometricError = nil
                 isPresented?.wrappedValue = false
             }
-            faceIDButton
+            biometricLoginButton
         }
         .opacity(isAppeared ? 1 : 0)
         .offset(y: isAppeared ? 0 : 20)
@@ -244,20 +247,20 @@ extension LoginView {
     }
 
     @ViewBuilder
-    private var faceIDButton: some View {
+    private var biometricLoginButton: some View {
         if let onBiometric {
             Button {
                 onBiometric()
             } label: {
                 HStack(spacing: DesignTokens.Spacing.sm) {
-                    Image(systemName: "faceid")
+                    Image(systemName: biometrySymbolName)
                         .font(PulpeTypography.body)
-                    Text("Face ID")
+                    Text(biometryDisplayName)
                 }
             }
             .secondaryButtonStyle()
             .padding(.top, DesignTokens.Spacing.sm)
-            .accessibilityIdentifier("faceIDButton")
+            .accessibilityIdentifier("biometricLoginButton")
         }
     }
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -149,7 +149,7 @@
     "asc-shots-pipeline": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
-      "computedHash": "49b1fbcef7f533112b55476c6ee312effb8bff8b9e93dffd7d4dcecf191c7c46"
+      "computedHash": "c1fcdf9efd0a6cf6bfce407b759506eb35bd11ce86b8fa3492535bc973ffb19f"
     },
     "asc-signing-setup": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
@@ -299,7 +299,7 @@
     "supabase-postgres-best-practices": {
       "source": "supabase/agent-skills",
       "sourceType": "github",
-      "computedHash": "f4cd7570115d97af6bcb2946eb891a958c8d04a43b479871c9ccadbc670ad058"
+      "computedHash": "d606a1146be6d54fb9e73f718b5320b9acac5ff2ba2d7230a555df4b5a923b4a"
     },
     "swift-concurrency-expert": {
       "source": "dimillian/skills",


### PR DESCRIPTION
## Summary

- `AuthService.validateBiometricSession` now derives the `localizedReason` from `BiometricService.biometryDisplayName` instead of the hardcoded "Se connecter avec Face ID", so the system prompt matches the device's actual biometric modality.
- `LoginView`'s sign-in button no longer hardcodes `"faceid"` + `"Face ID"` — it reads cached values from the service (icon + label now adaptive). New `biometrySFSymbolName` on `BiometricService` centralizes the SF Symbol mapping.
- `LAContext` is still created inline in `validateBiometricSession` to preserve the single-prompt optimization across subsequent keychain reads.

## Test plan

- [ ] iPhone Face ID simulator → prompt reads "Se connecter avec Face ID" + Face ID icon
- [ ] iPhone SE / iPad Touch ID simulator → "Se connecter avec Touch ID" + Touch ID icon
- [ ] Vision Pro Optic ID (if available) → "Se connecter avec Optic ID" + Optic ID icon
- [ ] `grep -rn 'Face ID' ios/Pulpe/` returns only Info.plist + BiometricService switch + one mechanism comment