### PR TITLE
fix(ios): persist onboarding currency post-PIN-setup (PUL-118)

### DIFF
--- a/ios/Pulpe/App/AppState+Auth.swift
+++ b/ios/Pulpe/App/AppState+Auth.swift
@@ -298,7 +298,8 @@ extension AppState {
     func completeOnboarding(
         user: UserInfo,
         onboardingData: BudgetTemplateCreateFromOnboarding,
-        signupMethod: String
+        signupMethod: String,
+        currency: SupportedCurrency? = nil
     ) async {
         authDebug("AUTH_ONBOARDING", "complete email=\(user.email.prefix(3))***")
         clearPreLoginFlags()
@@ -306,7 +307,11 @@ extension AppState {
         await keychainManager.saveLastUsedEmail(user.email)
         hasReturningUser = true
         returningUserFlagLoaded = true
-        onboardingBootstrapper.setPendingData(onboardingData, signupMethod: signupMethod)
+        onboardingBootstrapper.setPendingData(
+            onboardingData,
+            signupMethod: signupMethod,
+            currency: currency
+        )
         authState = .loading
 
         // Route based on actual vault status.

--- a/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
+++ b/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
@@ -12,11 +12,23 @@ final class OnboardingBootstrapper {
     /// `OnboardingState.authMethodProperty` convention.
     private var pendingSignupMethod: String?
 
+    /// Currency picked during onboarding. Persisted to `user_settings` post-PIN-setup
+    /// (see `bootstrapIfNeeded`) — calling the API earlier fails with `AUTH_CLIENT_KEY_MISSING`
+    /// because the client key is derived from the PIN.
+    private(set) var pendingCurrency: SupportedCurrency?
+
     // MARK: - Dependencies
 
     private let createTemplate: (BudgetTemplateCreateFromOnboarding) async throws -> BudgetTemplate
     private let createBudget: (BudgetCreate) async throws -> Budget
     private let toastManager: ToastManager
+    /// Persists the pending currency to `user_settings`. Wired post-init from `PulpeApp`
+    /// (mirrors `appState.sessionDataResetter`) — direct injection at construction would
+    /// circularize with `AppState` building `UserSettingsStore`. Returns `true` when the
+    /// API call succeeded; bootstrap surfaces a toast on `false` but still returns `true`
+    /// because the budget was created and we don't want `completePinSetup` to retry the
+    /// whole bootstrap on a non-fatal currency persistence error.
+    var persistCurrency: ((SupportedCurrency) async -> Bool)?
 
     init(
         createTemplate: @escaping (BudgetTemplateCreateFromOnboarding) async throws -> BudgetTemplate,
@@ -32,20 +44,35 @@ final class OnboardingBootstrapper {
 
     /// Legacy overload — kept so existing call sites (and tests) that set
     /// `pendingOnboardingData` through the `AppState` computed setter compile.
-    /// The new `completeOnboarding` flow uses `setPendingData(_:signupMethod:)`.
+    /// The new `completeOnboarding` flow uses `setPendingData(_:signupMethod:currency:)`.
     func setPendingData(_ data: BudgetTemplateCreateFromOnboarding?) {
         pendingOnboardingData = data
-        if data == nil { pendingSignupMethod = nil }
+        if data == nil {
+            pendingSignupMethod = nil
+            pendingCurrency = nil
+        }
     }
 
     func setPendingData(_ data: BudgetTemplateCreateFromOnboarding?, signupMethod: String?) {
         pendingOnboardingData = data
         pendingSignupMethod = data == nil ? nil : signupMethod
+        if data == nil { pendingCurrency = nil }
+    }
+
+    func setPendingData(
+        _ data: BudgetTemplateCreateFromOnboarding?,
+        signupMethod: String?,
+        currency: SupportedCurrency?
+    ) {
+        pendingOnboardingData = data
+        pendingSignupMethod = data == nil ? nil : signupMethod
+        pendingCurrency = data == nil ? nil : currency
     }
 
     func clearPendingData() {
         pendingOnboardingData = nil
         pendingSignupMethod = nil
+        pendingCurrency = nil
     }
 
     /// Creates template + budget from pending onboarding data if present.
@@ -67,10 +94,28 @@ final class OnboardingBootstrapper {
             )
             _ = try await createBudget(budgetData)
 
+            // Persist currency AFTER template + budget. Runs post-PIN-setup so the
+            // `X-Client-Key` header is available — calling earlier (during onboarding)
+            // would 403 with `AUTH_CLIENT_KEY_MISSING`. A failure here logs + surfaces a
+            // toast but does NOT fail the bootstrap: template + budget are already created,
+            // and `completePinSetup` retries the whole bootstrap on `false` which would
+            // duplicate them.
+            if let currency = pendingCurrency, let persistCurrency {
+                let ok = await persistCurrency(currency)
+                if !ok {
+                    Logger.auth.error("OnboardingBootstrapper: failed to persist currency")
+                    toastManager.show(
+                        "Devise non sauvegardée, réessaie depuis les paramètres",
+                        type: .error
+                    )
+                }
+            }
+
             let signupMethod = pendingSignupMethod ?? "email"
             let customCount = onboardingData.customTransactions.count
             pendingOnboardingData = nil
             pendingSignupMethod = nil
+            pendingCurrency = nil
 
             AnalyticsService.shared.capture(.firstBudgetCreated, properties: [
                 "signup_method": signupMethod,

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -40,6 +40,15 @@ struct PulpeApp: App {
             userSettingsStore: userSettingsStore
         )
 
+        // Wire currency persistence from `OnboardingBootstrapper` to `UserSettingsStore`.
+        // Runs after PIN setup completes so the API call carries `X-Client-Key`.
+        // Returns `true` only when the store's optimistic update was confirmed by the
+        // backend (no error after the await) — bootstrap toasts the user on `false`.
+        appState.onboardingBootstrapper.persistCurrency = { [userSettingsStore] currency in
+            await userSettingsStore.updateCurrency(currency)
+            return userSettingsStore.error == nil
+        }
+
         _appState = State(initialValue: appState)
         _currentMonthStore = State(initialValue: currentMonthStore)
         _budgetListStore = State(initialValue: budgetListStore)

--- a/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingFlow.swift
@@ -3,7 +3,6 @@ import SwiftUI
 /// Main onboarding flow coordinator
 struct OnboardingFlow: View {
     @Environment(AppState.self) private var appState
-    @Environment(UserSettingsStore.self) private var userSettingsStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
     @State private var state: OnboardingState
@@ -302,16 +301,15 @@ struct OnboardingFlow: View {
         state.isSubmitting = true
         defer { state.isSubmitting = false }
 
-        // The onboarding template schema doesn't carry currency, so persist the user's
-        // pick to user_settings before bootstrap so all subsequent amounts use it.
-        if state.currency != userSettingsStore.currency {
-            await userSettingsStore.updateCurrency(state.currency)
-        }
-
+        // Currency persistence is deferred to `OnboardingBootstrapper.bootstrapIfNeeded`,
+        // which runs post-PIN-setup. Calling `userSettingsStore.updateCurrency` here would
+        // 403 with `AUTH_CLIENT_KEY_MISSING` because the client key only exists after PIN
+        // setup, leaving the dashboard stuck on the default CHF.
         await appState.completeOnboarding(
             user: user,
             onboardingData: state.createTemplateData(),
-            signupMethod: state.authMethodProperty
+            signupMethod: state.authMethodProperty,
+            currency: state.currency
         )
         if appState.showPostAuthError {
             // Capture error locally and clear global flag
@@ -341,5 +339,4 @@ struct OnboardingFlow: View {
 #Preview {
     OnboardingFlow()
         .environment(AppState())
-        .environment(UserSettingsStore())
 }

--- a/ios/PulpeTests/App/Auth/OnboardingBootstrapperTests.swift
+++ b/ios/PulpeTests/App/Auth/OnboardingBootstrapperTests.swift
@@ -36,13 +36,16 @@ struct OnboardingBootstrapperTests {
     private func makeSUT(
         createTemplate: (@MainActor (BudgetTemplateCreateFromOnboarding) async throws -> BudgetTemplate)? = nil,
         createBudget: (@MainActor (BudgetCreate) async throws -> Budget)? = nil,
-        toastManager: ToastManager = ToastManager()
+        toastManager: ToastManager = ToastManager(),
+        persistCurrency: (@MainActor (SupportedCurrency) async -> Bool)? = nil
     ) -> OnboardingBootstrapper {
-        OnboardingBootstrapper(
+        let sut = OnboardingBootstrapper(
             createTemplate: createTemplate ?? { _ in Self.mockTemplate },
             createBudget: createBudget ?? { _ in Self.mockBudget },
             toastManager: toastManager
         )
+        sut.persistCurrency = persistCurrency
+        return sut
     }
 
     // MARK: - bootstrapIfNeeded
@@ -230,5 +233,99 @@ struct OnboardingBootstrapperTests {
 
         sut.clearPendingData()
         #expect(sut.pendingOnboardingData == nil)
+    }
+
+    // MARK: - Currency Persistence (PUL-118)
+
+    @Test("bootstrapIfNeeded with pending currency calls persistCurrency")
+    func bootstrapIfNeeded_withPendingCurrency_callsPersistCurrency() async {
+        nonisolated(unsafe) var capturedCurrency: SupportedCurrency?
+
+        let sut = makeSUT(
+            persistCurrency: { currency in
+                capturedCurrency = currency
+                return true
+            }
+        )
+        sut.setPendingData(
+            BudgetTemplateCreateFromOnboarding(),
+            signupMethod: "email",
+            currency: .eur
+        )
+
+        await sut.bootstrapIfNeeded()
+
+        #expect(capturedCurrency == .eur)
+    }
+
+    @Test("bootstrapIfNeeded when persistCurrency fails still returns true")
+    func bootstrapIfNeeded_whenPersistCurrencyFails_stillReturnsTrue() async {
+        let sut = makeSUT(
+            persistCurrency: { _ in false }
+        )
+        sut.setPendingData(
+            BudgetTemplateCreateFromOnboarding(),
+            signupMethod: "email",
+            currency: .eur
+        )
+
+        let result = await sut.bootstrapIfNeeded()
+
+        #expect(result == true)
+        #expect(sut.pendingOnboardingData == nil, "Pending data must be cleared on success path")
+        #expect(sut.pendingCurrency == nil, "Pending currency must be cleared on success path")
+    }
+
+    @Test("bootstrapIfNeeded when persistCurrency fails shows toast")
+    func bootstrapIfNeeded_whenPersistCurrencyFails_showsToast() async {
+        let toast = ToastManager()
+        let sut = makeSUT(
+            toastManager: toast,
+            persistCurrency: { _ in false }
+        )
+        sut.setPendingData(
+            BudgetTemplateCreateFromOnboarding(),
+            signupMethod: "email",
+            currency: .eur
+        )
+
+        await sut.bootstrapIfNeeded()
+
+        #expect(toast.currentToast != nil, "User must see an error toast on currency failure")
+    }
+
+    @Test("bootstrapIfNeeded without pending currency does not call persistCurrency")
+    func bootstrapIfNeeded_withoutPendingCurrency_doesNotCallPersistCurrency() async {
+        nonisolated(unsafe) var persistCallCount = 0
+
+        let sut = makeSUT(
+            persistCurrency: { _ in
+                persistCallCount += 1
+                return true
+            }
+        )
+        // setPendingData WITHOUT currency — pendingCurrency stays nil
+        sut.setPendingData(BudgetTemplateCreateFromOnboarding(), signupMethod: "email")
+
+        await sut.bootstrapIfNeeded()
+
+        #expect(persistCallCount == 0)
+    }
+
+    @Test("setPendingData with currency stores pendingCurrency; clearPendingData clears it")
+    func setPendingData_withCurrency_storesAndClears() {
+        let sut = makeSUT()
+
+        #expect(sut.pendingCurrency == nil)
+
+        sut.setPendingData(
+            BudgetTemplateCreateFromOnboarding(),
+            signupMethod: "email",
+            currency: .eur
+        )
+        #expect(sut.pendingCurrency == .eur)
+
+        sut.clearPendingData()
+        #expect(sut.pendingCurrency == nil)
     }
 }

--- a/ios/PulpeTests/Features/Onboarding/OnboardingFlowTests.swift
+++ b/ios/PulpeTests/Features/Onboarding/OnboardingFlowTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Tests for the onboarding completion flow's interaction with `UserSettingsStore`.
+///
+/// PUL-118: Currency picked during onboarding must NOT be persisted before PIN setup —
+/// the API call would fail with 403 `AUTH_CLIENT_KEY_MISSING` because the client key
+/// is derived from the PIN. The fix moves persistence into `OnboardingBootstrapper.bootstrapIfNeeded`,
+/// which runs post-PIN-setup. These tests pin that the pre-PIN path no longer touches
+/// `UserSettingsServicing.updateSettings`.
+@MainActor
+@Suite(.serialized)
+struct OnboardingFlowTests {
+    private let user = UserInfo(id: "user-1", email: "test@pulpe.app", firstName: "Max")
+
+    @Test("completeOnboarding does not call UserSettingsServicing.updateSettings during pre-auth")
+    func finishOnboarding_doesNotCallUpdateCurrencyDuringPreAuth() async {
+        let mockSettingsService = MockUserSettingsService()
+        // Build the store with the mock so we can assert no API call leaked through.
+        // We don't need to wire it onto AppState — the fix removed the pre-PIN call,
+        // so the store is now untouched until `bootstrapIfNeeded` runs (post-PIN).
+        _ = UserSettingsStore(service: mockSettingsService)
+
+        let sut = AppState(
+            keychainManager: AppStateTestFactory.keychainStore(),
+            postAuthResolver: MockPostAuthResolver(destination: .needsPinSetup),
+            biometricPreferenceStore: AppStateTestFactory.biometricDisabledStore()
+        )
+
+        // Wait for AppState init to settle.
+        try? await Task.sleep(for: .milliseconds(50))
+
+        await sut.completeOnboarding(
+            user: user,
+            onboardingData: BudgetTemplateCreateFromOnboarding(),
+            signupMethod: "email",
+            currency: .eur
+        )
+
+        let updateCallCount = await mockSettingsService.updateSettingsCallCount
+        #expect(
+            updateCallCount == 0,
+            "PUL-118: pre-PIN onboarding must not hit PUT /users/settings"
+        )
+    }
+
+    @Test("completeOnboarding stashes the picked currency on OnboardingBootstrapper")
+    func completeOnboarding_stashesPendingCurrency() async {
+        let sut = AppState(
+            keychainManager: AppStateTestFactory.keychainStore(),
+            postAuthResolver: MockPostAuthResolver(destination: .needsPinSetup),
+            biometricPreferenceStore: AppStateTestFactory.biometricDisabledStore()
+        )
+
+        try? await Task.sleep(for: .milliseconds(50))
+
+        await sut.completeOnboarding(
+            user: user,
+            onboardingData: BudgetTemplateCreateFromOnboarding(),
+            signupMethod: "email",
+            currency: .eur
+        )
+
+        #expect(
+            sut.onboardingBootstrapper.pendingCurrency == .eur,
+            "Picked currency must be retained for post-PIN persistence"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [PUL-118](https://linear.app/pulpe/issue/PUL-118): users who picked EUR during iOS onboarding were landing on a CHF dashboard. Root cause: `userSettingsStore.updateCurrency` fired in `OnboardingFlow.finishOnboarding` **before** PIN setup, so the `PUT /users/settings` was rejected by `AuthGuard` with 403 (`AUTH_CLIENT_KEY_MISSING`) and silently rolled back to CHF.

The persistence is now wired into `OnboardingBootstrapper.bootstrapIfNeeded` (post-PIN-setup, when the client key exists) via a `persistCurrency` closure injected from `PulpeApp.init` — same pattern as `sessionDataResetter`. Currency is forwarded through `completeOnboarding(currency:)` and `setPendingData(_:signupMethod:currency:)`. Persist failure surfaces a toast + `Logger.auth.error` but does not block the bootstrap (template + budget remain priority; user can retry from Settings).

## Test plan

- [x] Unit: 4 new `OnboardingBootstrapperTests` (closure called with currency / failure returns true / failure shows toast / no-op without currency)
- [x] Unit: new `OnboardingFlowTests.finishOnboarding_doesNotCallUpdateCurrencyDuringPreAuth`
- [x] Build: PulpeLocal scheme green on iPhone 17 Pro Max
- [x] Regression: 107/107 existing auth tests pass
- [ ] Manual QA on PulpePreview: signup → pick EUR → PIN → dashboard renders € with no CHF flash, Settings = EUR without manual toggle, Railway logs show 0 × `PUT /users/settings → 403`
- [ ] Manual QA: force `PUT /users/settings → 5xx` post-PIN → bootstrap succeeds, toast "Devise non sauvegardée, réessaie depuis les paramètres" shown