### PR TITLE
fix: harden PostHog identify + privacy policy post-DPA (PUL-211)

### DIFF
--- a/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
@@ -39,9 +39,19 @@ function createMockFeatureFlagsService(initial = false) {
   };
 }
 
-const DEFAULT_IDENTIFY_PROPERTIES = {
-  early_adopter: false,
-} as const;
+function expectedIdentifyProperties(
+  userId: string,
+  email?: string,
+  name?: string,
+): Record<string, unknown> {
+  const props: Record<string, unknown> = {
+    supabase_user_id: userId,
+    early_adopter: false,
+  };
+  if (email !== undefined) props['email'] = email;
+  if (name !== undefined) props['name'] = name;
+  return props;
+}
 
 describe('User consent and tracking behavior', () => {
   let analyticsService: AnalyticsService;
@@ -136,7 +146,7 @@ describe('User consent and tracking behavior', () => {
       expect(mockPostHogService.identify).toHaveBeenCalledTimes(1);
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         userId,
-        DEFAULT_IDENTIFY_PROPERTIES,
+        expectedIdentifyProperties(userId, 'user@example.com'),
       );
     });
   });
@@ -186,7 +196,7 @@ describe('User consent and tracking behavior', () => {
       expect(mockPostHogService.identify).toHaveBeenCalledTimes(1);
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         returningUserId,
-        DEFAULT_IDENTIFY_PROPERTIES,
+        expectedIdentifyProperties(returningUserId, 'returning@example.com'),
       );
     });
   });
@@ -322,10 +332,10 @@ describe('User consent and tracking behavior', () => {
       });
       TestBed.tick();
 
-      // THEN: Identify omits currency keys (only carries early_adopter)
+      // THEN: Identify omits currency keys (only carries identity + early_adopter)
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'user-currency-1',
-        DEFAULT_IDENTIFY_PROPERTIES,
+        expectedIdentifyProperties('user-currency-1', 'user@example.com'),
       );
       // AND: setPersonProperties carries the currency triplet via $set
       expect(mockPostHogService.setPersonProperties).toHaveBeenCalledWith({
@@ -356,7 +366,7 @@ describe('User consent and tracking behavior', () => {
       // until real settings arrive — avoids polluting the cohort with stale CHF defaults.
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'user-currency-2',
-        DEFAULT_IDENTIFY_PROPERTIES,
+        expectedIdentifyProperties('user-currency-2', 'user@example.com'),
       );
       expect(mockPostHogService.setPersonProperties).not.toHaveBeenCalled();
     });
@@ -390,6 +400,102 @@ describe('User consent and tracking behavior', () => {
         currency: 'EUR',
         show_currency_selector: false,
         multi_currency_enabled: false,
+      });
+    });
+  });
+
+  describe('identify shape: email and name presence', () => {
+    it('should include name when user_metadata.firstName is non-empty', () => {
+      TestBed.runInInjectionContext(() => {
+        analyticsService.initializeAnalyticsTracking();
+      });
+
+      mockAuthState.set({
+        user: {
+          id: 'user-with-name',
+          email: 'alice@example.com',
+          user_metadata: { firstName: 'Alice' },
+        },
+        session: { access_token: 'token', refresh_token: 'refresh' },
+        isLoading: false,
+        isAuthenticated: true,
+      });
+
+      TestBed.tick();
+
+      expect(mockPostHogService.identify).toHaveBeenCalledWith(
+        'user-with-name',
+        expectedIdentifyProperties(
+          'user-with-name',
+          'alice@example.com',
+          'Alice',
+        ),
+      );
+    });
+
+    it('should omit name when firstName is empty string', () => {
+      TestBed.runInInjectionContext(() => {
+        analyticsService.initializeAnalyticsTracking();
+      });
+
+      mockAuthState.set({
+        user: {
+          id: 'user-empty-name',
+          email: 'bob@example.com',
+          user_metadata: { firstName: '   ' },
+        },
+        session: { access_token: 'token', refresh_token: 'refresh' },
+        isLoading: false,
+        isAuthenticated: true,
+      });
+
+      TestBed.tick();
+
+      const [, props] = mockPostHogService.identify.mock.calls[0];
+      expect(props).not.toHaveProperty('name');
+      expect(props).toMatchObject({
+        supabase_user_id: 'user-empty-name',
+        email: 'bob@example.com',
+      });
+    });
+
+    it('should omit name when user_metadata is absent entirely', () => {
+      TestBed.runInInjectionContext(() => {
+        analyticsService.initializeAnalyticsTracking();
+      });
+
+      mockAuthState.set({
+        user: { id: 'user-no-meta', email: 'carol@example.com' },
+        session: { access_token: 'token', refresh_token: 'refresh' },
+        isLoading: false,
+        isAuthenticated: true,
+      });
+
+      TestBed.tick();
+
+      const [, props] = mockPostHogService.identify.mock.calls[0];
+      expect(props).not.toHaveProperty('name');
+    });
+
+    it('should omit email when user.email is undefined', () => {
+      TestBed.runInInjectionContext(() => {
+        analyticsService.initializeAnalyticsTracking();
+      });
+
+      mockAuthState.set({
+        user: { id: 'user-no-email', email: undefined },
+        session: { access_token: 'token', refresh_token: 'refresh' },
+        isLoading: false,
+        isAuthenticated: true,
+      });
+
+      TestBed.tick();
+
+      const [, props] = mockPostHogService.identify.mock.calls[0];
+      expect(props).not.toHaveProperty('email');
+      expect(props).toMatchObject({
+        supabase_user_id: 'user-no-email',
+        early_adopter: false,
       });
     });
   });
