### PR TITLE
fix(ios): revoke JWT server-side on password reset complete + cancel (PUL-130)

### DIFF
--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -154,7 +154,9 @@ extension AppState {
     /// and returning the app to the regular login screen.
     func completePasswordResetFlow() async {
         authDebug("AUTH_PASSWORD_RESET", "complete")
-        await authService.logout()
+        // Password reset → revoke JWT server-side so a snapped access_token
+        // cannot be replayed within its ~1h expiry window.
+        await performSignOut(.global)
         await authService.clearBiometricTokens()
         await clientKeyManager.clearAll()
         biometric.isEnabled = false
@@ -166,7 +168,9 @@ extension AppState {
     /// and returning the app to the regular login screen without success feedback.
     func cancelPasswordResetFlow() async {
         authDebug("AUTH_PASSWORD_RESET", "cancel")
-        await authService.logout()
+        // Cancel mid-recovery → revoke JWT server-side. Recovery session is
+        // write-capable (can change password) so a snapped token must not survive.
+        await performSignOut(.global)
         await authService.clearBiometricTokens()
         await clientKeyManager.clearAll()
         biometric.isEnabled = false

--- a/ios/PulpeTests/App/AppStateLogoutScopeTests.swift
+++ b/ios/PulpeTests/App/AppStateLogoutScopeTests.swift
@@ -3,12 +3,13 @@ import Foundation
 import Supabase
 import Testing
 
-/// PUL-129: account deletion must revoke the Supabase JWT server-side.
+/// PUL-129 / PUL-130: account deletion + password reset must revoke the Supabase JWT server-side.
 ///
 /// `AuthService.logout()` historically hardcoded `signOut(scope: .local)`, which
 /// only wipes client tokens and leaves the access token valid on the server for
 /// up to 1 hour. Tests below verify that:
 /// - `deleteAccount()` and `abandonInProgressSignup()` propagate `.global`
+/// - `completePasswordResetFlow()` and `cancelPasswordResetFlow()` propagate `.global`
 /// - Regular user-initiated logout keeps the `.local` default
 @MainActor
 @Suite(.serialized)
@@ -78,5 +79,49 @@ struct AppStateLogoutScopeTests {
             receivedScope.value == .global,
             "Signup abandon must revoke server-side session — backend may have provisioned one"
         )
+    }
+
+    @Test("completePasswordResetFlow() triggers performSignOut with .global scope")
+    func completePasswordResetFlow_triggersGlobalSignOutScope() async {
+        let receivedScope = AtomicProperty<SignOutScope?>(nil)
+        let user = UserInfo(id: "user-pwd-reset", email: "pwdreset@pulpe.app", firstName: "Reset")
+        let sut = AppState(
+            postAuthResolver: MockPostAuthResolver(destination: .authenticated(needsRecoveryKeyConsent: false)),
+            biometricPreferenceStore: AppStateTestFactory.biometricDisabledStore(),
+            performSignOut: { scope in receivedScope.set(scope) }
+        )
+
+        await sut.resolvePostAuth(user: user)
+        #expect(sut.authState == .authenticated, "Setup: should be authenticated")
+
+        await sut.completePasswordResetFlow()
+
+        #expect(
+            receivedScope.value == .global,
+            "Password reset must sign out with .global so Supabase revokes the JWT server-side"
+        )
+        #expect(sut.authState == .unauthenticated)
+    }
+
+    @Test("cancelPasswordResetFlow() triggers performSignOut with .global scope")
+    func cancelPasswordResetFlow_triggersGlobalSignOutScope() async {
+        let receivedScope = AtomicProperty<SignOutScope?>(nil)
+        let user = UserInfo(id: "user-pwd-cancel", email: "pwdcancel@pulpe.app", firstName: "Cancel")
+        let sut = AppState(
+            postAuthResolver: MockPostAuthResolver(destination: .authenticated(needsRecoveryKeyConsent: false)),
+            biometricPreferenceStore: AppStateTestFactory.biometricDisabledStore(),
+            performSignOut: { scope in receivedScope.set(scope) }
+        )
+
+        await sut.resolvePostAuth(user: user)
+        #expect(sut.authState == .authenticated, "Setup: should be authenticated")
+
+        await sut.cancelPasswordResetFlow()
+
+        #expect(
+            receivedScope.value == .global,
+            "Cancel password reset must sign out with .global — recovery JWT is write-capable"
+        )
+        #expect(sut.authState == .unauthenticated)
     }
 }


### PR DESCRIPTION
## Summary

`completePasswordResetFlow` and `cancelPasswordResetFlow` now route through `performSignOut(.global)` so Supabase revokes the recovery session server-side. Previously both used the default `.local` scope, leaving the recovery JWT replayable for ~1h after reset or cancel — and since recovery tokens are write-capable (`auth.updateUser`), a snapped token could change the password on either path. Adversarial review caught the cancel path as same-class vulnerability; both fixed in one PR.

## Test plan

- [x] `xcodebuild build -scheme PulpeLocal` ✓
- [x] `AppStateLogoutScopeTests` — 5/5 passing (incl. 2 new tests)
- [x] `AppStateResetMatrixTests` — 11/11 passing (regression preserved)

Note: `.global` revokes refresh tokens immediately; access JWT remains valid until `exp` (~1h) by Supabase design. Same defense-in-depth caveat as PUL-129.