### PR TITLE
fix(frontend): CHF decimal separator coherence (PUL-125)

### DIFF
--- a/frontend/e2e/tests/features/allocated-transaction-lifecycle.spec.ts
+++ b/frontend/e2e/tests/features/allocated-transaction-lifecycle.spec.ts
@@ -336,8 +336,8 @@ test.describe('Allocated Transaction Lifecycle', () => {
     await currentMonthPage.expectPageLoaded();
 
     // Verify expenses = 500 (envelope) + 100 (free) = 600
-    await currentMonthPage.expectExpensesAmount('600,00');
+    await currentMonthPage.expectExpensesAmount('600.00');
     // Verify remaining = 5000 - 600 = 4400
-    await currentMonthPage.expectRemainingAmount('4 400,00');
+    await currentMonthPage.expectRemainingAmount('4 400.00');
   });
 });

--- a/frontend/e2e/tests/features/budget-line-creation.spec.ts
+++ b/frontend/e2e/tests/features/budget-line-creation.spec.ts
@@ -390,7 +390,7 @@ test.describe('Budget Line Creation', () => {
     // Before creation: income=5000, expenses=1500, remaining=3500
     // Verify initial expenses in financial overview
     const financialOverview = authenticatedPage.locator('pulpe-budget-financial-overview');
-    await expect(financialOverview).toContainText("1\u202F500");
+    await expect(financialOverview).toContainText("1\u2019500");
 
     // Click add and fill form
     await authenticatedPage.getByTestId('add-budget-line').click();
@@ -408,11 +408,11 @@ test.describe('Budget Line Creation', () => {
 
     // After creation: income=5000, expenses=1500+500=2000, remaining=3000
     // Expenses total should now show 2000
-    await expect(financialOverview).toContainText("2\u202F000");
+    await expect(financialOverview).toContainText("2\u2019000");
 
     // Remaining should show 3000
     await expect(
       financialOverview.locator('.text-display-medium, .text-display-large'),
-    ).toContainText("3\u202F000");
+    ).toContainText("3\u2019000");
   });
 });

--- a/frontend/e2e/tests/features/current-month-transactions.spec.ts
+++ b/frontend/e2e/tests/features/current-month-transactions.spec.ts
@@ -196,16 +196,16 @@ test.describe('Current Month Transactions', () => {
     await currentMonthPage.goto();
 
     // Initial state: expenses = 500 (envelope) + 100 (free) = 600
-    await currentMonthPage.expectExpensesAmount('600,00');
+    await currentMonthPage.expectExpensesAmount('600.00');
     // Initial remaining = 5000 - 600 = 4400
-    await currentMonthPage.expectRemainingAmount('4 400,00');
+    await currentMonthPage.expectRemainingAmount('4 400.00');
 
     // Add a new free transaction of 200
     await currentMonthPage.addTransaction('200', 'New expense');
 
     // After adding: expenses = 500 (envelope) + 100 + 200 (free) = 800
-    await currentMonthPage.expectExpensesAmount('800,00');
+    await currentMonthPage.expectExpensesAmount('800.00');
     // Remaining = 5000 - 800 = 4200
-    await currentMonthPage.expectRemainingAmount('4 200,00');
+    await currentMonthPage.expectRemainingAmount('4 200.00');
   });
 });

