### PR TITLE
fix(ios): harden BudgetDetails soft-delete — view teardown (PUL-264) + month nav (PUL-258)

### DIFF
--- a/ios/Pulpe/Domain/Services/BudgetLineService.swift
+++ b/ios/Pulpe/Domain/Services/BudgetLineService.swift
@@ -1,7 +1,15 @@
 import Foundation
 
+/// Mutation surface of `BudgetLineService` consumed by `BudgetDetailsCoordinator`.
+/// Lets the coordinator be driven by a test double so the deferred soft-delete
+/// commit can be asserted deterministically (see `MockBudgetLineService`).
+protocol BudgetLineServicing: Sendable {
+    func deleteBudgetLine(id: String) async throws
+    func toggleCheck(id: String) async throws -> BudgetLine
+}
+
 /// Service for budget line API operations
-actor BudgetLineService {
+actor BudgetLineService: BudgetLineServicing {
     static let shared = BudgetLineService()
 
     private let apiClient: APIClient

--- a/ios/Pulpe/Domain/Services/TransactionService.swift
+++ b/ios/Pulpe/Domain/Services/TransactionService.swift
@@ -1,7 +1,17 @@
 import Foundation
 
+/// Mutation surface of `TransactionService` consumed by `BudgetDetailsCoordinator`.
+/// Lets the coordinator be driven by a test double so the deferred soft-delete
+/// commit can be asserted deterministically (see `MockTransactionService`).
+protocol TransactionServicing: Sendable {
+    func deleteTransaction(id: String) async throws
+    func toggleCheck(id: String) async throws -> Transaction
+    func createTransaction(_ data: TransactionCreate) async throws -> Transaction
+    func updateTransaction(id: String, data: TransactionUpdate) async throws -> Transaction
+}
+
 /// Service for transaction API operations
-actor TransactionService {
+actor TransactionService: TransactionServicing {
     static let shared = TransactionService()
 
     private let apiClient: APIClient

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+SoftDelete.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+SoftDelete.swift
@@ -63,11 +63,17 @@ extension BudgetDetailsCoordinator {
 
     private func presentOrRefreshDeletionToast(context: ToastContext) {
         let copy = mutationQueue.deletionToastCopy(presentationCurrency: context.presentationCurrency)
-        let undo: @MainActor () async -> Void = { [weak self] in
-            await self?.restoreLastPendingDeletion(context: context)
+        // Capture `self` strongly: the undo/commit work must outlive the view.
+        // `ToastContext.toastManager` is app-scoped, so when the user leaves the
+        // screen the view-scoped coordinator has to stay alive until the toast
+        // resolves — otherwise the deferred server DELETE is silently dropped
+        // (PUL-264). No retain cycle: the coordinator never holds the toast
+        // manager, so `self` is released as soon as the toast clears.
+        let undo: @MainActor () async -> Void = {
+            await self.restoreLastPendingDeletion(context: context)
         }
-        let commit: @MainActor () async -> Void = { [weak self] in
-            await self?.commitPendingSoftDeletions()
+        let commit: @MainActor () async -> Void = {
+            await self.commitPendingSoftDeletions()
         }
         if mutationQueue.count == 1 {
             context.toastManager.showWithUndo(
@@ -105,11 +111,13 @@ extension BudgetDetailsCoordinator {
         guard !mutationQueue.isEmpty else { return }
 
         let copy = mutationQueue.deletionToastCopy(presentationCurrency: context.presentationCurrency)
-        let undo: @MainActor () async -> Void = { [weak self] in
-            await self?.restoreLastPendingDeletion(context: context)
+        // Strong `self` — same app-scoped lifetime rationale as the initial
+        // toast presentation above (PUL-264).
+        let undo: @MainActor () async -> Void = {
+            await self.restoreLastPendingDeletion(context: context)
         }
-        let commit: @MainActor () async -> Void = { [weak self] in
-            await self?.commitPendingSoftDeletions()
+        let commit: @MainActor () async -> Void = {
+            await self.commitPendingSoftDeletions()
         }
         context.toastManager.showWithUndo(
             copy.title,
@@ -120,14 +128,17 @@ extension BudgetDetailsCoordinator {
     }
 
     private func commitPendingSoftDeletions() async {
+        // The queue is the source of truth: undo already removed any restored
+        // item via `popLast`, so everything still pending must be committed —
+        // even if a reload re-injected the line into the store in the meantime
+        // (PUL-264). A store-membership guard here would let that reload cancel
+        // a deletion the user confirmed.
         let batch = mutationQueue.drainAll()
         for item in batch {
             switch item {
             case .transaction(let tx):
-                guard !dataStore.transactions.contains(where: { $0.id == tx.id }) else { continue }
                 await commitDeleteTransaction(tx)
             case .budgetLine(let line):
-                guard !dataStore.budgetLines.contains(where: { $0.id == line.id }) else { continue }
                 await commitDeleteBudgetLine(line)
             }
         }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+SoftDelete.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+SoftDelete.swift
@@ -158,6 +158,15 @@ extension BudgetDetailsCoordinator {
     private func commitDeleteTransaction(_ tx: Transaction) async {
         do {
             try await transactionService.deleteTransaction(id: tx.id)
+            // A reload racing the undo window can re-inject the row via
+            // `applyDetails` (which overwrites the store and cache from the
+            // server, where the row still existed). The server DELETE has now
+            // succeeded, so drop the re-injected copy to keep the rendered
+            // store and the detail cache consistent (PUL-264). Idempotent when
+            // no reload raced — the row is already absent.
+            dataStore.removeTransaction(id: tx.id)
+            dataStore.recomputeMetrics()
+            dataStore.syncCache()
         } catch {
             dataStore.appendTransaction(tx)
             dataStore.recomputeMetrics()
@@ -169,6 +178,11 @@ extension BudgetDetailsCoordinator {
     private func commitDeleteBudgetLine(_ line: BudgetLine) async {
         do {
             try await budgetLineService.deleteBudgetLine(id: line.id)
+            // See `commitDeleteTransaction`: re-remove in case a reload
+            // re-injected the line during the undo window (PUL-264). Idempotent.
+            dataStore.removeBudgetLine(id: line.id)
+            dataStore.recomputeMetrics()
+            dataStore.syncCache()
         } catch {
             dataStore.appendBudgetLine(line)
             dataStore.recomputeMetrics()

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+SoftDelete.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+SoftDelete.swift
@@ -127,6 +127,17 @@ extension BudgetDetailsCoordinator {
         )
     }
 
+    /// Finalize pending soft-deletions before the screen navigates to another
+    /// month. Commits them against the still-current store and drops any stale
+    /// error, so neither the undo/rollback paths nor an error banner can target
+    /// the next month's data (PUL-258). Must be awaited BEFORE
+    /// `dataStore.prepareNavigation` swaps the budget — otherwise a failed
+    /// commit re-injects into, and a stale error surfaces on, the wrong month.
+    func commitPendingSoftDeletionsBeforeNavigation() async {
+        await commitPendingSoftDeletions()
+        syncStore.clearError()
+    }
+
     private func commitPendingSoftDeletions() async {
         // The queue is the source of truth: undo already removed any restored
         // item via `popLast`, so everything still pending must be committed —

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
@@ -16,14 +16,14 @@ final class BudgetDetailsCoordinator {
     let mutationQueue: MutationQueue
 
     @ObservationIgnored private let budgetService: BudgetService
-    @ObservationIgnored let budgetLineService: BudgetLineService
-    @ObservationIgnored let transactionService: TransactionService
+    @ObservationIgnored let budgetLineService: any BudgetLineServicing
+    @ObservationIgnored let transactionService: any TransactionServicing
 
     init(
         budgetId: String,
         budgetService: BudgetService = .shared,
-        budgetLineService: BudgetLineService = .shared,
-        transactionService: TransactionService = .shared,
+        budgetLineService: any BudgetLineServicing = BudgetLineService.shared,
+        transactionService: any TransactionServicing = TransactionService.shared,
         cache: BudgetDetailCache = .shared,
         defaults: UserDefaults = .standard
     ) {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
@@ -55,6 +55,7 @@ final class BudgetDetailsCoordinator {
         case .reloadCurrentBudget:
             await reloadCurrentBudget()
         case .prepareNavigation(let id):
+            await commitPendingSoftDeletionsBeforeNavigation()
             dataStore.prepareNavigation(to: id)
         case .setCheckedFilter(let filter):
             filtersStore.setCheckedFilter(filter)

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSoftDeleteCommitTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSoftDeleteCommitTests.swift
@@ -93,6 +93,61 @@ struct BudgetDetailsCoordinatorSoftDeleteTests {
         #expect(service.deletedIds == ["line-1"])
     }
 
+    // MARK: - Commit must clear a reload-re-injected row from the rendered store
+
+    @Test
+    func budgetLineSoftDelete_reinjectedByReload_commitClearsRowFromStore() async {
+        let service = MockBudgetLineService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            budgetLineService: service
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1")
+        await coord.dispatch(.addBudgetLine(line))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteBudgetLine(line, ctx))
+
+        // A reload races the undo window and re-injects the not-yet-deleted line.
+        await coord.dispatch(.addBudgetLine(line))
+        #expect(coord.dataStore.budgetLines.count == 1)
+
+        // Toast ends → the server DELETE commits. The row the user confirmed
+        // gone must not linger in the store the screen renders, even though the
+        // reload put it back after the local soft-delete removed it.
+        toastManager.dismiss()
+
+        await waitForCondition { service.deleteBudgetLineCallCount == 1 }
+        await waitForCondition { coord.dataStore.budgetLines.isEmpty }
+        #expect(service.deletedIds == ["line-1"])
+    }
+
+    @Test
+    func transactionSoftDelete_reinjectedByReload_commitClearsRowFromStore() async {
+        let service = MockTransactionService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            transactionService: service
+        )
+        let tx = TestDataFactory.createTransaction(id: "tx-1")
+        await coord.dispatch(.addTransaction(tx))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteTransaction(tx, ctx))
+
+        // A reload races the undo window and re-injects the not-yet-deleted row.
+        await coord.dispatch(.addTransaction(tx))
+        #expect(coord.dataStore.transactions.count == 1)
+
+        toastManager.dismiss()
+
+        await waitForCondition { service.deleteTransactionCallCount == 1 }
+        await waitForCondition { coord.dataStore.transactions.isEmpty }
+        #expect(service.deletedIds == ["tx-1"])
+    }
+
     // MARK: - Undo must NOT reach the server (regression lock for the fix)
 
     @Test

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSoftDeleteCommitTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSoftDeleteCommitTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Regression harness for PUL-264 — the deferred soft-delete commit.
+///
+/// The soft-delete flow removes a line locally immediately, but defers the
+/// server `DELETE` until the undo toast ends. Two defects let that commit be
+/// silently dropped: (1) the commit closure captured `[weak self]` while the
+/// coordinator is a view-scoped `@State` and the toast is app-scoped — leaving
+/// the screen deallocated the coordinator and the commit no-op'd; (2) a guard
+/// skipped the `DELETE` whenever the line was still in the store, which a
+/// reload racing the undo window re-injects.
+///
+/// These tests inject a `MockBudgetLineService` / `MockTransactionService`
+/// (the protocol seam) so the server commit is observable. They fail on the
+/// pre-fix code and lock the behaviour so the bug class cannot silently return.
+@Suite(.serialized)
+@MainActor
+struct BudgetDetailsCoordinatorSoftDeleteTests {
+    // MARK: - Lifetime: commit must survive view teardown
+
+    @Test
+    func budgetLineSoftDelete_commitsToServer_afterCoordinatorDeallocated() async {
+        let service = MockBudgetLineService()
+        let toastManager = ToastManager()
+        var coord: BudgetDetailsCoordinator? = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            budgetLineService: service
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1")
+        await coord?.dispatch(.addBudgetLine(line))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord?.dispatch(.softDeleteBudgetLine(line, ctx))
+        #expect(coord?.dataStore.budgetLines.isEmpty == true)
+
+        // Leaving the screen before the undo window ends tears down the view and
+        // its @State coordinator. The app-scoped toast must still drive the commit.
+        coord = nil
+        toastManager.dismiss()
+
+        await waitForCondition { service.deleteBudgetLineCallCount == 1 }
+        #expect(service.deletedIds == ["line-1"])
+    }
+
+    @Test
+    func transactionSoftDelete_commitsToServer_afterCoordinatorDeallocated() async {
+        let service = MockTransactionService()
+        let toastManager = ToastManager()
+        var coord: BudgetDetailsCoordinator? = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            transactionService: service
+        )
+        let tx = TestDataFactory.createTransaction(id: "tx-1")
+        await coord?.dispatch(.addTransaction(tx))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord?.dispatch(.softDeleteTransaction(tx, ctx))
+        #expect(coord?.dataStore.transactions.isEmpty == true)
+
+        coord = nil
+        toastManager.dismiss()
+
+        await waitForCondition { service.deleteTransactionCallCount == 1 }
+        #expect(service.deletedIds == ["tx-1"])
+    }
+
+    // MARK: - Guard: a reload re-injecting the line must not cancel the commit
+
+    @Test
+    func budgetLineSoftDelete_lineReinjectedByReload_stillCommitsDelete() async {
+        let service = MockBudgetLineService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            budgetLineService: service
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1")
+        await coord.dispatch(.addBudgetLine(line))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteBudgetLine(line, ctx))
+        #expect(coord.dataStore.budgetLines.isEmpty)
+
+        // A reload races the undo window and re-injects the not-yet-deleted line.
+        await coord.dispatch(.addBudgetLine(line))
+        #expect(coord.dataStore.budgetLines.count == 1)
+
+        toastManager.dismiss()
+
+        await waitForCondition { service.deleteBudgetLineCallCount == 1 }
+        #expect(service.deletedIds == ["line-1"])
+    }
+
+    // MARK: - Undo must NOT reach the server (regression lock for the fix)
+
+    @Test
+    func budgetLineSoftDelete_undo_doesNotCommitDelete() async {
+        let service = MockBudgetLineService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            budgetLineService: service
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1")
+        await coord.dispatch(.addBudgetLine(line))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteBudgetLine(line, ctx))
+
+        toastManager.executeUndo()
+
+        // Undo restores the line locally and must never issue a server DELETE.
+        await waitForCondition { coord.dataStore.budgetLines.count == 1 }
+        #expect(service.deleteBudgetLineCallCount == 0)
+        #expect(coord.dataStore.budgetLines.first?.id == "line-1")
+    }
+}

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSoftDeleteCommitTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSoftDeleteCommitTests.swift
@@ -117,3 +117,74 @@ struct BudgetDetailsCoordinatorSoftDeleteTests {
         #expect(coord.dataStore.budgetLines.first?.id == "line-1")
     }
 }
+
+/// Regression harness for PUL-258 — month navigation must not strand a pending
+/// soft-delete or a stale error on the previous month.
+///
+/// `prepareNavigation(to:)` swaps the `BudgetDataStore`'s budget out from under
+/// the still-open undo toast and its pending `MutationQueue`. Before the fix it
+/// left the queue and `syncStore.error` untouched, so a delete queued on month
+/// A could later commit, roll back, or undo against month B's store — deleting
+/// or re-injecting a transaction on the wrong budget — and a month-A error
+/// banner bled onto month B.
+///
+/// The fix commits the pending deletions against the month being LEFT and
+/// clears the error, all BEFORE the store swaps. These tests are deterministic:
+/// every assertion holds synchronously inside the awaited `dispatch`, no toast
+/// timing involved.
+@Suite(.serialized)
+@MainActor
+struct BudgetDetailsCoordinatorNavFlushTests {
+    @Test
+    func prepareNavigation_withPendingSoftDelete_commitsToServerBeforeSwap() async {
+        let service = MockTransactionService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(budgetId: "month-a", transactionService: service)
+        let tx = TestDataFactory.createTransaction(id: "tx-1")
+        await coord.dispatch(.addTransaction(tx))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteTransaction(tx, ctx))
+
+        await coord.dispatch(.prepareNavigation(to: "month-b"))
+
+        // Leaving the month finalizes the deletion the user walked away from.
+        #expect(service.deletedIds == ["tx-1"])
+        #expect(coord.mutationQueue.isEmpty)
+        #expect(coord.dataStore.budgetId == "month-b")
+    }
+
+    @Test
+    func prepareNavigation_failedCommit_doesNotBleedIntoNextMonth() async {
+        let service = MockTransactionService()
+        service.deleteError = URLError(.badServerResponse)
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(budgetId: "month-a", transactionService: service)
+        let tx = TestDataFactory.createTransaction(id: "tx-1")
+        await coord.dispatch(.addTransaction(tx))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteTransaction(tx, ctx))
+
+        await coord.dispatch(.prepareNavigation(to: "month-b"))
+
+        // The commit ran during navigation (against month A) and failed; its
+        // rollback re-injected into the month being left, which the swap then
+        // discards. Month B must be clean and the queue drained — pre-fix the
+        // delete was never attempted (count 0) and the queue still held tx-1.
+        #expect(service.deleteTransactionCallCount == 1)
+        #expect(coord.mutationQueue.isEmpty)
+        #expect(coord.dataStore.budgetId == "month-b")
+        #expect(!coord.dataStore.transactions.contains { $0.id == "tx-1" })
+    }
+
+    @Test
+    func prepareNavigation_clearsStaleErrorFromPreviousMonth() async {
+        let coord = BudgetDetailsCoordinator(budgetId: "month-a")
+        coord.syncStore.setError(URLError(.badServerResponse))
+
+        await coord.dispatch(.prepareNavigation(to: "month-b"))
+
+        #expect(coord.syncStore.error == nil)
+    }
+}

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSoftDeleteCommitTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSoftDeleteCommitTests.swift
@@ -21,7 +21,7 @@ struct BudgetDetailsCoordinatorSoftDeleteTests {
     // MARK: - Lifetime: commit must survive view teardown
 
     @Test
-    func budgetLineSoftDelete_commitsToServer_afterCoordinatorDeallocated() async {
+    func budgetLineSoftDelete_commitsToServer_survivesViewTeardown() async {
         let service = MockBudgetLineService()
         let toastManager = ToastManager()
         var coord: BudgetDetailsCoordinator? = BudgetDetailsCoordinator(
@@ -45,7 +45,7 @@ struct BudgetDetailsCoordinatorSoftDeleteTests {
     }
 
     @Test
-    func transactionSoftDelete_commitsToServer_afterCoordinatorDeallocated() async {
+    func transactionSoftDelete_commitsToServer_survivesViewTeardown() async {
         let service = MockTransactionService()
         let toastManager = ToastManager()
         var coord: BudgetDetailsCoordinator? = BudgetDetailsCoordinator(

--- a/ios/PulpeTests/Helpers/MockBudgetLineService.swift
+++ b/ios/PulpeTests/Helpers/MockBudgetLineService.swift
@@ -1,0 +1,26 @@
+import Foundation
+@testable import Pulpe
+
+/// Test double for `BudgetLineServicing`. Records delete calls so suites can
+/// assert the deferred soft-delete commit actually reaches the server.
+///
+/// `@MainActor`-isolated (not an `actor`) on purpose: tests are `@MainActor`,
+/// so call counts are readable synchronously and can be polled with
+/// `waitForCondition` for deterministic assertions on the toast-driven commit.
+@MainActor
+final class MockBudgetLineService: BudgetLineServicing {
+    private(set) var deleteBudgetLineCallCount = 0
+    private(set) var deletedIds: [String] = []
+    var deleteError: Error?
+    var stubbedToggle: BudgetLine?
+
+    func deleteBudgetLine(id: String) async throws {
+        deleteBudgetLineCallCount += 1
+        deletedIds.append(id)
+        if let deleteError { throw deleteError }
+    }
+
+    func toggleCheck(id: String) async throws -> BudgetLine {
+        stubbedToggle ?? TestDataFactory.createBudgetLine(id: id)
+    }
+}

--- a/ios/PulpeTests/Helpers/MockTransactionService.swift
+++ b/ios/PulpeTests/Helpers/MockTransactionService.swift
@@ -1,0 +1,36 @@
+import Foundation
+@testable import Pulpe
+
+/// Test double for `TransactionServicing`. Records delete calls so suites can
+/// assert the deferred soft-delete commit actually reaches the server.
+///
+/// `@MainActor`-isolated (not an `actor`) on purpose: tests are `@MainActor`,
+/// so call counts are readable synchronously and can be polled with
+/// `waitForCondition` for deterministic assertions on the toast-driven commit.
+@MainActor
+final class MockTransactionService: TransactionServicing {
+    private(set) var deleteTransactionCallCount = 0
+    private(set) var deletedIds: [String] = []
+    var deleteError: Error?
+    var stubbedToggle: Transaction?
+    var stubbedCreated: Transaction?
+    var stubbedUpdated: Transaction?
+
+    func deleteTransaction(id: String) async throws {
+        deleteTransactionCallCount += 1
+        deletedIds.append(id)
+        if let deleteError { throw deleteError }
+    }
+
+    func toggleCheck(id: String) async throws -> Transaction {
+        stubbedToggle ?? TestDataFactory.createTransaction(id: id)
+    }
+
+    func createTransaction(_ data: TransactionCreate) async throws -> Transaction {
+        stubbedCreated ?? TestDataFactory.createTransaction()
+    }
+
+    func updateTransaction(id: String, data: TransactionUpdate) async throws -> Transaction {
+        stubbedUpdated ?? TestDataFactory.createTransaction(id: id)
+    }
+}


### PR DESCRIPTION
## Two coupled BudgetDetails soft-delete fixes

This branch carries two sibling fixes in the same soft-delete + undo flow:

- **[PUL-264](https://linear.app/pulpe/issue/PUL-264)** — deferred commit must survive view teardown (commit `61e60f4`).
- **[PUL-258](https://linear.app/pulpe/issue/PUL-258)** — month navigation must flush the pending queue before swapping budget (commit `f967397`).

---

## Problem ([PUL-258](https://linear.app/pulpe/issue/PUL-258))

`prepareNavigation(to:)` swapped `BudgetDataStore`'s budget out from under the still-open undo toast and its pending `MutationQueue`. A delete queued on the month being **left** could then commit, roll back, or undo against the **new** month's store — deleting or re-injecting a transaction on the wrong budget — and a stale month-A sync error bled onto month B.

PUL-264 removed the commit-time store-membership guard, which makes the commit-on-leave unconditional — exactly what makes this navigation flush safe.

## Fix ([PUL-258] — `BudgetDetailsCoordinator+SoftDelete.swift`, `BudgetDetailsCoordinator.swift`)

- `dispatch(.prepareNavigation)` now `await`s `commitPendingSoftDeletionsBeforeNavigation()` **before** `dataStore.prepareNavigation(to:)` swaps the budget.
- The new method commits pending deletions against the **still-current** store, then `syncStore.clearError()`. A failed commit rolls back into the month being left (discarded by the swap), never the new month; the lingering toast's undo/commit become no-ops once the queue is drained.

## Test harness ([PUL-258])

- `BudgetDetailsCoordinatorNavFlushTests` — 3 deterministic tests (every assertion holds synchronously inside the awaited `dispatch`, no toast timing): commit-before-swap, failed-commit-doesn't-bleed-into-next-month, stale-error-cleared. Fail on the pre-fix code, pass after.

---

## Problem ([PUL-264](https://linear.app/pulpe/issue/PUL-264))

Deleting an envelope (or transaction) in BudgetDetails confirmed via toast, but the line reappeared on the next reload. The soft-delete removes the line locally immediately and defers the server `DELETE` until the undo toast resolves. Two defects let that commit be silently dropped:

1. **Lifetime** — the toast's `undo`/`commit` closures captured `[weak self]`, but the coordinator is view-scoped (`@State`) while `ToastManager` is app-scoped. Leaving the screen before the undo window ended tore down the view, deallocated the coordinator, and turned the deferred commit into a no-op. The server never received the `DELETE`.
2. **Guard** — `commitPendingSoftDeletions` skipped the `DELETE` whenever the line was still in the store. A reload racing the undo window re-injects the not-yet-deleted line, so the guard cancelled a delete the user had confirmed.

Backend `DELETE /budget-lines/:id` was verified correct — bug was 100% iOS-side.

## Fix (`BudgetDetailsCoordinator+SoftDelete.swift`)

- Capture `self` **strongly** in the undo/commit closures so the app-scoped toast keeps the coordinator alive until it resolves. No retain cycle: the coordinator never holds the toast manager, so `self` is released once the toast clears (auto-dismiss always fires).
- **Drop the store-membership guard** in `commitPendingSoftDeletions`. Undo already pops the queue via `popLast`, so everything still pending is a confirmed delete — even if a reload re-injected it.

## Test harness (by design, so the bug class can't silently return)

- `BudgetLineServicing` / `TransactionServicing` protocol seams; actors conform; coordinator depends on `any …Servicing` (`.shared` defaults → prod + existing tests untouched). Mirrors the existing `UserSettingsServicing` pattern.
- `MockBudgetLineService` / `MockTransactionService` (`@MainActor` → synchronous reads for deterministic `waitForCondition` polling).
- `BudgetDetailsCoordinatorSoftDeleteTests` — 4 tests locking all three failure modes: lifetime (drop coordinator ref → toast still commits), guard (reload re-injects → still deletes), regression (undo → no `DELETE`). **Fail on the pre-fix code, pass after.**

## Verification

- Regression suite + existing Mutation + Toast suites green (red→green proven).
- `swiftlint --strict` clean.
- Pre-commit hook (turbo quality + swiftlint) green.

Net diff well under 300 LOC; `+SoftDelete.swift` ~169 LOC (no lint disable).
