### PR TITLE
fix(backend): persist FX metadata in create_template_with_lines (PUL-133)

### DIFF
--- a/backend-nest/src/modules/budget-template/budget-template.service.spec.ts
+++ b/backend-nest/src/modules/budget-template/budget-template.service.spec.ts
@@ -68,8 +68,14 @@ describe('BudgetTemplateService - Simplified Tests', () => {
         Promise.resolve({ amount: 'encrypted-mock' }),
       prepareAmountsData: (amounts: number[]) =>
         Promise.resolve(amounts.map(() => ({ amount: 'encrypted-mock' }))),
+      encryptOptionalAmount: (amount: number | null | undefined) =>
+        Promise.resolve(amount == null ? null : 'encrypted-mock'),
       decryptAmount: () => 100,
       getUserDEK: () => Promise.resolve(Buffer.alloc(32)),
+    };
+
+    const mockCurrencyService = {
+      overrideExchangeRate: (dto: any) => Promise.resolve(dto),
     };
 
     service = new BudgetTemplateService(
@@ -77,7 +83,7 @@ describe('BudgetTemplateService - Simplified Tests', () => {
       mockBudgetService as any,
       mockEncryptionService as any,
       { invalidateForUser: () => Promise.resolve() } as any,
-      {} as any,
+      mockCurrencyService as any,
     );
   });
 
@@ -690,6 +696,246 @@ describe('BudgetTemplateService - Simplified Tests', () => {
       }>;
       expect(groupEntries[0]?.data).not.toHaveProperty('original_amount');
       expect(groupEntries[0]?.data).not.toHaveProperty('original_currency');
+    });
+  });
+
+  describe('createTemplateWithLines — FX metadata persistence (PUL-133)', () => {
+    type RpcCall = [string, Record<string, unknown>];
+
+    const buildServiceWithMocks = (
+      overrideMock: ReturnType<typeof mock>,
+      encryptOptionalMock: ReturnType<typeof mock>,
+      rpcMock: ReturnType<typeof mock>,
+    ): { service: BudgetTemplateService; supabase: any } => {
+      const customCurrencyService = { overrideExchangeRate: overrideMock };
+      const customEncryptionService = {
+        ensureUserDEK: () => Promise.resolve(Buffer.alloc(32)),
+        encryptAmount: () => 'encrypted-mock',
+        prepareAmountData: (_amount: number) =>
+          Promise.resolve({ amount: 'enc-amount' }),
+        prepareAmountsData: (amounts: number[]) =>
+          Promise.resolve(amounts.map(() => ({ amount: 'enc-amount' }))),
+        encryptOptionalAmount: encryptOptionalMock,
+        decryptAmount: () => 100,
+        getUserDEK: () => Promise.resolve(Buffer.alloc(32)),
+      };
+
+      const fxService = new BudgetTemplateService(
+        mockLogger as any,
+        mockBudgetService as any,
+        customEncryptionService as any,
+        { invalidateForUser: () => Promise.resolve() } as any,
+        customCurrencyService as any,
+      );
+
+      const supabase = {
+        from: () => ({
+          update: () => ({
+            eq: () => ({ eq: () => Promise.resolve({ error: null }) }),
+          }),
+        }),
+        rpc: rpcMock,
+      };
+
+      return { service: fxService, supabase };
+    };
+
+    it('should persist FX metadata for multi-currency lines', async () => {
+      const overrideMock = mock((dto: any) =>
+        Promise.resolve({
+          ...dto,
+          originalAmount: 100,
+          originalCurrency: 'EUR',
+          targetCurrency: 'CHF',
+          exchangeRate: 0.95,
+        }),
+      );
+      const encryptOptionalMock = mock((amount: number | null | undefined) =>
+        Promise.resolve(amount == null ? null : 'enc-orig'),
+      );
+      const rpcMock = mock(() =>
+        Promise.resolve({ data: mockTemplate, error: null }),
+      );
+
+      const { service: fxService, supabase } = buildServiceWithMocks(
+        overrideMock,
+        encryptOptionalMock,
+        rpcMock,
+      );
+
+      await (fxService as any).createTemplateWithLines(
+        {
+          name: 'Multi-FX template',
+          description: '',
+          isDefault: false,
+          lines: [
+            {
+              name: 'Rent EUR',
+              amount: 95,
+              kind: 'expense',
+              recurrence: 'fixed',
+              description: '',
+              originalAmount: 100,
+              originalCurrency: 'EUR',
+              targetCurrency: 'CHF',
+              exchangeRate: 999,
+            },
+          ],
+        },
+        mockUser,
+        supabase,
+      );
+
+      expect(overrideMock).toHaveBeenCalledTimes(1);
+      expect(encryptOptionalMock).toHaveBeenCalledWith(
+        100,
+        mockUser.id,
+        mockUser.clientKey,
+      );
+
+      const rpcCall = rpcMock.mock.calls[0] as unknown as RpcCall;
+      const payload = rpcCall[1];
+      const lines = payload.p_lines as Record<string, unknown>[];
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        name: 'Rent EUR',
+        amount: 'enc-amount',
+        kind: 'expense',
+        recurrence: 'fixed',
+        original_amount: 'enc-orig',
+        original_currency: 'EUR',
+        target_currency: 'CHF',
+        exchange_rate: 0.95,
+      });
+    });
+
+    it('should null FX columns for same-currency lines', async () => {
+      const overrideMock = mock((dto: any) => {
+        const sanitized: Record<string, unknown> = { ...dto };
+        delete sanitized.exchangeRate;
+        delete sanitized.originalAmount;
+        delete sanitized.originalCurrency;
+        return Promise.resolve(sanitized);
+      });
+      const encryptOptionalMock = mock(() => Promise.resolve(null));
+      const rpcMock = mock(() =>
+        Promise.resolve({ data: mockTemplate, error: null }),
+      );
+
+      const { service: fxService, supabase } = buildServiceWithMocks(
+        overrideMock,
+        encryptOptionalMock,
+        rpcMock,
+      );
+
+      await (fxService as any).createTemplateWithLines(
+        {
+          name: 'Mono template',
+          description: '',
+          isDefault: false,
+          lines: [
+            {
+              name: 'Salary',
+              amount: 5000,
+              kind: 'income',
+              recurrence: 'fixed',
+              description: '',
+            },
+          ],
+        },
+        mockUser,
+        supabase,
+      );
+
+      expect(overrideMock).toHaveBeenCalledTimes(1);
+
+      const rpcCall = rpcMock.mock.calls[0] as unknown as RpcCall;
+      const lines = (rpcCall[1].p_lines as Record<string, unknown>[]) ?? [];
+
+      expect(lines[0]).toMatchObject({
+        name: 'Salary',
+        amount: 'enc-amount',
+        original_amount: null,
+        original_currency: null,
+        target_currency: null,
+        exchange_rate: null,
+      });
+    });
+
+    it('should handle mixed batch independently per line', async () => {
+      const overrideMock = mock((dto: any) => {
+        if (dto.originalCurrency && dto.targetCurrency) {
+          return Promise.resolve({ ...dto, exchangeRate: 0.95 });
+        }
+        const sanitized: Record<string, unknown> = { ...dto };
+        delete sanitized.exchangeRate;
+        delete sanitized.originalAmount;
+        delete sanitized.originalCurrency;
+        return Promise.resolve(sanitized);
+      });
+      const encryptOptionalMock = mock((amount: number | null | undefined) =>
+        Promise.resolve(amount == null ? null : 'enc-orig'),
+      );
+      const rpcMock = mock(() =>
+        Promise.resolve({ data: mockTemplate, error: null }),
+      );
+
+      const { service: fxService, supabase } = buildServiceWithMocks(
+        overrideMock,
+        encryptOptionalMock,
+        rpcMock,
+      );
+
+      await (fxService as any).createTemplateWithLines(
+        {
+          name: 'Mixed template',
+          description: '',
+          isDefault: false,
+          lines: [
+            {
+              name: 'Rent EUR',
+              amount: 95,
+              kind: 'expense',
+              recurrence: 'fixed',
+              description: '',
+              originalAmount: 100,
+              originalCurrency: 'EUR',
+              targetCurrency: 'CHF',
+            },
+            {
+              name: 'Salary CHF',
+              amount: 5000,
+              kind: 'income',
+              recurrence: 'fixed',
+              description: '',
+            },
+          ],
+        },
+        mockUser,
+        supabase,
+      );
+
+      expect(overrideMock).toHaveBeenCalledTimes(2);
+
+      const rpcCall = rpcMock.mock.calls[0] as unknown as RpcCall;
+      const lines = rpcCall[1].p_lines as Record<string, unknown>[];
+
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toMatchObject({
+        name: 'Rent EUR',
+        original_amount: 'enc-orig',
+        original_currency: 'EUR',
+        target_currency: 'CHF',
+        exchange_rate: 0.95,
+      });
+      expect(lines[1]).toMatchObject({
+        name: 'Salary CHF',
+        original_amount: null,
+        original_currency: null,
+        target_currency: null,
+        exchange_rate: null,
+      });
     });
   });
 

