### PR TITLE
fix(ios): retry currency persistence in onboarding (PUL-203)

### DIFF
--- a/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
+++ b/ios/Pulpe/App/Auth/OnboardingBootstrapper.swift
@@ -22,22 +22,22 @@ final class OnboardingBootstrapper {
     private let createTemplate: (BudgetTemplateCreateFromOnboarding) async throws -> BudgetTemplate
     private let createBudget: (BudgetCreate) async throws -> Budget
     private let toastManager: ToastManager
-    /// Persists the pending currency to `user_settings`. Wired post-init from `PulpeApp`
-    /// (mirrors `appState.sessionDataResetter`) — direct injection at construction would
-    /// circularize with `AppState` building `UserSettingsStore`. Returns `true` when the
-    /// API call succeeded; bootstrap surfaces a toast on `false` but still returns `true`
-    /// because the budget was created and we don't want `completePinSetup` to retry the
-    /// whole bootstrap on a non-fatal currency persistence error.
+    /// Persists the pending currency to `user_settings`. Wired post-init from `PulpeApp`.
+    /// See `bootstrapIfNeeded` for retry + failure-tolerance semantics.
     var persistCurrency: ((SupportedCurrency) async -> Bool)?
+
+    private let retryDelays: [Duration]
 
     init(
         createTemplate: @escaping (BudgetTemplateCreateFromOnboarding) async throws -> BudgetTemplate,
         createBudget: @escaping (BudgetCreate) async throws -> Budget,
-        toastManager: ToastManager
+        toastManager: ToastManager,
+        retryDelays: [Duration] = [.milliseconds(300), .milliseconds(1500)]
     ) {
         self.createTemplate = createTemplate
         self.createBudget = createBudget
         self.toastManager = toastManager
+        self.retryDelays = retryDelays
     }
 
     // MARK: - Public API
@@ -100,16 +100,7 @@ final class OnboardingBootstrapper {
             // toast but does NOT fail the bootstrap: template + budget are already created,
             // and `completePinSetup` retries the whole bootstrap on `false` which would
             // duplicate them.
-            if let currency = pendingCurrency, let persistCurrency {
-                let ok = await persistCurrency(currency)
-                if !ok {
-                    Logger.auth.error("OnboardingBootstrapper: failed to persist currency")
-                    toastManager.show(
-                        "Devise non sauvegardée, réessaie depuis les paramètres",
-                        type: .error
-                    )
-                }
-            }
+            await persistPendingCurrencyWithRetry()
 
             let signupMethod = pendingSignupMethod ?? "email"
             let customCount = onboardingData.customTransactions.count
@@ -135,5 +126,36 @@ final class OnboardingBootstrapper {
             toastManager.show("Erreur lors de la création du budget", type: .error)
             return false
         }
+    }
+
+    private func persistPendingCurrencyWithRetry() async {
+        guard let currency = pendingCurrency else { return }
+        guard let persistCurrency else {
+            Logger.auth.fault("OnboardingBootstrapper: persistCurrency closure not wired")
+            assertionFailure("persistCurrency closure must be wired before bootstrap runs")
+            return
+        }
+
+        if await persistCurrency(currency) { return }
+
+        for delay in retryDelays {
+            if Task.isCancelled { return }
+            try? await Task.sleep(for: delay)
+            if Task.isCancelled { return }
+            if await persistCurrency(currency) { return }
+        }
+
+        let totalAttempts = retryDelays.count + 1
+        Logger.auth.error(
+            "OnboardingBootstrapper: failed to persist currency after \(totalAttempts) attempts"
+        )
+        AnalyticsService.shared.capture(.currencyPersistFailed, properties: [
+            "currency": currency.rawValue,
+            "attempts": totalAttempts
+        ])
+        toastManager.show(
+            "Devise non sauvegardée, réessaie depuis les paramètres",
+            type: .error
+        )
     }
 }

--- a/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
@@ -56,4 +56,7 @@ enum AnalyticsEvent: String, CaseIterable {
     // MARK: - Currency
     case currencyChanged = "currency_changed"
     case currencySelectorToggled = "currency_selector_toggled"
+    /// Fires when onboarding currency persistence exhausts all retry attempts.
+    /// Properties: `currency` (target ISO code), `attempts` (total tried).
+    case currencyPersistFailed = "currency_persist_failed"
 }

