### PR TITLE
fix(security): validate X-Request-Id header against UUID v4 (PUL-228)

### DIFF
--- a/backend-nest/src/common/utils/request-id.spec.ts
+++ b/backend-nest/src/common/utils/request-id.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock } from 'bun:test';
-import { createRequestIdGenerator } from './request-id';
+import { createRequestIdGenerator, UUID_V4_PATTERN } from './request-id';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 type Req = IncomingMessage & {
@@ -23,8 +23,8 @@ const createReq = (overrides: Partial<Req> = {}): Req =>
     ...overrides,
   }) as Req;
 
-const UUID_V4_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const VALID_V4 = '550e8400-e29b-41d4-a716-446655440000';
+const ANOTHER_VALID_V4 = '6ba7b810-9dad-41d1-80b4-00c04fd430c8';
 
 describe('createRequestIdGenerator', () => {
   it('should reuse req.id when already set by upstream middleware', () => {
@@ -38,29 +38,28 @@ describe('createRequestIdGenerator', () => {
     expect(setHeader).not.toHaveBeenCalled();
   });
 
-  it('should reuse the incoming x-request-id header when present', () => {
+  it('should reuse the incoming x-request-id header when valid UUID v4', () => {
     const generator = createRequestIdGenerator();
-    const incomingId = 'feedf00d-dead-beef-cafe-1234567890ab';
-    const req = createReq({ headers: { 'x-request-id': incomingId } });
+    const req = createReq({ headers: { 'x-request-id': VALID_V4 } });
     const { res, setHeader } = createRes();
 
     const result = generator(req, res);
 
-    expect(result).toBe(incomingId);
-    expect(setHeader).toHaveBeenCalledWith('X-Request-Id', incomingId);
+    expect(result).toBe(VALID_V4);
+    expect(setHeader).toHaveBeenCalledWith('X-Request-Id', VALID_V4);
   });
 
-  it('should pick the first value when x-request-id is an array', () => {
+  it('should pick the first value when x-request-id is an array of valid UUIDs', () => {
     const generator = createRequestIdGenerator();
     const req = createReq({
-      headers: { 'x-request-id': ['first-id', 'second-id'] },
+      headers: { 'x-request-id': [VALID_V4, ANOTHER_VALID_V4] },
     });
     const { res, setHeader } = createRes();
 
     const result = generator(req, res);
 
-    expect(result).toBe('first-id');
-    expect(setHeader).toHaveBeenCalledWith('X-Request-Id', 'first-id');
+    expect(result).toBe(VALID_V4);
+    expect(setHeader).toHaveBeenCalledWith('X-Request-Id', VALID_V4);
   });
 
   it('should generate a UUID v4 when no header is provided', () => {
@@ -96,5 +95,54 @@ describe('createRequestIdGenerator', () => {
 
     expect(result).toMatch(UUID_V4_PATTERN);
     expect(setHeader).toHaveBeenCalledWith('X-Request-Id', result);
+  });
+
+  describe('input validation against untrusted client headers', () => {
+    const MALICIOUS_INPUTS: Array<[string, string]> = [
+      ['arbitrary non-UUID string', 'not-a-uuid'],
+      ['CRLF log injection attempt', 'valid\r\n[FAKE LOG] hacked'],
+      ['newline injection attempt', 'first-line\nsecond-line'],
+      ['null byte injection', 'abc\x00def'],
+      ['ANSI escape sequence', '\x1b[31mRED\x1b[0m'],
+      ['SQL injection-like payload', "1' OR '1'='1"],
+      ['path traversal payload', '../../etc/passwd'],
+      ['oversized 1000-char string', 'a'.repeat(1000)],
+      ['UUID v1 (wrong version)', '6ba7b810-9dad-11d1-80b4-00c04fd430c8'],
+      [
+        'UUID with invalid variant nibble',
+        '550e8400-e29b-41d4-c716-446655440000',
+      ],
+      ['UUID with extra trailing chars', `${VALID_V4}-extra`],
+      ['truncated UUID', '550e8400-e29b-41d4-a716'],
+    ];
+
+    for (const [label, payload] of MALICIOUS_INPUTS) {
+      it(`should reject ${label} and generate a fresh UUID v4`, () => {
+        const generator = createRequestIdGenerator();
+        const req = createReq({ headers: { 'x-request-id': payload } });
+        const { res, setHeader } = createRes();
+
+        const result = generator(req, res);
+
+        expect(result).not.toBe(payload);
+        expect(result).toMatch(UUID_V4_PATTERN);
+        expect(setHeader).toHaveBeenCalledWith('X-Request-Id', result);
+      });
+    }
+
+    it('should reject array whose first value is malicious and fall back to generation', () => {
+      const generator = createRequestIdGenerator();
+      const req = createReq({
+        headers: { 'x-request-id': ['malicious\r\nvalue', VALID_V4] },
+      });
+      const { res, setHeader } = createRes();
+
+      const result = generator(req, res);
+
+      expect(result).not.toBe('malicious\r\nvalue');
+      expect(result).not.toBe(VALID_V4);
+      expect(result).toMatch(UUID_V4_PATTERN);
+      expect(setHeader).toHaveBeenCalledWith('X-Request-Id', result);
+    });
   });
 });

--- a/backend-nest/src/common/utils/request-id.ts
+++ b/backend-nest/src/common/utils/request-id.ts
@@ -4,12 +4,19 @@ import { REQUEST_ID_HEADER } from 'pulpe-shared';
 
 const REQUEST_ID_HEADER_LOWER = REQUEST_ID_HEADER.toLowerCase();
 
+export const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 type ReqId = string | number | object;
 
 type ReqWithHeaders = IncomingMessage & {
   id?: ReqId;
   headers: Record<string, string | string[] | undefined>;
 };
+
+function isValidRequestId(value: unknown): value is string {
+  return typeof value === 'string' && UUID_V4_PATTERN.test(value);
+}
 
 export function createRequestIdGenerator() {
   return (req: ReqWithHeaders, res: ServerResponse): string | number => {
@@ -23,7 +30,7 @@ export function createRequestIdGenerator() {
       const fromHeader = Array.isArray(headerValue)
         ? headerValue[0]
         : headerValue;
-      if (fromHeader) {
+      if (isValidRequestId(fromHeader)) {
         res.setHeader(REQUEST_ID_HEADER, fromHeader);
         return fromHeader;
       }


### PR DESCRIPTION
## Summary

- Validates client-provided `X-Request-Id` header against UUID v4 before echoing it to the response or propagating it to logs / PostHog.
- Falls back to `randomUUID()` for any malformed value (non-UUID strings, wrong version, CRLF/null-byte injection, oversized payloads, etc.).
- `UUID_V4_PATTERN` exported from `request-id.ts` as canonical definition (was duplicated in the spec).

## Why

`X-Request-Id` was previously trusted as-is. Pino's structured JSON logging mitigates active log injection today, but the moment anyone interpolates the ID into a plain-text log message — or swaps loggers — the unvalidated value becomes a real injection vector. Validating at the boundary is defense-in-depth and what the spec already implied by defining `UUID_V4_PATTERN`.

Linear: [PUL-228](https://linear.app/pulpe/issue/PUL-228)

## Test plan

- [x] `bun test src/common/utils/request-id.spec.ts` — 19 pass, 0 fail (12 new malicious-input cases: CRLF, newline, null byte, ANSI, SQLi, path traversal, oversized 1k-char, UUID v1, bad variant nibble, trailing junk, truncated UUID, array-with-malicious-first)
- [x] `bun test` (full suite) — 718 pass, 0 fail
- [x] `bun run quality` — 0 errors (18 pre-existing warnings in unrelated files)
- [x] `pnpm quality` via pre-commit hook — green