### PR TITLE
feat(analytics): track currency selection + selector adoption

### DIFF
--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -95,6 +95,15 @@ app_opened → welcome_screen_viewed → onboarding_started
 | `tutorial_completed` | Tutorial finish | — |
 | `tutorial_cancelled` | User skip tutorial | — |
 
+### Settings / Account Events
+
+| Event | When | Properties | Web | iOS |
+|-------|------|------------|-----|-----|
+| `currency_changed` | User select different currency in settings + save (web) or pick (iOS) succeeds | `from` (`CHF` \| `EUR`), `to` (`CHF` \| `EUR`) | ✅ | ✅ |
+| `currency_selector_toggled` | User toggle "Saisir dans une autre devise" + save succeeds | `enabled` (bool) | ✅ | ✅ |
+
+Both events naturally gate on the `multi-currency-enabled` flag because the corresponding UI is only rendered when it's enabled. Event names + property keys are sourced from `pulpe-shared` (`ANALYTICS_EVENTS`) — never hardcode.
+
 ### iOS App Events
 
 | Event | When | Properties |

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
@@ -2,20 +2,56 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, signal } from '@angular/core';
 import type { WritableSignal } from '@angular/core';
+import type { UserSettings } from 'pulpe-shared';
 import { AnalyticsService } from './analytics';
 import { PostHogService } from './posthog';
 import { AuthStore } from '../auth/auth-store';
 import { Logger } from '../logging/logger';
 import { DemoModeService } from '../demo/demo-mode.service';
+import { UserSettingsStore } from '../user-settings/user-settings-store';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import {
   createMockPostHogService,
   createMockLogger,
 } from '../../testing/mock-posthog';
 
+const DEFAULT_SETTINGS: UserSettings = {
+  payDayOfMonth: null,
+  currency: 'CHF',
+  showCurrencySelector: false,
+};
+
+function createMockUserSettingsStore(
+  initial: UserSettings | null = DEFAULT_SETTINGS,
+) {
+  const settingsSignal = signal<UserSettings | null>(initial);
+  return {
+    settings: settingsSignal,
+    setSettings: (value: UserSettings | null) => settingsSignal.set(value),
+  };
+}
+
+function createMockFeatureFlagsService(initial = false) {
+  const isMultiCurrencyEnabled = signal(initial);
+  return {
+    isMultiCurrencyEnabled,
+    setEnabled: (value: boolean) => isMultiCurrencyEnabled.set(value),
+  };
+}
+
+const DEFAULT_IDENTIFY_PROPERTIES = {
+  early_adopter: false,
+  currency: 'CHF',
+  show_currency_selector: false,
+  multi_currency_enabled: false,
+} as const;
+
 describe('User consent and tracking behavior', () => {
   let analyticsService: AnalyticsService;
   let mockAuthState: ReturnType<typeof signal>;
   let mockPostHogService: ReturnType<typeof createMockPostHogService>;
+  let mockUserSettingsStore: ReturnType<typeof createMockUserSettingsStore>;
+  let mockFeatureFlagsService: ReturnType<typeof createMockFeatureFlagsService>;
 
   beforeEach(() => {
     // Create mock auth state signal
@@ -40,6 +76,9 @@ describe('User consent and tracking behavior', () => {
       isDemoMode: signal(false),
     };
 
+    mockUserSettingsStore = createMockUserSettingsStore();
+    mockFeatureFlagsService = createMockFeatureFlagsService();
+
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
@@ -48,6 +87,8 @@ describe('User consent and tracking behavior', () => {
         { provide: AuthStore, useValue: mockAuthStore },
         { provide: Logger, useValue: mockLogger },
         { provide: DemoModeService, useValue: mockDemoModeService },
+        { provide: UserSettingsStore, useValue: mockUserSettingsStore },
+        { provide: FeatureFlagsService, useValue: mockFeatureFlagsService },
       ],
     });
 
@@ -96,9 +137,10 @@ describe('User consent and tracking behavior', () => {
 
       // Then: User should be identified in analytics
       expect(mockPostHogService.identify).toHaveBeenCalledTimes(1);
-      expect(mockPostHogService.identify).toHaveBeenCalledWith(userId, {
-        early_adopter: false,
-      });
+      expect(mockPostHogService.identify).toHaveBeenCalledWith(
+        userId,
+        DEFAULT_IDENTIFY_PROPERTIES,
+      );
     });
   });
 
@@ -147,7 +189,7 @@ describe('User consent and tracking behavior', () => {
       expect(mockPostHogService.identify).toHaveBeenCalledTimes(1);
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         returningUserId,
-        { early_adopter: false },
+        DEFAULT_IDENTIFY_PROPERTIES,
       );
     });
   });
@@ -260,6 +302,66 @@ describe('User consent and tracking behavior', () => {
     });
   });
 
+  describe('currency identify properties', () => {
+    it('should include user currency, selector toggle, and flag exposure on identify', () => {
+      // GIVEN: User has EUR + selector toggle on, multi-currency flag enabled
+      mockUserSettingsStore.setSettings({
+        payDayOfMonth: 25,
+        currency: 'EUR',
+        showCurrencySelector: true,
+      });
+      mockFeatureFlagsService.setEnabled(true);
+
+      TestBed.runInInjectionContext(() => {
+        analyticsService.initializeAnalyticsTracking();
+      });
+
+      // WHEN: User authenticates
+      mockAuthState.set({
+        user: { id: 'user-currency-1', email: 'user@example.com' },
+        session: { access_token: 'token', refresh_token: 'refresh' },
+        isLoading: false,
+        isAuthenticated: true,
+      });
+      TestBed.tick();
+
+      // THEN: Identify carries the currency person properties
+      expect(mockPostHogService.identify).toHaveBeenCalledWith(
+        'user-currency-1',
+        {
+          early_adopter: false,
+          currency: 'EUR',
+          show_currency_selector: true,
+          multi_currency_enabled: true,
+        },
+      );
+    });
+
+    it('should fall back to defaults when user settings are not yet loaded', () => {
+      // GIVEN: Settings still null (resource not resolved)
+      mockUserSettingsStore.setSettings(null);
+      mockFeatureFlagsService.setEnabled(false);
+
+      TestBed.runInInjectionContext(() => {
+        analyticsService.initializeAnalyticsTracking();
+      });
+
+      mockAuthState.set({
+        user: { id: 'user-currency-2', email: 'user@example.com' },
+        session: { access_token: 'token', refresh_token: 'refresh' },
+        isLoading: false,
+        isAuthenticated: true,
+      });
+      TestBed.tick();
+
+      // THEN: Defaults to CHF + selector off + flag off
+      expect(mockPostHogService.identify).toHaveBeenCalledWith(
+        'user-currency-2',
+        DEFAULT_IDENTIFY_PROPERTIES,
+      );
+    });
+  });
+
   describe('cleanup lifecycle', () => {
     it('should allow reinitialization after destroy', () => {
       // Given: analytics initialized and then destroyed
@@ -319,6 +421,14 @@ describe('captureEvent', () => {
         { provide: AuthStore, useValue: mockAuthStore },
         { provide: Logger, useValue: createMockLogger() },
         { provide: DemoModeService, useValue: mockDemoModeService },
+        {
+          provide: UserSettingsStore,
+          useValue: createMockUserSettingsStore(),
+        },
+        {
+          provide: FeatureFlagsService,
+          useValue: createMockFeatureFlagsService(),
+        },
       ],
     });
 
@@ -343,6 +453,16 @@ describe('captureEvent', () => {
     });
 
     expect(() => analyticsService.captureEvent('failing_event')).toThrow(error);
+  });
+
+  it('delegates setPersonProperties to PostHogService', () => {
+    const properties = { currency: 'EUR' };
+
+    analyticsService.setPersonProperties(properties);
+
+    expect(mockPostHogService.setPersonProperties).toHaveBeenCalledWith(
+      properties,
+    );
   });
 });
 