--- a/ios/PulpeTests/App/Auth/OnboardingBootstrapperTests.swift
+++ b/ios/PulpeTests/App/Auth/OnboardingBootstrapperTests.swift
@@ -2,6 +2,8 @@ import Foundation
 @testable import Pulpe
 import Testing
 
+// swiftlint:disable type_body_length
+
 @MainActor
 @Suite(.serialized)
 struct OnboardingBootstrapperTests {
@@ -37,15 +39,28 @@ struct OnboardingBootstrapperTests {
         createTemplate: (@MainActor (BudgetTemplateCreateFromOnboarding) async throws -> BudgetTemplate)? = nil,
         createBudget: (@MainActor (BudgetCreate) async throws -> Budget)? = nil,
         toastManager: ToastManager = ToastManager(),
+        retryDelays: [Duration] = [.zero, .zero],
         persistCurrency: (@MainActor (SupportedCurrency) async -> Bool)? = nil
     ) -> OnboardingBootstrapper {
         let sut = OnboardingBootstrapper(
             createTemplate: createTemplate ?? { _ in Self.mockTemplate },
             createBudget: createBudget ?? { _ in Self.mockBudget },
-            toastManager: toastManager
+            toastManager: toastManager,
+            retryDelays: retryDelays
         )
         sut.persistCurrency = persistCurrency
         return sut
+    }
+
+    private func arrangePendingCurrency(
+        on sut: OnboardingBootstrapper,
+        currency: SupportedCurrency = .eur
+    ) {
+        sut.setPendingData(
+            BudgetTemplateCreateFromOnboarding(),
+            signupMethod: "email",
+            currency: currency
+        )
     }
 
     // MARK: - bootstrapIfNeeded
@@ -247,11 +262,7 @@ struct OnboardingBootstrapperTests {
                 return true
             }
         )
-        sut.setPendingData(
-            BudgetTemplateCreateFromOnboarding(),
-            signupMethod: "email",
-            currency: .eur
-        )
+        arrangePendingCurrency(on: sut)
 
         await sut.bootstrapIfNeeded()
 
