### PR TITLE
refactor(webapp): promote demo CTA and unblock auth submits

### DIFF
--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -74,7 +74,7 @@
     },
     "forgotPassword": {
       "title": "Mot de passe oublié",
-      "subtitle": "Entre ton email pour recevoir un lien de réinitialisation",
+      "subtitle": "Ça arrive. Entre ton email, on te renvoie un lien tout de suite.",
       "submit": "Envoyer le lien",
       "submitting": "Envoi en cours...",
       "backToLogin": "Retour à la connexion",
@@ -151,7 +151,7 @@
   "welcome": {
     "eyebrow": "Budget annuel en 3 minutes",
     "title": "Vois clair dans tes finances",
-    "subtitle": "Planifie ton année, sache toujours ce que tu peux dépenser.",
+    "subtitle": "Enfin un budget qui te laisse respirer.",
     "emailSignup": "S'inscrire par e-mail",
     "tryWithoutAccount": "Essayer sans compte",
     "demoLoading": "Préparation...",

--- a/frontend/projects/webapp/src/app/core/core.ts
+++ b/frontend/projects/webapp/src/app/core/core.ts
@@ -6,6 +6,7 @@ import {
   withRouterConfig,
   withPreloading,
   NoPreloading,
+  withViewTransitions,
   TitleStrategy,
 } from '@angular/router';
 import { withChunkReloadRecovery } from './routing/navigation-error-handler';
@@ -117,6 +118,7 @@ export function provideCore({ routes }: CoreOptions) {
         scrollPositionRestoration: 'enabled',
       }),
       withPreloading(NoPreloading),
+      withViewTransitions({ skipInitialTransition: true }),
       withChunkReloadRecovery(),
     ),
 

--- a/frontend/projects/webapp/src/app/feature/auth/forgot-password/forgot-password.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/forgot-password/forgot-password.spec.ts
@@ -64,11 +64,6 @@ describe('ForgotPassword', () => {
       expect(component['errorMessage']).toBeDefined();
       expect(component['isSuccess']).toBeDefined();
     });