@@ -384,6 +504,14 @@ describe('Demo mode tracking', () => {
         { provide: AuthStore, useValue: mockAuthStore },
         { provide: Logger, useValue: mockLogger },
         { provide: DemoModeService, useValue: mockDemoModeService },
+        {
+          provide: UserSettingsStore,
+          useValue: createMockUserSettingsStore(),
+        },
+        {
+          provide: FeatureFlagsService,
+          useValue: createMockFeatureFlagsService(),
+        },
       ],
     });
 
@@ -413,7 +541,7 @@ describe('Demo mode tracking', () => {
       // THEN: User is identified with is_demo flag
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'demo-user-123',
-        { early_adopter: false, is_demo: true },
+        { ...DEFAULT_IDENTIFY_PROPERTIES, is_demo: true },
       );
     });
 
@@ -439,7 +567,7 @@ describe('Demo mode tracking', () => {
       // THEN: User is identified WITHOUT is_demo flag
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'real-user-456',
-        { early_adopter: false },
+        DEFAULT_IDENTIFY_PROPERTIES,
       );
     });
   });
@@ -462,7 +590,7 @@ describe('Demo mode tracking', () => {
 
       TestBed.tick();
       expect(mockPostHogService.identify).toHaveBeenCalledWith('demo-user', {
-        early_adopter: false,
+        ...DEFAULT_IDENTIFY_PROPERTIES,
         is_demo: true,
       });
 
@@ -523,9 +651,10 @@ describe('Demo mode tracking', () => {
       TestBed.tick();
 
       // THEN: Regular user is identified without demo flag
-      expect(mockPostHogService.identify).toHaveBeenCalledWith('real-user', {
-        early_adopter: false,
-      });
+      expect(mockPostHogService.identify).toHaveBeenCalledWith(
+        'real-user',
+        DEFAULT_IDENTIFY_PROPERTIES,
+      );
     });
   });
 
