### PR TITLE
fix(security): OWASP audit hardening for webapp + landing (PUL-215)

### DIFF
--- a/docs/CSP.md
+++ b/docs/CSP.md
@@ -1,0 +1,61 @@
+# Content Security Policy
+
+> Source of truth: `vercel.json` (webapp) + `landing/vercel.json` (landing).
+
+## Current state
+
+Both `script-src` and `script-src-elem` include `'unsafe-inline'`. This **weakens XSS defense-in-depth**: a successful HTML/script injection bypasses CSP and runs as page-origin script.
+
+Accepted risk, tracked: PUL-215 follow-up.
+
+## Why `'unsafe-inline'` is currently present
+
+| Source | Where | Why blocking |
+|--------|-------|---|
+| Splash + theme bootstrap | `frontend/projects/webapp/src/index.html` `<script>` blocks | Must run before Angular bootstrap to prevent FOUC + light/dark flash. Cannot move to a hashed external file without losing the synchronous pre-paint guarantee. |
+| Material Symbols `onload="..."` | `frontend/projects/webapp/src/index.html` `<link onload>` | Inline event handler. Removing requires `'unsafe-hashes'` + SHA-256 of the handler body, or a post-load JS attach (still inline). |
+| Cloudflare Turnstile | webapp signup/login | Loader injects an inline boot script before fetching the widget bundle. Documented requirement. |
+| PostHog autocapture snippet | proxied via `/ph/static/*` | Snippet bootstraps an inline `<script>` in some flows. |
+| Next.js hydration runtime | `landing/` | Next.js injects inline hydration scripts unless a nonce is plumbed through middleware. |
+| JSON-LD `<script type="application/ld+json">` | `landing/app/layout.tsx` | Static structured data, but emitted via `dangerouslySetInnerHTML`. Hashable but tied to bundler-produced output. |
+
+## Path to remediation
+
+Two viable strategies. Pick one per app.
+
+### A. SHA-256 hashes (static, no SSR change)
+
+For each known inline script, compute `sha256-<base64>` and add to `script-src` / `script-src-elem`. Drop `'unsafe-inline'`.
+
+- **Webapp**: 2 inline `<script>` blocks + 1 inline `onload` (`'unsafe-hashes'` required for the latter). Splash `<style>` keeps `style-src 'unsafe-inline'`.
+- **Landing**: only the JSON-LD inline. **But Next.js hydration scripts also need hashing**, and their content changes per build → not viable without further plumbing.
+
+Net: works cleanly for webapp, partially for landing.
+
+### B. Nonces via middleware (preferred long-term)
+
+Generate a per-request nonce in a Vercel edge middleware, inject into all inline scripts, set `script-src 'nonce-<value>' 'strict-dynamic'`. Drops every `'unsafe-inline'` and most allowlisted hosts.
+
+- **Landing (Next.js)**: well-supported via `middleware.ts` + `headers()`. Guide: <https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy>
+- **Webapp (Angular SPA on Vercel)**: needs an edge function rewriting `index.html` on each request to inject the nonce. Heavier change. Alternative: ship hashes for the 2 known scripts (option A) and document.
+
+## Current decision
+
+**Keep `'unsafe-inline'` until PUL-215 follow-up implements option A for webapp + option B for landing.** Other hardening already in place (see commits cb5d8f0e0, bf3010aa2, aad2c0095, ed9ec465b on `maximedesogus/pul-215-...`):
+
+- `frame-ancestors 'none'` (clickjacking)
+- `object-src 'none'` (legacy plugin XSS)
+- `base-uri 'self'` (base-tag injection)
+- `form-action 'self'`
+- HSTS preload, `X-Frame-Options DENY`, `X-Content-Type-Options nosniff`
+- `Permissions-Policy` denies camera/mic/geo/payment/usb/sensors + Topics API
+
+## Verification
+
+Before flipping `'unsafe-inline'` off, manually test:
+
+1. Cold-load webapp: splash renders, no FOUC, no console CSP violations.
+2. Cloudflare Turnstile renders on signup + login.
+3. PostHog `__$$ph` global is present, autocapture fires.
+4. Landing: JSON-LD `<script>` parses (Google Rich Results test), no hydration mismatch.
+5. Vercel Preview env: same checks (CSP headers are env-agnostic but worth confirming).