--- a/frontend/e2e/tests/features/envelope-allocation.spec.ts
+++ b/frontend/e2e/tests/features/envelope-allocation.spec.ts
@@ -121,9 +121,9 @@ test.describe('Envelope Allocation - Remaining Budget Calculation', () => {
     await currentMonthPage.expectPageLoaded();
 
     // Verify expenses = 500 (envelope amount, not 100)
-    await currentMonthPage.expectExpensesAmount('500,00');
+    await currentMonthPage.expectExpensesAmount('500.00');
     // Verify remaining = 5000 - 500 = 4500
-    await currentMonthPage.expectRemainingAmount('4 500,00');
+    await currentMonthPage.expectRemainingAmount('4 500.00');
   });
 
   test('allocated transaction exceeding envelope should only count overage', async ({
@@ -173,9 +173,9 @@ test.describe('Envelope Allocation - Remaining Budget Calculation', () => {
     await currentMonthPage.expectPageLoaded();
 
     // Verify expenses = 150 (consumed amount, not 100)
-    await currentMonthPage.expectExpensesAmount('150,00');
+    await currentMonthPage.expectExpensesAmount('150.00');
     // Verify remaining = 5000 - 150 = 4850
-    await currentMonthPage.expectRemainingAmount('4 850,00');
+    await currentMonthPage.expectRemainingAmount('4 850.00');
   });
 
   test('mixed free and allocated transactions should be calculated correctly', async ({
@@ -233,9 +233,9 @@ test.describe('Envelope Allocation - Remaining Budget Calculation', () => {
     await currentMonthPage.expectPageLoaded();
 
     // Verify expenses = 500 + 50 = 550
-    await currentMonthPage.expectExpensesAmount('550,00');
+    await currentMonthPage.expectExpensesAmount('550.00');
     // Verify remaining = 5000 - 550 = 4450
-    await currentMonthPage.expectRemainingAmount('4 450,00');
+    await currentMonthPage.expectRemainingAmount('4 450.00');
   });
 
   test('real user scenario: 88 CHF overage (envelope 100, allocated 188)', async ({
@@ -286,9 +286,9 @@ test.describe('Envelope Allocation - Remaining Budget Calculation', () => {
     await currentMonthPage.expectPageLoaded();
 
     // Verify expenses = 188 (consumed amount since > envelope)
-    await currentMonthPage.expectExpensesAmount('188,00');
+    await currentMonthPage.expectExpensesAmount('188.00');
     // Verify remaining = 1000 - 188 = 812
-    await currentMonthPage.expectRemainingAmount('812,00');
+    await currentMonthPage.expectRemainingAmount('812.00');
   });
 
   test('multiple envelopes with different states should calculate correctly', async ({
@@ -352,8 +352,8 @@ test.describe('Envelope Allocation - Remaining Budget Calculation', () => {
     await currentMonthPage.expectPageLoaded();
 
     // Verify expenses = 500 + 350 = 850
-    await currentMonthPage.expectExpensesAmount('850,00');
+    await currentMonthPage.expectExpensesAmount('850.00');
     // Verify remaining = 5000 - 850 = 4150
-    await currentMonthPage.expectRemainingAmount('4 150,00');
+    await currentMonthPage.expectRemainingAmount('4 150.00');
   });
 });

--- a/frontend/e2e/tests/features/envelope-deletion-cascade.spec.ts
+++ b/frontend/e2e/tests/features/envelope-deletion-cascade.spec.ts
@@ -88,7 +88,7 @@ test.describe('Envelope Deletion Cascade', () => {
 
     // Before deletion: hero shows Reste = 5500
     const heroSection = authenticatedPage.locator('pulpe-budget-financial-overview');
-    await expect(heroSection).toContainText("5\u202F500");
+    await expect(heroSection).toContainText("5\u2019500");
     await expect(heroSection).toContainText('Ce qu\'il te reste ce mois');
 
     // Delete the envelope via table view
@@ -98,7 +98,7 @@ test.describe('Envelope Deletion Cascade', () => {
     await budgetDetailsPage.confirmDelete();
 
     // After deletion: hero shows Reste = 6700
-    await expect(heroSection).toContainText("6\u202F700");
+    await expect(heroSection).toContainText("6\u2019700");
   });
 
   test('delete envelope without transactions increases Reste by full amount', async ({
@@ -154,7 +154,7 @@ test.describe('Envelope Deletion Cascade', () => {
 
     // Before deletion: hero shows Reste = 7300
     const heroSection = authenticatedPage.locator('pulpe-budget-financial-overview');
-    await expect(heroSection).toContainText("7\u202F300");
+    await expect(heroSection).toContainText("7\u2019300");
 
     // Delete the envelope
     await budgetDetailsPage.switchToTableView();
@@ -163,7 +163,7 @@ test.describe('Envelope Deletion Cascade', () => {
     await budgetDetailsPage.confirmDelete();
 
     // After deletion: hero shows Reste = 7500
-    await expect(heroSection).toContainText("7\u202F500");
+    await expect(heroSection).toContainText("7\u2019500");
   });
 
   test('delete envelope with overage keeps Reste unchanged', async ({
@@ -234,7 +234,7 @@ test.describe('Envelope Deletion Cascade', () => {
 
     // Before deletion: hero shows Reste = 6700 (max(500,800)=800, 7500-800=6700)
     const heroSection = authenticatedPage.locator('pulpe-budget-financial-overview');
-    await expect(heroSection).toContainText("6\u202F700");
+    await expect(heroSection).toContainText("6\u2019700");
 
     // Delete the envelope
     await budgetDetailsPage.switchToTableView();
@@ -243,6 +243,6 @@ test.describe('Envelope Deletion Cascade', () => {
     await budgetDetailsPage.confirmDelete();
 
     // After deletion: Reste unchanged at 6700 (free tx 800, 7500-800=6700)
-    await expect(heroSection).toContainText("6\u202F700");
+    await expect(heroSection).toContainText("6\u2019700");
   });
 });

--- a/frontend/e2e/tests/features/envelope-overage-reste-impact.spec.ts
+++ b/frontend/e2e/tests/features/envelope-overage-reste-impact.spec.ts
@@ -70,7 +70,7 @@ test.describe('Envelope Overage Reste Impact', () => {
 
     // Reste = 5000 - 200 = 4800 (envelope covers the 80 transaction)
     const heroSection = authenticatedPage.locator('pulpe-budget-financial-overview');
-    await expect(heroSection).toContainText("4\u202F800");
+    await expect(heroSection).toContainText("4\u2019800");
     await expect(heroSection).toContainText('Ce qu\'il te reste ce mois');
   });
 
@@ -132,7 +132,7 @@ test.describe('Envelope Overage Reste Impact', () => {
 
     // Reste = 5000 - 200 = 4800
     const heroSection = authenticatedPage.locator('pulpe-budget-financial-overview');
-    await expect(heroSection).toContainText("4\u202F800");
+    await expect(heroSection).toContainText("4\u2019800");
   });
 
   test('transactions exceeding envelope — Reste decreases by excess', async ({
@@ -193,7 +193,7 @@ test.describe('Envelope Overage Reste Impact', () => {
 
     // Reste = 5000 - 250 = 4750 (excess 50 reduces Reste)
     const heroSection = authenticatedPage.locator('pulpe-budget-financial-overview');
-    await expect(heroSection).toContainText("4\u202F750");
+    await expect(heroSection).toContainText("4\u2019750");
     await expect(heroSection).toContainText('Ce qu\'il te reste ce mois');
   });
 

--- a/frontend/e2e/tests/features/financial-overview-calculations.spec.ts
+++ b/frontend/e2e/tests/features/financial-overview-calculations.spec.ts
@@ -89,8 +89,8 @@ test.describe('Financial Overview Calculations', () => {
     await expect(financialOverview).toBeVisible();
 
     // Revenus pill should show 4800 (3500 + 800 + 500 rollover)
-    // Note: fr-CH locale uses NARROW NO-BREAK SPACE (U+202F) as thousands separator
-    await expect(financialOverview).toContainText("4\u202F800 CHF");
+    // Note: de-CH locale uses RIGHT SINGLE QUOTATION MARK (U+2019) as thousands separator
+    await expect(financialOverview).toContainText("4\u2019800 CHF");
   });
 
   test('Reste equals Disponible minus Depenses minus Epargne', async ({
@@ -111,7 +111,7 @@ test.describe('Financial Overview Calculations', () => {
     await expect(financialOverview).toBeVisible();
 
     // Dépenses pill: 1675
-    await expect(financialOverview).toContainText("1\u202F675 CHF");
+    await expect(financialOverview).toContainText("1\u2019675 CHF");
 
     // Épargne pill: 500
     await expect(financialOverview).toContainText('500 CHF');
@@ -119,7 +119,7 @@ test.describe('Financial Overview Calculations', () => {
     // Reste = 4800 - 1675 - 500 = 2625
     await expect(
       financialOverview.locator('.text-display-medium, .text-display-large'),
-    ).toContainText("2\u202F625");
+    ).toContainText("2\u2019625");
   });
 
   test('budget with rollover shows increased Disponible compared to without', async ({
@@ -146,10 +146,10 @@ test.describe('Financial Overview Calculations', () => {
     await expect(financialOverview).toBeVisible();
 
     // Without rollover: Revenus = 4300, Reste = 4300 - 1675 - 500 = 2125
-    await expect(financialOverview).toContainText("4\u202F300 CHF");
+    await expect(financialOverview).toContainText("4\u2019300 CHF");
     await expect(
       financialOverview.locator('.text-display-medium, .text-display-large'),
-    ).toContainText("2\u202F125");
+    ).toContainText("2\u2019125");
   });
 
   test('adding an expense decreases Reste by exactly the expense amount', async ({
@@ -208,7 +208,7 @@ test.describe('Financial Overview Calculations', () => {
     // Before: Reste = 2625
     await expect(
       financialOverview.locator('.text-display-medium, .text-display-large'),
-    ).toContainText("2\u202F625");
+    ).toContainText("2\u2019625");
 
     // Add expense
     await authenticatedPage.getByTestId('add-budget-line').click();
@@ -223,6 +223,6 @@ test.describe('Financial Overview Calculations', () => {
     // After: Reste = 2625 - 200 = 2425
     await expect(
       financialOverview.locator('.text-display-medium, .text-display-large'),
-    ).toContainText("2\u202F425");
+    ).toContainText("2\u2019425");
   });
 });

--- a/frontend/e2e/tests/features/realized-balance.spec.ts
+++ b/frontend/e2e/tests/features/realized-balance.spec.ts
@@ -71,7 +71,7 @@ test.describe('Checking Summary (Solde estimé)', () => {
     // All items checked → "Tout pointé"
     await expect(summary).toContainText('Tout pointé');
     // Realized balance = 5000 - max(2000, 1000) = 3000
-    await expect(summary).toContainText("3\u202F000 CHF");
+    await expect(summary).toContainText("3\u2019000 CHF");
   });
 
   test('(7.6) envelope checked with overage uses transaction sum', async ({
@@ -135,7 +135,7 @@ test.describe('Checking Summary (Solde estimé)', () => {
     // All items checked → "Tout pointé"
     await expect(summary).toContainText('Tout pointé');
     // Realized balance = 5000 - max(2000, 3000) = 2000
-    await expect(summary).toContainText("2\u202F000 CHF");
+    await expect(summary).toContainText("2\u2019000 CHF");
   });
 
   test('(7.7) no double counting when envelope and transactions are checked', async ({
@@ -200,7 +200,7 @@ test.describe('Checking Summary (Solde estimé)', () => {
     // All items checked → "Tout pointé"
     await expect(summary).toContainText('Tout pointé');
     // Realized balance = 5000 - max(500, 450) = 4500
-    await expect(summary).toContainText("4\u202F500 CHF");
+    await expect(summary).toContainText("4\u2019500 CHF");
   });
 
   test('(7.8) envelope not checked — only checked transactions count', async ({
@@ -265,6 +265,6 @@ test.describe('Checking Summary (Solde estimé)', () => {
     // Envelope not checked → "X/Y pointés" (not "Tout pointé")
     await expect(summary).toContainText('pointés');
     // Realized balance = 5000 - 450 = 4550
-    await expect(summary).toContainText("4\u202F550 CHF");
+    await expect(summary).toContainText("4\u2019550 CHF");
   });
 });

--- a/frontend/e2e/tests/features/rollover-propagation.spec.ts
+++ b/frontend/e2e/tests/features/rollover-propagation.spec.ts
@@ -239,6 +239,6 @@ test.describe('Rollover Propagation - Impact on next month', () => {
 
     // Remaining = income (5000 + 3800) - expenses (1200) = 7600
     // The hero section shows the remaining amount
-    await expect(financialOverview).toContainText("7\u202F600");
+    await expect(financialOverview).toContainText("7\u2019600");
   });
 });

--- a/frontend/projects/webapp/src/app/core/currency/app-currency.pipe.spec.ts
+++ b/frontend/projects/webapp/src/app/core/currency/app-currency.pipe.spec.ts
@@ -30,6 +30,12 @@ describe('AppCurrencyPipe', () => {
       const result = pipe.transform(100, 'CHF');
       expect(result).toContain('100.00');
     });
+
+    it('should always use dot decimal for CHF (Swiss banking standard)', () => {
+      const result = pipe.transform(1234.56, 'CHF');
+      expect(result).toContain('234.56');
+      expect(result).not.toContain(',');
+    });
   });
 
   describe('EUR formatting', () => {

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/template-detail.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/template-detail.ts
@@ -262,7 +262,7 @@ export default class TemplateDetail implements OnInit {
   readonly #budgetTemplatesStore = inject(BudgetTemplatesStore);
   protected readonly currency = inject(UserSettingsStore).currency;
   protected readonly locale = computed(
-    () => CURRENCY_CONFIG[this.currency()].locale,
+    () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );
   readonly #router = inject(Router);
   readonly #route = inject(ActivatedRoute);

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -164,7 +164,7 @@ export default class BudgetDetailsPage {
   readonly #destroyRef = inject(DestroyRef);
   protected readonly currency = this.#userSettingsStore.currency;
   protected readonly currencyLocale = computed(
-    () => CURRENCY_CONFIG[this.currency()].locale,
+    () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );
   readonly #breakpointObserver = inject(BreakpointObserver);
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-items-container.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-items-container.ts
@@ -239,7 +239,7 @@ export class BudgetItemsContainer {
   readonly currency = input<SupportedCurrency>('CHF');
 
   protected readonly locale = computed(
-    () => CURRENCY_CONFIG[this.currency()].locale,
+    () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );
 
   readonly isAllChecked = computed(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
@@ -176,7 +176,7 @@ export default class BudgetListPage {
 
   protected readonly currency = this.#userSettingsStore.currency;
   protected readonly currencyLocale = computed(
-    () => CURRENCY_CONFIG[this.currency()].locale,
+    () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );
   protected readonly isExporting = signal(false);
   protected readonly isExportingExcel = signal(false);

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts
@@ -638,7 +638,7 @@ export default class CompleteProfilePage {
 
   protected formatAmount(value: number): string {
     if (!Number.isFinite(value)) return '0';
-    const locale = CURRENCY_CONFIG[this.selectedCurrency()].locale;
+    const locale = CURRENCY_CONFIG[this.selectedCurrency()].numberLocale;
     return value.toLocaleString(locale, { maximumFractionDigits: 0 });
   }
 

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-next-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-next-month.ts
@@ -120,7 +120,7 @@ export class DashboardNextMonth {
   protected readonly hasBudget = computed(() => this.forecast().hasBudget);
 
   protected readonly formattedRollover = computed(() => {
-    const locale = CURRENCY_CONFIG[this.currency()].locale;
+    const locale = CURRENCY_CONFIG[this.currency()].numberLocale;
     return getRolloverFormatter(locale).format(this.estimatedRollover());
   });
 }

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-savings-summary.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-savings-summary.spec.ts
@@ -67,6 +67,15 @@ describe('DashboardSavingsSummary', () => {
         '1 sur 3 mises de côté',
       );
     });
+
+    it('should render CHF amounts with dot decimal separator (PUL-125)', () => {
+      setTestInput(component.totalRealized, 200.5);
+      fixture.detectChanges();
+      const text = fixture.nativeElement.textContent;
+      expect(text).toContain('200.50');
+      expect(text).toContain('500.00');
+      expect(text).not.toMatch(/\d,\d{2}/);
+    });
   });
 
   describe('when no savings planned', () => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-savings-summary.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-savings-summary.ts
@@ -126,7 +126,7 @@ export class DashboardSavingsSummary {
   readonly currency = input<SupportedCurrency>('CHF');
 
   protected readonly locale = computed(
-    () => CURRENCY_CONFIG[this.currency()].locale,
+    () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );
 
   protected readonly progressPercentage = computed(() => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-unchecked-forecasts.ts
@@ -172,7 +172,7 @@ export class DashboardUncheckedForecasts {
   );
 
   protected readonly locale = computed(
-    () => CURRENCY_CONFIG[this.currency()].locale,
+    () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );
 
   protected readonly displayedForecasts = computed(() =>

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -294,7 +294,7 @@ export default class Dashboard {
   protected readonly store = inject(DashboardStore);
   protected readonly currency = inject(UserSettingsStore).currency;
   protected readonly currencyLocale = computed(
-    () => CURRENCY_CONFIG[this.currency()].locale,
+    () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );
   readonly #productTourService = inject(ProductTourService);
   readonly #destroyRef = inject(DestroyRef);

--- a/shared/src/currency.ts
+++ b/shared/src/currency.ts
@@ -8,8 +8,13 @@ import type { SupportedCurrency } from '../schemas.js';
  * boundary that forbids `ui/` → `core/` dependencies.
  */
 export interface CurrencyMetadataEntry {
-  /** BCP 47 locale used for number formatting (e.g. fr-CH for CHF). */
+  /** BCP 47 locale used by Angular `CurrencyPipe` — keeps the existing
+   * layout (symbol position, thousands). fr-CH for CHF, fr-FR for EUR. */
   locale: string;
+  /** BCP 47 locale used by Angular `number` pipe for bare numeric amounts
+   * rendered alongside a separate currency span. CHF uses `de-CH` so the
+   * decimal separator stays `.` (Swiss banking standard); EUR stays `fr-FR`. */
+  numberLocale: string;
   /** Display symbol — `CHF` keeps the code, `€` for EUR. */
   symbol: string;
   /** Country/region flag emoji rendered in pickers and chips. */
@@ -24,12 +29,14 @@ export const CURRENCY_METADATA: Record<
 > = {
   CHF: {
     locale: 'fr-CH',
+    numberLocale: 'de-CH',
     symbol: 'CHF',
     flag: '🇨🇭',
     nativeName: 'Franc suisse',
   },
   EUR: {
     locale: 'fr-FR',
+    numberLocale: 'fr-FR',
     symbol: '€',
     flag: '🇪🇺',
     nativeName: 'Euro',


### PR DESCRIPTION
## Summary

- Split `CurrencyMetadataEntry` (shared) into `locale` (fr-CH, kept for `CurrencyPipe` — preserves `1 234.56 CHF` suffix layout) and `numberLocale` (de-CH for CHF, fr-FR for EUR — feeds the hero/overview `number` pipes so the decimal stays `.`).
- Wired `numberLocale` through the 3 `currencyLocale` computed in `current-month`, `budget-list-page`, `budget-details-page`.
- Added a CHF dot-decimal regression test in `app-currency.pipe.spec.ts`; migrated E2E hero/overview assertions from `,XX` and NNBSP (` `) to `.XX` and U+2019 apostrophe.

## Type

fix