### PR TITLE
fix(ios): keep biometric snapshot synced to rotated Supabase token

### DIFF
--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -167,12 +167,18 @@ actor AuthService {
         do {
             let session = try await supabase.auth.session
             return Self.userInfo(from: session.user, fallbackEmail: "")
+        } catch AuthError.sessionMissing {
+            // Genuinely logged out — no token to restore. Expected on every cold start of a
+            // signed-out user, so log at `.info` to keep `.error` meaningful (the line below
+            // stays reserved for the real bug we are hunting).
+            Logger.auth.info("validateSession: no active session (logged out)")
+            return nil
         } catch {
             // Instrumentation: surface WHY cold-start / foreground session restore fails.
-            // `AuthError.sessionMissing` = genuinely logged out (expected, no token); any
-            // other error here (e.g. refresh-token reuse detection revoking the family) is
-            // the bug we are hunting. `.public` so the exact Supabase cause is visible on a
-            // device repro without leaking tokens (AuthError descriptions carry no secrets).
+            // Any error reaching here (e.g. refresh-token reuse detection revoking the whole
+            // token family) is the bug we are hunting. `.public` so the exact Supabase cause
+            // is visible on a device repro without leaking tokens (AuthError descriptions
+            // carry no secrets).
             Logger.auth.error("validateSession: SDK session unavailable - \(error, privacy: .public)")
             return nil
         }
@@ -267,17 +273,17 @@ actor AuthService {
     /// drifted stale within ~1h and biometric re-entry replayed a revoked token (login
     /// screen Face ID dead-end + family revocation killing the next cold-start restore).
     /// Re-snapshotting on every `.tokenRefreshed` keeps the slot current. Only refreshes an
-    /// EXISTING slot — never creates one — so non-biometric users keep no snapshot, and the
-    /// `hasBiometricTokens` guard also prevents racing the single-use clear in
-    /// `validateBiometricSession` (if the slot was just cleared, we skip re-creating it).
+    /// EXISTING slot — never creates one — so non-biometric users keep no snapshot. The
+    /// check-and-write is atomic in `KeychainManager.resyncBiometricTokensIfPresent`, so a
+    /// concurrent clear (the single-use clear in `validateBiometricSession`, or a Face ID
+    /// disable) can never be straddled — a cleared slot is never resurrected.
     private func refreshBiometricSnapshotIfPresent(_ session: Session?) async {
         guard let session else { return }
-        guard await keychain.hasBiometricTokens() else { return }
-        let saved = await keychain.saveBiometricTokens(
+        let outcome = await keychain.resyncBiometricTokensIfPresent(
             accessToken: session.accessToken,
             refreshToken: session.refreshToken
         )
-        if !saved {
+        if case .failed = outcome {
             Logger.auth.warning("[AUTH] biometric snapshot resync failed after token refresh")
         }
     }

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -51,11 +51,12 @@ actor AuthService {
     private func startAuthStateListener() {
         authStateListenerTask?.cancel()
         let stream = supabase.auth.authStateChanges
-        authStateListenerTask = Task(name: "AuthService.authStateListener") {
-            for await (event, _) in stream {
+        authStateListenerTask = Task(name: "AuthService.authStateListener") { [weak self] in
+            for await (event, session) in stream {
                 switch event {
                 case .tokenRefreshed:
                     Logger.auth.debug("[AUTH] tokenRefreshed — SDK persisted via PulpeAuthStorage")
+                    await self?.refreshBiometricSnapshotIfPresent(session)
                 case .signedOut:
                     Logger.auth.debug("[AUTH] signedOut — SDK cleared storage")
                 default:
@@ -167,6 +168,12 @@ actor AuthService {
             let session = try await supabase.auth.session
             return Self.userInfo(from: session.user, fallbackEmail: "")
         } catch {
+            // Instrumentation: surface WHY cold-start / foreground session restore fails.
+            // `AuthError.sessionMissing` = genuinely logged out (expected, no token); any
+            // other error here (e.g. refresh-token reuse detection revoking the family) is
+            // the bug we are hunting. `.public` so the exact Supabase cause is visible on a
+            // device repro without leaking tokens (AuthError descriptions carry no secrets).
+            Logger.auth.error("validateSession: SDK session unavailable - \(error, privacy: .public)")
             return nil
         }
     }
@@ -253,6 +260,28 @@ actor AuthService {
         }
     }
 
+    /// Keeps the biometric snapshot in lock-step with the SDK's rotated refresh token.
+    /// `enable_refresh_token_rotation` is ON in Supabase: every refresh rotates the token,
+    /// and replaying a rotated-away one trips reuse detection — which revokes the WHOLE
+    /// token family. The snapshot was previously only re-written at auth transitions, so it
+    /// drifted stale within ~1h and biometric re-entry replayed a revoked token (login
+    /// screen Face ID dead-end + family revocation killing the next cold-start restore).
+    /// Re-snapshotting on every `.tokenRefreshed` keeps the slot current. Only refreshes an
+    /// EXISTING slot — never creates one — so non-biometric users keep no snapshot, and the
+    /// `hasBiometricTokens` guard also prevents racing the single-use clear in
+    /// `validateBiometricSession` (if the slot was just cleared, we skip re-creating it).
+    private func refreshBiometricSnapshotIfPresent(_ session: Session?) async {
+        guard let session else { return }
+        guard await keychain.hasBiometricTokens() else { return }
+        let saved = await keychain.saveBiometricTokens(
+            accessToken: session.accessToken,
+            refreshToken: session.refreshToken
+        )
+        if !saved {
+            Logger.auth.warning("[AUTH] biometric snapshot resync failed after token refresh")
+        }
+    }
+
     func validateBiometricSession() async throws -> BiometricSessionResult? {
         let hasBiometricTokens = await keychain.hasBiometricTokens()
         #if DEBUG
@@ -304,7 +333,16 @@ actor AuthService {
         do {
             session = try await supabase.auth.refreshSession(refreshToken: refreshToken)
         } catch {
-            Logger.auth.error("validateBiometricSession: session refresh failed - \(error)")
+            // The biometric snapshot is now kept in lock-step with the SDK's rotated token
+            // (see refreshBiometricSnapshotIfPresent), so a failure here means the refresh
+            // token is genuinely dead server-side (reuse detection / revoked / expired).
+            // `.public` + analytics so the exact Supabase cause is visible on a repro.
+            Logger.auth.error("validateBiometricSession: session refresh failed - \(error, privacy: .public)")
+            await MainActor.run {
+                AnalyticsService.shared.captureAuthError(
+                    .sessionRestoreFailed, error: error, method: "biometric_refresh"
+                )
+            }
             throw AuthServiceError.biometricSessionExpired
         }
 

--- a/ios/Pulpe/Core/Auth/KeychainManager.swift
+++ b/ios/Pulpe/Core/Auth/KeychainManager.swift
@@ -78,6 +78,25 @@ actor KeychainManager {
         return true
     }
 
+    /// Outcome of an atomic biometric resync — distinguishes "no slot to refresh"
+    /// (normal for non-biometric users) from an actual keychain write failure.
+    enum BiometricResyncOutcome {
+        case noSlot
+        case resnapshotted
+        case failed
+    }
+
+    /// Atomically re-snapshots the biometric slot **only if it already exists**.
+    /// The presence check and the write run in a single actor hop (both are
+    /// synchronous), so a concurrent `clearBiometricTokens()` cannot interleave
+    /// between them — this prevents resurrecting a slot the user just cleared
+    /// (e.g. disabling Face ID while a `.tokenRefreshed` fires). Never creates a
+    /// new slot, so non-biometric users keep no snapshot.
+    func resyncBiometricTokensIfPresent(accessToken: String, refreshToken: String) -> BiometricResyncOutcome {
+        guard hasBiometricTokens() else { return .noSlot }
+        return saveBiometricTokens(accessToken: accessToken, refreshToken: refreshToken) ? .resnapshotted : .failed
+    }
+
     func getBiometricAccessToken() throws -> String? {
         try getBiometric(key: biometricAccessTokenKey)
     }


### PR DESCRIPTION
## Summary

• Re-snapshot biometric tokens on every SDK `.tokenRefreshed` (gated by `hasBiometricTokens()`) so the biometric slot never drifts behind the rotated `PulpeAuthStorage` token
• Fixes cold-start logout after long background ("Ta session a expiré") and the silent Face ID button dead-end — both caused by replaying a stale snapshot that tripped Supabase refresh-token reuse detection and revoked the whole token family
• Add `.public` error logs + `session_restore_failed` / `biometric_refresh` analytics to confirm the exact Supabase cause on a device repro
• Refresh-token rotation stays enabled (project-wide control that protects the webapp)

Closes PUL-265

## Type

fix