--- a/docs/CSP.md
+++ b/docs/CSP.md
@@ -1,61 +1,26 @@
 # Content Security Policy
 
-> Source of truth: `vercel.json` (webapp) + `landing/vercel.json` (landing).
+CSP lives in `vercel.json` (webapp) and `landing/vercel.json` (landing).
 
-## Current state
+## Known weakness
 
-Both `script-src` and `script-src-elem` include `'unsafe-inline'`. This **weakens XSS defense-in-depth**: a successful HTML/script injection bypasses CSP and runs as page-origin script.
+`script-src` and `script-src-elem` ship with `'unsafe-inline'`. A successful HTML/script injection bypasses CSP. Tracked in PUL-215 follow-up.
 
-Accepted risk, tracked: PUL-215 follow-up.
+## What actually requires it
 
-## Why `'unsafe-inline'` is currently present
+| App | Inline source | File |
+|-----|---------------|------|
+| Webapp | Theme detection script (pre-paint, prevents dark/light flash) | `frontend/projects/webapp/src/index.html` |
+| Webapp | Splash spinner animation script | `frontend/projects/webapp/src/index.html` |
+| Webapp | `<link onload="this.media='all'">` for Material Symbols | `frontend/projects/webapp/src/index.html` |
+| Landing | JSON-LD via `dangerouslySetInnerHTML` | `landing/app/layout.tsx` |
+| Landing | Next.js hydration scripts (per-build content) | injected by framework |
 
-| Source | Where | Why blocking |
-|--------|-------|---|
-| Splash + theme bootstrap | `frontend/projects/webapp/src/index.html` `<script>` blocks | Must run before Angular bootstrap to prevent FOUC + light/dark flash. Cannot move to a hashed external file without losing the synchronous pre-paint guarantee. |
-| Material Symbols `onload="..."` | `frontend/projects/webapp/src/index.html` `<link onload>` | Inline event handler. Removing requires `'unsafe-hashes'` + SHA-256 of the handler body, or a post-load JS attach (still inline). |
-| Cloudflare Turnstile | webapp signup/login | Loader injects an inline boot script before fetching the widget bundle. Documented requirement. |
-| PostHog autocapture snippet | proxied via `/ph/static/*` | Snippet bootstraps an inline `<script>` in some flows. |
-| Next.js hydration runtime | `landing/` | Next.js injects inline hydration scripts unless a nonce is plumbed through middleware. |
-| JSON-LD `<script type="application/ld+json">` | `landing/app/layout.tsx` | Static structured data, but emitted via `dangerouslySetInnerHTML`. Hashable but tied to bundler-produced output. |
+Turnstile (`ngx-turnstile`) and PostHog (`posthog-js`) load external bundles; both are already covered by the host allowlist and do not need `'unsafe-inline'`.
 
-## Path to remediation
+## Path forward
 
-Two viable strategies. Pick one per app.
+- **Webapp**: extract the 3 inline pieces to `assets/init/{theme,splash,fonts}.js`, load render-blocking before `<pulpe-root>`. Remove `'unsafe-inline'`. No nonce needed. ~30 min of work + manual FOUC test.
+- **Landing**: needs a Vercel edge middleware that mints a per-request nonce and injects it into Next.js `headers()`. Drop `'unsafe-inline'` and add `'nonce-<value>' 'strict-dynamic'`. Reference: <https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy>.
 
