### PR TITLE
fix(onboarding): cap custom transactions at 50 in UI (PUL-137)

### DIFF
--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -835,6 +835,7 @@
       "amountMin": "Le montant doit être supérieur à 0",
       "sectionTitle": "Prévisions personnalisées",
       "addButton": "Ajouter une prévision",
+      "limitReached": "Limite atteinte ({{ max }} prévisions max). Supprime-en une pour en ajouter une autre.",
       "kindExpense": "Dépense",
       "kindSaving": "Épargne",
       "kindIncome": "Revenu",

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts
@@ -29,6 +29,7 @@ import { UserSettingsStore } from '@core/user-settings';
 import { ROUTES } from '@core/routing/routes-constants';
 import {
   CompleteProfileStore,
+  MAX_CUSTOM_TRANSACTIONS,
   ONBOARDING_SUGGESTIONS,
 } from './complete-profile-store';
 import { OnboardingPreviewDesktop } from './components/onboarding-preview-desktop';
@@ -606,9 +607,11 @@ import {
                       @for (suggestion of suggestions; track suggestion.name) {
                         @let isSelected =
                           store.selectedSuggestionNames().has(suggestion.name);
+                        @let isChipDisabled =
+                          !isSelected && store.customTransactionsLimitReached();
                         <button
                           type="button"
-                          class="inline-flex items-center gap-1.5 px-4 min-h-11 rounded-full text-label-large transition-colors border"
+                          class="inline-flex items-center gap-1.5 px-4 min-h-11 rounded-full text-label-large transition-colors border disabled:opacity-50 disabled:cursor-not-allowed"
                           [class.bg-primary-container]="isSelected"
                           [class.text-on-primary-container]="isSelected"
                           [class.border-primary]="isSelected"
@@ -616,6 +619,7 @@ import {
                           [class.text-on-surface-variant]="!isSelected"
                           [class.border-transparent]="!isSelected"
                           [attr.aria-pressed]="isSelected"
+                          [disabled]="isChipDisabled"
                           (click)="store.toggleSuggestion(suggestion)"
                           [attr.data-testid]="
                             'suggestion-chip-' + suggestion.name
@@ -702,6 +706,7 @@ import {
                     <button
                       matButton="outlined"
                       class="w-full h-12 rounded-2xl"
+                      [disabled]="store.customTransactionsLimitReached()"
                       (click)="openAddCustomDialog()"
                       data-testid="add-custom-expense-button"
                     >
@@ -712,6 +717,18 @@ import {
                         }}
                       </span>
                     </button>
+                    @if (store.customTransactionsLimitReached()) {
+                      <p
+                        class="mt-2 text-body-small text-on-surface-variant"
+                        role="status"
+                        data-testid="custom-expense-limit-message"
+                      >
+                        {{
+                          'completeProfile.customExpense.limitReached'
+                            | transloco: { max: maxCustomTransactions }
+                        }}
+                      </p>
+                    }
                   </section>
                 </div>
 
@@ -866,6 +883,7 @@ export default class CompleteProfilePage {
 
   readonly #locale = inject(LOCALE_ID);
   protected readonly suggestions = ONBOARDING_SUGGESTIONS;
+  protected readonly maxCustomTransactions = MAX_CUSTOM_TRANSACTIONS;
   protected readonly currencies = SUPPORTED_CURRENCIES;
   protected readonly currencyMetadata = CURRENCY_METADATA;
   protected readonly stepperSteps = [

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { of, throwError } from 'rxjs';
 import {
   CompleteProfileStore,
+  MAX_CUSTOM_TRANSACTIONS,
   ONBOARDING_SUGGESTIONS,
 } from './complete-profile-store';
 import { ProfileSetupService } from '@core/complete-profile';
@@ -543,6 +544,35 @@ describe('CompleteProfileStore', () => {
         expect(store.customTransactions()).toHaveLength(2);
         expect(store.customTransactions()[0].name).toBe('Salle de sport');
         expect(store.customTransactions()[1].name).toBe('Streaming');
+      });
+    });
+
+    describe('customTransactionsLimitReached', () => {
+      it('should return false when below the limit', () => {
+        for (let i = 0; i < MAX_CUSTOM_TRANSACTIONS - 1; i++) {
+          store.addCustomTransaction({ ...mockTransaction, name: `tx-${i}` });
+        }
+
+        expect(store.customTransactionsLimitReached()).toBe(false);
+      });
+
+      it('should return true at exactly MAX_CUSTOM_TRANSACTIONS', () => {
+        for (let i = 0; i < MAX_CUSTOM_TRANSACTIONS; i++) {
+          store.addCustomTransaction({ ...mockTransaction, name: `tx-${i}` });
+        }
+
+        expect(store.customTransactionsLimitReached()).toBe(true);
+      });
+
+      it('should not allow exceeding the limit via addCustomTransaction', () => {
+        for (let i = 0; i < MAX_CUSTOM_TRANSACTIONS + 5; i++) {
+          store.addCustomTransaction({ ...mockTransaction, name: `tx-${i}` });
+        }
+
+        expect(store.customTransactions()).toHaveLength(
+          MAX_CUSTOM_TRANSACTIONS,
+        );
+        expect(store.customTransactionsLimitReached()).toBe(true);
       });
     });
 

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.ts
@@ -50,7 +50,7 @@ export const ONBOARDING_SUGGESTIONS: readonly OnboardingTransaction[] = [
   },
 ];
 
-const MAX_CUSTOM_TRANSACTIONS = 50;
+export const MAX_CUSTOM_TRANSACTIONS = 50;
 
 /**
  * Client-only tag identifying a customTransactions entry sourced from a
@@ -141,6 +141,9 @@ export class CompleteProfileStore {
         .filter((id): id is string => id !== undefined),
     );
   });
+  readonly customTransactionsLimitReached = computed(
+    () => this.#state().customTransactions.length >= MAX_CUSTOM_TRANSACTIONS,
+  );
   readonly isLoading = computed(() => this.#state().isLoading);
   readonly isCheckingExistingBudget = computed(
     () => this.#state().isCheckingExistingBudget,

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -215,7 +215,7 @@
       "source": "pbakaus/impeccable",
       "sourceType": "github",
       "skillPath": ".agents/skills/impeccable/SKILL.md",
-      "computedHash": "3dbb5f75e60bad311a0910e97c034814c678d2454f75e8e4c64ba8c2e7b96973"
+      "computedHash": "30e5e2d1717a0a16ae0804575d8bbfacc2baab4abc3fa2467f5819b430a22193"
     },
     "ios-marketing-capture": {
       "source": "ParthJadhav/ios-marketing-capture",


### PR DESCRIPTION
## Summary

- Disable "Ajouter une prévision" button + unselected suggestion chips when `customTransactions.length >= 50`
- Show localized FR hint below button at limit
- Expose `MAX_CUSTOM_TRANSACTIONS` + `customTransactionsLimitReached` computed from store

Fixes PUL-137 — backend Zod schema enforces `.max(50)` but UI silently no-op'd, leaking raw ZodError on submit.

## Test plan

- [x] Lint + typecheck pass
- [x] All 1866 unit tests pass
- [ ] Manual: add 50 custom transactions → button disabled, hint visible, unselected chips disabled