### PR TITLE
fix(webapp): restore disponible + dépensé/% on mobile envelope card (PUL-210)

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-grid/budget-grid-mobile-card.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-grid/budget-grid-mobile-card.ts
@@ -120,32 +120,9 @@ import { BudgetActionMenu } from '../budget-action-menu';
           >
             {{ remaining | appCurrency: currency() : '1.0-0' }}
           </div>
-          <span class="text-label-small text-on-surface-variant">
-            {{
-              'budgetLine.availableOf'
-                | transloco
-                  : {
-                      amount:
-                        (item().data.amount
-                        | appCurrency: currency() : '1.2-2'),
-                    }
-            }}
-          </span>
-        </ng-container>
-
-        <ng-container ngProjectAs="[meta]">
-          <div class="text-right">
-            <div
-              class="ph-no-capture text-title-medium font-semibold text-on-surface"
-            >
-              {{
-                item().consumption!.consumed | appCurrency: currency() : '1.0-0'
-              }}
-            </div>
-            <span class="text-label-small text-on-surface-variant">{{
-              'budgetLine.spent' | transloco
-            }}</span>
-          </div>
+          <span class="text-label-small text-on-surface-variant">{{
+            'budgetLine.available' | transloco
+          }}</span>
         </ng-container>
       } @else {
         <ng-container ngProjectAs="[amount]">
@@ -193,32 +170,33 @@ import { BudgetActionMenu } from '../budget-action-menu';
               [height]="6"
               [consumptionState]="item().consumption!.consumptionState"
             />
-            <div class="text-label-small text-center mt-1.5">
-              @if (item().consumption!.consumptionState === 'over-budget') {
-                <span class="ph-no-capture text-financial-over-budget">
-                  {{
-                    'budgetLine.exceededBy'
-                      | transloco
-                        : {
-                            amount:
-                              (item().consumption!.consumed - item().data.amount
-                              | appCurrency: currency() : '1.0-0'),
-                          }
-                  }}
-                </span>
-              } @else if (
-                item().consumption!.consumptionState === 'near-limit'
-              ) {
-                <span class="text-financial-warning">{{
-                  'budgetLine.usedPercent'
-                    | transloco: { percent: item().consumption!.percentage }
-                }}</span>
-              } @else {
-                <span class="text-on-surface-variant">{{
-                  'budgetLine.usedPercent'
-                    | transloco: { percent: item().consumption!.percentage }
-                }}</span>
-              }
+            <div class="flex justify-between items-center mt-2">
+              <span
+                class="ph-no-capture text-body-small text-on-surface-variant"
+              >
+                {{
+                  item().consumption!.consumed
+                    | appCurrency: currency() : '1.0-0'
+                }}
+                {{ 'budgetLine.spent' | transloco }}
+              </span>
+              <span class="text-body-small font-medium">
+                @if (item().consumption!.consumptionState === 'over-budget') {
+                  <span class="text-financial-over-budget">{{
+                    'budgetLine.exceeded' | transloco
+                  }}</span>
+                } @else if (
+                  item().consumption!.consumptionState === 'near-limit'
+                ) {
+                  <span class="text-financial-warning"
+                    >{{ item().consumption!.percentage }}%</span
+                  >
+                } @else {
+                  <span class="text-on-surface-variant"
+                    >{{ item().consumption!.percentage }}%</span
+                  >
+                }
+              </span>
             </div>
           </div>
         }


### PR DESCRIPTION
## Summary

- Mobile envelope card lost the `disponible` amount and showed a centered `X% utilisé` instead of the desktop split (`dépensé` left / `%` right). Bring the responsive layout in line with desktop.
- `[amount]` sub-label: `budgetLine.availableOf` → `budgetLine.available` (matches desktop wording).
- Drop the `[meta]` projection — consumed amount moves into the progress-bar footer.
- `[footer]`: replace centered `usedPercent` with `flex justify-between` row (`{consumed} dépensé` left, `{percent}%` or `dépassé` right) with the same `text-financial-warning` / `text-financial-over-budget` colors as `BudgetGridCard`.
- No change to the `FinancialLineCard` pattern — `template-line-card` untouched. No new transloco keys.

## Type

fix

## Test plan

- [ ] Resize browser to <960 px landscape and <600 px portrait → envelope card shows `{remaining} CHF` + `disponible`, then progress bar, then `{consumed} CHF dépensé` left / `{percent}%` right.
- [ ] Desktop ≥960 px landscape → `BudgetGridCard` visually unchanged.
- [ ] Empty envelope (`!hasTransactions`) → planned amount + `prévu` label, no progress footer.
- [ ] `over-budget` state → right side shows `dépassé` in `text-financial-over-budget`.
- [ ] `near-limit` state → right side shows `{percent}%` in `text-financial-warning`.
- [ ] Templates list (`template-line-card`) → visually unchanged.
- [ ] `pnpm run lint` (frontend) — clean.
- [ ] `pnpm test` (frontend) — 1933 passing.

Linear: [PUL-210](https://linear.app/pulpe/issue/PUL-210/reafficher-le-montant-disponible-et-la-barre-depensepercent-sur-la)