-### A. SHA-256 hashes (static, no SSR change)
-
-For each known inline script, compute `sha256-<base64>` and add to `script-src` / `script-src-elem`. Drop `'unsafe-inline'`.
-
-- **Webapp**: 2 inline `<script>` blocks + 1 inline `onload` (`'unsafe-hashes'` required for the latter). Splash `<style>` keeps `style-src 'unsafe-inline'`.
-- **Landing**: only the JSON-LD inline. **But Next.js hydration scripts also need hashing**, and their content changes per build → not viable without further plumbing.
-
-Net: works cleanly for webapp, partially for landing.
-
-### B. Nonces via middleware (preferred long-term)
-
-Generate a per-request nonce in a Vercel edge middleware, inject into all inline scripts, set `script-src 'nonce-<value>' 'strict-dynamic'`. Drops every `'unsafe-inline'` and most allowlisted hosts.
-
-- **Landing (Next.js)**: well-supported via `middleware.ts` + `headers()`. Guide: <https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy>
-- **Webapp (Angular SPA on Vercel)**: needs an edge function rewriting `index.html` on each request to inject the nonce. Heavier change. Alternative: ship hashes for the 2 known scripts (option A) and document.
-
-## Current decision
-
-**Keep `'unsafe-inline'` until PUL-215 follow-up implements option A for webapp + option B for landing.** Other hardening already in place (see commits cb5d8f0e0, bf3010aa2, aad2c0095, ed9ec465b on `maximedesogus/pul-215-...`):
-
-- `frame-ancestors 'none'` (clickjacking)
-- `object-src 'none'` (legacy plugin XSS)
-- `base-uri 'self'` (base-tag injection)
-- `form-action 'self'`
-- HSTS preload, `X-Frame-Options DENY`, `X-Content-Type-Options nosniff`
-- `Permissions-Policy` denies camera/mic/geo/payment/usb/sensors + Topics API
-
-## Verification
-
-Before flipping `'unsafe-inline'` off, manually test:
-
-1. Cold-load webapp: splash renders, no FOUC, no console CSP violations.
-2. Cloudflare Turnstile renders on signup + login.
-3. PostHog `__$$ph` global is present, autocapture fires.
-4. Landing: JSON-LD `<script>` parses (Google Rich Results test), no hydration mismatch.
-5. Vercel Preview env: same checks (CSP headers are env-agnostic but worth confirming).
+`style-src 'unsafe-inline'` stays — Angular Material and Tailwind both emit inline styles by design.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,6 +29,7 @@
 
 ### 🔒 Sécurité
 - **[ENCRYPTION.md](./ENCRYPTION.md)** - Chiffrement AES-256-GCM des montants financiers (split-key, stockage clientKey web + iOS)
+- **[CSP.md](./CSP.md)** - Content Security Policy : état actuel, dette `unsafe-inline`, plan de remédiation
 - **[SCENARIOS.md](./SCENARIOS.md)** - Scénarios métier Web App + iOS (auth, biométrie, grace period, widget)
 
 ## 🎯 Par Problème Spécifique

--- a/frontend/projects/webapp/src/app/core/logging/logger.spec.ts
+++ b/frontend/projects/webapp/src/app/core/logging/logger.spec.ts
@@ -131,6 +131,42 @@ describe('Logger', () => {
       expect(sanitized['anonKey']).toBe('***');
     });
 
