### PR TITLE
feat(observability): propagate X-Request-Id correlation id FE↔BE + PostHog

### DIFF
--- a/backend-nest/src/app.module.ts
+++ b/backend-nest/src/app.module.ts
@@ -8,7 +8,6 @@ import {
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_GUARD, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 import { ThrottlerModule } from '@nestjs/throttler';
-import { randomUUID } from 'crypto';
 import { CurlGenerator } from 'curl-generator';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { ClsModule } from 'nestjs-cls';
@@ -55,31 +54,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 
 // Utils
 import { anonymizeIp, parseDeviceType } from '@common/utils/log-anonymization';
-
-// Logger configuration helpers
-function createRequestIdGenerator() {
-  return (
-    req: IncomingMessage & {
-      headers: Record<string, string | string[] | undefined>;
-    },
-    res: ServerResponse,
-  ) => {
-    const reqId = (req as typeof req & { id?: string }).id;
-    if (reqId) return reqId;
-
-    const headerValue = req.headers['x-request-id'];
-    if (headerValue) {
-      const existingId = Array.isArray(headerValue)
-        ? headerValue[0]
-        : headerValue;
-      if (existingId) return existingId;
-    }
-
-    const id = randomUUID();
-    res.setHeader('X-Request-Id', id);
-    return id;
-  };
-}
+import { createRequestIdGenerator } from '@common/utils/request-id';
 
 function createLoggerTransport(isProdLike: boolean) {
   if (!isProdLike) {

--- a/backend-nest/src/common/utils/request-id.spec.ts
+++ b/backend-nest/src/common/utils/request-id.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { createRequestIdGenerator } from './request-id';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+type Req = IncomingMessage & {
+  id?: string | number | object;
+  headers: Record<string, string | string[] | undefined>;
+};
+
+const createRes = (): {
+  res: ServerResponse;
+  setHeader: ReturnType<typeof mock>;
+} => {
+  const setHeader = mock(() => undefined);
+  const res = { setHeader } as unknown as ServerResponse;
+  return { res, setHeader };
+};
+
+const createReq = (overrides: Partial<Req> = {}): Req =>
+  ({
+    id: undefined,
+    headers: {},
+    ...overrides,
+  }) as Req;
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('createRequestIdGenerator', () => {
+  it('should reuse req.id when already set by upstream middleware', () => {
+    const generator = createRequestIdGenerator();
+    const req = createReq({ id: 'upstream-id-123' });
+    const { res, setHeader } = createRes();
+
+    const result = generator(req, res);
+
+    expect(result).toBe('upstream-id-123');
+    expect(setHeader).not.toHaveBeenCalled();
+  });
+
+  it('should reuse the incoming x-request-id header when present', () => {
+    const generator = createRequestIdGenerator();
+    const incomingId = 'feedf00d-dead-beef-cafe-1234567890ab';
+    const req = createReq({ headers: { 'x-request-id': incomingId } });
+    const { res, setHeader } = createRes();
+
+    const result = generator(req, res);
+
+    expect(result).toBe(incomingId);
+    expect(setHeader).toHaveBeenCalledWith('X-Request-Id', incomingId);
+  });
+
+  it('should pick the first value when x-request-id is an array', () => {
+    const generator = createRequestIdGenerator();
+    const req = createReq({
+      headers: { 'x-request-id': ['first-id', 'second-id'] },
+    });
+    const { res, setHeader } = createRes();
+
+    const result = generator(req, res);
+
+    expect(result).toBe('first-id');
+    expect(setHeader).toHaveBeenCalledWith('X-Request-Id', 'first-id');
+  });
+
+  it('should generate a UUID v4 when no header is provided', () => {
+    const generator = createRequestIdGenerator();
+    const req = createReq();
+    const { res, setHeader } = createRes();
+
+    const result = generator(req, res);
+
+    expect(result).toMatch(UUID_V4_PATTERN);
+    expect(setHeader).toHaveBeenCalledWith('X-Request-Id', result);
+  });
+
+  it('should generate a fresh UUID for each invocation when no header is provided', () => {
+    const generator = createRequestIdGenerator();
+    const firstReq = createReq();
+    const secondReq = createReq();
+    const { res: firstRes } = createRes();
+    const { res: secondRes } = createRes();
+
+    const firstId = generator(firstReq, firstRes);
+    const secondId = generator(secondReq, secondRes);
+
+    expect(firstId).not.toBe(secondId);
+  });
+
+  it('should fall back to generation when x-request-id is an empty string', () => {
+    const generator = createRequestIdGenerator();
+    const req = createReq({ headers: { 'x-request-id': '' } });
+    const { res, setHeader } = createRes();
+
+    const result = generator(req, res);
+
+    expect(result).toMatch(UUID_V4_PATTERN);
+    expect(setHeader).toHaveBeenCalledWith('X-Request-Id', result);
+  });
+});

--- a/backend-nest/src/common/utils/request-id.ts
+++ b/backend-nest/src/common/utils/request-id.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import { randomUUID } from 'crypto';
-import { REQUEST_ID_HEADER, REQUEST_ID_HEADER_LOWER } from 'pulpe-shared';
+import { REQUEST_ID_HEADER } from 'pulpe-shared';
+
+const REQUEST_ID_HEADER_LOWER = REQUEST_ID_HEADER.toLowerCase();
 
 type ReqId = string | number | object;
 

--- a/backend-nest/src/common/utils/request-id.ts
+++ b/backend-nest/src/common/utils/request-id.ts
@@ -1,0 +1,34 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import { randomUUID } from 'crypto';
+import { REQUEST_ID_HEADER, REQUEST_ID_HEADER_LOWER } from 'pulpe-shared';
+
+type ReqId = string | number | object;
+
+type ReqWithHeaders = IncomingMessage & {
+  id?: ReqId;
+  headers: Record<string, string | string[] | undefined>;
+};
+
+export function createRequestIdGenerator() {
+  return (req: ReqWithHeaders, res: ServerResponse): string | number => {
+    const existingId = req.id;
+    if (typeof existingId === 'string' || typeof existingId === 'number') {
+      return existingId;
+    }
+
+    const headerValue = req.headers[REQUEST_ID_HEADER_LOWER];
+    if (headerValue) {
+      const fromHeader = Array.isArray(headerValue)
+        ? headerValue[0]
+        : headerValue;
+      if (fromHeader) {
+        res.setHeader(REQUEST_ID_HEADER, fromHeader);
+        return fromHeader;
+      }
+    }
+
+    const generated = randomUUID();
+    res.setHeader(REQUEST_ID_HEADER, generated);
+    return generated;
+  };
+}

--- a/backend-nest/src/main.ts
+++ b/backend-nest/src/main.ts
@@ -8,6 +8,7 @@ import compression from 'compression';
 import { AppModule } from './app.module';
 import { cleanupOpenApiDoc } from 'nestjs-zod';
 import { isProductionLike, type Environment } from '@config/environment';
+import { REQUEST_ID_HEADER } from 'pulpe-shared';
 
 // ValidationPipe removed - using ZodValidationPipe from app.module.ts instead
 
@@ -23,7 +24,9 @@ function setupCors(app: import('@nestjs/common').INestApplication): void {
       'Authorization',
       'ngrok-skip-browser-warning',
       'X-Client-Key',
+      REQUEST_ID_HEADER,
     ],
+    exposedHeaders: [REQUEST_ID_HEADER],
     credentials: true,
   });
 }

