### PR TITLE
test(backend): stub PostHog port in account-deletion integration spec (PUL-248)

### DIFF
--- a/backend-nest/src/modules/account-deletion/account-deletion.integration.spec.ts
+++ b/backend-nest/src/modules/account-deletion/account-deletion.integration.spec.ts
@@ -5,7 +5,15 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { LoggerModule } from 'nestjs-pino';
 import { AccountDeletionModule } from './account-deletion.module';
 import { CleanupExpiredDeletionsUseCase } from './application/cleanup-expired-deletions.use-case';
+import {
+  POSTHOG_PERSON_DELETION_PORT,
+  type PostHogPersonDeletionPort,
+} from './domain/ports/posthog-person-deletion.port';
 import type { Database } from '../../types/database.types';
+
+const stubPostHogPort: PostHogPersonDeletionPort = {
+  deletePerson: async () => ({ ok: true, statusCode: 202 }),
+};
 
 const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
 
@@ -53,7 +61,10 @@ describe('AccountDeletionService Integration', () => {
         }),
         AccountDeletionModule,
       ],
-    }).compile();
+    })
+      .overrideProvider(POSTHOG_PERSON_DELETION_PORT)
+      .useValue(stubPostHogPort)
+      .compile();
 
     useCase = moduleRef.get<CleanupExpiredDeletionsUseCase>(
       CleanupExpiredDeletionsUseCase,


### PR DESCRIPTION
## Quoi

L'integration spec `account-deletion.integration.spec.ts` importait `AccountDeletionModule` direct, qui wire le vrai `HttpPostHogPersonDeletionAdapter`, sans override du port. Si les 3 vars `POSTHOG_API_KEY`/`POSTHOG_PROJECT_ID`/`POSTHOG_HOST` étaient set + Supabase joignable, `useCase.execute()` émettait un vrai `POST .../persons/bulk_delete/` vers PostHog.

Fix : override `POSTHOG_PERSON_DELETION_PORT` avec un stub via `.overrideProvider().useValue()` → l'adapter live n'est plus jamais injecté.

## Pourquoi (impact réel, revu à la baisse)

Défaut d'isolation de test, pas un risque prod concret :
- **Pas reachable en CI** — les integration specs ne tournent pas en CI (`test:unit` = 3 fichiers nommés seulement) et `POSTHOG_API_KEY` n'est pas injecté dans le job de test.
- **Pas de pollution prod** — le `distinct_id` est un UUID de user test inexistant côté PostHog → `bulk_delete` = no-op (404 → soft success).
- Worst case réel : un appel HTTP authentifié gaspillé depuis une machine de dev avec `.env.local` complet.

Précédent : l'unit spec `cleanup-expired-deletions.use-case.spec.ts:44` mocke déjà ce port.

## Vérifs

- `bun run quality` → 0 erreurs
- `bun test account-deletion.integration.spec.ts` → 1 pass

Closes PUL-248