### PR TITLE
refactor(ios): single-source-of-truth auth via Supabase AuthLocalStorage (PUL-132)

### DIFF
--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -116,14 +116,16 @@ extension AppState {
         let shouldPreserveBiometric = preserveBiometricSession ?? (source == .userInitiated)
         authDebug("AUTH_LOGOUT", "preserveBiometric=\(shouldPreserveBiometric)")
         if shouldPreserveBiometric && biometric.isEnabled {
-            // Refresh biometric tokens with the latest session before clearing
+            // Snapshot the live session into the biometric slot for cold-start re-entry.
+            // PUL-132: removed `saveBiometricTokensFromKeychain` fallback — SDK storage
+            // (PulpeAuthStorage) IS the source of truth, so a missing SDK session means
+            // there's nothing valid to snapshot.
             var biometricTokensSaved = false
             do {
                 try await authService.saveBiometricTokens()
                 biometricTokensSaved = true
             } catch {
-                Logger.auth.warning("logout: SDK session unavailable, falling back to keychain - \(error)")
-                biometricTokensSaved = await authService.saveBiometricTokensFromKeychain()
+                Logger.auth.warning("logout: biometric snapshot failed - \(error)")
             }
 
             if biometricTokensSaved {

--- a/ios/Pulpe/App/Auth/StartupCoordinator.swift
+++ b/ios/Pulpe/App/Auth/StartupCoordinator.swift
@@ -90,8 +90,11 @@ actor StartupCoordinator {
         // can take an arbitrary amount of time (phone on desk, etc.).
         // Skip the startup timeout — individual network operations within the
         // biometric flow have their own URLSession timeouts.
+        // PUL-132: biometric-keychain read only happens on explicit-logout cold start
+        // (re-entry path). Normal cold-start with biometric enabled relies on the
+        // SDK-restored session from PulpeAuthStorage.
         let biometricWillRun = context.biometricEnabled
-            && !context.didExplicitLogout
+            && context.didExplicitLogout
             && !context.manualBiometricRetryRequired
 
         let result: StartupResult
@@ -220,8 +223,11 @@ actor StartupCoordinator {
     }
 
     private func performBiometricValidationIfNeeded(runId: UUID, context: StartupContext) async -> StartupResult? {
-        guard context.biometricEnabled, !context.didExplicitLogout else { return nil }
-        Logger.auth.debug("[STARTUP] Attempting biometric session validation")
+        // PUL-132: biometric-keychain read is the re-entry path after an explicit logout.
+        // For normal cold-start with biometric enabled (didExplicitLogout == false),
+        // SDK-restored session from PulpeAuthStorage is used via performRegularValidation.
+        guard context.biometricEnabled, context.didExplicitLogout else { return nil }
+        Logger.auth.debug("[STARTUP] Attempting biometric session validation (explicit-logout re-entry)")
 
         do {
             guard let biometricResult = try await validateBiometricSession() else {

--- a/ios/Pulpe/App/BiometricManager.swift
+++ b/ios/Pulpe/App/BiometricManager.swift
@@ -230,18 +230,18 @@ final class BiometricManager {
         _ authService: AuthService
     ) -> @Sendable () async -> Bool {
         {
+            // PUL-132: SDK storage (PulpeAuthStorage) is the source of truth for the
+            // live session. saveBiometricTokens reads `supabase.auth.session` directly.
+            // No keychain fallback — if the SDK session is unavailable, there's
+            // nothing valid to snapshot into the biometric slot.
             do {
                 try await authService.saveBiometricTokens()
                 return true
             } catch {
-                Logger.auth.warning(
-                    "transitionToAuthenticated: saveBiometricTokens failed, trying fallback - \(error)"
+                Logger.auth.error(
+                    "transitionToAuthenticated: saveBiometricTokens failed - \(error)"
                 )
-                let saved = await authService.saveBiometricTokensFromKeychain()
-                if !saved {
-                    Logger.auth.error("transitionToAuthenticated: biometric token persistence failed")
-                }
-                return saved
+                return false
             }
         }
     }

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -10,43 +10,61 @@ actor AuthService {
 
     private var supabase: SupabaseClient
     private let keychain: KeychainManager
+    private let storage: PulpeAuthStorage
+    private var authStateListenerTask: Task<Void, Never>?
 
     private init(keychain: KeychainManager = .shared) {
         self.keychain = keychain
-        self.supabase = SupabaseClient(
+        self.storage = PulpeAuthStorage()
+        self.supabase = Self.makeSupabaseClient(storage: self.storage)
+        Task { [weak self] in
+            await self?.startAuthStateListener()
+        }
+    }
+
+    private func resetClient() {
+        authStateListenerTask?.cancel()
+        authStateListenerTask = nil
+        supabase = Self.makeSupabaseClient(storage: storage)
+        Task { [weak self] in
+            await self?.startAuthStateListener()
+        }
+    }
+
+    private static func makeSupabaseClient(storage: PulpeAuthStorage) -> SupabaseClient {
+        SupabaseClient(
             supabaseURL: AppConfiguration.supabaseURL,
             supabaseKey: AppConfiguration.supabaseAnonKey,
             options: SupabaseClientOptions(
                 auth: .init(
+                    storage: storage,
                     emitLocalSessionAsInitialSession: true
                 )
             )
         )
     }
 
-    private func resetClient() {
-        supabase = SupabaseClient(
-            supabaseURL: AppConfiguration.supabaseURL,
-            supabaseKey: AppConfiguration.supabaseAnonKey,
-            options: SupabaseClientOptions(
-                auth: .init(
-                    emitLocalSessionAsInitialSession: true
-                )
-            )
-        )
+    private func startAuthStateListener() {
+        authStateListenerTask?.cancel()
+        let stream = supabase.auth.authStateChanges
+        authStateListenerTask = Task(name: "AuthService.authStateListener") {
+            for await (event, _) in stream {
+                switch event {
+                case .tokenRefreshed:
+                    Logger.auth.debug("[AUTH] tokenRefreshed — SDK persisted via PulpeAuthStorage")
+                case .signedOut:
+                    Logger.auth.debug("[AUTH] signedOut — SDK cleared storage")
+                default:
+                    break
+                }
+            }
+        }
     }
 
     // MARK: - Login
 
     func login(email: String, password: String) async throws -> UserInfo {
         let session = try await supabase.auth.signIn(email: email, password: password)
-
-        // Save tokens to keychain for API calls
-        try await keychain.saveTokens(
-            accessToken: session.accessToken,
-            refreshToken: session.refreshToken
-        )
-
         return Self.userInfo(from: session.user, fallbackEmail: email)
     }
 
@@ -58,12 +76,6 @@ actor AuthService {
         guard let session = response.session else {
             throw AuthServiceError.signupFailed("No session returned. Email confirmation may be required.")
         }
-
-        // Save tokens to keychain for API calls
-        try await keychain.saveTokens(
-            accessToken: session.accessToken,
-            refreshToken: session.refreshToken
-        )
 
         return Self.userInfo(from: session.user, fallbackEmail: email)
     }
@@ -85,12 +97,6 @@ actor AuthService {
 
     private func signInWithIdToken(_ credentials: OpenIDConnectCredentials) async throws -> UserInfo {
         let session = try await supabase.auth.signInWithIdToken(credentials: credentials)
-
-        try await keychain.saveTokens(
-            accessToken: session.accessToken,
-            refreshToken: session.refreshToken
-        )
-
         return Self.userInfo(from: session.user, fallbackEmail: "")
     }
 
@@ -108,12 +114,6 @@ actor AuthService {
     /// Returns context required by the reset-password flow.
     func beginPasswordRecovery(from url: URL) async throws -> PasswordRecoveryContext {
         let session = try await supabase.auth.session(from: url)
-
-        try await keychain.saveTokens(
-            accessToken: session.accessToken,
-            refreshToken: session.refreshToken
-        )
-
         let user = session.user
         let metadata = user.userMetadata
 
@@ -139,12 +139,7 @@ actor AuthService {
 
     /// Re-authenticate with current credentials to verify password knowledge.
     func verifyPassword(email: String, password: String) async throws {
-        let session = try await supabase.auth.signIn(email: email, password: password)
-
-        try await keychain.saveTokens(
-            accessToken: session.accessToken,
-            refreshToken: session.refreshToken
-        )
+        _ = try await supabase.auth.signIn(email: email, password: password)
     }
 
     /// Persist a first name to Supabase user_metadata.
@@ -158,36 +153,16 @@ actor AuthService {
     /// Update the current user's password in Supabase auth.
     func updatePassword(_ newPassword: String) async throws {
         _ = try await supabase.auth.update(user: UserAttributes(password: newPassword))
-
-        let session = try await supabase.auth.session
-        try await keychain.saveTokens(
-            accessToken: session.accessToken,
-            refreshToken: session.refreshToken
-        )
+        // SDK persists refreshed session via PulpeAuthStorage automatically.
     }
 
     // MARK: - Session Validation
 
     func validateSession() async throws -> UserInfo? {
-        // Check if we have tokens
-        guard await keychain.hasTokens() else {
-            return nil
-        }
-
         do {
-            // Try to get current session from Supabase
             let session = try await supabase.auth.session
-
-            // Refresh tokens in keychain
-            try await keychain.saveTokens(
-                accessToken: session.accessToken,
-                refreshToken: session.refreshToken
-            )
-
             return Self.userInfo(from: session.user, fallbackEmail: "")
         } catch {
-            // Session invalid, clear tokens
-            await keychain.clearTokens()
             return nil
         }
     }
@@ -201,14 +176,21 @@ actor AuthService {
             Logger.auth.error("logout: signOut failed - \(error)")
         }
 
+        // SDK clears its own storage on signOut; clear legacy slot defensively.
         await keychain.clearTokens()
     }
 
     /// Logout without revoking the server-side refresh token.
-    /// Replaces the SupabaseClient to stop its auto-refresh timer,
-    /// then clears the regular keychain. Biometric tokens stay intact.
+    /// Replaces the SupabaseClient to stop its auto-refresh timer, clears the
+    /// SDK-owned storage (PulpeAuthStorage), and clears the legacy regular slot.
+    /// Biometric tokens stay intact as cold-storage for re-entry.
     func logoutKeepingBiometricSession() async {
         resetClient()
+        do {
+            try storage.remove(key: PulpeAuthStorage.sessionStorageKey)
+        } catch {
+            Logger.auth.warning("logoutKeepingBiometricSession: storage.remove failed - \(error)")
+        }
         await keychain.clearTokens()
     }
 
@@ -221,23 +203,13 @@ actor AuthService {
     // MARK: - Token Access (for API Client)
 
     func getAccessToken() async -> String? {
-        // Try to get fresh token from Supabase
-        if let session = try? await supabase.auth.session {
-            // Update keychain with latest token
-            do {
-                try await keychain.saveTokens(
-                    accessToken: session.accessToken,
-                    refreshToken: session.refreshToken
-                )
-            } catch {
-                Logger.auth.error("getAccessToken: failed to persist tokens - \(error)")
-            }
+        do {
+            let session = try await supabase.auth.session
             return session.accessToken
+        } catch {
+            Logger.auth.warning("getAccessToken: SDK session unavailable - \(error.localizedDescription)")
+            return nil
         }
-
-        // Supabase session unavailable — fall back to stored token
-        Logger.auth.warning("getAccessToken: Supabase session unavailable, falling back to keychain")
-        return await keychain.getAccessToken()
     }
 
     // MARK: - Biometric Session
@@ -254,27 +226,6 @@ actor AuthService {
         }
     }
 
-    /// Fallback: refresh and save tokens to biometric keychain.
-    /// Validates tokens before saving to prevent storing stale/expired tokens.
-    func saveBiometricTokensFromKeychain() async -> Bool {
-        guard let refreshToken = await keychain.getRefreshToken() else {
-            return false
-        }
-
-        // Validate token is still valid before saving
-        do {
-            let session = try await supabase.auth.refreshSession(refreshToken: refreshToken)
-            return await keychain.saveBiometricTokens(
-                accessToken: session.accessToken,
-                refreshToken: session.refreshToken
-            )
-        } catch {
-            Logger.auth.error("saveBiometricTokensFromKeychain: token refresh failed - \(error)")
-            return false
-        }
-    }
-
-    // swiftlint:disable:next function_body_length
     func validateBiometricSession() async throws -> BiometricSessionResult? {
         let hasBiometricTokens = await keychain.hasBiometricTokens()
         #if DEBUG
@@ -330,18 +281,10 @@ actor AuthService {
             throw AuthServiceError.biometricSessionExpired
         }
 
-        try await keychain.saveTokens(
-            accessToken: session.accessToken,
-            refreshToken: session.refreshToken
-        )
-
-        let biometricSaved = await keychain.saveBiometricTokens(
-            accessToken: session.accessToken,
-            refreshToken: session.refreshToken
-        )
-        if !biometricSaved {
-            Logger.auth.warning("validateBiometricSession: failed to persist biometric tokens")
-        }
+        // SDK persisted the new session via PulpeAuthStorage. The biometric slot
+        // is single-use cold-storage — clear it so the next logout-keep-biometric
+        // re-snapshots a fresh refresh token (PUL-132: prevents drift / reuse-detection).
+        await keychain.clearBiometricTokens()
 
         let user = Self.userInfo(from: session.user, fallbackEmail: "")
         return BiometricSessionResult(user: user, clientKeyHex: clientKeyHex)

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -17,7 +17,7 @@ actor AuthService {
         self.keychain = keychain
         self.storage = PulpeAuthStorage()
         self.supabase = Self.makeSupabaseClient(storage: self.storage)
-        Task { [weak self] in
+        Task(name: "AuthService.startListener") { [weak self] in
             await self?.startAuthStateListener()
         }
     }
@@ -26,7 +26,11 @@ actor AuthService {
         authStateListenerTask?.cancel()
         authStateListenerTask = nil
         supabase = Self.makeSupabaseClient(storage: storage)
-        Task { [weak self] in
+        // NOTE: gap between client assignment and listener subscription —
+        // `.initialSession` / `.tokenRefreshed` events emitted during this window
+        // are missed. Acceptable while the listener is logging-only; revisit if
+        // the listener takes corrective action.
+        Task(name: "AuthService.restartListener") { [weak self] in
             await self?.startAuthStateListener()
         }
     }
@@ -181,16 +185,18 @@ actor AuthService {
     }
 
     /// Logout without revoking the server-side refresh token.
-    /// Replaces the SupabaseClient to stop its auto-refresh timer, clears the
-    /// SDK-owned storage (PulpeAuthStorage), and clears the legacy regular slot.
+    /// Order matters: clear the SDK-owned storage slot BEFORE replacing the
+    /// SupabaseClient. The new client's `emitInitialSession` reads from
+    /// PulpeAuthStorage on subscribe and may trigger a silent refresh that
+    /// writes the slot back — see AuthClient.swift `emitInitialSession`.
     /// Biometric tokens stay intact as cold-storage for re-entry.
     func logoutKeepingBiometricSession() async {
-        resetClient()
         do {
             try storage.remove(key: PulpeAuthStorage.sessionStorageKey)
         } catch {
             Logger.auth.warning("logoutKeepingBiometricSession: storage.remove failed - \(error)")
         }
+        resetClient()
         await keychain.clearTokens()
     }
 

--- a/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
+++ b/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
@@ -41,7 +41,8 @@ public struct PulpeAuthStorage: AuthLocalStorage {
                 "PulpeAuthStorage update failed (\(updateStatus)), delete=\(deleteStatus) for key: \(key)"
             )
             guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
-                throw PulpeAuthStorageError.storeFailed(deleteStatus)
+                // Preserve original failure cause (update) — delete was best-effort cleanup.
+                throw PulpeAuthStorageError.storeFailed(updateStatus)
             }
         }
 

--- a/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
+++ b/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
@@ -1,0 +1,101 @@
+import Foundation
+import OSLog
+import Security
+import Supabase
+
+/// Single source of truth for live Supabase session tokens.
+/// Conforms to Supabase SDK's `AuthLocalStorage` (sync, throwing) so the SDK
+/// owns persistence across launches and silent token refreshes — eliminating
+/// drift between custom keychain slots that previously triggered
+/// refresh-token-reuse detection on cold-start biometric paths (PUL-132).
+public struct PulpeAuthStorage: AuthLocalStorage {
+    public static let sessionStorageKey = "supabase.auth.token"
+
+    private let service: String
+
+    public init(service: String = "app.pulpe.ios") {
+        self.service = service
+    }
+
+    public func store(key: String, value: Data) throws {
+        let baseQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+
+        let updateAttributes: [String: Any] = [
+            kSecValueData as String: value,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+
+        let updateStatus = SecItemUpdate(baseQuery as CFDictionary, updateAttributes as CFDictionary)
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            break
+        default:
+            let deleteStatus = SecItemDelete(baseQuery as CFDictionary)
+            Logger.auth.warning(
+                "PulpeAuthStorage update failed (\(updateStatus)), delete=\(deleteStatus) for key: \(key)"
+            )
+            guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                throw PulpeAuthStorageError.storeFailed(deleteStatus)
+            }
+        }
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: value,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw PulpeAuthStorageError.storeFailed(addStatus)
+        }
+    }
+
+    public func retrieve(key: String) throws -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            return result as? Data
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw PulpeAuthStorageError.retrieveFailed(status)
+        }
+    }
+
+    public func remove(key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw PulpeAuthStorageError.removeFailed(status)
+        }
+    }
+}
+
+public enum PulpeAuthStorageError: Error, Equatable {
+    case storeFailed(OSStatus)
+    case retrieveFailed(OSStatus)
+    case removeFailed(OSStatus)
+}

--- a/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
+++ b/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
@@ -53,7 +53,10 @@ public struct PulpeAuthStorage: AuthLocalStorage {
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        guard addStatus == errSecSuccess else {
+        // errSecDuplicateItem: a concurrent writer (e.g. SDK auto-refresh timer)
+        // re-inserted the item between our SecItemDelete and SecItemAdd. Treat
+        // as success — the slot now holds a more recent value than ours would.
+        guard addStatus == errSecSuccess || addStatus == errSecDuplicateItem else {
             throw PulpeAuthStorageError.storeFailed(addStatus)
         }
     }

--- a/ios/PulpeTests/App/AppStateBiometricColdStartTests.swift
+++ b/ios/PulpeTests/App/AppStateBiometricColdStartTests.swift
@@ -302,9 +302,10 @@ struct AppStateBiometricColdStartTests {
 
     @Test("checkAuthState sets biometricError when session expired path is triggered")
     func checkAuthState_biometricEnabled_noTokens_transitionsToUnauthenticated() async {
-        // When biometric is enabled but no tokens are stored,
-        // validateBiometricSession() returns nil → authState = .unauthenticated (no error set)
-        // This verifies the nil-tokens path is distinct from the expired-tokens path
+        // PUL-132: when biometric is enabled with no tokens AND no explicit logout,
+        // validateBiometricSession is NOT called (gate inverted) — the SDK-restored
+        // session path runs instead. With no real session, validateRegularSession
+        // returns nil → .unauthenticated, biometricError stays nil.
         let sut = AppState(
             biometricPreferenceStore: BiometricPreferenceStore(
                 keychain: MockBiometricPreferenceStore(enabled: true),
@@ -315,16 +316,15 @@ struct AppStateBiometricColdStartTests {
 
         await sut.bootstrap()
 
-        // Ensure no biometric tokens are stored so validateBiometricSession returns nil
+        // Ensure no biometric tokens are stored either (defensive cleanup)
         await AuthService.shared.clearBiometricTokens()
 
         await sut.checkAuthState()
 
-        // No tokens found path: authState = .unauthenticated, biometricError = nil
         #expect(sut.authState == .unauthenticated)
         #expect(
             sut.biometricError == nil,
-            "No-tokens path should not set biometricError (distinct from expired-session path)"
+            "No-session path should not set biometricError (distinct from expired-session path)"
         )
     }
 
@@ -476,7 +476,12 @@ struct AppStateBiometricColdStartTests {
     @Test("checkAuthState preserves biometricEnabled when biometric session expires")
     func checkAuthState_sessionExpired_preservesBiometricEnabled() async {
         UserDefaults.standard.set(true, forKey: "pulpe-has-launched-before")
-        defer { UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before") }
+        // PUL-132: biometric-keychain validation runs only on explicit-logout cold-start.
+        UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before")
+            UserDefaults.standard.removeObject(forKey: "pulpe-did-explicit-logout")
+        }
 
         let sut = AppState(
             biometricPreferenceStore: AppStateTestFactory.biometricEnabledStore(),
@@ -502,7 +507,12 @@ struct AppStateBiometricColdStartTests {
         struct SimulatedUnknownError: Error {}
 
         UserDefaults.standard.set(true, forKey: "pulpe-has-launched-before")
-        defer { UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before") }
+        // PUL-132: biometric-keychain validation runs only on explicit-logout cold-start.
+        UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before")
+            UserDefaults.standard.removeObject(forKey: "pulpe-did-explicit-logout")
+        }
 
         let sut = AppState(
             biometricPreferenceStore: AppStateTestFactory.biometricEnabledStore(),
@@ -530,7 +540,12 @@ struct AppStateBiometricColdStartTests {
         let user = UserInfo(id: "user-1", email: "test@pulpe.app", firstName: "Max")
 
         UserDefaults.standard.set(true, forKey: "pulpe-has-launched-before")
-        defer { UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before") }
+        // PUL-132: biometric-keychain validation runs only on explicit-logout cold-start.
+        UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before")
+            UserDefaults.standard.removeObject(forKey: "pulpe-did-explicit-logout")
+        }
 
         let sut = AppState(
             postAuthResolver: MockPostAuthResolver(
@@ -602,7 +617,14 @@ struct AppStateBiometricColdStartTests {
         let keychain = MockKeychainStore(lastUsedEmail: "returning@pulpe.app")
 
         UserDefaults.standard.set(true, forKey: "pulpe-has-launched-before")
-        defer { UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before") }
+        // PUL-132: biometric path (which surfaces URLError as networkError) runs only
+        // on explicit-logout cold-start. Without this flag, validateBiometricSession
+        // is skipped and validateRegularSession's URLError maps to .unauthenticated.
+        UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before")
+            UserDefaults.standard.removeObject(forKey: "pulpe-did-explicit-logout")
+        }
 
         let sut = AppState(
             keychainManager: keychain,
@@ -639,7 +661,12 @@ struct AppStateBiometricColdStartTests {
         let keychain = MockKeychainStore(lastUsedEmail: "returning@pulpe.app")
 
         UserDefaults.standard.set(true, forKey: "pulpe-has-launched-before")
-        defer { UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before") }
+        // PUL-132: biometric-keychain validation runs only on explicit-logout cold-start.
+        UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before")
+            UserDefaults.standard.removeObject(forKey: "pulpe-did-explicit-logout")
+        }
 
         let sut = AppState(
             keychainManager: keychain,

--- a/ios/PulpeTests/App/AppStateBiometricKeyValidationTests.swift
+++ b/ios/PulpeTests/App/AppStateBiometricKeyValidationTests.swift
@@ -94,8 +94,10 @@ struct AppStateBiometricKeyValidationTests {
             clientKeyHex: "valid-client-key-hex"
         )
 
+        // PUL-132: biometric-keychain validation runs only on explicit-logout cold-start.
         defer {
             UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before")
+            UserDefaults.standard.removeObject(forKey: "pulpe-did-explicit-logout")
         }
 
         let sut = AppState(
@@ -114,6 +116,7 @@ struct AppStateBiometricKeyValidationTests {
         )
 
         UserDefaults.standard.set(true, forKey: "pulpe-has-launched-before")
+        UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
 
         await sut.checkAuthState()
 
@@ -134,8 +137,10 @@ struct AppStateBiometricKeyValidationTests {
             clientKeyHex: "stale-client-key-hex"
         )
 
+        // PUL-132: biometric-keychain validation runs only on explicit-logout cold-start.
         defer {
             UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before")
+            UserDefaults.standard.removeObject(forKey: "pulpe-did-explicit-logout")
         }
 
         let sut = AppState(
@@ -153,6 +158,7 @@ struct AppStateBiometricKeyValidationTests {
         )
 
         UserDefaults.standard.set(true, forKey: "pulpe-has-launched-before")
+        UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
 
         await sut.checkAuthState()
 

--- a/ios/PulpeTests/App/AppStateCharacterizationTests.swift
+++ b/ios/PulpeTests/App/AppStateCharacterizationTests.swift
@@ -386,8 +386,12 @@ struct AppStateCharacterizationTests {
 
         #expect(sut.authState == .needsPinEntry)
     }
-    @Test("checkAuthState with biometric enabled resolves via biometric session")
+    @Test("checkAuthState with biometric enabled + explicit logout resolves via biometric session")
     func checkAuthState_biometricEnabled_resolvesViaBiometric() async {
+        // PUL-132: biometric-keychain validation runs only on explicit-logout cold-start.
+        UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
+        defer { UserDefaults.standard.removeObject(forKey: "pulpe-did-explicit-logout") }
+
         let sut = makeSUT(
             destination: .needsPinEntry(needsRecoveryKeyConsent: false),
             biometricEnabled: true,

--- a/ios/PulpeTests/App/AppStateLogoutBiometricTests.swift
+++ b/ios/PulpeTests/App/AppStateLogoutBiometricTests.swift
@@ -100,13 +100,13 @@ struct AppStateLogoutBiometricTests {
         #expect(sut.authState == .unauthenticated)
     }
 
-    // MARK: - Bug 3: checkAuthState Skips Biometric When didExplicitLogout
+    // MARK: - PUL-132: Biometric Gate Inverted (re-entry path on explicit logout only)
 
-    @Test("checkAuthState skips biometric auto-trigger when didExplicitLogout is true")
-    func checkAuthState_skipsBiometric_whenExplicitLogout() async {
+    @Test("checkAuthState ATTEMPTS biometric when didExplicitLogout is true (PUL-132)")
+    func checkAuthState_attemptsBiometric_whenExplicitLogout() async {
         let biometricAttempted = AtomicFlag()
 
-        // Set the explicit logout flag
+        // Set the explicit logout flag — biometric re-entry path
         UserDefaults.standard.set(true, forKey: Self.didExplicitLogoutKey)
         UserDefaults.standard.set(true, forKey: Self.hasLaunchedBeforeKey)
         defer {
@@ -128,14 +128,14 @@ struct AppStateLogoutBiometricTests {
         await sut.checkAuthState()
 
         #expect(
-            biometricAttempted.value == false,
-            "Biometric session validation must NOT be attempted when didExplicitLogout is true"
+            biometricAttempted.value == true,
+            "PUL-132: biometric-keychain re-entry path MUST run on explicit-logout cold-start"
         )
         #expect(sut.authState == .unauthenticated)
     }
 
-    @Test("checkAuthState attempts biometric when didExplicitLogout is false")
-    func checkAuthState_attemptsBiometric_whenNoExplicitLogout() async {
+    @Test("checkAuthState SKIPS biometric when didExplicitLogout is false (PUL-132)")
+    func checkAuthState_skipsBiometric_whenNoExplicitLogout() async {
         let biometricAttempted = AtomicFlag()
 
         // Ensure the explicit logout flag is NOT set
@@ -160,8 +160,8 @@ struct AppStateLogoutBiometricTests {
         await sut.checkAuthState()
 
         #expect(
-            biometricAttempted.value == true,
-            "Biometric session validation MUST be attempted when didExplicitLogout is false"
+            biometricAttempted.value == false,
+            "PUL-132: biometric slot must NOT be read on non-logout cold-start (drift prevention)"
         )
     }
 

--- a/ios/PulpeTests/App/AppStateStartupTimeoutIsolationTests.swift
+++ b/ios/PulpeTests/App/AppStateStartupTimeoutIsolationTests.swift
@@ -90,9 +90,10 @@ struct AppStateStartupTimeoutIsolationTests {
             }
         )
 
+        // PUL-132: biometric path requires didExplicitLogout=true.
         let context = StartupCoordinator.StartupContext(
             biometricEnabled: true,
-            didExplicitLogout: false,
+            didExplicitLogout: true,
             manualBiometricRetryRequired: false
         )
 

--- a/ios/PulpeTests/App/Auth/StartupCoordinatorTests.swift
+++ b/ios/PulpeTests/App/Auth/StartupCoordinatorTests.swift
@@ -78,7 +78,8 @@ struct StartupCoordinatorTests {
             resolvePostAuth: { .needsPinEntry(needsRecoveryKeyConsent: false) }
         )
 
-        let result = await sut.start(context: makeContext(biometricEnabled: true))
+        // PUL-132: biometric path runs only on explicit-logout cold-start.
+        let result = await sut.start(context: makeContext(biometricEnabled: true, didExplicitLogout: true))
 
         if case .authenticated(let user, let destination) = result {
             #expect(user.id == testUser.id)
@@ -103,7 +104,26 @@ struct StartupCoordinatorTests {
         #expect(biometricCalled.value == false)
     }
 
-    @Test func start_explicitLogout_skipsbiometricValidation() async {
+    /// PUL-132: gating semantics inverted — biometric-keychain validation now runs
+    /// ONLY on explicit-logout cold-start (re-entry path). Normal cold-start with
+    /// biometric enabled relies on the SDK-restored session via PulpeAuthStorage.
+    @Test func start_noExplicitLogout_skipsbiometricValidation() async {
+        let biometricCalled = AtomicFlag()
+        let sut = makeCoordinator(
+            validateBiometricSession: {
+                biometricCalled.set()
+                return nil
+            },
+            validateRegularSession: { [testUser] in testUser }
+        )
+
+        _ = await sut.start(context: makeContext(biometricEnabled: true, didExplicitLogout: false))
+
+        #expect(biometricCalled.value == false,
+                "PUL-132: biometric slot must not be read on non-logout cold-start")
+    }
+
+    @Test func start_explicitLogout_runsBiometricValidation() async {
         let biometricCalled = AtomicFlag()
         let sut = makeCoordinator(
             validateBiometricSession: {
@@ -115,7 +135,8 @@ struct StartupCoordinatorTests {
 
         _ = await sut.start(context: makeContext(biometricEnabled: true, didExplicitLogout: true))
 
-        #expect(biometricCalled.value == false)
+        #expect(biometricCalled.value == true,
+                "PUL-132: explicit-logout cold-start triggers biometric re-entry path")
     }
 
     @Test func start_maintenance_returnsMaintenance() async {
@@ -159,7 +180,8 @@ struct StartupCoordinatorTests {
             validateBiometricSession: { throw URLError(.notConnectedToInternet) }
         )
 
-        let result = await sut.start(context: makeContext(biometricEnabled: true))
+        // PUL-132: biometric path runs only on explicit-logout cold-start.
+        let result = await sut.start(context: makeContext(biometricEnabled: true, didExplicitLogout: true))
 
         if case .networkError = result {
             // Success
@@ -177,7 +199,8 @@ struct StartupCoordinatorTests {
             }
         )
 
-        let result = await sut.start(context: makeContext(biometricEnabled: true))
+        // PUL-132: biometric path requires didExplicitLogout=true.
+        let result = await sut.start(context: makeContext(biometricEnabled: true, didExplicitLogout: true))
 
         #expect(result == .biometricSessionExpired)
         #expect(expiredHandled.value == true)
@@ -194,7 +217,7 @@ struct StartupCoordinatorTests {
             }
         )
 
-        let result = await sut.start(context: makeContext(biometricEnabled: true))
+        let result = await sut.start(context: makeContext(biometricEnabled: true, didExplicitLogout: true))
 
         #expect(result == .biometricSessionExpired)
         #expect(expiredHandled.value == true)
@@ -215,7 +238,7 @@ struct StartupCoordinatorTests {
             }
         )
 
-        let result = await sut.start(context: makeContext(biometricEnabled: true))
+        let result = await sut.start(context: makeContext(biometricEnabled: true, didExplicitLogout: true))
 
         if case .authenticated(let user, _) = result {
             #expect(user.id == testUser.id)
@@ -237,7 +260,7 @@ struct StartupCoordinatorTests {
             }
         )
 
-        _ = await sut.start(context: makeContext(biometricEnabled: true))
+        _ = await sut.start(context: makeContext(biometricEnabled: true, didExplicitLogout: true))
 
         #expect(storedKey.value == "valid-key")
     }
@@ -597,8 +620,9 @@ struct StartupCoordinatorTimeoutTests {
             timeout: .milliseconds(100) // Timeout shorter than biometric
         )
 
+        // PUL-132: biometric path requires didExplicitLogout=true.
         let result = await sut.start(
-            context: makeContext(biometricEnabled: true)
+            context: makeContext(biometricEnabled: true, didExplicitLogout: true)
         )
 
         // Should NOT timeout — biometric path skips the startup timeout
@@ -609,7 +633,9 @@ struct StartupCoordinatorTimeoutTests {
         }
     }
 
-    @Test func start_biometricEnabled_explicitLogout_stillTimesOut() async {
+    /// PUL-132: with didExplicitLogout=false, biometric path is SKIPPED, regular
+    /// validation runs and is subject to the startup timeout.
+    @Test func start_biometricEnabled_noExplicitLogout_stillTimesOut() async {
         let sut = makeCoordinator(
             validateRegularSession: {
                 // Hang longer than the timeout
@@ -619,9 +645,10 @@ struct StartupCoordinatorTimeoutTests {
             timeout: .milliseconds(100)
         )
 
-        // biometricEnabled but didExplicitLogout → FaceID won't run → timeout applies
+        // biometricEnabled but no explicit logout → biometric path skipped → regular
+        // validation runs → subject to timeout.
         let result = await sut.start(
-            context: makeContext(biometricEnabled: true, didExplicitLogout: true)
+            context: makeContext(biometricEnabled: true, didExplicitLogout: false)
         )
 
         #expect(result == .timeout)
@@ -645,6 +672,9 @@ struct StartupCoordinatorBiometricDismissTests {
         )
     }
 
+    // PUL-132: biometric path runs ONLY on explicit-logout cold-start, so these
+    // dismiss-scenario tests must set didExplicitLogout=true to actually exercise
+    // the biometric error handling code paths.
     @Test func start_biometricUserCanceled_noRegularSession_returnsUnauthenticated() async {
         let expiredHandled = AtomicFlag()
         let sut = makeCoordinator(
@@ -653,7 +683,7 @@ struct StartupCoordinatorBiometricDismissTests {
         )
 
         let context = StartupCoordinator.StartupContext(
-            biometricEnabled: true, didExplicitLogout: false, manualBiometricRetryRequired: false
+            biometricEnabled: true, didExplicitLogout: true, manualBiometricRetryRequired: false
         )
         let result = await sut.start(context: context)
 
@@ -669,7 +699,7 @@ struct StartupCoordinatorBiometricDismissTests {
         )
 
         let context = StartupCoordinator.StartupContext(
-            biometricEnabled: true, didExplicitLogout: false, manualBiometricRetryRequired: false
+            biometricEnabled: true, didExplicitLogout: true, manualBiometricRetryRequired: false
         )
         let result = await sut.start(context: context)
 
@@ -690,7 +720,7 @@ struct StartupCoordinatorBiometricDismissTests {
         )
 
         let context = StartupCoordinator.StartupContext(
-            biometricEnabled: true, didExplicitLogout: false, manualBiometricRetryRequired: false
+            biometricEnabled: true, didExplicitLogout: true, manualBiometricRetryRequired: false
         )
         let result = await sut.start(context: context)
 
@@ -713,7 +743,7 @@ struct StartupCoordinatorBiometricDismissTests {
         )
 
         let context = StartupCoordinator.StartupContext(
-            biometricEnabled: true, didExplicitLogout: false, manualBiometricRetryRequired: false
+            biometricEnabled: true, didExplicitLogout: true, manualBiometricRetryRequired: false
         )
         let result = await sut.start(context: context)
 

--- a/ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift
+++ b/ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+@testable import Pulpe
+import Supabase
+import Testing
+
+/// PUL-132 — refactor verification tests.
+///
+/// Eliminates the dual-slot keychain drift that caused Supabase
+/// refresh-token-reuse detection to revoke session families on cold-start
+/// biometric paths. The new architecture:
+///
+/// - PulpeAuthStorage is the SDK's single source of truth for live session.
+/// - The biometric keychain slot is cold-storage, written ONLY at
+///   logout-keep-biometric, read ONLY on cold-start when didExplicitLogout=true.
+/// - StartupCoordinator's biometric path is gated on didExplicitLogout=true.
+@Suite("AuthService biometric refactor (PUL-132)")
+struct AuthServiceBiometricRefactorTests {
+    private static let testService = "app.pulpe.ios.tests.AuthServiceBiometricRefactor"
+
+    private func makeStorage() -> PulpeAuthStorage {
+        PulpeAuthStorage(service: Self.testService)
+    }
+
+    private func uniqueKey() -> String {
+        "session-\(UUID().uuidString)"
+    }
+
+    private func testUser() -> UserInfo {
+        UserInfo(id: "test-user", email: "test@pulpe.app", firstName: "Test")
+    }
+
+    // MARK: - Token rotation slot consistency
+
+    @Test("Token rotation via PulpeAuthStorage does not touch biometric slot bytes",
+          .enabled(if: KeychainManager.checkAvailability()))
+    func tokenRotation_doesNotTouchBiometricSlot() throws {
+        let storage = makeStorage()
+        let key = uniqueKey()
+        defer { try? storage.remove(key: key) }
+
+        // Pre-populate "biometric snapshot" — independent storage instance
+        let biometricSnapshot = Data("biometric-refresh-token-r0".utf8)
+        let snapshotStorage = PulpeAuthStorage(service: "\(Self.testService).biometric")
+        let snapshotKey = "snapshot-\(UUID().uuidString)"
+        defer { try? snapshotStorage.remove(key: snapshotKey) }
+        try snapshotStorage.store(key: snapshotKey, value: biometricSnapshot)
+
+        // Simulate SDK rotating refresh token N times via the live-session storage
+        for index in 0..<3 {
+            let rotated = Data("session-r\(index)".utf8)
+            try storage.store(key: key, value: rotated)
+        }
+
+        // Biometric snapshot must be byte-identical — rotation never touched it.
+        let postRotation = try snapshotStorage.retrieve(key: snapshotKey)
+        #expect(postRotation == biometricSnapshot)
+    }
+
+    // MARK: - Cold-start gating: no explicit logout
+
+    @Test("Cold-start with biometric enabled but no explicit logout does NOT call validateBiometricSession")
+    func coldStart_noExplicitLogout_skipsBiometricValidation() async {
+        let user = testUser()
+        let biometricCalls = AtomicProperty(0)
+        let regularCalls = AtomicProperty(0)
+
+        let coordinator = StartupCoordinator(
+            checkMaintenance: { false },
+            validateBiometricSession: {
+                biometricCalls.increment()
+                return BiometricSessionResult(user: user, clientKeyHex: nil)
+            },
+            validateRegularSession: {
+                regularCalls.increment()
+                return user
+            },
+            resolvePostAuth: { .authenticated(needsRecoveryKeyConsent: false) }
+        )
+
+        let context = StartupCoordinator.StartupContext(
+            biometricEnabled: true,
+            didExplicitLogout: false,
+            manualBiometricRetryRequired: false
+        )
+        let result = await coordinator.start(context: context)
+
+        #expect(biometricCalls.value == 0, "Biometric-keychain validation must not run on non-logout cold-start")
+        #expect(regularCalls.value == 1)
+        if case .authenticated = result { } else {
+            Issue.record("Expected authenticated result, got \(result)")
+        }
+    }
+
+    // MARK: - Cold-start gating: explicit logout re-entry
+
+    @Test("Cold-start with biometric enabled AND explicit logout DOES call validateBiometricSession")
+    func coldStart_explicitLogout_runsBiometricValidation() async {
+        let user = testUser()
+        let biometricCalls = AtomicProperty(0)
+        let regularCalls = AtomicProperty(0)
+
+        let coordinator = StartupCoordinator(
+            checkMaintenance: { false },
+            validateBiometricSession: {
+                biometricCalls.increment()
+                return BiometricSessionResult(user: user, clientKeyHex: nil)
+            },
+            validateRegularSession: {
+                regularCalls.increment()
+                return nil
+            },
+            resolvePostAuth: { .authenticated(needsRecoveryKeyConsent: false) }
+        )
+
+        let context = StartupCoordinator.StartupContext(
+            biometricEnabled: true,
+            didExplicitLogout: true,
+            manualBiometricRetryRequired: false
+        )
+        let result = await coordinator.start(context: context)
+
+        #expect(biometricCalls.value == 1)
+        #expect(regularCalls.value == 0, "Biometric path satisfied; regular validation must not also run")
+        if case .authenticated = result { } else {
+            Issue.record("Expected authenticated result, got \(result)")
+        }
+    }
+
+    // MARK: - Cold-start gating: biometric disabled
+
+    @Test("Cold-start with biometric disabled never calls validateBiometricSession")
+    func coldStart_biometricDisabled_skipsBiometricValidation() async {
+        let user = testUser()
+        let biometricCalls = AtomicProperty(0)
+
+        let coordinator = StartupCoordinator(
+            checkMaintenance: { false },
+            validateBiometricSession: {
+                biometricCalls.increment()
+                return nil
+            },
+            validateRegularSession: { user },
+            resolvePostAuth: { .authenticated(needsRecoveryKeyConsent: false) }
+        )
+
+        let context = StartupCoordinator.StartupContext(
+            biometricEnabled: false,
+            didExplicitLogout: true, // even with logout flag — gate requires biometricEnabled too
+            manualBiometricRetryRequired: false
+        )
+        _ = await coordinator.start(context: context)
+
+        #expect(biometricCalls.value == 0)
+    }
+
+    // MARK: - Stale biometric token routes to expired
+
+    @Test("Stale biometric refresh token on explicit-logout cold-start surfaces .biometricSessionExpired")
+    func coldStart_explicitLogout_staleBiometric_routesToBiometricSessionExpired() async {
+        let cleanedExpired = AtomicFlag()
+
+        let coordinator = StartupCoordinator(
+            checkMaintenance: { false },
+            validateBiometricSession: { throw AuthServiceError.biometricSessionExpired },
+            validateRegularSession: { nil },
+            resolvePostAuth: { .needsPinEntry(needsRecoveryKeyConsent: false) },
+            clearExpiredBiometricState: { cleanedExpired.set() }
+        )
+
+        let context = StartupCoordinator.StartupContext(
+            biometricEnabled: true,
+            didExplicitLogout: true,
+            manualBiometricRetryRequired: false
+        )
+        let result = await coordinator.start(context: context)
+
+        #expect(result == .biometricSessionExpired)
+        #expect(cleanedExpired.value == true, "Coordinator must clear expired biometric state")
+    }
+
+    // MARK: - Logout-keep-biometric clears live, preserves biometric
+
+    @Test("logoutKeepingBiometricSession clears the SDK live-session slot",
+          .enabled(if: KeychainManager.checkAvailability()))
+    func logoutKeepingBiometric_clearsLiveSlot() async throws {
+        let storage = makeStorage()
+        let liveKey = uniqueKey()
+        defer { try? storage.remove(key: liveKey) }
+
+        // Pre-populate "live session" data
+        try storage.store(key: liveKey, value: Data("session-payload".utf8))
+        #expect(try storage.retrieve(key: liveKey) != nil)
+
+        // Simulate the cleanup performed in logoutKeepingBiometricSession
+        try storage.remove(key: liveKey)
+
+        #expect(try storage.retrieve(key: liveKey) == nil)
+    }
+
+    // MARK: - Manual biometric retry skip
+
+    @Test("manualBiometricRetryRequired short-circuits to .unauthenticated")
+    func manualBiometricRetryRequired_returnsUnauthenticatedImmediately() async {
+        let biometricCalls = AtomicProperty(0)
+
+        let coordinator = StartupCoordinator(
+            checkMaintenance: { false },
+            validateBiometricSession: {
+                biometricCalls.increment()
+                return nil
+            },
+            validateRegularSession: { nil },
+            resolvePostAuth: { .needsPinEntry(needsRecoveryKeyConsent: false) }
+        )
+
+        let context = StartupCoordinator.StartupContext(
+            biometricEnabled: true,
+            didExplicitLogout: true,
+            manualBiometricRetryRequired: true
+        )
+        let result = await coordinator.start(context: context)
+
+        #expect(result == .unauthenticated)
+        #expect(biometricCalls.value == 0)
+    }
+
+    // MARK: - Regression: refresh-token-reuse scenario
+
+    @Test("Regression: silent rotation does not poison cold-start when biometric enabled and no explicit logout")
+    func regression_refreshTokenReuse_biometricEnabledColdStart_doesNotReadStaleBiometricSlot() async {
+        let user = testUser()
+        let biometricReads = AtomicProperty(0)
+
+        // Without the fix: cold-start always runs validateBiometricSession,
+        // which reads the stale biometric refresh token written hours ago.
+        // SDK had since rotated to r_N; biometric still has r_0 → reuse-detected
+        // → entire family revoked → user booted to login.
+        //
+        // With the fix: validateBiometricSession is NOT called on
+        // didExplicitLogout=false cold-start. The SDK reads its persisted
+        // session via PulpeAuthStorage (already containing the latest rotation).
+        let coordinator = StartupCoordinator(
+            checkMaintenance: { false },
+            validateBiometricSession: {
+                biometricReads.increment()
+                throw AuthServiceError.biometricSessionExpired
+            },
+            validateRegularSession: { user },
+            resolvePostAuth: { .authenticated(needsRecoveryKeyConsent: false) }
+        )
+
+        let context = StartupCoordinator.StartupContext(
+            biometricEnabled: true,
+            didExplicitLogout: false, // user just force-quit; no explicit logout
+            manualBiometricRetryRequired: false
+        )
+        let result = await coordinator.start(context: context)
+
+        #expect(biometricReads.value == 0,
+                "Regression guard: biometric slot must NOT be read on force-quit cold-start")
+        if case .authenticated = result { } else {
+            Issue.record("Expected authenticated cold-start, got \(result)")
+        }
+    }
+}

--- a/ios/PulpeTests/Core/Auth/PulpeAuthStorageTests.swift
+++ b/ios/PulpeTests/Core/Auth/PulpeAuthStorageTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+@testable import Pulpe
+import Supabase
+import Testing
+
+@Suite("PulpeAuthStorage", .enabled(if: KeychainManager.checkAvailability()))
+struct PulpeAuthStorageTests {
+    /// Use a unique test service so we never collide with the live SDK key
+    /// (`supabase.auth.token`) under `app.pulpe.ios`.
+    private static let testService = "app.pulpe.ios.tests.PulpeAuthStorage"
+
+    private func makeStorage() -> PulpeAuthStorage {
+        PulpeAuthStorage(service: Self.testService)
+    }
+
+    private func uniqueKey() -> String {
+        "test-\(UUID().uuidString)"
+    }
+
+    @Test func store_thenRetrieve_returnsSameData() throws {
+        let storage = makeStorage()
+        let key = uniqueKey()
+        let value = Data("session-payload".utf8)
+
+        defer { try? storage.remove(key: key) }
+        try storage.store(key: key, value: value)
+
+        let retrieved = try storage.retrieve(key: key)
+        #expect(retrieved == value)
+    }
+
+    @Test func retrieve_missingKey_returnsNil() throws {
+        let storage = makeStorage()
+        let key = uniqueKey()
+
+        let retrieved = try storage.retrieve(key: key)
+        #expect(retrieved == nil)
+    }
+
+    @Test func store_overwrites_previousValue() throws {
+        let storage = makeStorage()
+        let key = uniqueKey()
+        let first = Data("first".utf8)
+        let second = Data("second".utf8)
+
+        defer { try? storage.remove(key: key) }
+        try storage.store(key: key, value: first)
+        try storage.store(key: key, value: second)
+
+        let retrieved = try storage.retrieve(key: key)
+        #expect(retrieved == second)
+    }
+
+    @Test func remove_deletesEntry_subsequentRetrieveIsNil() throws {
+        let storage = makeStorage()
+        let key = uniqueKey()
+        try storage.store(key: key, value: Data("payload".utf8))
+
+        try storage.remove(key: key)
+
+        #expect(try storage.retrieve(key: key) == nil)
+    }
+
+    @Test func remove_missingKey_doesNotThrow() throws {
+        let storage = makeStorage()
+        let key = uniqueKey()
+
+        try storage.remove(key: key)
+    }
+
+    @Test func protocolConformance_acceptsAsAuthLocalStorage() {
+        let storage: any AuthLocalStorage = makeStorage()
+        #expect(storage is PulpeAuthStorage)
+    }
+
+    @Test func storesArbitraryBinaryData_notJustUTF8() throws {
+        let storage = makeStorage()
+        let key = uniqueKey()
+        let binary = Data([0x00, 0xFF, 0x10, 0x80, 0x7F])
+
+        defer { try? storage.remove(key: key) }
+        try storage.store(key: key, value: binary)
+
+        let retrieved = try storage.retrieve(key: key)
+        #expect(retrieved == binary)
+    }
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -234,7 +234,7 @@
     "impeccable": {
       "source": "pbakaus/impeccable",
       "sourceType": "github",
-      "computedHash": "a26b3dd377c4572b1c34c68f82ab9a1cb806f21c7157060327fe60e9b6d2e277"
+      "computedHash": "bd24f9b2f67dfdac55f76a85877ce302fe75d6204d2b329d3d05342904abf336"
     },
     "ios-marketing-capture": {
       "source": "ParthJadhav/ios-marketing-capture",


### PR DESCRIPTION
## Summary

Eliminates dual-slot keychain drift causing Supabase refresh-token-reuse detection to revoke session families on cold-start biometric paths. New `PulpeAuthStorage` conforms to the SDK's `AuthLocalStorage` protocol so the SDK owns live-session persistence (key `supabase.auth.token`, `WhenUnlockedThisDeviceOnly`, no biometric ACL); `AuthService` drops 8 mirror `keychain.saveTokens` writes, `validateBiometricSession` clears the biometric slot post-refresh (single-use cold-storage), and `logoutKeepingBiometricSession` clears SDK storage explicitly. `StartupCoordinator` gate inverted: biometric-keychain validation runs ONLY on `didExplicitLogout && biometricEnabled` cold-start; normal launches rely on SDK-restored session, so the biometric slot is never read while the SDK silently rotates refresh tokens.

## Test plan
- [x] `xcodebuild build -scheme PulpeLocal` — green
- [x] `xcodebuild test -scheme PulpeLocal -only-testing:PulpeTests` — 1383/1383 pass (15 new tests + 6 existing test files updated for new gating semantics)
- [x] No stale `saveBiometricTokensFromKeychain` callsites; only one comment ref in `AppState+SessionReset.swift`
- [ ] Manual E2E — login + enable biometric → 5+ minutes of API calls (force `auth.refreshSession` in DEBUG) → force-quit → reopen succeeds with biometric prompt, no Supabase revocation
- [ ] Manual E2E — login + biometric + user logout → reopen → biometric prompt → re-enter without password
- [ ] Supabase dashboard: confirm no `refresh_token_already_used` errors after E2E