@@ -598,7 +704,10 @@ describe('Demo mode tracking', () => {
       // THEN: User is identified with is_demo flag
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'demo-user-123',
-        { ...DEFAULT_IDENTIFY_PROPERTIES, is_demo: true },
+        {
+          ...expectedIdentifyProperties('demo-user-123', 'demo@pulpe.app'),
+          is_demo: true,
+        },
       );
     });
 
@@ -624,7 +733,7 @@ describe('Demo mode tracking', () => {
       // THEN: User is identified WITHOUT is_demo flag
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'real-user-456',
-        DEFAULT_IDENTIFY_PROPERTIES,
+        expectedIdentifyProperties('real-user-456', 'user@example.com'),
       );
     });
   });
@@ -647,7 +756,7 @@ describe('Demo mode tracking', () => {
 
       TestBed.tick();
       expect(mockPostHogService.identify).toHaveBeenCalledWith('demo-user', {
-        ...DEFAULT_IDENTIFY_PROPERTIES,
+        ...expectedIdentifyProperties('demo-user', 'demo@pulpe.app'),
         is_demo: true,
       });
 
@@ -710,7 +819,7 @@ describe('Demo mode tracking', () => {
       // THEN: Regular user is identified without demo flag
       expect(mockPostHogService.identify).toHaveBeenCalledWith(
         'real-user',
-        DEFAULT_IDENTIFY_PROPERTIES,
+        expectedIdentifyProperties('real-user', 'real@example.com'),
       );
     });
   });
@@ -741,7 +850,7 @@ describe('Demo mode tracking', () => {
 
       // THEN: User is re-identified with demo flag
       expect(mockPostHogService.identify).toHaveBeenCalledWith('user-123', {
-        ...DEFAULT_IDENTIFY_PROPERTIES,
+        ...expectedIdentifyProperties('user-123', 'user@example.com'),
         is_demo: true,
       });
     });

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.ts
@@ -15,6 +15,14 @@ import { UserSettingsStore } from '../user-settings/user-settings-store';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import type { Properties } from 'posthog-js';
 
