### PR TITLE
fix(backend): coerce PostgREST string exchange_rate in RPC schemas (PUL-182)

### DIFF
--- a/backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.spec.ts
+++ b/backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.spec.ts
@@ -92,6 +92,43 @@ describe('createTemplateLineRpcPayloadSchema', () => {
 
     expect(() => createTemplateLineRpcPayloadSchema.parse(bad)).toThrow();
   });
+
+  it('should accept PostgREST string exchange_rate "1.05000000" (PUL-182)', () => {
+    const payload = {
+      ...monoBase,
+      original_amount: VALID_CIPHERTEXT,
+      original_currency: 'EUR' as const,
+      target_currency: 'CHF' as const,
+      exchange_rate: '1.05000000',
+    };
+
+    const result = createTemplateLineRpcPayloadSchema.parse(payload);
+
+    expect(result.exchange_rate).toBe(1.05);
+    expect(typeof result.exchange_rate).toBe('number');
+  });
+
+  describe('non-numeric exchange_rate (PUL-114 hardening)', () => {
+    const cases: ReadonlyArray<{ label: string; value: unknown }> = [
+      { label: 'boolean true', value: true },
+      { label: 'array ["1.2"]', value: ['1.2'] },
+      { label: 'unparseable string', value: 'not-a-number' },
+      { label: 'empty string', value: '' },
+    ];
+
+    for (const { label, value } of cases) {
+      it(`should reject ${label}`, () => {
+        const bad = {
+          ...monoBase,
+          original_currency: 'EUR' as const,
+          target_currency: 'CHF' as const,
+          exchange_rate: value,
+        };
+
+        expect(() => createTemplateLineRpcPayloadSchema.parse(bad)).toThrow();
+      });
+    }
+  });
 });
 
 describe('createTemplateLinesRpcPayloadSchema', () => {
@@ -195,6 +232,45 @@ describe('applyTemplateLineOperationsItemSchema', () => {
     const result = applyTemplateLineOperationsItemSchema.parse(payload);
 
     expect(result.amount).toBeNull();
+  });
+
+  it('should accept PostgREST string exchange_rate "1.05000000" (PUL-182)', () => {
+    const payload = {
+      ...base,
+      original_amount: VALID_CIPHERTEXT,
+      original_currency: 'EUR' as const,
+      target_currency: 'CHF' as const,
+      exchange_rate: '1.05000000',
+    };
+
+    const result = applyTemplateLineOperationsItemSchema.parse(payload);
+
+    expect(result.exchange_rate).toBe(1.05);
+    expect(typeof result.exchange_rate).toBe('number');
+  });
+
+  describe('non-numeric exchange_rate (PUL-114 hardening)', () => {
+    const cases: ReadonlyArray<{ label: string; value: unknown }> = [
+      { label: 'boolean true', value: true },
+      { label: 'array ["1.2"]', value: ['1.2'] },
+      { label: 'unparseable string', value: 'not-a-number' },
+      { label: 'empty string', value: '' },
+    ];
+
+    for (const { label, value } of cases) {
+      it(`should reject ${label}`, () => {
+        const bad = {
+          ...base,
+          original_currency: 'EUR' as const,
+          target_currency: 'CHF' as const,
+          exchange_rate: value,
+        };
+
+        expect(() =>
+          applyTemplateLineOperationsItemSchema.parse(bad),
+        ).toThrow();
+      });
+    }
   });
 });
 

--- a/backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.ts
+++ b/backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+  exchangeRateWirePositive,
   supportedCurrencySchema,
   transactionKindSchema,
   transactionRecurrenceSchema,
@@ -24,7 +25,7 @@ export const createTemplateLineRpcPayloadSchema = z
     original_amount: z.string().min(1).nullable(),
     original_currency: supportedCurrencySchema.nullable(),
     target_currency: supportedCurrencySchema.nullable(),
-    exchange_rate: z.number().finite().positive().nullable(),
+    exchange_rate: exchangeRateWirePositive.nullable(),
   })
   .strict();
 
@@ -55,7 +56,7 @@ export const applyTemplateLineOperationsItemSchema = z
     original_amount: z.string().min(1).nullable(),
     original_currency: supportedCurrencySchema.nullable(),
     target_currency: supportedCurrencySchema.nullable(),
-    exchange_rate: z.number().finite().positive().nullable(),
+    exchange_rate: exchangeRateWirePositive.nullable(),
   })
   .strict();
 

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -93,6 +93,8 @@ export {
   SUPPORTED_CURRENCIES,
   currencyRateQuerySchema,
   currencyRateResponseSchema,
+  exchangeRateWire,
+  exchangeRateWirePositive,
 
   // User schemas
   userProfileSchema,

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -85,7 +85,7 @@ export type CurrencyRateResponse = z.infer<typeof currencyRateResponseSchema>;
  * ([1.2] → 1.2) into valid financial values — which z.coerce.number() would.
  * Infinity and -Infinity are rejected on both branches.
  */
-const exchangeRateWire = z.union([
+export const exchangeRateWire = z.union([
   z.number().finite(),
   z.string().transform((value, ctx) => {
     if (value.trim() === '') {
@@ -107,7 +107,9 @@ const exchangeRateWire = z.union([
   }),
 ]);
 
-const exchangeRateWirePositive = exchangeRateWire.pipe(z.number().positive());
+export const exchangeRateWirePositive = exchangeRateWire.pipe(
+  z.number().positive(),
+);
 
 /**
  * BUDGET - Instance mensuelle d'un template


### PR DESCRIPTION
## Summary

PostgREST returns `NUMERIC(18,8)` columns as strings (e.g. `"1.05000000"`), but `applyTemplateLineOperationsItemSchema` and `createTemplateLineRpcPayloadSchema` declared `exchange_rate` as `z.number()` with no coercion — so every propagation of a multi-currency template change crashed with `ZodError → 500`. Export the canonical PUL-114 helpers `exchangeRateWire` / `exchangeRateWirePositive` from `pulpe-shared` (already used by every other FX field in `shared/schemas.ts`) and swap both backend RPC schema fields to `exchangeRateWirePositive.nullable()`. Adds regression tests for the realistic PostgREST string input plus PUL-114 hardening (boolean/array/non-numeric/empty rejected).

## Test plan

- [x] `bun test backend-nest/src/modules/budget-template/schemas/rpc-payload.schemas.spec.ts` — 29/29 pass (red→green verified by stashing fix; both PUL-182 string tests fail with exact `ZodError: Invalid input: expected number, received string` before fix)
- [x] `bun run quality` (backend) — 0 errors
- [x] `pnpm test` (shared) — 362/362 pass
- [ ] Manual e2e: edit multi-currency template line (EUR↔CHF) on a template applied to ≥1 budget with "propager" toggle on → confirm 200 (was 500)