--- a/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.spec.ts
@@ -1,0 +1,127 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import {
+  HttpClient,
+  HttpHeaders,
+  provideHttpClient,
+  withInterceptors,
+} from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { REQUEST_ID_HEADER } from 'pulpe-shared';
+
+import { PostHogService } from './posthog';
+import { ApplicationConfiguration } from '../config/application-configuration';
+import { Logger } from '../logging/logger';
+import { httpErrorInterceptor } from './http-error-interceptor';
+
+describe('httpErrorInterceptor', () => {
+  let http: HttpClient;
+  let httpTesting: HttpTestingController;
+  let captureException: ReturnType<typeof vi.fn>;
+
+  const url = 'http://localhost:3000/api/test';
+
+  beforeEach(() => {
+    captureException = vi.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(withInterceptors([httpErrorInterceptor])),
+        provideHttpClientTesting(),
+        { provide: PostHogService, useValue: { captureException } },
+        { provide: Logger, useValue: { debug: vi.fn(), warn: vi.fn() } },
+        {
+          provide: ApplicationConfiguration,
+          useValue: { isDevelopment: () => false },
+        },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('should attach request_id to PostHog context when the X-Request-Id header is present', () => {
+    const requestId = 'feedf00d-dead-beef-cafe-1234567890ab';
+    const headers = new HttpHeaders({ [REQUEST_ID_HEADER]: requestId });
+
+    http.get(url, { headers }).subscribe({ error: () => undefined });
+    const req = httpTesting.expectOne(url);
+    req.flush(
+      { code: 'ERR_X', message: 'boom' },
+      { status: 500, statusText: 'Server Error' },
+    );
+
+    expect(captureException).toHaveBeenCalledOnce();
+    const context = captureException.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(context['request_id']).toBe(requestId);
+  });
+
+  it('should omit request_id from PostHog context when the X-Request-Id header is missing', () => {
+    http.get(url).subscribe({ error: () => undefined });
+    const req = httpTesting.expectOne(url);
+    req.flush({ code: 'ERR_Y' }, { status: 500, statusText: 'Server Error' });
+
+    expect(captureException).toHaveBeenCalledOnce();
+    const context = captureException.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(context).not.toHaveProperty('request_id');
+  });
+
+  it('should not capture 401 errors (handled by authInterceptor)', () => {
+    const headers = new HttpHeaders({ [REQUEST_ID_HEADER]: 'any-id' });
+
+    http.get(url, { headers }).subscribe({ error: () => undefined });
+    const req = httpTesting.expectOne(url);
+    req.flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('should not capture 403 errors (handled by authInterceptor)', () => {
+    http.get(url).subscribe({ error: () => undefined });
+    const req = httpTesting.expectOne(url);
+    req.flush({}, { status: 403, statusText: 'Forbidden' });
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('should preserve request_id end-to-end including backend payload details', () => {
+    const requestId = 'abc-correlation-id-123';
+    const headers = new HttpHeaders({ [REQUEST_ID_HEADER]: requestId });
+    const backendPayload = {
+      success: false,
+      code: 'ERR_BUDGET_NOT_FOUND',
+      message: 'Budget not found',
+      statusCode: 404,
+      error: 'BusinessException',
+    };
+
+    http.get(url, { headers }).subscribe({ error: () => undefined });
+    const req = httpTesting.expectOne(url);
+    req.flush(backendPayload, { status: 404, statusText: 'Not Found' });
+
+    expect(captureException).toHaveBeenCalledOnce();
+    const context = captureException.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(context['request_id']).toBe(requestId);
+    expect(context['backendErrorCode']).toBe('ERR_BUDGET_NOT_FOUND');
+    expect(context['httpStatus']).toBe(404);
+  });
+});

--- a/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/http-error-interceptor.ts
@@ -6,6 +6,7 @@ import { inject } from '@angular/core';
 import { catchError, throwError } from 'rxjs';
 import { isExpectedBusinessHttpError } from '@core/api/http-expected-business-noise';
 import { PostHogService, sanitizeUrl, sanitizeRecord } from '@core/analytics';
+import { REQUEST_ID_HEADER } from 'pulpe-shared';
 import { Logger } from '../logging/logger';
 import { ApplicationConfiguration } from '../config/application-configuration';
 
@@ -17,6 +18,7 @@ export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
   const postHogService = inject(PostHogService);
   const logger = inject(Logger);
   const applicationConfiguration = inject(ApplicationConfiguration);
+  const requestId = req.headers.get(REQUEST_ID_HEADER) ?? undefined;
 
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
@@ -24,6 +26,7 @@ export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
       captureHttpError(
         error,
         req.method,
+        requestId,
         postHogService,
         logger,
         applicationConfiguration,
@@ -44,6 +47,7 @@ const AUTH_HANDLED_STATUSES = new Set([401, 403]);
 function captureHttpError(
   error: HttpErrorResponse,
   requestMethod: string,
+  requestId: string | undefined,
   postHogService: PostHogService,
   logger: Logger,
   applicationConfiguration: ApplicationConfiguration,
@@ -64,6 +68,7 @@ function captureHttpError(
       httpStatus: error.status,
       errorName: posthogError.name,
       errorMessage: posthogError.message,
+      ...(requestId ? { request_id: requestId } : {}),
     };
 
     if (error.url) {
@@ -136,6 +141,7 @@ interface HttpErrorContext extends Record<string, unknown> {
   httpStatus: number;
   errorName: string;
   errorMessage: string;
+  request_id?: string;
   httpUrl?: string;
   backendErrorCode?: string;
   backendErrorName?: string;

--- a/frontend/projects/webapp/src/app/core/analytics/posthog-sanitizer.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/posthog-sanitizer.spec.ts
@@ -103,6 +103,21 @@ describe('posthog-sanitizer', () => {
       });
     });
 
+    it('preserves the request_id correlation id (snake_case and camelCase)', () => {
+      const requestId = 'feedf00d-dead-beef-cafe-1234567890ab';
+      const sanitized = sanitizeRecord({
+        request_id: requestId,
+        requestId,
+        source: 'http_interceptor',
+      });
+
+      expect(sanitized).toEqual({
+        request_id: requestId,
+        requestId,
+        source: 'http_interceptor',
+      });
+    });
+
     it('recursively sanitizes nested objects', () => {
       const sanitized = sanitizeRecord({
         budget: {

--- a/frontend/projects/webapp/src/app/core/analytics/request-id-interceptor.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/request-id-interceptor.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import {
+  HttpHeaders,
   HttpRequest,
   HttpResponse,
   type HttpHandlerFn,
 } from '@angular/common/http';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { firstValueFrom, of } from 'rxjs';
 import { REQUEST_ID_HEADER } from 'pulpe-shared';
 import { requestIdInterceptor } from './request-id-interceptor';
@@ -53,24 +54,11 @@ describe('requestIdInterceptor', () => {
   it('should preserve an existing X-Request-Id header set by upstream code', async () => {
     const existingId = 'caller-provided-id-abc';
     const request = new HttpRequest('GET', '/api/test', null, {
-      headers: new HttpRequest('GET', '/').headers.set(
-        REQUEST_ID_HEADER,
-        existingId,
-      ),
+      headers: new HttpHeaders({ [REQUEST_ID_HEADER]: existingId }),
     });
 
     const forwarded = await runInterceptor(request);
 
     expect(forwarded.headers.get(REQUEST_ID_HEADER)).toBe(existingId);
-  });
-
-  it('should use crypto.randomUUID for header generation', async () => {
-    const spy = vi.spyOn(crypto, 'randomUUID');
-    const request = new HttpRequest('GET', '/api/test');
-
-    await runInterceptor(request);
-
-    expect(spy).toHaveBeenCalledOnce();
-    spy.mockRestore();
   });
 });

--- a/frontend/projects/webapp/src/app/core/analytics/request-id-interceptor.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/request-id-interceptor.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpRequest,
+  HttpResponse,
+  type HttpHandlerFn,
+} from '@angular/common/http';
+import { describe, it, expect, vi } from 'vitest';
+import { firstValueFrom, of } from 'rxjs';
+import { REQUEST_ID_HEADER } from 'pulpe-shared';
+import { requestIdInterceptor } from './request-id-interceptor';
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const runInterceptor = async (
+  request: HttpRequest<unknown>,
+): Promise<HttpRequest<unknown>> => {
+  let captured!: HttpRequest<unknown>;
+  const next: HttpHandlerFn = (req) => {
+    captured = req;
+    return of(new HttpResponse({ status: 200 }));
+  };
+
+  await TestBed.runInInjectionContext(() =>
+    firstValueFrom(requestIdInterceptor(request, next)),
+  );
+
+  return captured;
+};
+
+describe('requestIdInterceptor', () => {
+  it('should attach a UUID v4 X-Request-Id header to outgoing requests', async () => {
+    const request = new HttpRequest('GET', '/api/test');
+
+    const forwarded = await runInterceptor(request);
+
+    const headerValue = forwarded.headers.get(REQUEST_ID_HEADER);
+    expect(headerValue).toMatch(UUID_V4_PATTERN);
+  });
+
+  it('should generate a different id for each request', async () => {
+    const firstRequest = new HttpRequest('GET', '/api/first');
+    const secondRequest = new HttpRequest('GET', '/api/second');
+
+    const firstForwarded = await runInterceptor(firstRequest);
+    const secondForwarded = await runInterceptor(secondRequest);
+
+    expect(firstForwarded.headers.get(REQUEST_ID_HEADER)).not.toBe(
+      secondForwarded.headers.get(REQUEST_ID_HEADER),
+    );
+  });
+
+  it('should preserve an existing X-Request-Id header set by upstream code', async () => {
+    const existingId = 'caller-provided-id-abc';
+    const request = new HttpRequest('GET', '/api/test', null, {
+      headers: new HttpRequest('GET', '/').headers.set(
+        REQUEST_ID_HEADER,
+        existingId,
+      ),
+    });
+
+    const forwarded = await runInterceptor(request);
+
+    expect(forwarded.headers.get(REQUEST_ID_HEADER)).toBe(existingId);
+  });
+
+  it('should use crypto.randomUUID for header generation', async () => {
+    const spy = vi.spyOn(crypto, 'randomUUID');
+    const request = new HttpRequest('GET', '/api/test');
+
+    await runInterceptor(request);
+
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+});

--- a/frontend/projects/webapp/src/app/core/analytics/request-id-interceptor.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/request-id-interceptor.ts
@@ -1,0 +1,14 @@
+import { type HttpInterceptorFn } from '@angular/common/http';
+import { REQUEST_ID_HEADER } from 'pulpe-shared';
+
+export const requestIdInterceptor: HttpInterceptorFn = (req, next) => {
+  if (req.headers.has(REQUEST_ID_HEADER)) {
+    return next(req);
+  }
+
+  return next(
+    req.clone({
+      headers: req.headers.set(REQUEST_ID_HEADER, crypto.randomUUID()),
+    }),
+  );
+};

--- a/frontend/projects/webapp/src/app/core/auth/auth-providers.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-providers.ts
@@ -5,6 +5,7 @@ import { clientKeyInterceptor } from '@core/encryption';
 
 import { authInterceptor } from './auth-interceptor';
 import { httpErrorInterceptor } from '../analytics/http-error-interceptor';
+import { requestIdInterceptor } from '../analytics/request-id-interceptor';
 import { maintenanceInterceptor } from '../maintenance';
 import { ngrokInterceptor } from '../config/ngrok.interceptor';
 
@@ -12,6 +13,7 @@ export function provideAuth(): (Provider | EnvironmentProviders)[] {
   return [
     provideHttpClient(
       withInterceptors([
+        requestIdInterceptor, // Attach X-Request-Id correlation header before all other interceptors
         ngrokInterceptor, // Skip ngrok browser warning when tunneling
         maintenanceInterceptor, // Handle 503 maintenance before auth retry
         authInterceptor,

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -133,6 +133,12 @@ export {
 // Export error codes
 export { API_ERROR_CODES, type ApiErrorCode } from './src/error-codes.js';
 
+// Export HTTP header constants
+export {
+  REQUEST_ID_HEADER,
+  REQUEST_ID_HEADER_LOWER,
+} from './src/http-headers.js';
+
 // Export feature flag keys
 export {
   FEATURE_FLAGS,

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -134,10 +134,7 @@ export {
 export { API_ERROR_CODES, type ApiErrorCode } from './src/error-codes.js';
 
 // Export HTTP header constants
-export {
-  REQUEST_ID_HEADER,
-  REQUEST_ID_HEADER_LOWER,
-} from './src/http-headers.js';
+export { REQUEST_ID_HEADER } from './src/http-headers.js';
 
 // Export feature flag keys
 export {

--- a/shared/src/http-headers.ts
+++ b/shared/src/http-headers.ts
@@ -1,0 +1,17 @@
+/**
+ * HTTP header constants shared between frontend and backend.
+ *
+ * REQUEST_ID_HEADER carries a correlation id for the request:
+ * - Frontend generates a UUID per outgoing HTTP call and sends it.
+ * - Backend reuses it for Pino logs and echoes it in the response and error envelope.
+ * - PostHog events related to the request attach it as `request_id`.
+ * - Non-FE callers (iOS, server-to-server, curl) that omit the header get a
+ *   server-generated UUID instead.
+ */
+export const REQUEST_ID_HEADER = 'X-Request-Id';
+
+/**
+ * Lowercased variant for environments that normalize incoming headers
+ * (Node.js `IncomingMessage.headers`, Express, etc.).
+ */
+export const REQUEST_ID_HEADER_LOWER = 'x-request-id';

--- a/shared/src/http-headers.ts
+++ b/shared/src/http-headers.ts
@@ -9,9 +9,3 @@
  *   server-generated UUID instead.
  */
 export const REQUEST_ID_HEADER = 'X-Request-Id';
-
-/**
- * Lowercased variant for environments that normalize incoming headers
- * (Node.js `IncomingMessage.headers`, Express, etc.).
- */
-export const REQUEST_ID_HEADER_LOWER = 'x-request-id';


### PR DESCRIPTION
## Summary

- Frontend now generates a UUID per outgoing HTTP request and sends it as `X-Request-Id`; the backend reuses it for its Pino `reqId` and echoes it in the response and error envelope
- `httpErrorInterceptor` attaches `request_id` to every PostHog `$exception` event → captured errors are now cross-referencable with backend Pino logs
- `pulpe-shared` exposes `REQUEST_ID_HEADER` as the single source of truth (consumed by FE + BE)
- Backend CORS updated: `X-Request-Id` added to both `allowedHeaders` and `exposedHeaders`
- `createRequestIdGenerator()` extracted from `app.module.ts` (private fn) to `common/utils/request-id.ts` (testable util)
- Non-FE callers (iOS, server-to-server, curl) remain unaffected — backend still generates UUID when the header is absent

## Type

feat

## Test plan

- [x] `bun run quality` (backend) — pass, 0 errors
- [x] `pnpm run lint` (frontend) — pass
- [x] `tsc --noEmit` (frontend) — pass
- [x] Backend tests: 705 pass (+6 new: req-id generator covering reuse of `req.id`, header reuse, array header, UUID generation, uniqueness, empty-string fallback)
- [x] Frontend tests: 1950 pass (+10 new: 4 request-id-interceptor, 5 http-error-interceptor request_id propagation + 401/403 skip + end-to-end, 1 sanitizer regression for `request_id` pass-through)
- [ ] Manual round-trip in dev: DevTools Network → request `X-Request-Id` ↔ response `X-Request-Id` ↔ backend Pino `reqId` ↔ PostHog `$exception` event `request_id`