+// Trim + reject empty so re-identify can't overwrite a known-good
+// email/name with `undefined` (posthog-js serializes that as null).
+function pickNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 /**
  * Simplified analytics service following KISS principle.
  * Leverages PostHog's auto-capture for most tracking needs.
@@ -84,19 +92,11 @@ export class AnalyticsService implements OnDestroy {
             | Record<string, unknown>
             | undefined;
 
-          // Trim + reject empty so re-identify can't overwrite a known-good
-          // email/name with `undefined` (posthog-js serializes that as null).
-          const pickString = (value: unknown): string | undefined => {
-            if (typeof value !== 'string') return undefined;
-            const trimmed = value.trim();
-            return trimmed.length > 0 ? trimmed : undefined;
-          };
-
           const fullName =
-            pickString(userMetadata?.['firstName']) ??
-            pickString(userMetadata?.['full_name']) ??
-            pickString(userMetadata?.['name']);
-          const userEmail = pickString(authState.user.email);
+            pickNonEmptyString(userMetadata?.['firstName']) ??
+            pickNonEmptyString(userMetadata?.['full_name']) ??
+            pickNonEmptyString(userMetadata?.['name']);
+          const userEmail = pickNonEmptyString(authState.user.email);
 
           const identifyProperties: Properties = {
             [ANALYTICS_PROPERTIES.SUPABASE_USER_ID]: authState.user.id,

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.ts
@@ -79,9 +79,30 @@ export class AnalyticsService implements OnDestroy {
           // would otherwise re-fire identify on every settings tick or PostHog
           // `flagsVersion` bump (feedback loop with this same identify call).
           const isDemoMode = this.#demoModeService.isDemoMode();
+          const userMetadata = authState.user.user_metadata as
+            | Record<string, unknown>
+            | undefined;
+
+          // Trim + reject empty so re-identify can't overwrite a known-good
+          // email/name with `undefined` (posthog-js serializes that as null).
+          const pickString = (value: unknown): string | undefined => {
+            if (typeof value !== 'string') return undefined;
+            const trimmed = value.trim();
+            return trimmed.length > 0 ? trimmed : undefined;
+          };
+
+          const fullName =
+            pickString(userMetadata?.['firstName']) ??
+            pickString(userMetadata?.['full_name']) ??
+            pickString(userMetadata?.['name']);
+          const userEmail = pickString(authState.user.email);
+
           const identifyProperties: Properties = {
+            [ANALYTICS_PROPERTIES.SUPABASE_USER_ID]: authState.user.id,
             [ANALYTICS_PROPERTIES.EARLY_ADOPTER]:
               this.#authStore.isEarlyAdopter(),
+            ...(userEmail && { [ANALYTICS_PROPERTIES.EMAIL]: userEmail }),
+            ...(fullName && { [ANALYTICS_PROPERTIES.NAME]: fullName }),
             ...(isDemoMode && { is_demo: true }),
           };
 

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.ts
@@ -92,10 +92,11 @@ export class AnalyticsService implements OnDestroy {
             | Record<string, unknown>
             | undefined;
 
-          const fullName =
-            pickNonEmptyString(userMetadata?.['firstName']) ??
-            pickNonEmptyString(userMetadata?.['full_name']) ??
-            pickNonEmptyString(userMetadata?.['name']);
+          // Privacy policy commits to "prénom" only (legal/privacy-policy.ts).
+          // iOS pushes user.firstName — keep webapp aligned. Do NOT fall back
+          // to `full_name`/`name` from OAuth providers: Google returns the
+          // full given+family name there, which would breach the policy.
+          const firstName = pickNonEmptyString(userMetadata?.['firstName']);
           const userEmail = pickNonEmptyString(authState.user.email);
 
           const identifyProperties: Properties = {
@@ -103,7 +104,7 @@ export class AnalyticsService implements OnDestroy {
             [ANALYTICS_PROPERTIES.EARLY_ADOPTER]:
               this.#authStore.isEarlyAdopter(),
             ...(userEmail && { [ANALYTICS_PROPERTIES.EMAIL]: userEmail }),
-            ...(fullName && { [ANALYTICS_PROPERTIES.NAME]: fullName }),
+            ...(firstName && { [ANALYTICS_PROPERTIES.NAME]: firstName }),
             ...(isDemoMode && { is_demo: true }),
           };
 

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.ts
@@ -73,7 +73,8 @@ export class AnalyticsService implements OnDestroy {
             this.#logger.debug('PostHog tracking enabled for session');
           }
 
-          // Identify carries demo + early adopter flags only. Settings + the
+          // Identify carries the user identity (email, name, supabase_user_id)
+          // plus stable session flags (early adopter, demo). Settings + the
           // multi-currency flag are pushed separately via `$set` from
           // `#personPropertiesEffect` — they are heavier signal deps that
           // would otherwise re-fire identify on every settings tick or PostHog

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -48,6 +48,12 @@ function generateTempId(): string {
   return `${TEMP_ID_PREFIX}${uuidv4()}`;
 }
 
+interface PendingCreate {
+  promise: Promise<string>;
+  resolve: (realId: string) => void;
+  reject: (err: unknown) => void;
+}
+
 const BUDGET_DETAIL_INVALIDATION_KEYS: string[][] = [
   ['budget', 'details'],
   ['budget', 'list'],
@@ -70,6 +76,8 @@ export class BudgetDetailsStore {
 
   // Mutex: prevents concurrent toggle mutations on the same item
   readonly #mutatingIds = new Set<string>();
+
+  readonly #pendingCreates = new Map<string, PendingCreate>();
 
   readonly #isShowingOnlyUnchecked = signal<boolean>(
     this.#storage.get<boolean>(STORAGE_KEYS.BUDGET_SHOW_ONLY_UNCHECKED) ?? true,
@@ -383,10 +391,25 @@ export class BudgetDetailsStore {
   });
 
   async createBudgetLine(budgetLine: BudgetLineCreate): Promise<void> {
-    await this.#createBudgetLineMutation.mutate({
-      budgetLine,
-      tempId: generateTempId(),
-    });
+    const tempId = generateTempId();
+    this.#registerPendingCreate(tempId);
+    try {
+      const result = await this.#createBudgetLineMutation.mutate({
+        budgetLine,
+        tempId,
+      });
+      if (result) {
+        this.#settlePendingCreate(tempId, { realId: result.data.id });
+      } else {
+        this.#settlePendingCreate(tempId, {
+          error:
+            this.#createBudgetLineMutation.error() ??
+            new Error('Budget line create did not complete'),
+        });
+      }
+    } catch (err) {
+      this.#settlePendingCreate(tempId, { error: err });
+    }
   }
 
   readonly #updateBudgetLineMutation = cachedMutation<
@@ -417,7 +440,9 @@ export class BudgetDetailsStore {
   });
 
   async updateBudgetLine(data: BudgetLineUpdate): Promise<void> {
-    await this.#updateBudgetLineMutation.mutate(data);
+    const realId = await this.#resolveServerId(data.id);
+    if (realId === null) return;
+    await this.#updateBudgetLineMutation.mutate({ ...data, id: realId });
   }
 
   readonly #updateTransactionMutation = cachedMutation<
@@ -450,7 +475,9 @@ export class BudgetDetailsStore {
   });
 
   async updateTransaction(id: string, data: TransactionUpdate): Promise<void> {
-    await this.#updateTransactionMutation.mutate({ id, data });
+    const realId = await this.#resolveServerId(id);
+    if (realId === null) return;
+    await this.#updateTransactionMutation.mutate({ id: realId, data });
   }
 
   readonly #deleteBudgetLineMutation = cachedMutation<
@@ -481,7 +508,9 @@ export class BudgetDetailsStore {
   });
 
   async deleteBudgetLine(id: string): Promise<void> {
-    await this.#deleteBudgetLineMutation.mutate(id);
+    const realId = await this.#resolveServerId(id);
+    if (realId === null) return;
+    await this.#deleteBudgetLineMutation.mutate(realId);
   }
 
   readonly #deleteTransactionMutation = cachedMutation<
@@ -511,7 +540,9 @@ export class BudgetDetailsStore {
   });
 
   async deleteTransaction(id: string): Promise<void> {
-    await this.#deleteTransactionMutation.mutate(id);
+    const realId = await this.#resolveServerId(id);
+    if (realId === null) return;
+    await this.#deleteTransactionMutation.mutate(realId);
   }
 
   readonly #createAllocatedTransactionMutation = cachedMutation<
@@ -560,10 +591,25 @@ export class BudgetDetailsStore {
   async createAllocatedTransaction(
     transactionData: TransactionCreate,
   ): Promise<void> {
-    await this.#createAllocatedTransactionMutation.mutate({
-      data: transactionData,
-      tempId: generateTempId(),
-    });
+    const tempId = generateTempId();
+    this.#registerPendingCreate(tempId);
+    try {
+      const result = await this.#createAllocatedTransactionMutation.mutate({
+        data: transactionData,
+        tempId,
+      });
+      if (result) {
+        this.#settlePendingCreate(tempId, { realId: result.data.id });
+      } else {
+        this.#settlePendingCreate(tempId, {
+          error:
+            this.#createAllocatedTransactionMutation.error() ??
+            new Error('Transaction create did not complete'),
+        });
+      }
+    } catch (err) {
+      this.#settlePendingCreate(tempId, { error: err });
+    }
   }
 
   readonly #resetBudgetLineMutation = cachedMutation<
@@ -643,20 +689,24 @@ export class BudgetDetailsStore {
       );
       return true;
     }
-    if (this.#mutatingIds.has(id)) return false;
+
+    const realId = await this.#resolveServerId(id);
+    if (realId === null) return false;
+
+    if (this.#mutatingIds.has(realId)) return false;
 
     const details = this.budgetDetails();
     if (!details) return false;
 
-    const lineExists = details.budgetLines.some((l) => l.id === id);
+    const lineExists = details.budgetLines.some((l) => l.id === realId);
     if (!lineExists) return false;
 
-    this.#mutatingIds.add(id);
+    this.#mutatingIds.add(realId);
     try {
-      const result = await this.#toggleCheckMutation.mutate(id);
+      const result = await this.#toggleCheckMutation.mutate(realId);
       return result !== undefined;
     } finally {
-      this.#mutatingIds.delete(id);
+      this.#mutatingIds.delete(realId);
     }
   }
 
@@ -701,12 +751,14 @@ export class BudgetDetailsStore {
   });
 
   async toggleTransactionCheck(id: string): Promise<void> {
-    if (this.#mutatingIds.has(id)) return;
-    this.#mutatingIds.add(id);
+    const realId = await this.#resolveServerId(id);
+    if (realId === null) return;
+    if (this.#mutatingIds.has(realId)) return;
+    this.#mutatingIds.add(realId);
     try {
-      await this.#toggleTransactionCheckMutation.mutate(id);
+      await this.#toggleTransactionCheckMutation.mutate(realId);
     } finally {
-      this.#mutatingIds.delete(id);
+      this.#mutatingIds.delete(realId);
     }
   }
 
@@ -790,6 +842,39 @@ export class BudgetDetailsStore {
   }
 
   // ── 6. Private utility methods ──
+
+  #registerPendingCreate(tempId: string): void {
+    let resolve!: (realId: string) => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<string>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    promise.catch(() => undefined);
+    this.#pendingCreates.set(tempId, { promise, resolve, reject });
+  }
+
+  #settlePendingCreate(
+    tempId: string,
+    result: { realId: string } | { error: unknown },
+  ): void {
+    const pending = this.#pendingCreates.get(tempId);
+    if (!pending) return;
+    if ('realId' in result) pending.resolve(result.realId);
+    else pending.reject(result.error);
+    this.#pendingCreates.delete(tempId);
+  }
+
+  async #resolveServerId(id: string): Promise<string | null> {
+    if (!isTempId(id)) return id;
+    const pending = this.#pendingCreates.get(id);
+    if (!pending) return null;
+    try {
+      return await pending.promise;
+    } catch {
+      return null;
+    }
+  }
 
   #updateDetails(
     fn: (details: BudgetDetailsViewModel) => BudgetDetailsViewModel,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -639,7 +639,15 @@ export class BudgetDetailsStore {
   });
 
   async resetBudgetLineFromTemplate(id: string): Promise<void> {
-    await this.#resetBudgetLineMutation.mutate(id);
+    const realId = await this.#resolveServerId(id);
+    if (realId === null) return;
+    if (this.#mutatingIds.has(realId)) return;
+    this.#mutatingIds.add(realId);
+    try {
+      await this.#resetBudgetLineMutation.mutate(realId);
+    } finally {
+      this.#mutatingIds.delete(realId);
+    }
   }
 
   readonly #toggleCheckMutation = cachedMutation<
@@ -818,21 +826,21 @@ export class BudgetDetailsStore {
   });
 
   async checkAllAllocatedTransactions(budgetLineId: string): Promise<void> {
-    if (this.#mutatingIds.has(budgetLineId)) return;
+    const realId = await this.#resolveServerId(budgetLineId);
+    if (realId === null) return;
+    if (this.#mutatingIds.has(realId)) return;
     const details = this.budgetDetails();
     if (!details) return;
     const hasUnchecked = details.transactions.some(
       (tx) =>
-        tx.budgetLineId === budgetLineId &&
-        tx.checkedAt === null &&
-        !isTempId(tx.id),
+        tx.budgetLineId === realId && tx.checkedAt === null && !isTempId(tx.id),
     );
     if (!hasUnchecked) return;
-    this.#mutatingIds.add(budgetLineId);
+    this.#mutatingIds.add(realId);
     try {
-      await this.#checkAllAllocatedMutation.mutate(budgetLineId);
+      await this.#checkAllAllocatedMutation.mutate(realId);
     } finally {
-      this.#mutatingIds.delete(budgetLineId);
+      this.#mutatingIds.delete(realId);
     }
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -591,11 +591,19 @@ export class BudgetDetailsStore {
   async createAllocatedTransaction(
     transactionData: TransactionCreate,
   ): Promise<void> {
+    let dataToPersist = transactionData;
+    if (transactionData.budgetLineId) {
+      const realLineId = await this.#resolveServerId(
+        transactionData.budgetLineId,
+      );
+      if (realLineId === null) return;
+      dataToPersist = { ...transactionData, budgetLineId: realLineId };
+    }
     const tempId = generateTempId();
     this.#registerPendingCreate(tempId);
     try {
       const result = await this.#createAllocatedTransactionMutation.mutate({
-        data: transactionData,
+        data: dataToPersist,
         tempId,
       });
       if (result) {

--- a/frontend/projects/webapp/src/app/feature/legal/components/privacy-policy.ts
+++ b/frontend/projects/webapp/src/app/feature/legal/components/privacy-policy.ts
@@ -83,29 +83,47 @@ import { ROUTES } from '@core/routing';
             <li>Améliorer l'expérience utilisateur</li>
           </ul>
           <p class="text-body-large mt-4">
-            <strong>Enregistrement de sessions :</strong> PostHog peut
-            enregistrer des sessions d'utilisation (replay des interactions)
-            pour m'aider à comprendre et résoudre les problèmes techniques.
+            <strong>Données envoyées à PostHog :</strong>
           </p>
+          <ul class="list-disc pl-6 text-body-large">
+            <li>Identifiant utilisateur (UUID Supabase) et email</li>
+            <li>Prénom (si renseigné lors de l'inscription)</li>
+            <li>Préférences produit : devise, paramètres d'affichage</li>
+            <li>
+              Statut early-adopter (utilisateur ayant activé son compte avant
+              une date de référence)
+            </li>
+            <li>Pages visitées et interactions (clics, navigation)</li>
+            <li>Traces d'erreur techniques (sans contenu sensible)</li>
+          </ul>
           <p class="text-body-large mt-4">
-            <strong>Protection de vos données financières :</strong>
+            <strong>Données NON envoyées à PostHog :</strong>
           </p>
           <ul class="list-disc pl-6 text-body-large">
             <li>
-              Vos montants financiers sont automatiquement masqués dans toutes
-              les analyses et les enregistrements de sessions
+              Vos montants financiers — masqués automatiquement avant envoi,
+              jamais transmis
             </li>
-            <li>
-              Les données sont pseudonymisées (votre identité n'est pas
-              directement visible)
-            </li>
-            <li>
-              Vos données financières ne sont
-              <strong>jamais transmises à des tiers</strong>
-            </li>
-            <li>Aucune utilisation commerciale de vos données</li>
-            <li>Pas de publicité ciblée</li>
+            <li>Mots de passe, tokens d'authentification</li>
+            <li>Identifiants de transactions ou de catégories budgétaires</li>
           </ul>
+          <p class="text-body-large mt-4">
+            <strong>Enregistrement de sessions :</strong> PostHog peut
+            enregistrer des sessions d'utilisation (replay des interactions)
+            pour m'aider à comprendre et résoudre les problèmes techniques. Tous
+            les champs de saisie sont automatiquement masqués.
+          </p>
+          <p class="text-body-large mt-4">
+            <strong>Base légale :</strong> intérêt légitime (article 6.1.f du
+            RGPD) — analytics produit nécessaires à l'amélioration du service,
+            avec données minimisées et hébergement Europe.
+          </p>
+          <p class="text-body-large mt-4">
+            <strong>Accord de traitement (DPA) :</strong> un Data Processing
+            Agreement a été signé avec PostHog Inc., conforme à l'article 28 du
+            RGPD. PostHog agit en tant que sous-traitant (processor) pour les
+            données collectées via Pulpe.
+          </p>
         </section>
 
         <section class="mb-8">
@@ -165,6 +183,14 @@ import { ROUTES } from '@core/routing';
             ci-dessus. Le code source est open source sur GitHub mais vos
             données restent privées.
           </p>
+          <p class="text-body-large mt-4">
+            Les services tiers listés (Supabase, Railway, Vercel, PostHog,
+            Cloudflare, Google) agissent comme sous-traitants au sens de
+            l'article 28 du RGPD. Un Data Processing Agreement (DPA) dédié a été
+            signé avec PostHog Inc. Pour les autres sous-traitants, les
+            engagements de traitement sont fournis via leurs conditions de
+            service standard, conformément à l'article 28 du RGPD.
+          </p>
         </section>
 
         <section class="mb-8">
@@ -179,6 +205,14 @@ import { ROUTES } from '@core/routing';
               heures
             </li>
           </ul>
+          <p class="text-body-large mt-4">
+            <strong>Note sur PostHog :</strong> à ce jour, la suppression du
+            compte côté Pulpe n'entraîne pas automatiquement la suppression du
+            profil analytics chez PostHog. Pour exercer votre droit à
+            l'effacement sur les données analytics, contactez-moi par email — je
+            procéderai à la suppression manuelle via l'API PostHog (sous 7 jours
+            ouvrés).
+          </p>
         </section>
 
         <section class="mb-8">
@@ -192,8 +226,11 @@ import { ROUTES } from '@core/routing';
             <li>Droit de rectification de vos données</li>
             <li>Droit à l'effacement (suppression du compte)</li>
             <li>Droit à la portabilité (export JSON)</li>
-            <li>Droit d'opposition à certains traitements</li>
-            <li>Droit de retirer votre consentement à tout moment</li>
+            <li>
+              Droit d'opposition (article 21 RGPD) — vous pouvez vous opposer à
+              tout traitement fondé sur l'intérêt légitime, notamment
+              l'analytics
+            </li>
           </ul>
           <p class="text-body-large mt-4">
             Pour exercer ces droits, contactez-moi à :
@@ -222,10 +259,14 @@ import { ROUTES } from '@core/routing';
           </p>
           <ul class="list-disc pl-6 text-body-large">
             <li>
-              Activés lors de la création de votre compte (base légale : intérêt
-              légitime pour l'amélioration du service)
+              Activés automatiquement (base légale : intérêt légitime, article
+              6.1.f du RGPD). Vous pouvez exercer votre droit d'opposition à
+              tout moment via l'email de contact ci-dessous.
             </li>
-            <li>Données pseudonymisées (pas d'identification directe)</li>
+            <li>
+              Données identifiables (email, identifiant utilisateur, prénom) —
+              voir section 4 pour le détail des données envoyées à PostHog
+            </li>
             <li>
               Vous pouvez vous opposer à ces cookies en me contactant à
               <a href="mailto:maxime.desogus@gmail.com" class="text-primary"
@@ -300,5 +341,5 @@ import { ROUTES } from '@core/routing';
 export default class PrivacyPolicyComponent {
   protected readonly ROUTES = ROUTES;
 
-  protected readonly currentDate = '27 janvier 2026';
+  protected readonly currentDate = '6 mai 2026';
 }

--- a/ios/Pulpe/App/AppState+Auth.swift
+++ b/ios/Pulpe/App/AppState+Auth.swift
@@ -114,10 +114,16 @@ extension AppState {
         if case .unauthenticatedSessionExpired = destination { return }
 
         var properties: [String: Any] = [
-            AnalyticsService.emailProperty: user.email,
             AnalyticsService.supabaseUserIdProperty: user.id,
             AnalyticsService.earlyAdopterProperty: user.isEarlyAdopter
         ]
+        // Apple hides email via private relay → `signInWithIdToken` falls back to "".
+        // Sending "" overwrites a previously-identified valid email in PostHog.
+        // Mirrors webapp's `pickString(authState.user.email)` (rejects empty/whitespace).
+        let trimmedEmail = user.email.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedEmail.isEmpty {
+            properties[AnalyticsService.emailProperty] = trimmedEmail
+        }
         if let trimmed = user.firstName?.trimmingCharacters(in: .whitespacesAndNewlines),
            !trimmed.isEmpty {
             properties[AnalyticsService.nameProperty] = trimmed

--- a/ios/Pulpe/App/AppState+Auth.swift
+++ b/ios/Pulpe/App/AppState+Auth.swift
@@ -103,24 +103,33 @@ extension AppState {
         }
     }
 
+    /// Skip identify on `.unauthenticatedSessionExpired`: the server already
+    /// invalidated this session, so associating analytics + person-property
+    /// feature flags with this user would leak identity into a state PostHog
+    /// would otherwise treat as anonymous-and-rejected.
+    /// Otherwise: identify with email/name/supabase_user_id so PostHog UI
+    /// surfaces persons by human-readable identity (cf. PostHog
+    /// identity-resolution doc). `early_adopter` drives feature flag targeting.
+    private func identifyUserForAnalytics(_ user: UserInfo, destination: PostAuthDestination) {
+        if case .unauthenticatedSessionExpired = destination { return }
+
+        var properties: [String: Any] = [
+            AnalyticsService.emailProperty: user.email,
+            AnalyticsService.supabaseUserIdProperty: user.id,
+            AnalyticsService.earlyAdopterProperty: user.isEarlyAdopter
+        ]
+        if let trimmed = user.firstName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !trimmed.isEmpty {
+            properties[AnalyticsService.nameProperty] = trimmed
+        }
+        AnalyticsService.shared.identify(userId: user.id, properties: properties)
+        AnalyticsService.shared.reloadFeatureFlags()
+    }
+
     func applyPostAuthDestination(_ destination: PostAuthDestination, user: UserInfo? = nil) async {
         if let user {
             currentUser = user
-            // Skip identify on `.unauthenticatedSessionExpired`: the server already
-            // invalidated this session, so associating analytics + person-property
-            // feature flags with this user would leak identity into a state PostHog
-            // would otherwise treat as anonymous-and-rejected.
-            if case .unauthenticatedSessionExpired = destination {
-                // intentionally no-op
-            } else {
-                // `early_adopter` drives targeted feature flag rollouts via PostHog
-                // person properties — must be passed on identify().
-                AnalyticsService.shared.identify(
-                    userId: user.id,
-                    properties: [AnalyticsService.earlyAdopterProperty: user.isEarlyAdopter]
-                )
-                AnalyticsService.shared.reloadFeatureFlags()
-            }
+            identifyUserForAnalytics(user, destination: destination)
         }
         authState = .loading
 

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -9,11 +9,14 @@ final class AnalyticsService {
     static let shared = AnalyticsService()
 
     /// PostHog person property keys — must mirror `ANALYTICS_PROPERTIES`
-    /// in `shared/src/feature-flags.ts`.
+    /// in `shared/src/feature-flags.ts` exactly.
     nonisolated static let earlyAdopterProperty = "early_adopter"
     nonisolated static let currencyProperty = "currency"
     nonisolated static let showCurrencySelectorProperty = "show_currency_selector"
     nonisolated static let multiCurrencyEnabledProperty = "multi_currency_enabled"
+    nonisolated static let emailProperty = "email"
+    nonisolated static let nameProperty = "name"
+    nonisolated static let supabaseUserIdProperty = "supabase_user_id"
 
     private(set) var isInitialized = false
     private(set) var isEventCapturingEnabled = false

--- a/shared/src/feature-flags.ts
+++ b/shared/src/feature-flags.ts
@@ -17,10 +17,15 @@ export const FEATURE_FLAGS = {
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];
 
 /**
- * PostHog person property keys used for feature flag targeting and dashboards.
+ * PostHog person property keys pushed at `identify` time.
+ *
+ * Used for feature flag targeting, dashboard cohort filters, and surfacing
+ * persons by human-readable identifiers (email/name) in the PostHog UI
+ * instead of raw `person.id`.
  *
  * Must stay in sync with iOS `AnalyticsService` static property keys and the
- * property names referenced in PostHog dashboard flag conditions.
+ * property names referenced in PostHog dashboard flag conditions. Adding a
+ * key here does NOT auto-add it on iOS — keep `AnalyticsService.swift` in sync.
  */
 export const ANALYTICS_PROPERTIES = {
   /** Mirrors Supabase `auth.users.app_metadata.early_adopter`. */
@@ -31,6 +36,12 @@ export const ANALYTICS_PROPERTIES = {
   SHOW_CURRENCY_SELECTOR: 'show_currency_selector',
   /** Mirrors `multi-currency-enabled` flag exposure for dashboard cohort filters. */
   MULTI_CURRENCY_ENABLED: 'multi_currency_enabled',
+  /** User's email — pushed at identify so PostHog UI shows persons by email. */
+  EMAIL: 'email',
+  /** User's display name (firstName from Supabase user_metadata). */
+  NAME: 'name',
+  /** Supabase auth.users.id — kept as person property in addition to being the distinct_id, so it's filterable in PostHog dashboards. */
+  SUPABASE_USER_ID: 'supabase_user_id',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Three coupled changes after the PostHog DPA was signed:

- **Bug fix** — race condition where rapid create→delete leaked client-side `temp-<uuid>` ids to the backend (PostHog `$exception` `019dfc5c`). Pending-creates registry resolves real id before dependent mutations; settle moved out of `cachedMutation` callbacks (ngx-ziflux latest-wins gate would skip them on rapid double-create).
- **PostHog identify enrichment** — push `email`, `name` (firstName), `supabase_user_id` at identify (previously only `early_adopter`). Persons are now searchable by email in the PostHog UI. Webapp + iOS parity. Empty/whitespace/undefined values are filtered out via conditional spread.
- **Privacy policy** aligned with the DPA + the actual data sent — section 4 precise list, section 7 DPA coverage, section 8 honest PostHog deletion limitation, section 9 'Droit d'opposition' for the legitimate-interest basis, section 10 'données identifiables' replacing the now-false 'pseudonymisées' claim.

Linear: [PUL-211](https://linear.app/pulpe/issue/PUL-211/fiabiliser-lidentification-posthog-et-conformite-rgpd-post-signature)

## Files touched

| Package | File | Change |
|---------|------|--------|
| `frontend` | `analytics.ts` + `.spec.ts` | identify push + tests for absent/present email/name |
| `frontend` | `budget-details-store.ts` | pending-creates registry, settle outside callbacks |
| `frontend` | `privacy-policy.ts` | sections 4/7/8/9/10 rewritten, currentDate bumped |
| `ios` | `AnalyticsService.swift` | 3 new static property keys |
| `ios` | `AppState+Auth.swift` | identify push extracted into `identifyUserForAnalytics` helper |
| `shared` | `feature-flags.ts` | `EMAIL`, `NAME`, `SUPABASE_USER_ID` added to `ANALYTICS_PROPERTIES` |

## Validation

- `pnpm quality` 10/10 green
- `pnpm test` 1937/1937 (+4 new identify-shape tests)
- `xcodebuild build -scheme PulpeLocal` BUILD SUCCEEDED
- `xcodebuild test -only-testing:PulpeTests` 1443/1443

## Adversarial review summary

12 findings surfaced, 11 fixed in-PR (1 critical conditional-spread, 5 high legal-text corrections, 5 medium/low hygiene). 1 deferred:

- **F6 — backend account-deletion → PostHog person delete (RGPD Art. 17)** — pre-existing gap amplified by this PR. Tracked separately, must ship within 30 days of DPA signing.

## Test plan

- [ ] Create a transaction, immediately delete it: no `$exception` in PostHog, server returns 200 on the delete
- [ ] Sign in on a fresh browser (or after `posthog.reset()` via DevTools): the user appears in PostHog UI Persons searchable by email
- [ ] iOS sign-in path: same — person searchable by email + firstName visible
- [ ] Privacy policy renders correctly, all sections coherent, `currentDate = 6 mai 2026`
- [ ] Sign-out then sign-in as a different user: no PostHog merge, distinct person profiles