+    it('should mask user identifier keys to prevent PII leakage', () => {
+      const data = {
+        userId: 'auth0|123456',
+        user_id: 'supabase-uuid-789',
+        sub: 'jwt-subject-claim',
+        username: 'john',
+      };
+
+      logger.debug('Identity data', data);
+
+      const args =
+        consoleDebugSpy.mock.calls[consoleDebugSpy.mock.calls.length - 1];
+      const sanitized = args[1] as Record<string, unknown>;
+      expect(sanitized['userId']).toBe('***');
+      expect(sanitized['user_id']).toBe('***');
+      expect(sanitized['sub']).toBe('***');
+      expect(sanitized['username']).toBe('john');
+    });
+
+    it('should not mask keys that merely contain "sub" as substring', () => {
+      const data = {
+        subject: 'meeting agenda',
+        subtitle: 'chapter 1',
+        substring: 'foo',
+      };
+
+      logger.debug('Non-PII data', data);
+
+      const args =
+        consoleDebugSpy.mock.calls[consoleDebugSpy.mock.calls.length - 1];
+      const sanitized = args[1] as Record<string, unknown>;
+      expect(sanitized['subject']).toBe('meeting agenda');
+      expect(sanitized['subtitle']).toBe('chapter 1');
+      expect(sanitized['substring']).toBe('foo');
+    });
+
     it('should handle nested objects', () => {
       const data = {
         user: {

--- a/frontend/projects/webapp/src/app/core/logging/logger.ts
+++ b/frontend/projects/webapp/src/app/core/logging/logger.ts
@@ -135,7 +135,6 @@ export class Logger {
             lowerKey.includes('secret') ||
             lowerKey.includes('token') ||
             lowerKey.includes('key') ||
-            lowerKey.includes('anonkey') ||
             lowerKey === 'userid' ||
             lowerKey === 'user_id' ||
             lowerKey === 'sub'

--- a/frontend/projects/webapp/src/app/core/logging/logger.ts
+++ b/frontend/projects/webapp/src/app/core/logging/logger.ts
@@ -133,7 +133,10 @@ export class Logger {
             lowerKey.includes('secret') ||
             lowerKey.includes('token') ||
             lowerKey.includes('key') ||
-            lowerKey.includes('anonkey')
+            lowerKey.includes('anonkey') ||
+            lowerKey === 'userid' ||
+            lowerKey === 'user_id' ||
+            lowerKey === 'sub'
           ) {
             (sanitized as Record<string, unknown>)[key] = '***';
           } else {

--- a/frontend/projects/webapp/src/app/core/logging/logger.ts
+++ b/frontend/projects/webapp/src/app/core/logging/logger.ts
@@ -128,6 +128,8 @@ export class Logger {
           const lowerKey = key.toLowerCase();
 
           // Mask sensitive keys
+          // Exact match on 'userid' / 'user_id' / 'sub' (JWT subject claim)
+          // avoids false positives on substrings like subject, subtitle, subscription, userIdentity.
           if (
             lowerKey.includes('password') ||
             lowerKey.includes('secret') ||

--- a/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.spec.ts
+++ b/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.spec.ts
@@ -19,6 +19,7 @@ const mockCache = {
   clear: vi.fn(),
   clearDirty: vi.fn(),
   version: signal(0),
+  _dataVersion: signal(0),
 };
 
 describe('UserSettingsStore', () => {

--- a/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
@@ -203,6 +203,7 @@ import { signupFormSchema } from './signup-form.schema';
               <a
                 [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_TERMS]"
                 target="_blank"
+                rel="noopener noreferrer"
                 class="text-primary underline"
                 (click)="$event.stopPropagation()"
               >
@@ -212,6 +213,7 @@ import { signupFormSchema } from './signup-form.schema';
               <a
                 [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_PRIVACY]"
                 target="_blank"
+                rel="noopener noreferrer"
                 class="text-primary underline"
                 (click)="$event.stopPropagation()"
               >

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-details-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-details-store.spec.ts
@@ -16,6 +16,7 @@ const mockCache = {
   clear: vi.fn(),
   clearDirty: vi.fn(),
   version: signal(0),
+  _dataVersion: signal(0),
 };
 
 describe('TemplateDetailsStore', () => {

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-line-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-line-store.spec.ts
@@ -111,6 +111,7 @@ describe('TemplateLineStore', () => {
       bulkOperationsTemplateLines$: vi.fn(),
       cache: {
         version: signal(0),
+        _dataVersion: signal(0),
         get: vi.fn().mockReturnValue(null),
         set: vi.fn(),
         has: vi.fn().mockReturnValue(false),

--- a/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-store.spec.ts
@@ -17,6 +17,7 @@ const mockCache = {
   clear: vi.fn(),
   clearDirty: vi.fn(),
   version: signal(0),
+  _dataVersion: signal(0),
 };
 
 describe('BudgetTemplatesStore', () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -127,6 +127,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       toggleTransactionCheck$: vi.fn(),
       cache: {
         version: signal(0),
+        _dataVersion: signal(0),
         get: vi.fn().mockReturnValue(null),
         set: vi.fn(),
         has: vi.fn().mockReturnValue(false),

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-search.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-search.spec.ts
@@ -133,6 +133,7 @@ describe('BudgetDetailsStore - Search Filtering', () => {
             getAllBudgets$: vi.fn().mockReturnValue(of([])),
             cache: {
               version: signal(0),
+              _dataVersion: signal(0),
               get: vi.fn().mockReturnValue(null),
               set: vi.fn(),
               has: vi.fn().mockReturnValue(false),

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-store.spec.ts
@@ -16,6 +16,7 @@ const mockCache = {
   clear: vi.fn(),
   clearDirty: vi.fn(),
   version: signal(0),
+  _dataVersion: signal(0),
 };
 
 const mockUserSettingsStore = {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/services/template-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/services/template-store.spec.ts
@@ -16,6 +16,7 @@ const mockCache = {
   clear: vi.fn(),
   clearDirty: vi.fn(),
   version: signal(0),
+  _dataVersion: signal(0),
 };
 
 const mockBudgetCache = {
@@ -27,6 +28,7 @@ const mockBudgetCache = {
   clear: vi.fn(),
   clearDirty: vi.fn(),
   version: signal(0),
+  _dataVersion: signal(0),
 };
 
 describe('TemplateStore', () => {

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.spec.ts
@@ -96,6 +96,7 @@ function createMocks() {
       toggleBudgetLineCheck$: vi.fn(),
       cache: {
         version: signal(0),
+        _dataVersion: signal(0),
         get: vi.fn().mockReturnValue(null),
         set: vi.fn(),
         invalidate: vi.fn(),

--- a/frontend/projects/webapp/src/app/feature/legal/components/privacy-policy.ts
+++ b/frontend/projects/webapp/src/app/feature/legal/components/privacy-policy.ts
@@ -310,6 +310,7 @@ import { ROUTES } from '@core/routing';
                 href="https://github.com/neogenz/pulpe"
                 class="text-primary"
                 target="_blank"
+                rel="noopener noreferrer"
                 >Issues & Discussions</a
               >
             </li>

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
@@ -160,6 +160,7 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
         <a
           [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_TERMS]"
           target="_blank"
+          rel="noopener noreferrer"
           class="text-primary underline underline-offset-2"
           >{{ 'welcome.termsShort' | transloco }}</a
         >
@@ -167,6 +168,7 @@ import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
         <a
           [routerLink]="['/', ROUTES.LEGAL, ROUTES.LEGAL_PRIVACY]"
           target="_blank"
+          rel="noopener noreferrer"
           class="text-primary underline underline-offset-2"
           >{{ 'welcome.privacyPolicy' | transloco }}</a
         >

--- a/frontend/projects/webapp/src/app/layout/about-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/layout/about-dialog.spec.ts
@@ -124,7 +124,7 @@ describe('AboutDialog', () => {
       'https://pulpe.app/changelog',
     );
     expect(changelogLink?.getAttribute('target')).toBe('_blank');
-    expect(changelogLink?.getAttribute('rel')).toBe('noopener');
+    expect(changelogLink?.getAttribute('rel')).toBe('noopener noreferrer');
   });
 
   it('should have a link to CGU', () => {

--- a/frontend/projects/webapp/src/app/layout/about-dialog.ts
+++ b/frontend/projects/webapp/src/app/layout/about-dialog.ts
@@ -76,7 +76,7 @@ const LONG_PRESS_DURATION_MS = 10_000;
               class="text-body-medium text-primary py-1 hover:underline"
               href="https://pulpe.app/changelog"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               {{ 'about.newFeatures' | transloco }}
             </a>

--- a/frontend/projects/webapp/src/app/layout/whats-new/whats-new-toast.spec.ts
+++ b/frontend/projects/webapp/src/app/layout/whats-new/whats-new-toast.spec.ts
@@ -93,7 +93,7 @@ describe('WhatsNewToast', () => {
       expect(link).toBeTruthy();
       expect(link.getAttribute('href')).toBe('https://pulpe.app/changelog');
       expect(link.getAttribute('target')).toBe('_blank');
-      expect(link.getAttribute('rel')).toBe('noopener');
+      expect(link.getAttribute('rel')).toBe('noopener noreferrer');
     });
   });
 

--- a/frontend/projects/webapp/src/app/layout/whats-new/whats-new-toast.ts
+++ b/frontend/projects/webapp/src/app/layout/whats-new/whats-new-toast.ts
@@ -48,7 +48,7 @@ import { LATEST_RELEASE } from './whats-new-releases';
             <a
               href="https://pulpe.app/changelog"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
               class="inline-flex items-center gap-1 mt-3 text-label-medium text-primary hover:underline"
               data-testid="whats-new-changelog-link"
             >

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -42,7 +42,7 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=(), interest-cohort=()"
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=(), interest-cohort=(), browsing-topics=()"
         },
         {
           "key": "Content-Security-Policy",

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -42,7 +42,7 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=(), interest-cohort=(), browsing-topics=()"
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=(), browsing-topics=()"
         },
         {
           "key": "Content-Security-Policy",

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -33,12 +33,20 @@
           "value": "nosniff"
         },
         {
-          "key": "X-XSS-Protection",
-          "value": "1; mode=block"
-        },
-        {
           "key": "Strict-Transport-Security",
           "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=(), interest-cohort=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://eu-assets.i.posthog.com; script-src-elem 'self' 'unsafe-inline' https://eu-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://eu.i.posthog.com https://eu-assets.i.posthog.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'; upgrade-insecure-requests"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -63,12 +63,20 @@
           "value": "nosniff"
         },
         {
-          "key": "X-XSS-Protection",
-          "value": "1; mode=block"
-        },
-        {
           "key": "Strict-Transport-Security",
           "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://eu-assets.i.posthog.com; script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com https://eu-assets.i.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://eu.i.posthog.com https://eu-assets.i.posthog.com https://challenges.cloudflare.com; frame-src 'self' https://challenges.cloudflare.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'; worker-src 'self' blob:"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -72,11 +72,11 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=()"
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=(), interest-cohort=(), browsing-topics=()"
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://eu-assets.i.posthog.com; script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com https://eu-assets.i.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://eu.i.posthog.com https://eu-assets.i.posthog.com https://challenges.cloudflare.com; frame-src 'self' https://challenges.cloudflare.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'; worker-src 'self' blob:"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://eu-assets.i.posthog.com; script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com https://eu-assets.i.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://eu.i.posthog.com https://eu-assets.i.posthog.com https://challenges.cloudflare.com; frame-src 'self' https://challenges.cloudflare.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'; worker-src 'self' blob:; upgrade-insecure-requests"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -72,7 +72,7 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=(), interest-cohort=(), browsing-topics=()"
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), accelerometer=(), gyroscope=(), browsing-topics=()"
         },
         {
           "key": "Content-Security-Policy",


### PR DESCRIPTION
## Summary

OWASP Top 10 audit findings — applied safe fixes to webapp + landing. Architectural items (token storage, dep bumps) deferred to follow-up.

### Commit 1 — webapp + root vercel.json
- **CSP**: added `Content-Security-Policy` (script-src self+inline+Cloudflare Turnstile+PostHog assets; connect-src Supabase wss/https + PostHog + Cloudflare; frame-ancestors none; object-src none)
- **Headers**: added `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (camera/mic/geo/payment/usb/sensors blocked), removed deprecated `X-XSS-Protection`
- **Logger**: sanitize `userId` / `user_id` / `sub` keys to prevent PII leakage to console + PostHog (GDPR)
- **`rel="noopener noreferrer"`** on all `target="_blank"` links (privacy, signup, welcome, whats-new, about) — was missing on external GitHub link, others upgraded from `noopener` only
- 2 unit specs updated to match new rel value

### Commit 2 — landing/vercel.json
- **CSP**: tighter version for static export (script-src self+inline+PostHog; frame-ancestors none; upgrade-insecure-requests)
- Same headers hardening as webapp (Referrer-Policy, Permissions-Policy, drop X-XSS-Protection)

## Deferred (non-blocking, separate PRs)
- **Critical**: rotate `POSTHOG_PERSONAL_API_KEY` in PostHog dashboard (was in worktree `.env`, never committed to git)
- **High**: bump `@angular/*` to ≥21.2.4 (5 known XSS advisories)
- **High**: replace or upgrade `xlsx@0.18.5` (prototype pollution + ReDoS)
- **High**: bump Next.js to `^15.5.15` (5 advisories, mostly N/A under static export)
- **High**: migrate Supabase session + client encryption key off `localStorage` to httpOnly cookies (single XSS = full account takeover today)
- **Medium**: gitignore `landing/.env.development` to prevent future secret leaks
- Add `pnpm audit` as blocking CI step

## Test plan
- [x] `pnpm quality` — 0 errors
- [x] `pnpm test` — 1938/1938 unit tests pass (frontend)
- [x] `pnpm lint` — landing clean
- [ ] **CSP smoke test on preview deploy** — watch browser console for blocked resources (Material/PostHog/Turnstile/Supabase). Tighten or relax CSP as needed before promoting to prod.
- [ ] Verify PostHog distinct_id flow still works end-to-end
- [ ] Verify Cloudflare Turnstile renders + validates on auth flows

🔒 PUL-215