@@ -263,11 +274,7 @@ struct OnboardingBootstrapperTests {
         let sut = makeSUT(
             persistCurrency: { _ in false }
         )
-        sut.setPendingData(
-            BudgetTemplateCreateFromOnboarding(),
-            signupMethod: "email",
-            currency: .eur
-        )
+        arrangePendingCurrency(on: sut)
 
         let result = await sut.bootstrapIfNeeded()
 
@@ -283,11 +290,7 @@ struct OnboardingBootstrapperTests {
             toastManager: toast,
             persistCurrency: { _ in false }
         )
-        sut.setPendingData(
-            BudgetTemplateCreateFromOnboarding(),
-            signupMethod: "email",
-            currency: .eur
-        )
+        arrangePendingCurrency(on: sut)
 
         await sut.bootstrapIfNeeded()
 
@@ -310,6 +313,108 @@ struct OnboardingBootstrapperTests {
         await sut.bootstrapIfNeeded()
 
         #expect(persistCallCount == 0)
+    }
+
+    // MARK: - Currency Persistence Retry (PUL-203)
+
+    @Test("bootstrapIfNeeded retries persistCurrency on failure and succeeds on 2nd attempt")
+    func bootstrapIfNeeded_persistCurrencyFailsThenSucceeds_succeedsWithoutToast() async {
+        nonisolated(unsafe) var attemptCount = 0
+        let toast = ToastManager()
+        let sut = makeSUT(
+            toastManager: toast,
+            persistCurrency: { _ in
+                attemptCount += 1
+                return attemptCount >= 2
+            }
+        )
+        arrangePendingCurrency(on: sut)
+
+        await sut.bootstrapIfNeeded()
+
+        #expect(attemptCount == 2)
+        #expect(toast.currentToast == nil, "No toast when retry eventually succeeds")
+    }
+
+    @Test("bootstrapIfNeeded retries persistCurrency twice and succeeds on 3rd attempt")
+    func bootstrapIfNeeded_persistCurrencyFailsTwiceThenSucceeds_succeedsOnFinalAttempt() async {
+        nonisolated(unsafe) var attemptCount = 0
+        let toast = ToastManager()
+        let sut = makeSUT(
+            toastManager: toast,
+            persistCurrency: { _ in
+                attemptCount += 1
+                return attemptCount >= 3
+            }
+        )
+        arrangePendingCurrency(on: sut)
+
+        await sut.bootstrapIfNeeded()
+
+        #expect(attemptCount == 3)
+        #expect(toast.currentToast == nil)
+    }
+
+    @Test("bootstrapIfNeeded persistCurrency fails all 3 attempts shows toast and returns true")
+    func bootstrapIfNeeded_persistCurrencyFailsAllAttempts_showsToastReturnsTrue() async {
+        nonisolated(unsafe) var attemptCount = 0
+        let toast = ToastManager()
+        let sut = makeSUT(
+            toastManager: toast,
+            persistCurrency: { _ in
+                attemptCount += 1
+                return false
+            }
+        )
+        arrangePendingCurrency(on: sut)
+
+        let result = await sut.bootstrapIfNeeded()
+
+        #expect(attemptCount == 3, "Initial attempt + 2 retries = 3 total")
+        #expect(toast.currentToast != nil)
+        #expect(result == true, "Bootstrap still returns true to avoid duplicating template/budget on retry")
+    }
+
+    @Test("bootstrapIfNeeded persistCurrency succeeds on first attempt does not retry")
+    func bootstrapIfNeeded_persistCurrencySucceedsImmediately_doesNotRetry() async {
+        nonisolated(unsafe) var attemptCount = 0
+        let sut = makeSUT(
+            persistCurrency: { _ in
+                attemptCount += 1
+                return true
+            }
+        )
+        arrangePendingCurrency(on: sut)
+
+        await sut.bootstrapIfNeeded()
+
+        #expect(attemptCount == 1, "Success on first attempt must short-circuit retries")
+    }
+
+    @Test("bootstrapIfNeeded cancellation mid-retry aborts loop without toast")
+    func bootstrapIfNeeded_cancelledMidRetry_abortsLoopNoToast() async {
+        nonisolated(unsafe) var attemptCount = 0
+        let toast = ToastManager()
+        let sut = makeSUT(
+            toastManager: toast,
+            retryDelays: [.milliseconds(50), .milliseconds(50)],
+            persistCurrency: { _ in
+                attemptCount += 1
+                return false
+            }
+        )
+        arrangePendingCurrency(on: sut)
+
+        // Run bootstrap in a detached task so Task.sleep in the retry loop can actually
+        // yield on the main actor while we cancel from the test body.
+        let task = Task.detached { await sut.bootstrapIfNeeded() }
+        // Let first attempt fire, then cancel during the 50ms sleep window.
+        try? await Task.sleep(for: .milliseconds(10))
+        task.cancel()
+        await task.value
+
+        #expect(attemptCount < 3, "Cancellation must short-circuit retry loop")
+        #expect(toast.currentToast == nil, "No toast on cancellation — bootstrap was aborted, not exhausted")
     }
 
     @Test("setPendingData with currency stores pendingCurrency; clearPendingData clears it")

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -29,6 +29,7 @@ struct AnalyticsServiceTests {
         #expect(AnalyticsEvent.budgetCreated.rawValue == "budget_created")
         #expect(AnalyticsEvent.transactionCreated.rawValue == "transaction_created")
         #expect(AnalyticsEvent.tabSwitched.rawValue == "tab_switched")
+        #expect(AnalyticsEvent.currencyPersistFailed.rawValue == "currency_persist_failed")
     }
 
     // MARK: - Sanitization


### PR DESCRIPTION
## Summary

Fixes [PUL-203](https://linear.app/pulpe/issue/PUL-203/ios-currency-persistence-onboarding-sans-retry-devise-perdue-si-api): a single API failure during post-PIN bootstrap left users with the wrong currency on the dashboard with no recovery beyond a manual fix in Settings.

`OnboardingBootstrapper` now retries currency persistence inline (3 attempts, 300ms/1500ms backoff) with cooperative cancellation; toast + log + new `currency_persist_failed` analytics event only fire after full exhaustion. `retryDelays` is constructor-injected so tests run with `[.zero, .zero]` (no wall-clock waits), and a programmer-error guard (`assertionFailure`) catches a missing `persistCurrency` wiring before it ships silently.

## Test plan

- [x] `xcodebuild test PulpeTests/OnboardingBootstrapperTests` — 22/22 green (4 existing PUL-118 + 4 new PUL-203 retry + 1 cancellation)
- [x] `xcodebuild test PulpeTests/AnalyticsServiceTests` — 12/12 green (raw value assertion for `currency_persist_failed`)
- [x] SwiftLint clean
- [ ] Manual: trigger transient failure mid-onboarding (airplane-mode toggle) and confirm retry recovers without toast