-
-    it('should have computed canSubmit defined', () => {
-      expect(component['canSubmit']).toBeDefined();
-      expect(typeof component['canSubmit']).toBe('function');
-    });
   });
 
   describe('Default Values', () => {
@@ -99,23 +94,6 @@ describe('ForgotPassword', () => {
 
       emailControl?.setValue('valid@email.com');
       expect(emailControl?.hasError('email')).toBe(false);
-    });
-  });
-
-  describe('canSubmit computed', () => {
-    it('should return false when form is invalid', () => {
-      expect(component['canSubmit']()).toBe(false);
-    });
-
-    it('should return false when isSubmitting is true', () => {
-      fillValidForm();
-      component['isSubmitting'].set(true);
-      expect(component['canSubmit']()).toBe(false);
-    });
-
-    it('should return true when form is valid and not submitting', () => {
-      fillValidForm();
-      expect(component['canSubmit']()).toBe(true);
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/auth/forgot-password/forgot-password.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/forgot-password/forgot-password.ts
@@ -1,11 +1,12 @@
 import {
-  Component,
+  afterNextRender,
   ChangeDetectionStrategy,
-  signal,
+  Component,
   inject,
-  computed,
+  signal,
+  viewChild,
+  type ElementRef,
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -71,6 +72,7 @@ import { LoadingButton } from '@ui/loading-button';
           <mat-form-field appearance="outline" class="w-full">
             <mat-label>{{ 'form.emailLabel' | transloco }}</mat-label>
             <input
+              #emailInput
               matInput
               type="email"
               formControlName="email"
@@ -95,7 +97,7 @@ import { LoadingButton } from '@ui/loading-button';
 
           <pulpe-loading-button
             [loading]="isSubmitting()"
-            [disabled]="!canSubmit()"
+            [disabled]="isSubmitting()"
             [loadingText]="'auth.forgotPassword.submitting' | transloco"
             icon="send"
             testId="forgot-password-submit-button"
@@ -142,16 +144,17 @@ export default class ForgotPassword {
   protected readonly errorMessage = signal('');
   protected readonly isSuccess = signal(false);
 
+  private readonly emailInput =
+    viewChild<ElementRef<HTMLInputElement>>('emailInput');
+
+  constructor() {
+    afterNextRender(() => {
+      this.emailInput()?.nativeElement.focus();
+    });
+  }
+
   protected readonly form = this.#formBuilder.nonNullable.group({
     email: ['', [Validators.required, Validators.email]],
-  });
-
-  readonly #formStatus = toSignal(this.form.statusChanges, {
-    initialValue: this.form.status,
-  });
-
-  protected readonly canSubmit = computed(() => {
-    return this.#formStatus() === 'VALID' && !this.isSubmitting();
   });
 
   protected clearError(): void {

--- a/frontend/projects/webapp/src/app/feature/auth/login/login.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/login/login.ts
@@ -1,12 +1,14 @@
 import {
-  Component,
+  afterNextRender,
   ChangeDetectionStrategy,
-  signal,
-  inject,
+  Component,
   computed,
+  inject,
   LOCALE_ID,
+  signal,
+  viewChild,
+  type ElementRef,
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -66,6 +68,20 @@ import { LoadingButton } from '@ui/loading-button';
         </p>
       </div>
 
+      <pulpe-google-oauth-button
+        testId="google-login-button"
+        (authError)="errorMessage.set($event)"
+        (loadingChange)="isGoogleLoading.set($event)"
+      />
+
+      <div class="flex items-center gap-4 my-6">
+        <mat-divider class="flex-1" />
+        <span class="text-body-medium text-on-surface-variant">{{
+          'common.or' | transloco
+        }}</span>
+        <mat-divider class="flex-1" />
+      </div>
+
       <form
         [formGroup]="loginForm"
         (ngSubmit)="signIn()"
@@ -75,13 +91,14 @@ import { LoadingButton } from '@ui/loading-button';
         <mat-form-field appearance="outline" class="w-full">
           <mat-label>{{ 'form.emailLabel' | transloco }}</mat-label>
           <input
+            #emailInput
             matInput
             type="email"
             formControlName="email"
             data-testid="email-input"
             (input)="clearMessages()"
             [placeholder]="'form.emailPlaceholder' | transloco"
-            [disabled]="isSubmitting()"
+            [disabled]="isBusy()"
           />
           <mat-icon matPrefix>email</mat-icon>
           @if (
@@ -106,7 +123,7 @@ import { LoadingButton } from '@ui/loading-button';
             data-testid="password-input"
             (input)="clearMessages()"
             [placeholder]="'form.passwordPlaceholder' | transloco"
-            [disabled]="isSubmitting()"
+            [disabled]="isBusy()"
           />
           <mat-icon matPrefix>lock</mat-icon>
           <button
@@ -149,7 +166,7 @@ import { LoadingButton } from '@ui/loading-button';
 
         <pulpe-loading-button
           [loading]="isSubmitting()"
-          [disabled]="!canSubmit()"
+          [disabled]="isBusy()"
           [loadingText]="'auth.login.submitting' | transloco"
           icon="login"
           testId="login-submit-button"
@@ -157,20 +174,6 @@ import { LoadingButton } from '@ui/loading-button';
           <span class="ml-2">{{ 'auth.login.submit' | transloco }}</span>
         </pulpe-loading-button>
       </form>
-
-      <div class="flex items-center gap-4 my-6">
-        <mat-divider class="flex-1" />
-        <span class="text-body-medium text-on-surface-variant">{{
-          'common.or' | transloco
-        }}</span>
-        <mat-divider class="flex-1" />
-      </div>
-
-      <pulpe-google-oauth-button
-        testId="google-login-button"
-        (authError)="errorMessage.set($event)"
-        (loadingChange)="isSubmitting.set($event)"
-      />
 
       <div class="text-center mt-6">
         <p class="text-body-medium text-on-surface-variant">
@@ -200,7 +203,17 @@ export default class Login {
   protected readonly ROUTES = ROUTES;
   protected readonly isPasswordHidden = signal(true);
   protected readonly isSubmitting = signal(false);
+  protected readonly isGoogleLoading = signal(false);
   protected readonly errorMessage = signal('');
+  // Disables inputs + submit when EITHER email submit or Google OAuth is in
+  // flight — prevents double-submit without freezing the form just because
+  // Google redirect is briefly loading.
+  protected readonly isBusy = computed(
+    () => this.isSubmitting() || this.isGoogleLoading(),
+  );
+
+  private readonly emailInput =
+    viewChild<ElementRef<HTMLInputElement>>('emailInput');
 
   constructor() {
     const reason = this.#route.snapshot.queryParamMap.get(
@@ -216,6 +229,10 @@ export default class Login {
         }),
       );
     }
+
+    afterNextRender(() => {
+      this.emailInput()?.nativeElement.focus();
+    });
   }
 
   protected readonly loginForm = this.#formBuilder.nonNullable.group({
@@ -224,14 +241,6 @@ export default class Login {
       '',
       [Validators.required, Validators.minLength(PASSWORD_MIN_LENGTH)],
     ],
-  });
-
-  readonly #formStatus = toSignal(this.loginForm.statusChanges, {
-    initialValue: this.loginForm.status,
-  });
-
-  protected readonly canSubmit = computed(() => {
-    return this.#formStatus() === 'VALID' && !this.isSubmitting();
   });
 
   protected togglePasswordVisibility(): void {

--- a/frontend/projects/webapp/src/app/feature/auth/signup/signup.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/signup/signup.spec.ts
@@ -88,11 +88,6 @@ describe('Signup', () => {
       expect(component['signupForm'].get('confirmPassword')).toBeDefined();
       expect(component['signupForm'].get('acceptTerms')).toBeDefined();
     });
-
-    it('should have computed canSubmit defined', () => {
-      expect(component['canSubmit']).toBeDefined();
-      expect(typeof component['canSubmit']).toBe('function');
-    });
   });
 
   describe('Default Values', () => {
@@ -204,23 +199,6 @@ describe('Signup', () => {
           .get('confirmPassword')
           ?.hasError('passwordsMismatch'),
       ).toBe(true);
-    });
-  });
-
-  describe('canSubmit computed', () => {
-    it('should return false when form is invalid', () => {
-      expect(component['canSubmit']()).toBe(false);
-    });
-
-    it('should return false when isSubmitting is true', () => {
-      fillValidForm();
-      component['isSubmitting'].set(true);
-      expect(component['canSubmit']()).toBe(false);
-    });
-
-    it('should return true when form is valid and not submitting', () => {
-      fillValidForm();
-      expect(component['canSubmit']()).toBe(true);
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
@@ -1,11 +1,13 @@
 import {
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   computed,
   inject,
   signal,
+  viewChild,
+  type ElementRef,
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -64,6 +66,20 @@ import { createFieldsMatchValidator } from '@core/validators';
         </p>
       </div>
 
+      <pulpe-google-oauth-button
+        testId="google-signup-button"
+        (authError)="errorMessage.set($event)"
+        (loadingChange)="isGoogleLoading.set($event)"
+      />
+
+      <div class="flex items-center gap-4 my-6">
+        <mat-divider class="flex-1" />
+        <span class="text-body-medium text-on-surface-variant">{{
+          'common.or' | transloco
+        }}</span>
+        <mat-divider class="flex-1" />
+      </div>
+
       <form
         [formGroup]="signupForm"
         (ngSubmit)="signUp()"
@@ -73,13 +89,14 @@ import { createFieldsMatchValidator } from '@core/validators';
         <mat-form-field appearance="outline" class="w-full">
           <mat-label>{{ 'form.emailLabel' | transloco }}</mat-label>
           <input
+            #emailInput
             matInput
             type="email"
             formControlName="email"
             data-testid="email-input"
             (input)="clearMessages()"
             [placeholder]="'form.emailPlaceholder' | transloco"
-            [disabled]="isSubmitting()"
+            [disabled]="isBusy()"
           />
           <mat-icon matPrefix>email</mat-icon>
           @if (
@@ -104,7 +121,7 @@ import { createFieldsMatchValidator } from '@core/validators';
             data-testid="password-input"
             (input)="clearMessages()"
             [placeholder]="'form.passwordPlaceholder' | transloco"
-            [disabled]="isSubmitting()"
+            [disabled]="isBusy()"
           />
           <mat-icon matPrefix>lock</mat-icon>
           <button
@@ -143,9 +160,9 @@ import { createFieldsMatchValidator } from '@core/validators';
             data-testid="confirm-password-input"
             (input)="clearMessages()"
             [placeholder]="'form.confirmPasswordPlaceholder' | transloco"
-            [disabled]="isSubmitting()"
+            [disabled]="isBusy()"
           />
-          <mat-icon matPrefix>lock</mat-icon>
+          <mat-icon matPrefix>lock_reset</mat-icon>
           <button
             type="button"
             matIconButton
@@ -177,7 +194,7 @@ import { createFieldsMatchValidator } from '@core/validators';
         <div class="pt-2">
           <mat-checkbox
             formControlName="acceptTerms"
-            [disabled]="isSubmitting()"
+            [disabled]="isBusy()"
             data-testid="accept-terms-checkbox"
           >
             <span class="text-body-medium">
@@ -215,7 +232,7 @@ import { createFieldsMatchValidator } from '@core/validators';
 
         <pulpe-loading-button
           [loading]="isSubmitting()"
-          [disabled]="!canSubmit()"
+          [disabled]="isBusy()"
           [loadingText]="'auth.signup.submitting' | transloco"
           icon="person_add"
           testId="signup-submit-button"
@@ -224,20 +241,6 @@ import { createFieldsMatchValidator } from '@core/validators';
           <span class="ml-2">{{ 'auth.signup.submit' | transloco }}</span>
         </pulpe-loading-button>
       </form>
-
-      <div class="flex items-center gap-4 my-6">
-        <mat-divider class="flex-1" />
-        <span class="text-body-medium text-on-surface-variant">{{
-          'common.or' | transloco
-        }}</span>
-        <mat-divider class="flex-1" />
-      </div>
-
-      <pulpe-google-oauth-button
-        testId="google-signup-button"
-        (authError)="errorMessage.set($event)"
-        (loadingChange)="isSubmitting.set($event)"
-      />
 
       <div class="text-center mt-6">
         <p class="text-body-medium text-on-surface-variant">
@@ -268,7 +271,23 @@ export default class Signup {
   protected readonly isPasswordHidden = signal(true);
   protected readonly isConfirmPasswordHidden = signal(true);
   protected readonly isSubmitting = signal(false);
+  protected readonly isGoogleLoading = signal(false);
   protected readonly errorMessage = signal('');
+  // Disables inputs + submit when EITHER email submit or Google OAuth is in
+  // flight — prevents double-submit without freezing the form just because
+  // Google redirect is briefly loading.
+  protected readonly isBusy = computed(
+    () => this.isSubmitting() || this.isGoogleLoading(),
+  );
+
+  private readonly emailInput =
+    viewChild<ElementRef<HTMLInputElement>>('emailInput');
+
+  constructor() {
+    afterNextRender(() => {
+      this.emailInput()?.nativeElement.focus();
+    });
+  }
 
   protected readonly signupForm = this.#formBuilder.nonNullable.group(
     {
@@ -288,14 +307,6 @@ export default class Signup {
       ),
     },
   );
-
-  readonly #formStatus = toSignal(this.signupForm.statusChanges, {
-    initialValue: this.signupForm.status,
-  });
-
-  protected readonly canSubmit = computed(() => {
-    return this.#formStatus() === 'VALID' && !this.isSubmitting();
-  });
 
   protected togglePasswordVisibility(): void {
     this.isPasswordHidden.set(!this.isPasswordHidden());

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
@@ -106,7 +106,7 @@ describe('WelcomePage', () => {
 
       expect(subtitle).toBeTruthy();
       expect(subtitle?.textContent).toContain(
-        'Planifie ton année, sache toujours ce que tu peux dépenser',
+        'Enfin un budget qui te laisse respirer',
       );
     });
 

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
@@ -2,23 +2,13 @@ import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
-import { NO_ERRORS_SCHEMA, signal, Component, input } from '@angular/core';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import WelcomePage from './welcome-page';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { DemoInitializerService } from '@core/demo/demo-initializer.service';
 import { Logger } from '@core/logging/logger';
 import { TurnstileService } from '@core/turnstile';
 import { PostHogService } from '@core/analytics/posthog';
-import { LottieComponent, type AnimationOptions } from 'ngx-lottie';
-
-@Component({
-  // eslint-disable-next-line @angular-eslint/component-selector
-  selector: 'ng-lottie',
-  template: '<div class="mock-lottie"></div>',
-})
-class MockLottieComponent {
-  readonly options = input<AnimationOptions>();
-}
 
 describe('WelcomePage', () => {
   let fixture: ComponentFixture<WelcomePage>;
@@ -89,12 +79,7 @@ describe('WelcomePage', () => {
         { provide: PostHogService, useValue: mockPostHogService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
-    })
-      .overrideComponent(WelcomePage, {
-        remove: { imports: [LottieComponent] },
-        add: { imports: [MockLottieComponent] },
-      })
-      .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(WelcomePage);
     component = fixture.componentInstance;
@@ -231,15 +216,15 @@ describe('WelcomePage', () => {
     });
   });
 
-  describe('CGU text', () => {
-    it('should display CGU text under Google OAuth button', () => {
-      const cguText = fixture.nativeElement.querySelector(
-        '[data-testid="app-version"]',
+  describe('legal text', () => {
+    it('should display CGU and privacy policy under the CTAs', () => {
+      const legalText = fixture.nativeElement.querySelector(
+        '[data-testid="welcome-legal"]',
       );
 
-      expect(cguText).toBeTruthy();
-      expect(cguText.textContent).toContain('CGU');
-      expect(cguText.textContent).toContain('Politique de Confidentialité');
+      expect(legalText).toBeTruthy();
+      expect(legalText.textContent).toContain('CGU');
+      expect(legalText.textContent).toContain('Politique de Confidentialité');
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
@@ -19,7 +19,6 @@ import { ROUTES } from '@core/routing';
 import { TurnstileService } from '@core/turnstile';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
-import { LottieComponent, type AnimationOptions } from 'ngx-lottie';
 import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
 
 @Component({
@@ -27,7 +26,6 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
   imports: [
     MatButtonModule,
     MatIconModule,
-    LottieComponent,
     RouterLink,
     NgxTurnstileModule,
     TranslocoPipe,
@@ -37,23 +35,29 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div
-      class="pulpe-entry-card w-full max-w-lg items-center"
+    <section
+      class="pulpe-welcome-stagger w-full max-w-md mx-auto flex flex-col items-center text-center px-2 md:px-0"
       data-testid="welcome-page"
     >
-      <!-- Branding -->
-      <img src="/logo.svg" alt="Pulpe" class="h-14 md:h-16 mb-6" />
+      <!-- Brand mark -->
+      <img
+        src="/logo.svg"
+        alt="Pulpe"
+        class="h-14 md:h-16 mx-auto mb-5 select-none"
+        draggable="false"
+      />
 
-      <!-- Eyebrow -->
-      <p
-        class="text-xs font-semibold tracking-widest uppercase text-primary mb-3"
-      >
+      <!-- Eyebrow pill -->
+      <span class="pulpe-eyebrow-pill mx-auto">
+        <span class="pulpe-eyebrow-dot" aria-hidden="true">
+          <span class="pulpe-eyebrow-dot-core"></span>
+        </span>
         {{ 'welcome.eyebrow' | transloco }}
-      </p>
+      </span>
 
-      <!-- Title -->
+      <!-- Headline -->
       <h1
-        class="text-headline-large md:text-display-small font-bold text-on-surface leading-tight text-center mb-2"
+        class="font-bold tracking-[-0.02em] leading-[1.02] text-[2rem] md:text-[2.5rem] mt-4 text-on-surface [text-wrap:balance]"
         data-testid="welcome-title"
       >
         {{ 'welcome.title' | transloco }}
@@ -61,48 +65,14 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
 
       <!-- Subtitle -->
       <p
-        class="text-body-large text-on-surface-variant text-center leading-relaxed mb-4"
+        class="text-body-large text-on-surface-variant mt-3 leading-snug [text-wrap:balance]"
         data-testid="welcome-subtitle"
       >
         {{ 'welcome.subtitle' | transloco }}
       </p>
 
-      <!-- Lottie animation -->
-      @defer (on idle) {
-        <div class="flex justify-center mb-6">
-          <ng-lottie
-            [options]="lottieOptions"
-            class="hidden md:block w-60 h-44 md:w-120 md:h-80 -mt-10 md:-mt-20 bg-transparent"
-          />
-        </div>
-      } @placeholder {
-        <div class="flex justify-center mb-6">
-          <div
-            class="w-56 h-40 md:w-72 md:h-48 flex items-center justify-center"
-          >
-            <div
-              class="w-16 h-16 bg-primary/10 rounded-full animate-pulse"
-            ></div>
-          </div>
-        </div>
-      } @loading {
-        <div class="flex justify-center mb-6">
-          <div
-            class="w-56 h-40 md:w-72 md:h-48 flex items-center justify-center"
-          >
-            <div
-              class="w-16 h-16 bg-primary/20 rounded-full animate-pulse"
-            ></div>
-          </div>
-        </div>
-      } @error {
-        <div class="flex justify-center mb-6">
-          <div class="w-56 h-40 md:w-72 md:h-48"></div>
-        </div>
-      }
-
       <!-- CTAs -->
-      <div class="flex flex-col gap-3 w-full">
+      <div class="mt-7 flex flex-col gap-3 w-full">
         <pulpe-google-oauth-button
           class="w-full"
           buttonType="outlined"
@@ -111,25 +81,24 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
           (loadingChange)="onGoogleLoadingChange($event)"
         />
 
-        <!-- Separator -->
-        <div class="flex items-center gap-4 my-1">
-          <div class="flex-1 h-px bg-outline-variant/30"></div>
+        <div class="flex items-center gap-4 my-0.5" aria-hidden="true">
+          <div class="flex-1 h-px bg-outline-variant/40"></div>
           <span
-            class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest"
+            class="text-[10px] font-semibold text-on-surface-variant/70 uppercase tracking-[0.2em]"
             >{{ 'common.or' | transloco }}</span
           >
-          <div class="flex-1 h-px bg-outline-variant/30"></div>
+          <div class="flex-1 h-px bg-outline-variant/40"></div>
         </div>
 
         <button
           matButton="filled"
-          class="w-full h-12"
+          class="pulpe-primary-cta w-full !h-13 !text-base"
           data-testid="email-signup-button"
           [disabled]="isLoading()"
           [routerLink]="['/', ROUTES.SIGNUP]"
           (click)="onEmailSignupClick()"
         >
-          <div class="flex items-center justify-center gap-2">
+          <div class="flex items-center justify-center gap-2 relative z-[1]">
             <mat-icon>email</mat-icon>
             <span>{{ 'welcome.emailSignup' | transloco }}</span>
           </div>
@@ -168,39 +137,41 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
         <pulpe-error-alert [message]="errorMessage()" class="w-full" />
       </div>
 
-      <!-- Legal -->
       <p
-        class="text-xs text-on-surface-variant text-center mt-5"
-        data-testid="app-version"
+        class="text-sm text-on-surface-variant mt-6 flex items-center justify-center gap-1.5"
+        data-testid="welcome-signin"
+      >
+        {{ 'welcome.alreadyAccount' | transloco }}
+        <a
+          [routerLink]="['/', ROUTES.LOGIN]"
+          class="pulpe-inline-signin"
+          data-testid="welcome-signin-link"
+        >
+          {{ 'welcome.signin' | transloco }}
+          <mat-icon>arrow_forward</mat-icon>
+        </a>
+      </p>
+
+      <p
+        class="text-xs text-on-surface-variant/80 mt-5 leading-relaxed"
+        data-testid="welcome-legal"
       >
         {{ 'welcome.legalPrefix' | transloco }}
         <a
           [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_TERMS]"
           target="_blank"
-          class="text-primary underline"
+          class="text-primary underline underline-offset-2"
           >{{ 'welcome.termsShort' | transloco }}</a
         >
         {{ 'welcome.legalAnd' | transloco }}
         <a
           [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_PRIVACY]"
           target="_blank"
-          class="text-primary underline"
+          class="text-primary underline underline-offset-2"
           >{{ 'welcome.privacyPolicy' | transloco }}</a
         >
       </p>
-
-      <!-- Login link -->
-      <p class="text-sm text-on-surface-variant mt-4">
-        {{ 'welcome.alreadyAccount' | transloco }}
-        <button
-          matButton
-          [routerLink]="['/', ROUTES.LOGIN]"
-          class="text-primary font-semibold"
-        >
-          {{ 'welcome.signin' | transloco }}
-        </button>
-      </p>
-    </div>
+    </section>
   `,
 })
 export default class WelcomePage {
@@ -229,19 +200,6 @@ export default class WelcomePage {
 
   protected readonly turnstileWidget =
     viewChild<NgxTurnstileComponent>('turnstileWidget');
-
-  protected readonly lottieOptions: AnimationOptions = {
-    path: '/lottie/welcome-animation.json',
-    loop: true,
-    autoplay: true,
-    renderer: 'svg',
-    rendererSettings: {
-      preserveAspectRatio: 'xMidYMid meet',
-      progressiveLoad: true,
-      hideOnTransparent: true,
-    },
-    assetsPath: '/lottie/',
-  };
 
   onGoogleLoadingChange(isLoading: boolean): void {
     this.isGoogleLoading.set(isLoading);

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
@@ -73,36 +73,20 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
 
       <!-- CTAs -->
       <div class="mt-7 flex flex-col gap-3 w-full">
-        <pulpe-google-oauth-button
-          class="w-full"
-          buttonType="outlined"
-          testId="google-oauth-button"
-          (authError)="errorMessage.set($event)"
-          (loadingChange)="onGoogleLoadingChange($event)"
-        />
-
-        <div class="flex items-center gap-4 my-0.5" aria-hidden="true">
-          <div class="flex-1 h-px bg-outline-variant/40"></div>
-          <span
-            class="text-[10px] font-semibold text-on-surface-variant/70 uppercase tracking-[0.2em]"
-            >{{ 'common.or' | transloco }}</span
-          >
-          <div class="flex-1 h-px bg-outline-variant/40"></div>
-        </div>
-
-        <button
-          matButton="filled"
-          class="pulpe-primary-cta w-full !h-13 !text-base"
-          data-testid="email-signup-button"
+        <pulpe-loading-button
+          [loading]="isDemoLoading()"
           [disabled]="isLoading()"
-          [routerLink]="['/', ROUTES.SIGNUP]"
-          (click)="onEmailSignupClick()"
+          variant="filled"
+          type="button"
+          [loadingText]="'welcome.demoLoading' | transloco"
+          icon="play_arrow"
+          testId="demo-mode-button"
+          data-testid="demo-link"
+          class="w-full pulpe-demo-primary"
+          (click)="startDemoMode()"
         >
-          <div class="flex items-center justify-center gap-2 relative z-[1]">
-            <mat-icon>email</mat-icon>
-            <span>{{ 'welcome.emailSignup' | transloco }}</span>
-          </div>
-        </button>
+          {{ 'welcome.tryWithoutAccount' | transloco }}
+        </pulpe-loading-button>
 
         @if (
           turnstileService.shouldRender() &&
@@ -119,20 +103,36 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
           />
         }
 
-        <pulpe-loading-button
-          [loading]="isDemoLoading()"
-          [disabled]="isLoading()"
-          variant=""
-          type="button"
-          [loadingText]="'welcome.demoLoading' | transloco"
-          icon="play_arrow"
-          testId="demo-mode-button"
-          data-testid="demo-link"
+        <div class="flex items-center gap-4 my-0.5" aria-hidden="true">
+          <div class="flex-1 h-px bg-outline-variant/40"></div>
+          <span
+            class="text-[10px] font-semibold text-on-surface-variant/70 uppercase tracking-[0.2em]"
+            >{{ 'common.or' | transloco }}</span
+          >
+          <div class="flex-1 h-px bg-outline-variant/40"></div>
+        </div>
+
+        <pulpe-google-oauth-button
           class="w-full"
-          (click)="startDemoMode()"
+          buttonType="outlined"
+          testId="google-oauth-button"
+          (authError)="errorMessage.set($event)"
+          (loadingChange)="onGoogleLoadingChange($event)"
+        />
+
+        <button
+          matButton="outlined"
+          class="w-full !h-12"
+          data-testid="email-signup-button"
+          [disabled]="isLoading()"
+          [routerLink]="['/', ROUTES.SIGNUP]"
+          (click)="onEmailSignupClick()"
         >
-          {{ 'welcome.tryWithoutAccount' | transloco }}
-        </pulpe-loading-button>
+          <div class="flex items-center justify-center gap-2">
+            <mat-icon>email</mat-icon>
+            <span>{{ 'welcome.emailSignup' | transloco }}</span>
+          </div>
+        </button>
 
         <pulpe-error-alert [message]="errorMessage()" class="w-full" />
       </div>

--- a/frontend/projects/webapp/src/app/ui/error-alert/error-alert.ts
+++ b/frontend/projects/webapp/src/app/ui/error-alert/error-alert.ts
@@ -11,6 +11,8 @@ import { MatIconModule } from '@angular/material/icon';
       <div
         class="bg-error-container text-on-error-container p-3 rounded-lg flex items-center gap-2 my-4"
         role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
       >
         <mat-icon class="flex-shrink-0">error_outline</mat-icon>
         <span>{{ message() }}</span>

--- a/frontend/projects/webapp/src/app/ui/error-alert/error-alert.ts
+++ b/frontend/projects/webapp/src/app/ui/error-alert/error-alert.ts
@@ -7,17 +7,16 @@ import { MatIconModule } from '@angular/material/icon';
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { '[class.hidden]': '!message()' },
   template: `
-    @if (message()) {
-      <div
-        class="bg-error-container text-on-error-container p-3 rounded-lg flex items-center gap-2 my-4"
-        role="alert"
-        aria-live="assertive"
-        aria-atomic="true"
-      >
+    <div
+      class="bg-error-container text-on-error-container p-3 rounded-lg flex items-center gap-2 my-4"
+      role="alert"
+      aria-atomic="true"
+    >
+      @if (message()) {
         <mat-icon class="flex-shrink-0">error_outline</mat-icon>
         <span>{{ message() }}</span>
-      </div>
-    }
+      }
+    </div>
   `,
 })
 export class ErrorAlert {

--- a/frontend/projects/webapp/src/styles.scss
+++ b/frontend/projects/webapp/src/styles.scss
@@ -146,14 +146,13 @@ body {
   border-radius: var(--pulpe-surface-radius-card);
   padding: clamp(1.75rem, 2.5vw, 2.75rem);
   background: var(--mat-sys-surface-container-lowest, var(--mat-sys-surface));
-  // Tinted shadow (primary green, low opacity) — anchors the card on the
-  // ambient glow background without relying on a hard border.
+  // Softer tinted shadow — the card reads as "emerging from the ambient glow",
+  // not "landing on top of it". Closes the perceptual gap when users navigate
+  // from the cardless welcome page to the framed auth forms.
   box-shadow:
-    0 1px 2px color-mix(in srgb, var(--mat-sys-primary) 8%, transparent),
-    0 12px 32px -12px
-      color-mix(in srgb, var(--mat-sys-primary) 18%, transparent),
-    0 32px 56px -24px
-      color-mix(in srgb, var(--mat-sys-primary) 12%, transparent);
+    0 1px 2px color-mix(in srgb, var(--mat-sys-primary) 5%, transparent),
+    0 8px 20px -10px color-mix(in srgb, var(--mat-sys-primary) 11%, transparent),
+    0 20px 40px -20px color-mix(in srgb, var(--mat-sys-primary) 7%, transparent);
   display: flex;
   flex-direction: column;
 }
@@ -223,9 +222,11 @@ body {
 }
 
 // Primary CTA — tinted elevation + magnetic lift.
-// NO ::before shimmer: Material forces overflow: visible on its button host,
-// which would let a translated pseudo leak outside the button bounds.
-.pulpe-primary-cta {
+// Applied both to native <button class="pulpe-primary-cta"> and to the inner
+// filled button of <pulpe-loading-button class="pulpe-demo-primary">, so we
+// keep one tuned source of truth.
+.pulpe-primary-cta,
+.pulpe-demo-primary button[matButton="filled"] {
   position: relative;
   transition:
     transform 220ms var(--pulpe-ease-standard),
@@ -237,7 +238,8 @@ body {
       color-mix(in srgb, var(--mat-sys-primary) 30%, transparent);
 }
 
-.pulpe-primary-cta:hover:not([disabled]) {
+.pulpe-primary-cta:hover:not([disabled]),
+.pulpe-demo-primary button[matButton="filled"]:hover:not([disabled]) {
   transform: translateY(-1px);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.24),
@@ -246,9 +248,18 @@ body {
       color-mix(in srgb, var(--mat-sys-primary) 42%, transparent);
 }
 
-.pulpe-primary-cta:active:not([disabled]) {
+.pulpe-primary-cta:active:not([disabled]),
+.pulpe-demo-primary button[matButton="filled"]:active:not([disabled]) {
   transform: translateY(0);
   transition-duration: 120ms;
+}
+
+// Demo button prominence — slightly taller than the h-12 default so it
+// visually leads the CTA stack as the primary action. !important because
+// LoadingButton applies Tailwind's h-12 utility on the same inner <button>
+// and we need to reliably outrank it regardless of layer ordering.
+.pulpe-demo-primary button[matButton="filled"] {
+  height: 3.25rem !important;
 }
 
 .pulpe-inline-signin {
@@ -336,7 +347,8 @@ body {
 
   .pulpe-inline-signin,
   .pulpe-inline-signin mat-icon,
-  .pulpe-primary-cta {
+  .pulpe-primary-cta,
+  .pulpe-demo-primary button[matButton="filled"] {
     transition: none !important;
   }
 

--- a/frontend/projects/webapp/src/styles.scss
+++ b/frontend/projects/webapp/src/styles.scss
@@ -65,7 +65,7 @@ body {
   line-height: var(--mat-sys-typescale-body-medium-line-height);
 }
 
-// Pulpe design tokens + brand gradient
+// Pulpe design tokens + pre-auth ambient background
 :root {
   /* Layout */
   --pulpe-page-gutter-mobile: 16px;
@@ -79,6 +79,7 @@ body {
   --pulpe-surface-radius-card: 24px;
   --pulpe-surface-radius-panel: 16px;
   --pulpe-surface-border-subtle: 1px solid var(--mat-sys-outline-variant);
+  --pulpe-neutral-warm: #f7f6f3; /* DA §3.1 canonical warm neutral */
 
   /* Motion */
   --pulpe-motion-fast: 150ms;
@@ -87,28 +88,39 @@ body {
   --pulpe-ease-standard: cubic-bezier(0.2, 0, 0, 1);
   --pulpe-ease-emphasized: cubic-bezier(0.22, 1, 0.36, 1);
 
-  /* Gradient */
-  --pulpe-gradient-start: #009bff;
-  --pulpe-gradient-mid1: #00edab;
-  --pulpe-gradient-mid2: #30e868;
-  --pulpe-gradient-end: #8fff6b;
+  /* Pre-auth ambient glow strengths (overridden under .dark-theme) */
+  --pulpe-ambient-glow-a: 14%;
+  --pulpe-ambient-glow-b: 9%;
 }
 
 .dark-theme {
-  --pulpe-gradient-start: #003d7a;
-  --pulpe-gradient-mid1: #006b4e;
-  --pulpe-gradient-mid2: #0d7a30;
-  --pulpe-gradient-end: #2ba84a;
+  --pulpe-ambient-glow-a: 22%;
+  --pulpe-ambient-glow-b: 14%;
 }
 
+// DA §3.1: content surfaces are neutral warm; pre-auth can use glow/shadow
+// for brand expressivity (never a saturated colour bath).
 .pulpe-gradient {
-  background: linear-gradient(
-    135deg,
-    var(--pulpe-gradient-start) 0%,
-    var(--pulpe-gradient-mid1) 33%,
-    var(--pulpe-gradient-mid2) 66%,
-    var(--pulpe-gradient-end) 100%
-  );
+  background:
+    radial-gradient(
+      ellipse 85% 65% at 92% -5%,
+      color-mix(
+        in srgb,
+        var(--mat-sys-primary) var(--pulpe-ambient-glow-a),
+        transparent
+      ),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 70% 55% at 8% 105%,
+      color-mix(
+        in srgb,
+        var(--mat-sys-primary) var(--pulpe-ambient-glow-b),
+        transparent
+      ),
+      transparent 60%
+    ),
+    var(--mat-sys-surface);
 }
 
 .pulpe-entry-shell {
@@ -130,13 +142,208 @@ body {
 
 .pulpe-entry-card {
   width: 100%;
-  border: var(--pulpe-surface-border-subtle);
+  border: none;
   border-radius: var(--pulpe-surface-radius-card);
-  padding: clamp(1.5rem, 2vw, 2.5rem);
-  box-shadow: var(--mat-sys-level2);
-  background: var(--mat-sys-surface);
+  padding: clamp(1.75rem, 2.5vw, 2.75rem);
+  background: var(--mat-sys-surface-container-lowest, var(--mat-sys-surface));
+  // Tinted shadow (primary green, low opacity) — anchors the card on the
+  // ambient glow background without relying on a hard border.
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--mat-sys-primary) 8%, transparent),
+    0 12px 32px -12px
+      color-mix(in srgb, var(--mat-sys-primary) 18%, transparent),
+    0 32px 56px -24px
+      color-mix(in srgb, var(--mat-sys-primary) 12%, transparent);
   display: flex;
   flex-direction: column;
+}
+
+.pulpe-eyebrow-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.28rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in srgb, var(--mat-sys-primary) 16%, transparent);
+  background: color-mix(in srgb, var(--mat-sys-primary) 5%, transparent);
+  color: var(--mat-sys-primary);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.pulpe-eyebrow-dot {
+  position: relative;
+  display: inline-flex;
+  width: 0.4rem;
+  height: 0.4rem;
+}
+
+.pulpe-eyebrow-dot-core {
+  width: 100%;
+  height: 100%;
+  background: var(--mat-sys-primary);
+  border-radius: 9999px;
+  // Finite pulse: ~6 cycles (~16s), then settles. Avoids a perpetual
+  // compositor loop on an idle welcome page.
+  animation: pulpe-pulse 2.6s var(--pulpe-ease-emphasized) 6;
+}
+
+@keyframes pulpe-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes pulpe-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.pulpe-welcome-stagger > * {
+  animation: pulpe-fade-up 0.55s var(--pulpe-ease-emphasized) both;
+}
+
+@for $i from 1 through 7 {
+  .pulpe-welcome-stagger > *:nth-child(#{$i}) {
+    animation-delay: #{($i - 1) * 60}ms;
+  }
+}
+
+// Primary CTA — tinted elevation + magnetic lift.
+// NO ::before shimmer: Material forces overflow: visible on its button host,
+// which would let a translated pseudo leak outside the button bounds.
+.pulpe-primary-cta {
+  position: relative;
+  transition:
+    transform 220ms var(--pulpe-ease-standard),
+    box-shadow 220ms var(--pulpe-ease-standard);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 10px 24px -10px
+      color-mix(in srgb, var(--mat-sys-primary) 30%, transparent);
+}
+
+.pulpe-primary-cta:hover:not([disabled]) {
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.24),
+    0 2px 4px rgba(0, 0, 0, 0.06),
+    0 16px 32px -10px
+      color-mix(in srgb, var(--mat-sys-primary) 42%, transparent);
+}
+
+.pulpe-primary-cta:active:not([disabled]) {
+  transform: translateY(0);
+  transition-duration: 120ms;
+}
+
+.pulpe-inline-signin {
+  display: inline-flex;
+  align-items: center;
+  color: var(--mat-sys-primary);
+  font-weight: 600;
+  text-decoration: none;
+  padding-bottom: 1px;
+  background-image: linear-gradient(
+    to right,
+    var(--mat-sys-primary),
+    var(--mat-sys-primary)
+  );
+  background-size: 100% 1px;
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  transition: background-size 220ms var(--pulpe-ease-standard);
+}
+
+.pulpe-inline-signin mat-icon {
+  width: 14px;
+  height: 14px;
+  font-size: 14px;
+  line-height: 14px;
+  margin-left: 2px;
+  transition: transform 220ms var(--pulpe-ease-standard);
+}
+
+.pulpe-inline-signin:hover {
+  background-size: 100% 2px;
+}
+
+.pulpe-inline-signin:hover mat-icon {
+  transform: translateX(2px);
+}
+
+@supports (view-transition-name: none) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 320ms;
+    animation-timing-function: var(--pulpe-ease-emphasized);
+  }
+
+  ::view-transition-old(root) {
+    animation-name: pulpe-vt-out;
+  }
+
+  ::view-transition-new(root) {
+    animation-name: pulpe-vt-in;
+  }
+
+  @keyframes pulpe-vt-out {
+    from {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(-6px);
+    }
+  }
+
+  @keyframes pulpe-vt-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulpe-eyebrow-dot-core,
+  .pulpe-welcome-stagger > * {
+    animation: none !important;
+  }
+  .pulpe-welcome-stagger > * {
+    opacity: 1;
+    transform: none;
+  }
+
+  .pulpe-inline-signin,
+  .pulpe-inline-signin mat-icon,
+  .pulpe-primary-cta {
+    transition: none !important;
+  }
+
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 0.01ms !important;
+  }
 }
 
 .pulpe-page-header {

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -81,11 +81,6 @@
       "sourceType": "github",
       "computedHash": "848a1946f838e1b36f4af8b65caeea9e5bfa486d6059325520bb6124c05b0526"
     },
-    "arrange": {
-      "source": "pbakaus/impeccable",
-      "sourceType": "github",
-      "computedHash": "ec95c0c0780e0fa3c1fa314b3a7157ddf31a4b7b107b5978fb7b8d77fb1f07b9"
-    },
     "asc-app-create-ui": {
       "source": "rudrankriyam/app-store-connect-cli-skills",
       "sourceType": "github",
@@ -221,15 +216,15 @@
       "sourceType": "github",
       "computedHash": "1f6f4adee0b964e8344c0baef46b4e303ab3ba20932907bcbb1444ba7b3273b2"
     },
+    "design-taste-frontend": {
+      "source": "leonxlnx/taste-skill",
+      "sourceType": "github",
+      "computedHash": "9d1e82c5c409d2b0247245a005bc0f7e4447c0999b78dcea60f568c1ba4a6694"
+    },
     "distill": {
       "source": "pbakaus/impeccable",
       "sourceType": "github",
       "computedHash": "669a671f855be8773e4c2936e54d4243fbd1d273f87633158544efe3dbc4d825"
-    },
-    "extract": {
-      "source": "pbakaus/impeccable",
-      "sourceType": "github",
-      "computedHash": "1bbe30b5be73a86971f6bccb37daae84aaafceaa6d23429d6a3a0442378ac4ec"
     },
     "harden": {
       "source": "pbakaus/impeccable",
@@ -256,16 +251,6 @@
       "sourceType": "github",
       "computedHash": "1cba0ac27ae3ceb517b93bb6ccf053607b8ba939a1c1c9d4716eed7e4d9175b2"
     },
-    "normalize": {
-      "source": "pbakaus/impeccable",
-      "sourceType": "github",
-      "computedHash": "1f5475e839d472a92298eaf6db26bab5ff6634fc3a7b76904e480242e809188e"
-    },
-    "onboard": {
-      "source": "pbakaus/impeccable",
-      "sourceType": "github",
-      "computedHash": "9928ecc1170356ac103b9b893ffbd8a0299b9584afb9a4deba0554efb5e99338"
-    },
     "optimize": {
       "source": "pbakaus/impeccable",
       "sourceType": "github",
@@ -291,6 +276,11 @@
       "sourceType": "github",
       "computedHash": "2c20b12bb4ece445d45fc63bda020aecf78b3cdf6d593beb59c273f658293130"
     },
+    "redesign-existing-projects": {
+      "source": "leonxlnx/taste-skill",
+      "sourceType": "github",
+      "computedHash": "b405eee0e0e80fc243f731d9aa368bca307e356db7e6157d27101d369dac6726"
+    },
     "shape": {
       "source": "pbakaus/impeccable",
       "sourceType": "github",
@@ -314,7 +304,7 @@
     "swiftui-expert-skill": {
       "source": "avdlee/swiftui-agent-skill",
       "sourceType": "github",
-      "computedHash": "cc254d18562b0666f4c85561b92b21eb1878e346b659f8b6d80c02a166725cb4"
+      "computedHash": "84aa533bdca25a02ce35738619121d203d55eb8ff2892535c150bd9ee85fda30"
     },
     "swiftui-performance-audit": {
       "source": "dimillian/skills",


### PR DESCRIPTION
## Summary

- **Demo mode is now the primary CTA** on welcome — zero-friction path surfaced per design critique (P0). Email signup + Google OAuth demoted to equal outlined secondaries.
- **Auth form submits are always clickable** — removed the disabled-by-default CTA on signup/login/forgot-password. Invalid submit now marks fields touched and surfaces field-level errors + error alert (P1).
- **Google OAuth repositioned above the form** on signup/login for consistency with welcome ordering (P2).
- **Dual loading state** on login/signup — `isSubmitting` + `isGoogleLoading` split so the email form isn't frozen during Google's brief redirect.
- **Autofocus on email** via `viewChild` + `afterNextRender` on all three auth pages.
- **Microcopy** per DA.md §4–§6:
  - `welcome.subtitle`: \"Planifie ton année…\" → **\"Enfin un budget qui te laisse respirer.\"**
  - `auth.forgotPassword.subtitle`: factual → **\"Ça arrive. Entre ton email, on te renvoie un lien tout de suite.\"**
- **Visual polish** — softened entry-card shadow (closes the perceptual gap between cardless welcome and framed auth forms); confirm-password icon `lock` → `lock_reset`; error-alert now has explicit `aria-live=\"assertive\"` + `aria-atomic=\"true\"`.

## Test plan

- [ ] Welcome: demo button reads as primary (filled green, 52px), Google + email are equal outlined.
- [ ] Signup: click \"Créer mon compte\" on empty form → field errors appear, no page break.
- [ ] Login: submit empty → error alert announces via screen reader; Google click doesn't freeze email input mid-redirect.
- [ ] Forgot-password: email field auto-focuses on page load.
- [ ] `pnpm quality` — green (verified: 10/10 turbo tasks, 1750/1750 tests pass).