### PR TITLE
fix(webapp): localize client-side ZodError to FR (PUL-136)

### DIFF
--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -984,6 +984,7 @@
     "profileNotFound": "Profil introuvable",
     "profileUpdateFailed": "La mise à jour du profil a échoué — réessaie",
     "validationFailed": "Les données envoyées ne sont pas valides",
+    "clientValidationFailed": "Les données saisies ne sont pas valides — vérifie tes champs",
     "unauthorized": "Tu dois te connecter pour continuer",
     "forbidden": "Tu n'as pas accès à cette ressource",
     "rateLimited": "Trop de tentatives — patiente une minute avant de réessayer",

--- a/frontend/projects/webapp/src/app/core/api/api-error-localizer.spec.ts
+++ b/frontend/projects/webapp/src/app/core/api/api-error-localizer.spec.ts
@@ -81,6 +81,18 @@ describe('ApiErrorLocalizer', () => {
     );
   });
 
+  it('should localize client-side Zod parse errors', () => {
+    const error = new ApiError(
+      'Validation failed: Array must contain at most 50 element(s)',
+      'ZOD_PARSE_ERROR',
+      0,
+      null,
+    );
+    expect(service.localizeApiError(error)).toBe(
+      'Les données saisies ne sont pas valides — vérifie tes champs',
+    );
+  });
+
   it('should return generic message for unknown error codes', () => {
     const error = new ApiError('Unknown', 'ERR_UNKNOWN_CODE', 500, null);
     expect(service.localizeApiError(error)).toBe(

--- a/frontend/projects/webapp/src/app/core/api/api-error-localizer.ts
+++ b/frontend/projects/webapp/src/app/core/api/api-error-localizer.ts
@@ -1,7 +1,13 @@
 import { Injectable, inject } from '@angular/core';
 import { TranslocoService } from '@jsverse/transloco';
 import { API_ERROR_CODES, type ApiErrorCode } from 'pulpe-shared';
-import type { ApiError } from './api-error';
+import {
+  CLIENT_ERROR_CODES,
+  type ApiError,
+  type ClientErrorCode,
+} from './api-error';
+
+type LocalizableCode = ApiErrorCode | ClientErrorCode;
 
 const CODE_KEY_MAP = {
   [API_ERROR_CODES.BUDGET_NOT_FOUND]: 'apiError.budgetNotFound',
@@ -34,7 +40,8 @@ const CODE_KEY_MAP = {
   [API_ERROR_CODES.RECOVERY_KEY_INVALID]: 'apiError.recoveryKeyInvalid',
   [API_ERROR_CODES.RECOVERY_KEY_NOT_CONFIGURED]:
     'apiError.recoveryKeyNotConfigured',
-} as const satisfies Partial<Record<ApiErrorCode, string>>;
+  [CLIENT_ERROR_CODES.ZOD_PARSE_ERROR]: 'apiError.clientValidationFailed',
+} as const satisfies Partial<Record<LocalizableCode, string>>;
 
 @Injectable({ providedIn: 'root' })
 export class ApiErrorLocalizer {

--- a/frontend/projects/webapp/src/app/core/api/api-error.ts
+++ b/frontend/projects/webapp/src/app/core/api/api-error.ts
@@ -2,6 +2,13 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { errorResponseSchema } from 'pulpe-shared';
 import { ZodError } from 'zod';
 
+export const CLIENT_ERROR_CODES = {
+  ZOD_PARSE_ERROR: 'ZOD_PARSE_ERROR',
+} as const;
+
+export type ClientErrorCode =
+  (typeof CLIENT_ERROR_CODES)[keyof typeof CLIENT_ERROR_CODES];
+
 export class ApiError extends Error {
   constructor(
     message: string,
@@ -22,7 +29,7 @@ export function normalizeApiError(error: unknown): ApiError {
   if (error instanceof ZodError) {
     return new ApiError(
       `Validation failed: ${error.issues.map((i) => i.message).join(', ')}`,
-      'ZOD_PARSE_ERROR',
+      CLIENT_ERROR_CODES.ZOD_PARSE_ERROR,
       0,
       error.issues,
     );


### PR DESCRIPTION
## Summary

- `ApiClient` `requestSchema.parse()` rejection produced `ApiError` code `ZOD_PARSE_ERROR` with raw English message; not mapped in `ApiErrorLocalizer.CODE_KEY_MAP` → consumers displaying `error.message` directly leaked English.
- Extracted `CLIENT_ERROR_CODES` typed constant in `api-error.ts`, added `ZOD_PARSE_ERROR → apiError.clientValidationFailed` mapping, added FR string in `fr.json`.
- Onboarding flow already double-protected (`MAX_CUSTOM_TRANSACTIONS = 50` guard + custom FR catch in `profile-setup.service.ts`); fix is defense-in-depth for any other route using `requestSchema`.

## Test plan

- [x] `pnpm test -- src/app/core/api/api-error-localizer.spec.ts` (9/9 pass, new test added)
- [x] Full webapp suite (1867/1867 pass)
- [x] `pnpm quality` clean (0 errors)