--- a/backend-nest/src/modules/budget-template/budget-template.service.ts
+++ b/backend-nest/src/modules/budget-template/budget-template.service.ts
@@ -276,20 +276,41 @@ export class BudgetTemplateService {
         .eq('is_default', true);
     }
 
-    const amounts = validated.lines.map((line) => line.amount);
-    const preparedAmounts = await this.encryptionService.prepareAmountsData(
-      amounts,
-      user.id,
-      user.clientKey,
+    const overriddenLines = await Promise.all(
+      validated.lines.map((line) =>
+        this.currencyService.overrideExchangeRate(line),
+      ),
     );
 
-    const rpcLines = validated.lines.map((line, index) => ({
+    const amounts = overriddenLines.map((line) => line.amount);
+    const [preparedAmounts, encryptedOriginalAmounts] = await Promise.all([
+      this.encryptionService.prepareAmountsData(
+        amounts,
+        user.id,
+        user.clientKey,
+      ),
+      Promise.all(
+        overriddenLines.map((line) =>
+          this.encryptionService.encryptOptionalAmount(
+            line.originalAmount,
+            user.id,
+            user.clientKey,
+          ),
+        ),
+      ),
+    ]);
+
+    const rpcLines = overriddenLines.map((line, index) => ({
       name: line.name,
       amount: preparedAmounts[index].amount,
       kind: line.kind as Database['public']['Enums']['transaction_kind'],
       recurrence:
         line.recurrence as Database['public']['Enums']['transaction_recurrence'],
       description: line.description || '',
+      original_amount: encryptedOriginalAmounts[index],
+      original_currency: line.originalCurrency ?? null,
+      target_currency: line.targetCurrency ?? null,
+      exchange_rate: line.exchangeRate ?? null,
     }));
 
     const validatedRpcLines =

--- a/backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.spec.ts
+++ b/backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.spec.ts
@@ -10,52 +10,84 @@ const VALID_CIPHERTEXT =
   'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==';
 
 describe('createTemplateLineRpcPayloadSchema', () => {
-  it('should accept a valid payload', () => {
+  const monoBase = {
+    name: 'Rent',
+    amount: VALID_CIPHERTEXT,
+    kind: 'expense' as const,
+    recurrence: 'fixed' as const,
+    description: 'Monthly',
+    original_amount: null,
+    original_currency: null,
+    target_currency: null,
+    exchange_rate: null,
+  };
+
+  it('should accept a valid mono-currency payload', () => {
+    const result = createTemplateLineRpcPayloadSchema.parse(monoBase);
+
+    expect(result).toEqual(monoBase);
+  });
+
+  it('should accept a valid multi-currency payload (PUL-133)', () => {
     const payload = {
-      name: 'Rent',
-      amount: VALID_CIPHERTEXT,
-      kind: 'expense' as const,
-      recurrence: 'fixed' as const,
-      description: 'Monthly',
+      ...monoBase,
+      original_amount: VALID_CIPHERTEXT,
+      original_currency: 'EUR' as const,
+      target_currency: 'CHF' as const,
+      exchange_rate: 0.94,
     };
 
     const result = createTemplateLineRpcPayloadSchema.parse(payload);
 
-    expect(result).toEqual(payload);
+    expect(result.exchange_rate).toBe(0.94);
+    expect(result.original_currency).toBe('EUR');
   });
 
   it('should reject extra keys (forged bypass attempt)', () => {
-    const forged = {
-      name: 'Rent',
-      amount: VALID_CIPHERTEXT,
-      kind: 'expense' as const,
-      recurrence: 'fixed' as const,
-      description: 'Monthly',
-      user_id: 'attacker',
-    };
+    const forged = { ...monoBase, user_id: 'attacker' };
 
     expect(() => createTemplateLineRpcPayloadSchema.parse(forged)).toThrow();
   });
 
   it('should reject invalid kind', () => {
-    const bad = {
-      name: 'Rent',
-      amount: VALID_CIPHERTEXT,
-      kind: 'transfer',
-      recurrence: 'fixed' as const,
-      description: '',
-    };
+    const bad = { ...monoBase, kind: 'transfer' };
 
     expect(() => createTemplateLineRpcPayloadSchema.parse(bad)).toThrow();
   });
 
   it('should reject plaintext numeric amount (must be encrypted ciphertext)', () => {
+    const bad = { ...monoBase, amount: 1500 };
+
+    expect(() => createTemplateLineRpcPayloadSchema.parse(bad)).toThrow();
+  });
+
+  it('should reject unsupported currency (PUL-133)', () => {
     const bad = {
-      name: 'Rent',
-      amount: 1500,
-      kind: 'expense' as const,
-      recurrence: 'fixed' as const,
-      description: '',
+      ...monoBase,
+      original_currency: 'USD',
+      target_currency: 'CHF',
+    };
+
+    expect(() => createTemplateLineRpcPayloadSchema.parse(bad)).toThrow();
+  });
+
+  it('should reject negative exchange rate (PUL-133)', () => {
+    const bad = {
+      ...monoBase,
+      original_currency: 'EUR' as const,
+      target_currency: 'CHF' as const,
+      exchange_rate: -1,
+    };
+
+    expect(() => createTemplateLineRpcPayloadSchema.parse(bad)).toThrow();
+  });
+
+  it('should reject non-finite exchange rate (PUL-133)', () => {
+    const bad = {
+      ...monoBase,
+      original_currency: 'EUR' as const,
+      target_currency: 'CHF' as const,
+      exchange_rate: Number.POSITIVE_INFINITY,
     };
 
     expect(() => createTemplateLineRpcPayloadSchema.parse(bad)).toThrow();
@@ -71,6 +103,10 @@ describe('createTemplateLinesRpcPayloadSchema', () => {
         kind: 'expense' as const,
         recurrence: 'fixed' as const,
         description: '',
+        original_amount: null,
+        original_currency: null,
+        target_currency: null,
+        exchange_rate: null,
       },
     ];
 

--- a/backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.ts
+++ b/backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.ts
@@ -9,9 +9,10 @@ import {
 // create_template_with_lines — p_lines JSONB item shape
 //
 // Matches SQL access `line->>'name' | 'amount' | 'kind' | 'recurrence' |
-// 'description'` (see migrations 20260129200002_update_rpc_functions_encryption
-// and 20260214120000_update_rpc_functions_single_column). `amount` is an
-// AES-256-GCM ciphertext produced by EncryptionService.prepareAmountsData.
+// 'description' | 'original_amount' | 'original_currency' | 'target_currency'
+// | 'exchange_rate'` (see migration 20260427120000_create_template_with_lines_fx_columns).
+// `amount` + `original_amount` are AES-256-GCM ciphertexts produced by
+// EncryptionService. `exchange_rate` is a finite positive number or null.
 // ----------------------------------------------------------------------------
 export const createTemplateLineRpcPayloadSchema = z
   .object({
@@ -20,6 +21,10 @@ export const createTemplateLineRpcPayloadSchema = z
     kind: transactionKindSchema,
     recurrence: transactionRecurrenceSchema,
     description: z.string(),
+    original_amount: z.string().min(1).nullable(),
+    original_currency: supportedCurrencySchema.nullable(),
+    target_currency: supportedCurrencySchema.nullable(),
+    exchange_rate: z.number().finite().positive().nullable(),
   })
   .strict();
 

--- a/backend-nest/supabase/migrations/20260427120000_create_template_with_lines_fx_columns.sql
+++ b/backend-nest/supabase/migrations/20260427120000_create_template_with_lines_fx_columns.sql
@@ -1,0 +1,100 @@
+-- Migration: PUL-133 - Add FX columns to create_template_with_lines RPC
+-- Bug: bulk template creation silently dropped original_amount, original_currency,
+-- target_currency, exchange_rate. Brings parity with single-line createTemplateLine
+-- and apply_template_line_operations (migration 20260417120000).
+--
+-- Pattern mirrors apply_template_line_operations: jsonb -> typed columns,
+-- with null-safe cast for exchange_rate (numeric). original_amount stays text
+-- (AES-256-GCM ciphertext, no cast). Coherence enforced by fx_metadata_coherent
+-- CHECK constraint (migration 20260420120000).
+
+CREATE OR REPLACE FUNCTION public.create_template_with_lines(
+  p_user_id uuid,
+  p_name text,
+  p_description text DEFAULT NULL,
+  p_is_default boolean DEFAULT false,
+  p_lines jsonb DEFAULT NULL
+) RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  new_template_id uuid;
+  line_record jsonb;
+  result json;
+BEGIN
+  INSERT INTO public.template (user_id, name, description, is_default)
+  VALUES (p_user_id, p_name, p_description, p_is_default)
+  RETURNING id INTO new_template_id;
+
+  IF p_lines IS NOT NULL THEN
+    FOR line_record IN SELECT * FROM jsonb_array_elements(p_lines)
+    LOOP
+      INSERT INTO public.template_line (
+        template_id,
+        name,
+        amount,
+        kind,
+        recurrence,
+        description,
+        original_amount,
+        original_currency,
+        target_currency,
+        exchange_rate
+      ) VALUES (
+        new_template_id,
+        line_record->>'name',
+        line_record->>'amount',
+        (line_record->>'kind')::public.transaction_kind,
+        (line_record->>'recurrence')::public.transaction_recurrence,
+        line_record->>'description',
+        line_record->>'original_amount',
+        line_record->>'original_currency',
+        line_record->>'target_currency',
+        CASE
+          WHEN (line_record->>'exchange_rate') IS NULL
+            OR (line_record->>'exchange_rate') = ''
+          THEN NULL
+          ELSE (line_record->>'exchange_rate')::numeric
+        END
+      );
+    END LOOP;
+  END IF;
+
+  SELECT json_build_object(
+    'id', t.id,
+    'user_id', t.user_id,
+    'name', t.name,
+    'description', t.description,
+    'is_default', t.is_default,
+    'created_at', t.created_at,
+    'updated_at', t.updated_at,
+    'template_lines', COALESCE(
+      (SELECT json_agg(json_build_object(
+        'id', tl.id,
+        'template_id', tl.template_id,
+        'name', tl.name,
+        'amount', tl.amount,
+        'kind', tl.kind,
+        'recurrence', tl.recurrence,
+        'description', tl.description,
+        'original_amount', tl.original_amount,
+        'original_currency', tl.original_currency,
+        'target_currency', tl.target_currency,
+        'exchange_rate', tl.exchange_rate,
+        'created_at', tl.created_at,
+        'updated_at', tl.updated_at
+      ) ORDER BY tl.created_at)
+      FROM public.template_line tl
+      WHERE tl.template_id = new_template_id),
+      '[]'::json
+    )
+  ) INTO result
+  FROM public.template t
+  WHERE t.id = new_template_id;
+
+  RETURN result;
+END;
+$$;
+
+ALTER FUNCTION public.create_template_with_lines(uuid, text, text, boolean, jsonb) OWNER TO postgres;


### PR DESCRIPTION
## Summary
- Bulk template creation silently dropped `original_amount`, `original_currency`, `target_currency`, `exchange_rate` — `CurrencyConversionBadge` never rendered, rekey had nothing to rotate.
- Service now routes lines through `currencyService.overrideExchangeRate` + `encryptionService.encryptOptionalAmount` (parallel), RPC schema accepts FX fields strictly, SQL function INSERTs and RETURNs the four columns.
- Pattern ported verbatim from `performBulkCreates` and `apply_template_line_operations` (migration 20260417120000); coherence enforced by existing `fx_metadata_coherent` CHECK.

## Test plan
- [x] `bun test src/modules/budget-template/` — 65 pass (3 new service tests + 3 new schema tests for PUL-133)
- [x] `pnpm quality` (full workspace) — 0 errors
- [x] Manual: create template with EUR→CHF + CHF-only lines, verify `template_line` row has all 4 FX columns populated for multi-currency line and NULL for mono-currency