### PR TITLE
fix(webapp): clear settings resource on reset to prevent user data leak (PUL-147)

### DIFF
--- a/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.spec.ts
+++ b/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.spec.ts
@@ -160,6 +160,29 @@ describe('UserSettingsStore', () => {
       store.reset();
       expect(mockCache.clear).toHaveBeenCalled();
     });
+
+    it('should reset settings() to null so previous user data does not leak', async () => {
+      const previousUserSettings: UserSettings = {
+        payDayOfMonth: 25,
+        currency: 'EUR',
+        showCurrencySelector: false,
+      };
+      mockApi.getSettings$ = vi
+        .fn()
+        .mockReturnValue(of({ data: previousUserSettings, success: true }));
+      store.reload();
+
+      await vi.waitFor(() => {
+        expect(store.currency()).toBe('EUR');
+        expect(store.payDayOfMonth()).toBe(25);
+      });
+
+      store.reset();
+
+      expect(store.settings()).toBeNull();
+      expect(store.currency()).toBe('CHF');
+      expect(store.payDayOfMonth()).toBeNull();
+    });
   });
 
   describe('reload', () => {

--- a/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.ts
+++ b/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.ts
@@ -63,5 +63,6 @@ export class UserSettingsStore {
 
   reset(): void {
     this.#api.cache.clear();
+    this.#settingsResource.set(null);
   }
 }


### PR DESCRIPTION
## Summary

- `UserSettingsStore.reset()` only cleared the API cache, leaving `#settingsResource` populated with the previous user's data → `settings()`, `currency()`, `payDayOfMonth()` kept returning stale values after logout (privacy bug on shared device / fast account switch).
- Add `this.#settingsResource.set(null)` after `cache.clear()` so selectors return null immediately. Verified via ngx-ziflux source: when `params()` is undefined at logout (auth flipped before cleanup), `set(null)` only updates the underlying resource — no stale cache entry to starve next user's fetch.
- Unit test seeds previous-user `currency: 'EUR'`, calls `reset()`, asserts `settings()` is null and `currency()` falls back to `'CHF'` default.

Linear: [PUL-147](https://linear.app/pulpe/issue/PUL-147)

## Test plan

- [x] Unit test: `UserSettingsStore > reset > should reset settings() to null so previous user data does not leak`
- [x] Full test suite: 1879/1879 passing
- [x] Quality: lint + typecheck + format clean
- [ ] Manual: login User A (EUR) → logout → login User B (CHF) → verify no EUR flash before fetch