@@ -555,7 +684,7 @@ describe('Demo mode tracking', () => {
 
       // THEN: User is re-identified with demo flag
       expect(mockPostHogService.identify).toHaveBeenCalledWith('user-123', {
-        early_adopter: false,
+        ...DEFAULT_IDENTIFY_PROPERTIES,
         is_demo: true,
       });
     });

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
@@ -41,9 +41,6 @@ function createMockFeatureFlagsService(initial = false) {
 
 const DEFAULT_IDENTIFY_PROPERTIES = {
   early_adopter: false,
-  currency: 'CHF',
-  show_currency_selector: false,
-  multi_currency_enabled: false,
 } as const;
 
 describe('User consent and tracking behavior', () => {
@@ -302,8 +299,8 @@ describe('User consent and tracking behavior', () => {
     });
   });
 
-  describe('currency identify properties', () => {
-    it('should include user currency, selector toggle, and flag exposure on identify', () => {
+  describe('currency person properties', () => {
+    it('should push currency person properties via setPersonProperties once settings load', () => {
       // GIVEN: User has EUR + selector toggle on, multi-currency flag enabled
       mockUserSettingsStore.setSettings({
         payDayOfMonth: 25,
@@ -325,19 +322,20 @@ describe('User consent and tracking behavior', () => {
       });
       TestBed.tick();
 
-      // THEN: Identify carries the currency person properties
+      // THEN: Identify omits currency keys (only carries early_adopter)
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'user-currency-1',
-        {
-          early_adopter: false,
-          currency: 'EUR',
-          show_currency_selector: true,
-          multi_currency_enabled: true,
-        },
+        DEFAULT_IDENTIFY_PROPERTIES,
       );
+      // AND: setPersonProperties carries the currency triplet via $set
+      expect(mockPostHogService.setPersonProperties).toHaveBeenCalledWith({
+        currency: 'EUR',
+        show_currency_selector: true,
+        multi_currency_enabled: true,
+      });
     });
 
-    it('should fall back to defaults when user settings are not yet loaded', () => {
+    it('should not push person properties while user settings are still null', () => {
       // GIVEN: Settings still null (resource not resolved)
       mockUserSettingsStore.setSettings(null);
       mockFeatureFlagsService.setEnabled(false);
@@ -354,11 +352,45 @@ describe('User consent and tracking behavior', () => {
       });
       TestBed.tick();
 
-      // THEN: Defaults to CHF + selector off + flag off
+      // THEN: Identify still fires (without currency keys), but setPersonProperties holds
+      // until real settings arrive — avoids polluting the cohort with stale CHF defaults.
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'user-currency-2',
         DEFAULT_IDENTIFY_PROPERTIES,
       );
+      expect(mockPostHogService.setPersonProperties).not.toHaveBeenCalled();
+    });
+
+    it('should push person properties once settings transition from null to loaded', () => {
+      // GIVEN: Settings null at identify time
+      mockUserSettingsStore.setSettings(null);
+      TestBed.runInInjectionContext(() => {
+        analyticsService.initializeAnalyticsTracking();
+      });
+
+      mockAuthState.set({
+        user: { id: 'user-late-settings', email: 'user@example.com' },
+        session: { access_token: 'token', refresh_token: 'refresh' },
+        isLoading: false,
+        isAuthenticated: true,
+      });
+      TestBed.tick();
+      expect(mockPostHogService.setPersonProperties).not.toHaveBeenCalled();
+
+      // WHEN: Settings resource resolves
+      mockUserSettingsStore.setSettings({
+        payDayOfMonth: 1,
+        currency: 'EUR',
+        showCurrencySelector: false,
+      });
+      TestBed.tick();
+
+      // THEN: Person properties are pushed with the real values
+      expect(mockPostHogService.setPersonProperties).toHaveBeenCalledWith({
+        currency: 'EUR',
+        show_currency_selector: false,
+        multi_currency_enabled: false,
+      });
     });
   });
 
@@ -395,17 +427,25 @@ describe('User consent and tracking behavior', () => {
 describe('captureEvent', () => {
   let analyticsService: AnalyticsService;
   let mockPostHogService: ReturnType<typeof createMockPostHogService>;
+  let mockAuthState: WritableSignal<{
+    user: { id: string; email: string } | null;
+    session: { access_token: string; refresh_token: string } | null;
+    isLoading: boolean;
+    isAuthenticated: boolean;
+  }>;
 
   beforeEach(() => {
     mockPostHogService = createMockPostHogService();
 
+    mockAuthState = signal({
+      user: null,
+      session: null,
+      isLoading: false,
+      isAuthenticated: false,
+    });
+
     const mockAuthStore = {
-      authState: signal({
-        user: null,
-        session: null,
-        isLoading: false,
-        isAuthenticated: false,
-      }),
+      authState: mockAuthState,
       isEarlyAdopter: signal(false),
     };
 
@@ -455,8 +495,25 @@ describe('captureEvent', () => {
     expect(() => analyticsService.captureEvent('failing_event')).toThrow(error);
   });
 
-  it('delegates setPersonProperties to PostHogService', () => {
+  it('delegates setPersonProperties to PostHogService once identified', () => {
     const properties = { currency: 'EUR' };
+
+    // Pre-identify gate: should no-op until identify has fired.
+    analyticsService.setPersonProperties(properties);
+    expect(mockPostHogService.setPersonProperties).not.toHaveBeenCalled();
+
+    // Identify the user via the auth effect, then retry.
+    TestBed.runInInjectionContext(() => {
+      analyticsService.initializeAnalyticsTracking();
+    });
+    mockAuthState.set({
+      user: { id: 'identified-user', email: 'user@example.com' },
+      session: { access_token: 'token', refresh_token: 'refresh' },
+      isLoading: false,
+      isAuthenticated: true,
+    });
+    TestBed.tick();
+    mockPostHogService.setPersonProperties.mockClear();
 
     analyticsService.setPersonProperties(properties);
 

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.ts
@@ -11,6 +11,8 @@ import { AuthStore } from '../auth/auth-store';
 import { PostHogService } from './posthog';
 import { Logger } from '../logging/logger';
 import { DemoModeService } from '../demo/demo-mode.service';
+import { UserSettingsStore } from '../user-settings/user-settings-store';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import type { Properties } from 'posthog-js';
 
 /**
@@ -25,6 +27,8 @@ export class AnalyticsService implements OnDestroy {
   readonly #postHogService = inject(PostHogService);
   readonly #logger = inject(Logger);
   readonly #demoModeService = inject(DemoModeService);
+  readonly #userSettingsStore = inject(UserSettingsStore);
+  readonly #featureFlagsService = inject(FeatureFlagsService);
 
   // Track if we've already enabled tracking for the current session
   #trackingEnabledForSession = false;
@@ -67,9 +71,17 @@ export class AnalyticsService implements OnDestroy {
           // `early_adopter` drives the targeted rollout of gated features via
           // PostHog feature flag conditions (person property match).
           const isDemoMode = this.#demoModeService.isDemoMode();
+          const userSettings = this.#userSettingsStore.settings();
+          const isMultiCurrencyEnabled =
+            this.#featureFlagsService.isMultiCurrencyEnabled();
           const identifyProperties: Properties = {
             [ANALYTICS_PROPERTIES.EARLY_ADOPTER]:
               this.#authStore.isEarlyAdopter(),
+            [ANALYTICS_PROPERTIES.CURRENCY]: userSettings?.currency ?? 'CHF',
+            [ANALYTICS_PROPERTIES.SHOW_CURRENCY_SELECTOR]:
+              userSettings?.showCurrencySelector ?? false,
+            [ANALYTICS_PROPERTIES.MULTI_CURRENCY_ENABLED]:
+              isMultiCurrencyEnabled,
             ...(isDemoMode && { is_demo: true }),
           };
 
@@ -99,6 +111,15 @@ export class AnalyticsService implements OnDestroy {
    */
   captureEvent(event: string, properties?: Properties): void {
     this.#postHogService.captureEvent(event, properties);
+  }
+
+  /**
+   * Update person properties on the current PostHog profile.
+   * Use after a user action that mutates a tracked property
+   * (e.g., currency change in settings) so dashboards reflect the new state.
+   */
+  setPersonProperties(properties: Properties): void {
+    this.#postHogService.setPersonProperties(properties);
   }
 
   /**

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.ts
@@ -33,8 +33,14 @@ export class AnalyticsService implements OnDestroy {
   // Track if we've already enabled tracking for the current session
   #trackingEnabledForSession = false;
 
+  // Tracks whether `identify(userId)` has fired this session. Person property
+  // updates are gated on this flag — mirrors the iOS `isIdentified` guard.
+  #isIdentified = false;
+
   // Track the auth synchronization effect to ensure idempotency
   #authEffect?: EffectRef;
+  // Re-emits person properties when settings or flag exposure change post-identify
+  #personPropertiesEffect?: EffectRef;
 
   /**
    * Check if analytics is active and ready
@@ -67,25 +73,20 @@ export class AnalyticsService implements OnDestroy {
             this.#logger.debug('PostHog tracking enabled for session');
           }
 
-          // Identify user with demo mode + early adopter flags.
-          // `early_adopter` drives the targeted rollout of gated features via
-          // PostHog feature flag conditions (person property match).
+          // Identify carries demo + early adopter flags only. Settings + the
+          // multi-currency flag are pushed separately via `$set` from
+          // `#personPropertiesEffect` — they are heavier signal deps that
+          // would otherwise re-fire identify on every settings tick or PostHog
+          // `flagsVersion` bump (feedback loop with this same identify call).
           const isDemoMode = this.#demoModeService.isDemoMode();
-          const userSettings = this.#userSettingsStore.settings();
-          const isMultiCurrencyEnabled =
-            this.#featureFlagsService.isMultiCurrencyEnabled();
           const identifyProperties: Properties = {
             [ANALYTICS_PROPERTIES.EARLY_ADOPTER]:
               this.#authStore.isEarlyAdopter(),
-            [ANALYTICS_PROPERTIES.CURRENCY]: userSettings?.currency ?? 'CHF',
-            [ANALYTICS_PROPERTIES.SHOW_CURRENCY_SELECTOR]:
-              userSettings?.showCurrencySelector ?? false,
-            [ANALYTICS_PROPERTIES.MULTI_CURRENCY_ENABLED]:
-              isMultiCurrencyEnabled,
             ...(isDemoMode && { is_demo: true }),
           };
 
           this.#postHogService.identify(authState.user.id, identifyProperties);
+          this.#isIdentified = true;
           this.#postHogService.capturePendingSignupCompleted();
           this.#logger.debug('User identified for analytics', {
             userId: authState.user.id,
@@ -97,7 +98,28 @@ export class AnalyticsService implements OnDestroy {
           // and wipe registered super properties (platform, environment, app_version).
           // reset() belongs in the explicit signOut flow; see AuthStore.
           this.#trackingEnabledForSession = false;
+          this.#isIdentified = false;
         }
+      });
+
+      this.#personPropertiesEffect = effect(() => {
+        const userSettings = this.#userSettingsStore.settings();
+        const isMultiCurrencyEnabled =
+          this.#featureFlagsService.isMultiCurrencyEnabled();
+
+        // Skip until identify has fired and settings have actually loaded.
+        // Without this guard a user with `currency = EUR` would briefly land
+        // on the CHF cohort before the settings resource resolves.
+        if (!this.#isIdentified || !userSettings) {
+          return;
+        }
+
+        this.#postHogService.setPersonProperties({
+          [ANALYTICS_PROPERTIES.CURRENCY]: userSettings.currency,
+          [ANALYTICS_PROPERTIES.SHOW_CURRENCY_SELECTOR]:
+            userSettings.showCurrencySelector,
+          [ANALYTICS_PROPERTIES.MULTI_CURRENCY_ENABLED]: isMultiCurrencyEnabled,
+        });
       });
 
       this.#logger.info('Analytics service initialized');
@@ -114,11 +136,14 @@ export class AnalyticsService implements OnDestroy {
   }
 
   /**
-   * Update person properties on the current PostHog profile.
-   * Use after a user action that mutates a tracked property
-   * (e.g., currency change in settings) so dashboards reflect the new state.
+   * Update person properties on the current PostHog profile via `$set`.
+   * No-op until `identify(userId)` has fired this session — prevents leaking
+   * preferences onto the anonymous person profile.
    */
   setPersonProperties(properties: Properties): void {
+    if (!this.#isIdentified) {
+      return;
+    }
     this.#postHogService.setPersonProperties(properties);
   }
 
@@ -129,7 +154,10 @@ export class AnalyticsService implements OnDestroy {
   destroy(): void {
     this.#authEffect?.destroy();
     this.#authEffect = undefined;
+    this.#personPropertiesEffect?.destroy();
+    this.#personPropertiesEffect = undefined;
     this.#trackingEnabledForSession = false;
+    this.#isIdentified = false;
   }
 
   ngOnDestroy(): void {

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.spec.ts
@@ -18,6 +18,7 @@ import { DemoModeService } from '@core/demo/demo-mode.service';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { CurrencyConverterService } from '@core/currency';
 import { FeatureFlagsService } from '@core/feature-flags';
+import { AnalyticsService } from '@core/analytics';
 
 import SettingsPage from './settings-page';
 
@@ -39,6 +40,10 @@ describe('SettingsPage', () => {
   let mockAuthStore: { isOAuthOnly: ReturnType<typeof signal<boolean>> };
   let mockFeatureFlags: {
     isMultiCurrencyEnabled: ReturnType<typeof signal<boolean>>;
+  };
+  let mockAnalytics: {
+    captureEvent: ReturnType<typeof vi.fn>;
+    setPersonProperties: ReturnType<typeof vi.fn>;
   };
   let mockDialog: { open: ReturnType<typeof vi.fn> };
   let mockDialogRef: { afterClosed: () => Observable<boolean> };
@@ -81,6 +86,11 @@ describe('SettingsPage', () => {
       isMultiCurrencyEnabled: signal(true),
     };
 
+    mockAnalytics = {
+      captureEvent: vi.fn(),
+      setPersonProperties: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [SettingsPage],
       providers: [
@@ -98,6 +108,7 @@ describe('SettingsPage', () => {
         { provide: AuthSessionService, useValue: mockAuthSession },
         { provide: AuthStore, useValue: mockAuthStore },
         { provide: FeatureFlagsService, useValue: mockFeatureFlags },
+        { provide: AnalyticsService, useValue: mockAnalytics },
         {
           provide: EncryptionApi,
           useValue: {
@@ -260,6 +271,87 @@ describe('SettingsPage', () => {
         'OK',
         expect.any(Object),
       );
+    });
+  });
+
+  describe('saveSettings currency analytics', () => {
+    async function saveSettings(): Promise<void> {
+      await fixture.componentInstance.saveSettings();
+      await fixture.whenStable();
+    }
+
+    it('should not capture any event when neither currency nor selector change', async () => {
+      await saveSettings();
+
+      expect(mockAnalytics.captureEvent).not.toHaveBeenCalled();
+    });
+
+    it('should still refresh person properties even when nothing changed', async () => {
+      await saveSettings();
+
+      expect(mockAnalytics.setPersonProperties).toHaveBeenCalledWith({
+        currency: 'CHF',
+        show_currency_selector: false,
+      });
+    });
+
+    it('should capture currency_changed when currency changes', async () => {
+      fixture.componentInstance.onCurrencyChange('EUR');
+
+      await saveSettings();
+
+      expect(mockAnalytics.captureEvent).toHaveBeenCalledWith(
+        'currency_changed',
+        { from: 'CHF', to: 'EUR' },
+      );
+      expect(mockAnalytics.setPersonProperties).toHaveBeenCalledWith({
+        currency: 'EUR',
+        show_currency_selector: false,
+      });
+    });
+
+    it('should capture currency_selector_toggled when toggle changes', async () => {
+      fixture.componentInstance.onShowCurrencySelectorChange(true);
+
+      await saveSettings();
+
+      expect(mockAnalytics.captureEvent).toHaveBeenCalledWith(
+        'currency_selector_toggled',
+        { enabled: true },
+      );
+      expect(mockAnalytics.setPersonProperties).toHaveBeenCalledWith({
+        currency: 'CHF',
+        show_currency_selector: true,
+      });
+    });
+
+    it('should capture both events when both currency and selector change', async () => {
+      fixture.componentInstance.onCurrencyChange('EUR');
+      fixture.componentInstance.onShowCurrencySelectorChange(true);
+
+      await saveSettings();
+
+      expect(mockAnalytics.captureEvent).toHaveBeenCalledWith(
+        'currency_changed',
+        { from: 'CHF', to: 'EUR' },
+      );
+      expect(mockAnalytics.captureEvent).toHaveBeenCalledWith(
+        'currency_selector_toggled',
+        { enabled: true },
+      );
+      expect(mockAnalytics.captureEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not capture analytics when updateSettings rejects', async () => {
+      mockUserSettingsStore.updateSettings.mockRejectedValueOnce(
+        new Error('boom'),
+      );
+      fixture.componentInstance.onCurrencyChange('EUR');
+
+      await saveSettings();
+
+      expect(mockAnalytics.captureEvent).not.toHaveBeenCalled();
+      expect(mockAnalytics.setPersonProperties).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.spec.ts
@@ -286,13 +286,10 @@ describe('SettingsPage', () => {
       expect(mockAnalytics.captureEvent).not.toHaveBeenCalled();
     });
 
-    it('should still refresh person properties even when nothing changed', async () => {
+    it('should not refresh person properties when nothing currency-related changed', async () => {
       await saveSettings();
 
-      expect(mockAnalytics.setPersonProperties).toHaveBeenCalledWith({
-        currency: 'CHF',
-        show_currency_selector: false,
-      });
+      expect(mockAnalytics.setPersonProperties).not.toHaveBeenCalled();
     });
 
     it('should capture currency_changed when currency changes', async () => {

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
@@ -514,24 +514,32 @@ export default class SettingsPage {
   }): void {
     const { previousCurrency, newCurrency, previousSelector, newSelector } =
       args;
+    const currencyChanged = previousCurrency !== newCurrency;
+    const selectorChanged = previousSelector !== newSelector;
 
-    if (previousCurrency !== newCurrency) {
+    if (currencyChanged) {
       this.#analytics.captureEvent(ANALYTICS_EVENTS.CURRENCY_CHANGED, {
         from: previousCurrency,
         to: newCurrency,
       });
     }
 
-    if (previousSelector !== newSelector) {
+    if (selectorChanged) {
       this.#analytics.captureEvent(ANALYTICS_EVENTS.CURRENCY_SELECTOR_TOGGLED, {
         enabled: newSelector,
       });
     }
 
-    this.#analytics.setPersonProperties({
-      [ANALYTICS_PROPERTIES.CURRENCY]: newCurrency,
-      [ANALYTICS_PROPERTIES.SHOW_CURRENCY_SELECTOR]: newSelector,
-    });
+    // The auth-store-driven `personPropertiesEffect` already mirrors store
+    // state to PostHog reactively. Only fire an explicit `$set` when a tracked
+    // value actually changed in this save — avoids redundant network calls
+    // when only `payDayOfMonth` was edited.
+    if (currencyChanged || selectorChanged) {
+      this.#analytics.setPersonProperties({
+        [ANALYTICS_PROPERTIES.CURRENCY]: newCurrency,
+        [ANALYTICS_PROPERTIES.SHOW_CURRENCY_SELECTOR]: newSelector,
+      });
+    }
   }
 
   async onChangePassword(): Promise<void> {

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
@@ -39,7 +39,13 @@ import {
   type RecoveryKeyDialogData,
 } from '@ui/dialogs/recovery-key-dialog';
 import { CurrencyConverterWidget } from '@pattern/currency-converter-widget';
-import { PAY_DAY_MAX, type SupportedCurrency } from 'pulpe-shared';
+import {
+  ANALYTICS_EVENTS,
+  ANALYTICS_PROPERTIES,
+  PAY_DAY_MAX,
+  type SupportedCurrency,
+} from 'pulpe-shared';
+import { AnalyticsService } from '@core/analytics';
 import { ChangePasswordDialog } from './components/change-password-dialog';
 import { ChangePinDialog } from './components/change-pin-dialog';
 import { DeleteAccountDialog } from './components/delete-account-dialog';
@@ -387,6 +393,7 @@ export default class SettingsPage {
   readonly #authStore = inject(AuthStore);
   readonly #transloco = inject(TranslocoService);
   readonly #featureFlags = inject(FeatureFlagsService);
+  readonly #analytics = inject(AnalyticsService);
 
   readonly isDemoMode = this.#demoMode.isDemoMode;
   protected readonly isMultiCurrencyEnabled =
@@ -447,13 +454,25 @@ export default class SettingsPage {
   async saveSettings(): Promise<void> {
     if (this.isSaving()) return;
 
+    const previousCurrency = this.initialCurrency();
+    const newCurrency = this.selectedCurrency();
+    const previousSelector = this.initialShowCurrencySelector();
+    const newSelector = this.selectedShowCurrencySelector();
+
     try {
       this.isSaving.set(true);
 
       await this.#userSettingsStore.updateSettings({
         payDayOfMonth: this.selectedPayDay(),
-        currency: this.selectedCurrency(),
-        showCurrencySelector: this.selectedShowCurrencySelector(),
+        currency: newCurrency,
+        showCurrencySelector: newSelector,
+      });
+
+      this.#trackCurrencyAnalytics({
+        previousCurrency,
+        newCurrency,
+        previousSelector,
+        newSelector,
       });
 
       this.#snackBar.open(
@@ -485,6 +504,34 @@ export default class SettingsPage {
     this.selectedPayDay.set(this.initialPayDay());
     this.selectedCurrency.set(this.initialCurrency());
     this.selectedShowCurrencySelector.set(this.initialShowCurrencySelector());
+  }
+
+  #trackCurrencyAnalytics(args: {
+    previousCurrency: SupportedCurrency;
+    newCurrency: SupportedCurrency;
+    previousSelector: boolean;
+    newSelector: boolean;
+  }): void {
+    const { previousCurrency, newCurrency, previousSelector, newSelector } =
+      args;
+
+    if (previousCurrency !== newCurrency) {
+      this.#analytics.captureEvent(ANALYTICS_EVENTS.CURRENCY_CHANGED, {
+        from: previousCurrency,
+        to: newCurrency,
+      });
+    }
+
+    if (previousSelector !== newSelector) {
+      this.#analytics.captureEvent(ANALYTICS_EVENTS.CURRENCY_SELECTOR_TOGGLED, {
+        enabled: newSelector,
+      });
+    }
+
+    this.#analytics.setPersonProperties({
+      [ANALYTICS_PROPERTIES.CURRENCY]: newCurrency,
+      [ANALYTICS_PROPERTIES.SHOW_CURRENCY_SELECTOR]: newSelector,
+    });
   }
 
   async onChangePassword(): Promise<void> {

--- a/frontend/projects/webapp/src/app/testing/mock-posthog.ts
+++ b/frontend/projects/webapp/src/app/testing/mock-posthog.ts
@@ -16,6 +16,7 @@ export function createMockPostHogService() {
     captureEvent: vi.fn(),
     capture: vi.fn(),
     captureException: vi.fn(),
+    setPersonProperties: vi.fn(),
     capturePendingSignupCompleted: vi.fn(),
     setPendingSignupMethod: vi.fn(),
     clearPendingSignupMethod: vi.fn(),

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -353,10 +353,10 @@ struct RootView: View {
         }
     }
 
-    /// Pushes the current currency-related state to PostHog as person properties.
-    /// Safe to call multiple times — `identify()` with the same distinct id merges
-    /// `userProperties`. Skipped when unauthenticated to avoid associating these
-    /// properties with the anonymous person profile.
+    /// Pushes the current currency-related state to PostHog as person properties
+    /// via `$set`. Double-gated: requires both an authenticated app state AND a
+    /// fired `identify(userId:)` (enforced inside `AnalyticsService.setPersonProperties`)
+    /// so properties never land on the anonymous profile.
     private func refreshCurrencyPersonProperties() {
         guard appState.authState == .authenticated else { return }
         AnalyticsService.shared.setPersonProperties([

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -135,6 +135,7 @@ struct RootView: View {
     @Environment(UIPreferencesState.self) private var uiPreferences
     @Environment(CurrentMonthStore.self) private var currentMonthStore
     @Environment(UserSettingsStore.self) private var userSettingsStore
+    @Environment(FeatureFlagsStore.self) private var featureFlagsStore
     @Environment(\.scenePhase) private var scenePhase
     var runtimeCoordinator: AppRuntimeCoordinator
     @Binding var deepLinkDestination: DeepLinkDestination?
@@ -202,6 +203,9 @@ struct RootView: View {
         }
         .onChange(of: appState.authState) { _, _ in
             handlePendingDeepLink()
+        }
+        .onChange(of: featureFlagsStore.isMultiCurrencyEnabled) { _, _ in
+            refreshCurrencyPersonProperties()
         }
         .environment(\.amountsHidden, uiPreferences.amountsHidden)
     }
@@ -345,7 +349,21 @@ struct RootView: View {
             await currentMonthStore.loadBudgetSummary(
                 payDayOfMonth: userSettingsStore.payDayOfMonth
             )
+            refreshCurrencyPersonProperties()
         }
+    }
+
+    /// Pushes the current currency-related state to PostHog as person properties.
+    /// Safe to call multiple times — `identify()` with the same distinct id merges
+    /// `userProperties`. Skipped when unauthenticated to avoid associating these
+    /// properties with the anonymous person profile.
+    private func refreshCurrencyPersonProperties() {
+        guard appState.authState == .authenticated else { return }
+        AnalyticsService.shared.setPersonProperties([
+            AnalyticsService.currencyProperty: userSettingsStore.currency.rawValue,
+            AnalyticsService.showCurrencySelectorProperty: userSettingsStore.showCurrencySelector,
+            AnalyticsService.multiCurrencyEnabledProperty: featureFlagsStore.isMultiCurrencyEnabled
+        ])
     }
 
     private func handlePendingDeepLink() {

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -135,7 +135,6 @@ struct RootView: View {
     @Environment(UIPreferencesState.self) private var uiPreferences
     @Environment(CurrentMonthStore.self) private var currentMonthStore
     @Environment(UserSettingsStore.self) private var userSettingsStore
-    @Environment(FeatureFlagsStore.self) private var featureFlagsStore
     @Environment(\.scenePhase) private var scenePhase
     var runtimeCoordinator: AppRuntimeCoordinator
     @Binding var deepLinkDestination: DeepLinkDestination?
@@ -204,17 +203,7 @@ struct RootView: View {
         .onChange(of: appState.authState) { _, _ in
             handlePendingDeepLink()
         }
-        .onChange(of: featureFlagsStore.isMultiCurrencyEnabled) { _, _ in
-            refreshCurrencyPersonProperties()
-        }
-        // Catches mutations outside the settings page — e.g. the onboarding
-        // income step persists `state.currency` on completion.
-        .onChange(of: userSettingsStore.currency) { _, _ in
-            refreshCurrencyPersonProperties()
-        }
-        .onChange(of: userSettingsStore.showCurrencySelector) { _, _ in
-            refreshCurrencyPersonProperties()
-        }
+        .syncCurrencyAnalytics()
         .environment(\.amountsHidden, uiPreferences.amountsHidden)
     }
 
@@ -357,21 +346,7 @@ struct RootView: View {
             await currentMonthStore.loadBudgetSummary(
                 payDayOfMonth: userSettingsStore.payDayOfMonth
             )
-            refreshCurrencyPersonProperties()
         }
-    }
-
-    /// Pushes the current currency-related state to PostHog as person properties
-    /// via `$set`. Double-gated: requires both an authenticated app state AND a
-    /// fired `identify(userId:)` (enforced inside `AnalyticsService.setPersonProperties`)
-    /// so properties never land on the anonymous profile.
-    private func refreshCurrencyPersonProperties() {
-        guard appState.authState == .authenticated else { return }
-        AnalyticsService.shared.setPersonProperties([
-            AnalyticsService.currencyProperty: userSettingsStore.currency.rawValue,
-            AnalyticsService.showCurrencySelectorProperty: userSettingsStore.showCurrencySelector,
-            AnalyticsService.multiCurrencyEnabledProperty: featureFlagsStore.isMultiCurrencyEnabled
-        ])
     }
 
     private func handlePendingDeepLink() {

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -207,6 +207,14 @@ struct RootView: View {
         .onChange(of: featureFlagsStore.isMultiCurrencyEnabled) { _, _ in
             refreshCurrencyPersonProperties()
         }
+        // Catches mutations outside the settings page — e.g. the onboarding
+        // income step persists `state.currency` on completion.
+        .onChange(of: userSettingsStore.currency) { _, _ in
+            refreshCurrencyPersonProperties()
+        }
+        .onChange(of: userSettingsStore.showCurrencySelector) { _, _ in
+            refreshCurrencyPersonProperties()
+        }
         .environment(\.amountsHidden, uiPreferences.amountsHidden)
     }
 

--- a/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
@@ -52,4 +52,8 @@ enum AnalyticsEvent: String, CaseIterable {
 
     // MARK: - Navigation
     case tabSwitched = "tab_switched"
+
+    // MARK: - Currency
+    case currencyChanged = "currency_changed"
+    case currencySelectorToggled = "currency_selector_toggled"
 }

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -11,6 +11,9 @@ final class AnalyticsService {
     /// PostHog person property keys — must mirror `ANALYTICS_PROPERTIES`
     /// in `shared/src/feature-flags.ts`.
     nonisolated static let earlyAdopterProperty = "early_adopter"
+    nonisolated static let currencyProperty = "currency"
+    nonisolated static let showCurrencySelectorProperty = "show_currency_selector"
+    nonisolated static let multiCurrencyEnabledProperty = "multi_currency_enabled"
 
     private(set) var isInitialized = false
     private(set) var isEventCapturingEnabled = false
@@ -73,6 +76,19 @@ final class AnalyticsService {
             userPropertiesSetOnce: [
                 "first_app_version": AppConfiguration.appVersion
             ]
+        )
+    }
+
+    /// Updates person properties on the currently identified user (PostHog `$set`).
+    /// Re-uses `identify()` with the current distinct id so we don't generate a new
+    /// person — PostHog merges `userProperties` into the existing profile.
+    /// Caller must ensure `identify(...)` has already fired.
+    func setPersonProperties(_ properties: [String: Any]) {
+        guard isEventCapturingEnabled else { return }
+        let sanitized = Self.sanitizeProperties(properties)
+        PostHogSDK.shared.identify(
+            PostHogSDK.shared.getDistinctId(),
+            userProperties: sanitized
         )
     }
 

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -17,6 +17,10 @@ final class AnalyticsService {
 
     private(set) var isInitialized = false
     private(set) var isEventCapturingEnabled = false
+    /// Tracks whether `identify(userId:)` has fired in this session. Person property
+    /// updates are gated on this flag to prevent writing to the anonymous profile
+    /// before the user has been identified.
+    private(set) var isIdentified = false
 
     private init() {}
 
@@ -77,24 +81,22 @@ final class AnalyticsService {
                 "first_app_version": AppConfiguration.appVersion
             ]
         )
+        isIdentified = true
     }
 
-    /// Updates person properties on the currently identified user (PostHog `$set`).
-    /// Re-uses `identify()` with the current distinct id so we don't generate a new
-    /// person — PostHog merges `userProperties` into the existing profile.
-    /// Caller must ensure `identify(...)` has already fired.
+    /// Updates person properties on the currently identified user via PostHog `$set`.
+    /// No-op when the user has not yet been identified — prevents leaking
+    /// preferences onto the anonymous person profile.
     func setPersonProperties(_ properties: [String: Any]) {
-        guard isEventCapturingEnabled else { return }
+        guard isEventCapturingEnabled, isIdentified else { return }
         let sanitized = Self.sanitizeProperties(properties)
-        PostHogSDK.shared.identify(
-            PostHogSDK.shared.getDistinctId(),
-            userProperties: sanitized
-        )
+        PostHogSDK.shared.setPersonProperties(userPropertiesToSet: sanitized)
     }
 
     func reset() {
         guard isInitialized else { return }
         PostHogSDK.shared.reset()
+        isIdentified = false
     }
 
     // MARK: - Feature Flags

--- a/ios/Pulpe/Core/Analytics/CurrencyAnalyticsSyncModifier.swift
+++ b/ios/Pulpe/Core/Analytics/CurrencyAnalyticsSyncModifier.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Mirrors currency-related state to PostHog as person properties.
+///
+/// Applied once near the authenticated app root. The modifier observes the
+/// canonical sources of truth — `UserSettingsStore` for `currency` and
+/// `showCurrencySelector`, `FeatureFlagsStore` for the
+/// `multi-currency-enabled` flag — and pushes a `$set` whenever any of them
+/// changes. `AnalyticsService.setPersonProperties` already no-ops until the
+/// user has been identified, so the modifier is safe to mount before
+/// authentication completes; the SDK also dedupes identical payloads, so
+/// the redundant call on initial appearance is free.
+///
+/// Centralizing the sync here keeps the responsibility off `RootView` and
+/// out of every store mutation site (settings page picker, onboarding
+/// completion, future cross-device sync) — a single observer subscribed to
+/// the canonical state.
+struct CurrencyAnalyticsSyncModifier: ViewModifier {
+    @Environment(UserSettingsStore.self) private var userSettingsStore
+    @Environment(FeatureFlagsStore.self) private var featureFlagsStore
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: userSettingsStore.currency, initial: true) { _, _ in
+                pushPersonProperties()
+            }
+            .onChange(of: userSettingsStore.showCurrencySelector) { _, _ in
+                pushPersonProperties()
+            }
+            .onChange(of: featureFlagsStore.isMultiCurrencyEnabled) { _, _ in
+                pushPersonProperties()
+            }
+    }
+
+    private func pushPersonProperties() {
+        AnalyticsService.shared.setPersonProperties([
+            AnalyticsService.currencyProperty: userSettingsStore.currency.rawValue,
+            AnalyticsService.showCurrencySelectorProperty: userSettingsStore.showCurrencySelector,
+            AnalyticsService.multiCurrencyEnabledProperty: featureFlagsStore.isMultiCurrencyEnabled
+        ])
+    }
+}
+
+extension View {
+    /// Keeps PostHog person properties in sync with the user's currency state.
+    /// See `CurrencyAnalyticsSyncModifier` for behavior.
+    func syncCurrencyAnalytics() -> some View {
+        modifier(CurrencyAnalyticsSyncModifier())
+    }
+}

--- a/ios/Pulpe/Features/Account/CurrencySettingView.swift
+++ b/ios/Pulpe/Features/Account/CurrencySettingView.swift
@@ -8,7 +8,7 @@ struct CurrencySettingView: View {
         case input
     }
 
-    private struct ConverterValueRowModel {
+    fileprivate struct ConverterValueRowModel {
         var title: String
         var caption: String?
         var currency: SupportedCurrency
@@ -73,6 +73,7 @@ struct CurrencySettingView: View {
                     get: { viewModel.selectedCurrency },
                     set: { newValue in
                         guard newValue != viewModel.selectedCurrency else { return }
+                        let previousCurrency = viewModel.selectedCurrency
                         viewModel.selectedCurrency = newValue
                         viewModel.applyConverterBase(newValue)
                         if isConverterExpanded {
@@ -80,7 +81,7 @@ struct CurrencySettingView: View {
                         }
                         saveCurrencyTask?.cancel()
                         saveCurrencyTask = Task(name: "CurrencySetting.saveCurrency") {
-                            await persistCurrencyChange()
+                            await persistCurrencyChange(from: previousCurrency, to: newValue)
                         }
                     }
                 ),
@@ -133,10 +134,17 @@ struct CurrencySettingView: View {
 
     // MARK: - Persistence
 
-    private func persistCurrencyChange() async {
+    private func persistCurrencyChange(from: SupportedCurrency, to: SupportedCurrency) async {
         await viewModel.save(using: userSettingsStore)
         guard !Task.isCancelled else { return }
         if userSettingsStore.error == nil {
+            AnalyticsService.shared.capture(.currencyChanged, properties: [
+                "from": from.rawValue,
+                "to": to.rawValue
+            ])
+            AnalyticsService.shared.setPersonProperties([
+                AnalyticsService.currencyProperty: to.rawValue
+            ])
             submitSuccessTrigger.toggle()
             appState.toastManager.show("Devise enregistrée", type: .success)
             announceForVoiceOver("Devise enregistrée")
@@ -155,6 +163,12 @@ struct CurrencySettingView: View {
         await userSettingsStore.updateShowCurrencySelector(newValue)
         guard !Task.isCancelled else { return }
         if userSettingsStore.error == nil {
+            AnalyticsService.shared.capture(.currencySelectorToggled, properties: [
+                "enabled": newValue
+            ])
+            AnalyticsService.shared.setPersonProperties([
+                AnalyticsService.showCurrencySelectorProperty: newValue
+            ])
             submitSuccessTrigger.toggle()
             appState.toastManager.show("Préférence enregistrée", type: .success)
             announceForVoiceOver("Préférence enregistrée")
@@ -169,10 +183,12 @@ struct CurrencySettingView: View {
         UIAccessibility.post(notification: .announcement, argument: message)
         #endif
     }
+}
 
-    // MARK: - Converter
+// MARK: - Converter
 
-    private var converterDisclosure: some View {
+extension CurrencySettingView {
+    var converterDisclosure: some View {
         DisclosureGroup(isExpanded: $isConverterExpanded) {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                 Text(
@@ -212,7 +228,7 @@ struct CurrencySettingView: View {
         .tint(Color.pulpePrimary)
     }
 
-    private var converterInputRow: some View {
+    fileprivate var converterInputRow: some View {
         converterValueRow(
             ConverterValueRowModel(
                 title: "Depuis",
@@ -232,7 +248,7 @@ struct CurrencySettingView: View {
         }
     }
 
-    private var converterOutputRow: some View {
+    fileprivate var converterOutputRow: some View {
         converterValueRow(
             ConverterValueRowModel(
                 title: "Vers",
@@ -252,7 +268,7 @@ struct CurrencySettingView: View {
     }
 
     @ViewBuilder
-    private func converterValueRow<Content: View>(
+    fileprivate func converterValueRow<Content: View>(
         _ model: ConverterValueRowModel,
         @ViewBuilder valueContent: () -> Content
     ) -> some View {
@@ -292,7 +308,7 @@ struct CurrencySettingView: View {
     }
 
     @ViewBuilder
-    private var rateFooter: some View {
+    fileprivate var rateFooter: some View {
         if viewModel.isLoadingRate {
             HStack(alignment: .center, spacing: DesignTokens.Spacing.sm) {
                 ProgressView()

--- a/ios/Pulpe/Features/Account/CurrencySettingView.swift
+++ b/ios/Pulpe/Features/Account/CurrencySettingView.swift
@@ -138,12 +138,11 @@ struct CurrencySettingView: View {
         await viewModel.save(using: userSettingsStore)
         guard !Task.isCancelled else { return }
         if userSettingsStore.error == nil {
+            // Action event only — the person property `$set` is handled by
+            // `CurrencyAnalyticsSyncModifier` observing the store directly.
             AnalyticsService.shared.capture(.currencyChanged, properties: [
                 "from": from.rawValue,
                 "to": to.rawValue
-            ])
-            AnalyticsService.shared.setPersonProperties([
-                AnalyticsService.currencyProperty: to.rawValue
             ])
             submitSuccessTrigger.toggle()
             appState.toastManager.show("Devise enregistrée", type: .success)
@@ -163,11 +162,10 @@ struct CurrencySettingView: View {
         await userSettingsStore.updateShowCurrencySelector(newValue)
         guard !Task.isCancelled else { return }
         if userSettingsStore.error == nil {
+            // See `persistCurrencyChange`: person property sync lives in
+            // `CurrencyAnalyticsSyncModifier`, this only fires the action event.
             AnalyticsService.shared.capture(.currencySelectorToggled, properties: [
                 "enabled": newValue
-            ])
-            AnalyticsService.shared.setPersonProperties([
-                AnalyticsService.showCurrencySelectorProperty: newValue
             ])
             submitSuccessTrigger.toggle()
             appState.toastManager.show("Préférence enregistrée", type: .success)

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -137,7 +137,9 @@ export { API_ERROR_CODES, type ApiErrorCode } from './src/error-codes.js';
 export {
   FEATURE_FLAGS,
   ANALYTICS_PROPERTIES,
+  ANALYTICS_EVENTS,
   type FeatureFlagKey,
+  type AnalyticsEventName,
 } from './src/feature-flags.js';
 
 // Export response schema factories

--- a/shared/src/feature-flags.ts
+++ b/shared/src/feature-flags.ts
@@ -17,12 +17,35 @@ export const FEATURE_FLAGS = {
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];
 
 /**
- * PostHog person property keys used for feature flag targeting.
+ * PostHog person property keys used for feature flag targeting and dashboards.
  *
- * Mirrors Supabase `auth.users.app_metadata` keys. Must stay in sync with
- * the iOS `AnalyticsService.earlyAdopterProperty` constant and the property
- * names referenced in PostHog dashboard flag conditions.
+ * Must stay in sync with iOS `AnalyticsService` static property keys and the
+ * property names referenced in PostHog dashboard flag conditions.
  */
 export const ANALYTICS_PROPERTIES = {
+  /** Mirrors Supabase `auth.users.app_metadata.early_adopter`. */
   EARLY_ADOPTER: 'early_adopter',
+  /** User's selected display currency (`'CHF' | 'EUR'`). */
+  CURRENCY: 'currency',
+  /** Whether the per-amount currency selector input is enabled. */
+  SHOW_CURRENCY_SELECTOR: 'show_currency_selector',
+  /** Mirrors `multi-currency-enabled` flag exposure for dashboard cohort filters. */
+  MULTI_CURRENCY_ENABLED: 'multi_currency_enabled',
 } as const;
+
+/**
+ * PostHog event names — cross-platform source of truth (web + iOS).
+ *
+ * Event values follow `object_action` past-tense `snake_case`. iOS mirrors
+ * via `AnalyticsEvent` raw values. Adding an event here does not auto-add it
+ * on iOS — keep `AnalyticsEvent.swift` in sync.
+ */
+export const ANALYTICS_EVENTS = {
+  /** Fires after a successful currency change in settings. Properties: `from`, `to`. */
+  CURRENCY_CHANGED: 'currency_changed',
+  /** Fires after a successful "Saisir dans une autre devise" toggle in settings. Properties: `enabled`. */
+  CURRENCY_SELECTOR_TOGGLED: 'currency_selector_toggled',
+} as const;
+
+export type AnalyticsEventName =
+  (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];


### PR DESCRIPTION
## Summary

Adds PostHog events + person properties so dashboards can answer:
1. **% of users on CHF vs EUR**
2. **% adoption of the "Saisir dans une autre devise" toggle**

Cross-platform parity (web + iOS), names + values sourced from `pulpe-shared`.

### Events
- `currency_changed` — props `from`, `to`
- `currency_selector_toggled` — prop `enabled`

### Person properties (set at identify + on every successful change)
- `currency` (`'CHF' | 'EUR'`)
- `show_currency_selector` (boolean)
- `multi_currency_enabled` (boolean — mirrors the `multi-currency-enabled` flag exposure for cohort filtering)

The flag gate is intentional: events only fire from gated UI, but the person property fires for *all* identified users so dashboards can cohort-filter to users who actually had the choice — preventing flag=OFF users from diluting the CHF/EUR distribution.

## Test plan

- [x] `pnpm quality` (0 errors)
- [x] Web tests: 143 files / 1935 tests pass (incl. new identify-time + save-time captures)
- [x] iOS `xcodebuild build -scheme PulpeLocal` — `BUILD SUCCEEDED`
- [x] Adversarial review: SHIP, no HIGH findings
- [ ] Manual web: change CHF → EUR in Settings → confirm `currency_changed` in PostHog Live Events + person property update
- [ ] Manual web: toggle "Saisir dans une autre devise" → confirm `currency_selector_toggled` + person property
- [ ] Manual iOS (PulpePreview): same two flows, verify person property + event capture
- [ ] PostHog: build cohort `multi_currency_enabled = true` → distribution insight by `currency`