### PR TITLE
fix(ios): revoke JWT server-side on account deletion (PUL-129)

### DIFF
--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -1,4 +1,5 @@
 import OSLog
+import Supabase
 import SwiftUI
 
 // MARK: - Session Lifecycle, Logout & Reset
@@ -90,7 +91,8 @@ extension AppState {
 
     func logout(
         source: LogoutSource = .userInitiated,
-        preserveBiometricSession: Bool? = nil
+        preserveBiometricSession: Bool? = nil,
+        scope: SignOutScope = .local
     ) async {
         guard !isLoggingOut else { return }
         isLoggingOut = true
@@ -131,12 +133,12 @@ extension AppState {
                 // Both save attempts failed — biometric tokens are unusable.
                 // Do a full logout instead of silently losing Face ID.
                 Logger.auth.error("logout: biometric token preservation failed, doing full logout")
-                await authService.logout()
+                await performSignOut(scope)
                 await biometric.handleSessionExpired()
                 biometric.isEnabled = false
             }
         } else {
-            await authService.logout()
+            await performSignOut(scope)
             await biometric.handleSessionExpired()
             biometric.isEnabled = false
         }
@@ -206,7 +208,9 @@ extension AppState {
         OnboardingState.clearPersistedData()
         onboardingBootstrapper.clearPendingData()
         clearManualBiometricRetryRequiredFlag()
-        await logout(source: .system, preserveBiometricSession: false)
+        // Account deletion / signup abandon → revoke JWT server-side so a
+        // snapped access_token cannot be replayed within its ~1h expiry window.
+        await logout(source: .system, preserveBiometricSession: false, scope: .global)
     }
 
     // MARK: - Session Reset

--- a/ios/Pulpe/App/AppState.swift
+++ b/ios/Pulpe/App/AppState.swift
@@ -1,4 +1,5 @@
 import OSLog
+import Supabase
 import SwiftUI
 
 @Observable @MainActor
@@ -163,6 +164,7 @@ final class AppState {
     let postAuthResolver: any PostAuthResolving
     let validateRegularSession: @Sendable () async throws -> UserInfo?
     let deleteAccountRequest: @Sendable () async throws -> DeleteAccountResponse
+    let performSignOut: @Sendable (SignOutScope) async -> Void
     @ObservationIgnored let flagsStore: any AppAuthFlagsStoring
     @ObservationIgnored let widgetSyncing: any WidgetSyncing
     @ObservationIgnored let maintenanceChecking: @Sendable () async throws -> Bool
@@ -192,6 +194,7 @@ final class AppState {
         self.validateRegularSession =
             deps.validateRegularSession ?? Self.defaultValidateRegularSession(deps.authService)
         self.deleteAccountRequest = Self.makeDeleteAccountRequest(deps)
+        self.performSignOut = Self.makePerformSignOut(deps)
         self.flagsStore = deps.flagsStore
         self.widgetSyncing = deps.widgetSyncing
         self.maintenanceChecking = deps.maintenanceChecking
@@ -311,6 +314,7 @@ final class AppState {
         validateRegularSession: (@Sendable () async throws -> UserInfo?)? = nil,
         validateBiometricSession: (@Sendable () async throws -> BiometricSessionResult?)? = nil,
         deleteAccountRequest: (@Sendable () async throws -> DeleteAccountResponse)? = nil,
+        performSignOut: (@Sendable (SignOutScope) async -> Void)? = nil,
         maintenanceChecking: @escaping @Sendable () async throws -> Bool = {
             try await MaintenanceService.shared.checkStatus()
         },
@@ -334,6 +338,7 @@ final class AppState {
             validateRegularSession: validateRegularSession,
             validateBiometricSession: validateBiometricSession,
             deleteAccountRequest: deleteAccountRequest,
+            performSignOut: performSignOut,
             maintenanceChecking: maintenanceChecking,
             nowProvider: nowProvider
         ))
@@ -374,6 +379,15 @@ final class AppState {
         deps.deleteAccountRequest
             ?? { [authService = deps.authService] in
                 try await authService.deleteAccount()
+            }
+    }
+
+    private static func makePerformSignOut(
+        _ deps: AppStateDependencies
+    ) -> @Sendable (SignOutScope) async -> Void {
+        deps.performSignOut
+            ?? { [authService = deps.authService] scope in
+                await authService.logout(scope: scope)
             }
     }
 

--- a/ios/Pulpe/App/AppStateDependencies.swift
+++ b/ios/Pulpe/App/AppStateDependencies.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Supabase
 
 /// Groups all external dependencies for AppState construction.
 /// Provides `.default` for production use.
@@ -31,6 +32,10 @@ struct AppStateDependencies {
     var validateRegularSession: (@Sendable () async throws -> UserInfo?)?
     var validateBiometricSession: (@Sendable () async throws -> BiometricSessionResult?)?
     var deleteAccountRequest: (@Sendable () async throws -> DeleteAccountResponse)?
+
+    /// Override for the sign-out side-effect. Defaults to `authService.logout(scope:)`.
+    /// Primarily a test seam — production should leave this `nil`.
+    var performSignOut: (@Sendable (SignOutScope) async -> Void)?
 
     // MARK: - Auth Flags & Widget
 
@@ -69,6 +74,7 @@ struct AppStateDependencies {
         validateRegularSession: (@Sendable () async throws -> UserInfo?)? = nil,
         validateBiometricSession: (@Sendable () async throws -> BiometricSessionResult?)? = nil,
         deleteAccountRequest: (@Sendable () async throws -> DeleteAccountResponse)? = nil,
+        performSignOut: (@Sendable (SignOutScope) async -> Void)? = nil,
         flagsStore: any AppAuthFlagsStoring = AppAuthFlagsStore(),
         widgetSyncing: any WidgetSyncing = WidgetSyncAdapter(),
         maintenanceChecking: @escaping @Sendable () async throws -> Bool = {
@@ -101,6 +107,7 @@ struct AppStateDependencies {
         self.validateRegularSession = validateRegularSession
         self.validateBiometricSession = validateBiometricSession
         self.deleteAccountRequest = deleteAccountRequest
+        self.performSignOut = performSignOut
         self.flagsStore = flagsStore
         self.widgetSyncing = widgetSyncing
         self.maintenanceChecking = maintenanceChecking

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -195,9 +195,9 @@ actor AuthService {
 
     // MARK: - Logout
 
-    func logout() async {
+    func logout(scope: SignOutScope = .local) async {
         do {
-            try await supabase.auth.signOut(scope: .local)
+            try await supabase.auth.signOut(scope: scope)
         } catch {
             Logger.auth.error("logout: signOut failed - \(error)")
         }

--- a/ios/PulpeTests/App/AppStateLogoutScopeTests.swift
+++ b/ios/PulpeTests/App/AppStateLogoutScopeTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+@testable import Pulpe
+import Supabase
+import Testing
+
+/// PUL-129: account deletion must revoke the Supabase JWT server-side.
+///
+/// `AuthService.logout()` historically hardcoded `signOut(scope: .local)`, which
+/// only wipes client tokens and leaves the access token valid on the server for
+/// up to 1 hour. Tests below verify that:
+/// - `deleteAccount()` and `abandonInProgressSignup()` propagate `.global`
+/// - Regular user-initiated logout keeps the `.local` default
+@MainActor
+@Suite(.serialized)
+struct AppStateLogoutScopeTests {
+    @Test("deleteAccount() triggers performSignOut with .global scope")
+    func deleteAccount_triggersGlobalSignOutScope() async {
+        let receivedScope = AtomicProperty<SignOutScope?>(nil)
+        let user = UserInfo(id: "user-del-scope", email: "delscope@pulpe.app", firstName: "Del")
+        let sut = AppState(
+            postAuthResolver: MockPostAuthResolver(destination: .authenticated(needsRecoveryKeyConsent: false)),
+            biometricPreferenceStore: AppStateTestFactory.biometricDisabledStore(),
+            deleteAccountRequest: {
+                DeleteAccountResponse(
+                    success: true,
+                    message: "scheduled",
+                    scheduledDeletionAt: "2026-03-01T00:00:00Z"
+                )
+            },
+            performSignOut: { scope in receivedScope.set(scope) }
+        )
+
+        await sut.bootstrap()
+        await sut.resolvePostAuth(user: user)
+        #expect(sut.authState == .authenticated, "Setup: should be authenticated")
+
+        await sut.deleteAccount()
+
+        #expect(
+            receivedScope.value == .global,
+            "Account deletion must sign out with .global so Supabase revokes the JWT server-side"
+        )
+        #expect(sut.authState == .unauthenticated)
+    }
+
+    @Test("logout(source: .userInitiated) defaults to .local scope")
+    func logout_userInitiated_defaultsToLocalScope() async throws {
+        let receivedScope = AtomicProperty<SignOutScope?>(nil)
+        let user = UserInfo(id: "user-local-scope", email: "local@pulpe.app", firstName: "Local")
+        let sut = AppState(
+            postAuthResolver: MockPostAuthResolver(destination: .authenticated(needsRecoveryKeyConsent: false)),
+            biometricPreferenceStore: AppStateTestFactory.biometricDisabledStore(),
+            performSignOut: { scope in receivedScope.set(scope) }
+        )
+
+        await sut.resolvePostAuth(user: user)
+        try #require(sut.authState == .authenticated)
+
+        await sut.logout()
+
+        #expect(
+            receivedScope.value == .local,
+            "Regular user logout keeps default .local scope — no server revocation needed"
+        )
+    }
+
+    @Test("abandonInProgressSignup() triggers performSignOut with .global scope")
+    func abandonInProgressSignup_triggersGlobalSignOutScope() async {
+        let receivedScope = AtomicProperty<SignOutScope?>(nil)
+        let sut = AppState(
+            biometricPreferenceStore: AppStateTestFactory.biometricDisabledStore(),
+            performSignOut: { scope in receivedScope.set(scope) }
+        )
+
+        await sut.abandonInProgressSignup()
+
+        #expect(
+            receivedScope.value == .global,
+            "Signup abandon must revoke server-side session — backend may have provisioned one"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes [PUL-129](https://linear.app/pulpe/issue/PUL-129).

`AuthService.logout()` hardcoded `signOut(scope: .local)` — the JWT stays valid on Supabase for ~1h after account deletion, so a snapped access token can be replayed against an already-deleted account. Added a `scope` parameter (default `.local`, all 9+ existing callers unchanged) and pass `.global` from `clearLocalSignupState()` so Supabase revokes the refresh token immediately for both `deleteAccount()` and `abandonInProgressSignup()` paths. Added `performSignOut` injection point in `AppStateDependencies` to enable scope-verification tests without mocking the real `AuthService` singleton.

## Test plan

- [x] Unit: 3 new Swift Testing cases in `AppStateLogoutScopeTests` — deleteAccount→.global, userInitiated→.local default, abandonInProgressSignup→.global
- [x] Regression: full iOS test suite (1362 tests, 120 suites) passes
- [x] Build: `xcodebuild build -scheme PulpeLocal` succeeds
- [ ] Manual smoke (recommended): trigger account deletion → confirm `POST /auth/v1/logout?scope=global` via Proxyman, then verify a queued API call with the cached access_token returns 401