### PR TITLE
fix(ios): wipe onboarding draft before social signup (PUL-196)

### DIFF
--- a/ios/Pulpe/Features/Onboarding/OnboardingState+Persistence.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState+Persistence.swift
@@ -88,6 +88,22 @@ extension OnboardingState {
     static func clearPersistedData() {
         UserDefaults.standard.removeObject(forKey: storageKey)
     }
+
+    /// Reset every in-memory field populated by `loadFromStorage()` to its
+    /// pristine default. Called from `configureSocialUser` exclusively — the
+    /// email recovery path relies on persisted draft and must NOT reset.
+    func resetDraftFields() {
+        firstName = ""
+        currency = .chf
+        monthlyIncome = nil
+        housingCosts = nil
+        healthInsurance = nil
+        phonePlan = nil
+        transportCosts = nil
+        leasingCredit = nil
+        customTransactions = []
+        wasEmailRegistered = false
+    }
 }
 
 // MARK: - Storage Data

--- a/ios/Pulpe/Features/Onboarding/OnboardingState+Persistence.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState+Persistence.swift
@@ -115,6 +115,9 @@ extension OnboardingState {
 // `transportCosts`, `leasingCredit`, and per-transaction `amount`.
 // Threat model: physical device access + jailbreak can read self-reported draft estimates.
 // If this window needs hardening later, migrate the blob to Keychain (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`).
+//
+// Adding a field here requires updating 3 sites (no compiler enforcement):
+// `saveToStorage()`, `loadFromStorage()`, and `resetDraftFields()`.
 private struct OnboardingStorageData: Codable {
     let firstName: String
     let currency: SupportedCurrency?

--- a/ios/Pulpe/Features/Onboarding/OnboardingState+Persistence.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState+Persistence.swift
@@ -89,12 +89,13 @@ extension OnboardingState {
         UserDefaults.standard.removeObject(forKey: storageKey)
     }
 
-    /// Reset every in-memory field populated by `loadFromStorage()` to its
-    /// pristine default. Called from `configureSocialUser` exclusively — the
-    /// email recovery path relies on persisted draft and must NOT reset.
+    /// Reset every field that could carry over from a prior onboarding session.
+    /// Called from `configureSocialUser` exclusively — the email recovery path
+    /// relies on the persisted draft and must NOT reset.
     func resetDraftFields() {
         firstName = ""
         currency = .chf
+        currentStep = .welcome
         monthlyIncome = nil
         housingCosts = nil
         healthInsurance = nil
@@ -103,6 +104,11 @@ extension OnboardingState {
         leasingCredit = nil
         customTransactions = []
         wasEmailRegistered = false
+        // Below: not persisted, but leaks across same-instance auth-path pivots.
+        email = ""
+        hasEmittedWelcomeViewed = false
+        hasEmittedSignupStarted = false
+        hasEmittedBudgetPreviewCompleted = false
     }
 }
 
@@ -116,8 +122,11 @@ extension OnboardingState {
 // Threat model: physical device access + jailbreak can read self-reported draft estimates.
 // If this window needs hardening later, migrate the blob to Keychain (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`).
 //
-// Adding a field here requires updating 3 sites (no compiler enforcement):
-// `saveToStorage()`, `loadFromStorage()`, and `resetDraftFields()`.
+// Adding a persisted field here requires updating 4 sites (no compiler
+// enforcement): the `OnboardingStorageData` struct below, `saveToStorage()`,
+// `loadFromStorage()`, and `resetDraftFields()`. The PUL-196 regression test
+// (`configureSocialUser_wipesDraftLoadedFromStorage`) is the load-bearing
+// guard — assert every new persisted field there.
 private struct OnboardingStorageData: Codable {
     let firstName: String
     let currency: SupportedCurrency?

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -67,6 +67,11 @@ final class OnboardingState {
     /// Pre-fills firstName from provider metadata and clears persisted step
     /// so cold-start after app kill resets to welcome.
     func configureSocialUser(_ user: UserInfo) {
+        // PUL-196: wipe draft loaded by `init()` so a social signup never inherits
+        // financial/personal data from a prior abandoned email signup on the same
+        // device. `clearStorage()` alone only wipes UserDefaults — not the in-memory
+        // fields already populated by `loadFromStorage()`.
+        resetDraftFields()
         authenticatedUser = user
         isSocialAuth = true
         if let name = user.firstName, !name.isEmpty {

--- a/ios/Pulpe/Features/Onboarding/OnboardingState.swift
+++ b/ios/Pulpe/Features/Onboarding/OnboardingState.swift
@@ -67,10 +67,8 @@ final class OnboardingState {
     /// Pre-fills firstName from provider metadata and clears persisted step
     /// so cold-start after app kill resets to welcome.
     func configureSocialUser(_ user: UserInfo) {
-        // PUL-196: wipe draft loaded by `init()` so a social signup never inherits
-        // financial/personal data from a prior abandoned email signup on the same
-        // device. `clearStorage()` alone only wipes UserDefaults — not the in-memory
-        // fields already populated by `loadFromStorage()`.
+        // PUL-196: `clearStorage()` alone leaves draft fields loaded by `init()` in
+        // memory, so a prior email signup's data would bleed into the social form.
         resetDraftFields()
         authenticatedUser = user
         isSocialAuth = true

--- a/ios/PulpeTests/Features/Onboarding/OnboardingSocialSignupTests.swift
+++ b/ios/PulpeTests/Features/Onboarding/OnboardingSocialSignupTests.swift
@@ -163,7 +163,7 @@ struct OnboardingSocialSignupTests {
         OnboardingState.clearPersistedData()
         defer { OnboardingState.clearPersistedData() }
 
-        // 1) Email user fills draft and abandons.
+        // 1) Email user fills draft, advances mid-flow, and abandons.
         let prior = OnboardingState()
         prior.firstName = "Alice"
         prior.currency = .eur
@@ -176,6 +176,8 @@ struct OnboardingSocialSignupTests {
         prior.addCustomTransaction(
             OnboardingTransaction(amount: 50, type: .expense, name: "Spotify")
         )
+        // Non-welcome step exercises the in-memory `currentStep` pollution path.
+        prior.currentStep = .charges
         prior.saveToStorage()
 
         // 2) Fresh flow init for a social user — same device, different account.
@@ -187,6 +189,7 @@ struct OnboardingSocialSignupTests {
         // 3) All draft fields must be reset; provider name overrides.
         #expect(socialState.firstName == "Bob")
         #expect(socialState.currency == .chf)
+        #expect(socialState.currentStep == .welcome)
         #expect(socialState.monthlyIncome == nil)
         #expect(socialState.housingCosts == nil)
         #expect(socialState.healthInsurance == nil)
@@ -255,8 +258,10 @@ struct OnboardingSocialSignupTests {
         state.currentStep = .budgetPreview
         let nonSocialPercentage = state.progressPercentage
 
-        // With social: registration excluded → 5 visible steps → 100%
+        // With social: registration excluded → 5 visible steps → 100%.
+        // Re-set step after `configureSocialUser` (PUL-196 resets it to .welcome).
         state.configureSocialUser(UserInfo(id: "social-1", email: "social@pulpe.app", firstName: "Max"))
+        state.currentStep = .budgetPreview
         let socialPercentage = state.progressPercentage
 
         // Both hit 100% at budgetPreview (last step for both paths)

--- a/ios/PulpeTests/Features/Onboarding/OnboardingSocialSignupTests.swift
+++ b/ios/PulpeTests/Features/Onboarding/OnboardingSocialSignupTests.swift
@@ -151,6 +151,101 @@ struct OnboardingSocialSignupTests {
         #expect(!state.isFirstNameValid)
     }
 
+    // MARK: - PUL-196: Cross-account draft pollution
+
+    /// Repro from PUL-196: a previous email signup left a persisted draft on the
+    /// device. The next OnboardingFlow init for a social user runs
+    /// `OnboardingState() → loadFromStorage() → configureSocialUser()`. Without
+    /// the draft reset, financial fields from the email user bleed into the
+    /// social form. Asserts every persisted field is wiped after configure.
+    @Test
+    func configureSocialUser_wipesDraftLoadedFromStorage() {
+        OnboardingState.clearPersistedData()
+        defer { OnboardingState.clearPersistedData() }
+
+        // 1) Email user fills draft and abandons.
+        let prior = OnboardingState()
+        prior.firstName = "Alice"
+        prior.currency = .eur
+        prior.monthlyIncome = 5000
+        prior.housingCosts = 1500
+        prior.healthInsurance = 400
+        prior.phonePlan = 50
+        prior.transportCosts = 100
+        prior.leasingCredit = 300
+        prior.addCustomTransaction(
+            OnboardingTransaction(amount: 50, type: .expense, name: "Spotify")
+        )
+        prior.saveToStorage()
+
+        // 2) Fresh flow init for a social user — same device, different account.
+        let socialState = OnboardingState()
+        socialState.configureSocialUser(
+            UserInfo(id: "social-1", email: "social@pulpe.app", firstName: "Bob")
+        )
+
+        // 3) All draft fields must be reset; provider name overrides.
+        #expect(socialState.firstName == "Bob")
+        #expect(socialState.currency == .chf)
+        #expect(socialState.monthlyIncome == nil)
+        #expect(socialState.housingCosts == nil)
+        #expect(socialState.healthInsurance == nil)
+        #expect(socialState.phonePlan == nil)
+        #expect(socialState.transportCosts == nil)
+        #expect(socialState.leasingCredit == nil)
+        #expect(socialState.customTransactions.isEmpty)
+        #expect(!socialState.wasEmailRegistered)
+    }
+
+    /// Apple Private Relay path: provider returns no name. The draft's leftover
+    /// firstName must NOT survive — would otherwise pre-fill the social user's
+    /// firstName step with the previous email user's name.
+    @Test
+    func configureSocialUser_withoutProviderName_clearsLeftoverFirstName() {
+        OnboardingState.clearPersistedData()
+        defer { OnboardingState.clearPersistedData() }
+
+        let prior = OnboardingState()
+        prior.firstName = "Alice"
+        prior.monthlyIncome = 5000
+        prior.saveToStorage()
+
+        let socialState = OnboardingState()
+        socialState.configureSocialUser(
+            UserInfo(id: "apple-relay", email: "x@relay.appleid.com", firstName: nil)
+        )
+
+        #expect(socialState.firstName.isEmpty)
+        #expect(!socialState.socialProvidedName)
+        #expect(socialState.monthlyIncome == nil)
+    }
+
+    /// Non-regression: email recovery path MUST keep the persisted draft.
+    /// `configureEmailUser` is called when restoring a mid-flow signup — wiping
+    /// would force the user to re-enter every value.
+    @Test
+    func configureEmailUser_preservesDraftFromStorage() {
+        OnboardingState.clearPersistedData()
+        defer { OnboardingState.clearPersistedData() }
+
+        let prior = OnboardingState()
+        prior.firstName = "Alice"
+        prior.monthlyIncome = 5000
+        prior.housingCosts = 1500
+        prior.currency = .eur
+        prior.currentStep = .charges
+        prior.saveToStorage()
+
+        let recovered = OnboardingState()
+        recovered.configureEmailUser(UserInfo(id: "1", email: "alice@example.com"))
+
+        #expect(recovered.firstName == "Alice")
+        #expect(recovered.monthlyIncome == 5000)
+        #expect(recovered.housingCosts == 1500)
+        #expect(recovered.currency == .eur)
+        #expect(recovered.currentStep == .charges)
+    }
+
     @Test
     func progressPercentage_socialUser_budgetPreviewHigherThanNonSocial() {
         let state = makeSUT()


### PR DESCRIPTION
## Summary

`OnboardingState.clearStorage()` only wipes `UserDefaults`, not the in-memory fields already populated by `init() → loadFromStorage()`. A user starting an email signup on a device, then abandoning and creating a social account, saw the previous account's revenus/charges/épargne pre-filled — including currency and firstName.

`configureSocialUser` now calls a new `resetDraftFields()` (lives in the persistence extension to keep the main type body under SwiftLint's length budget) before applying provider data. Email recovery path (`configureEmailUser`) is untouched and still rehydrates from the persisted draft as the resume flow expects.

## Test plan

- [x] New unit tests in `OnboardingSocialSignupTests`: PUL-196 repro (draft → social init → all fields wiped), Apple Private Relay (firstName nil clears leftover name), non-regression on email recovery preserving the draft
- [x] `xcodebuild test -only-testing:PulpeTests/OnboardingSocialSignupTests -only-testing:PulpeTests/OnboardingStateTests` ✅ 76/76
- [ ] Manual: start email onboarding → enter income/charges → abandon → sign up via Apple/Google on same device → fields empty