### PR TITLE
fix(backend): validate MIN <= LATEST app version at boot (PUL-242)

### DIFF
--- a/backend-nest/src/config/environment.spec.ts
+++ b/backend-nest/src/config/environment.spec.ts
@@ -209,4 +209,66 @@ describe('Environment Validation', () => {
       expect(() => validateConfig(config)).toThrow(/POSTHOG_PROJECT_ID/);
     });
   });
+
+  describe('Force-update version invariants (MIN <= LATEST)', () => {
+    const baseConfig = {
+      NODE_ENV: 'production',
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_ANON_KEY: 'prod-anon-key',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+      TURNSTILE_SECRET_KEY: 'prod-turnstile-key',
+      ENCRYPTION_MASTER_KEY:
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    };
+
+    it('should accept iOS versions when MIN is below LATEST', () => {
+      const config = {
+        ...baseConfig,
+        MIN_IOS_VERSION: '1.0.0',
+        LATEST_IOS_VERSION: '1.0.2',
+      };
+
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('should accept versions when MIN equals LATEST', () => {
+      const config = {
+        ...baseConfig,
+        MIN_IOS_VERSION: '2.1.0',
+        LATEST_IOS_VERSION: '2.1.0',
+      };
+
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('should reject when MIN_IOS_VERSION is above LATEST_IOS_VERSION', () => {
+      const config = {
+        ...baseConfig,
+        MIN_IOS_VERSION: '2.0.0',
+        LATEST_IOS_VERSION: '0.1.0',
+      };
+
+      expect(() => validateConfig(config)).toThrow(/LATEST_IOS_VERSION/);
+    });
+
+    it('should reject when MIN_WEB_VERSION is above LATEST_WEB_VERSION', () => {
+      const config = {
+        ...baseConfig,
+        MIN_WEB_VERSION: '3.0.0',
+        LATEST_WEB_VERSION: '2.9.9',
+      };
+
+      expect(() => validateConfig(config)).toThrow(/LATEST_WEB_VERSION/);
+    });
+
+    it('should compare segments numerically (1.0.10 is above 1.0.2)', () => {
+      const config = {
+        ...baseConfig,
+        MIN_IOS_VERSION: '1.0.2',
+        LATEST_IOS_VERSION: '1.0.10',
+      };
+
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+  });
 });

--- a/backend-nest/src/config/environment.ts
+++ b/backend-nest/src/config/environment.ts
@@ -1,72 +1,106 @@
 import { ConfigService } from '@nestjs/config';
 import { z } from 'zod';
 
-const envSchema = z.object({
-  NODE_ENV: z
-    .enum(['development', 'production', 'preview', 'test'])
-    .default('development'),
-  PORT: z.coerce.number().default(3000),
-  SUPABASE_URL: z.string().min(1, { error: 'SUPABASE_URL is required' }),
-  SUPABASE_ANON_KEY: z
-    .string()
-    .min(1, { error: 'SUPABASE_ANON_KEY is required' }),
-  SUPABASE_SERVICE_ROLE_KEY: z
-    .string()
-    .min(1, { error: 'SUPABASE_SERVICE_ROLE_KEY is required' }),
-  TURNSTILE_SECRET_KEY: z
-    .string()
-    .min(1, { error: 'TURNSTILE_SECRET_KEY is required' }),
-  ENCRYPTION_MASTER_KEY: z
-    .string()
-    .length(64, {
-      error:
-        'ENCRYPTION_MASTER_KEY must be exactly 64 hex characters (32 bytes)',
-    })
-    .regex(/^[0-9a-f]+$/i, {
-      error: 'ENCRYPTION_MASTER_KEY must be a valid hex string',
-    }),
-  CORS_ORIGIN: z.string().optional(),
-  DEBUG_HTTP_FULL: z.string().optional(),
-  MAINTENANCE_MODE: z.string().optional(),
-  IP_BLACKLIST: z.string().optional(),
+const SEMVER_SEGMENT_COUNT = 3;
 
-  // PostHog person deletion (RGPD Art. 17). Requires a Personal API Key
-  // with `person:write` scope — NOT a project key (PostHog rejects project
-  // keys for person deletion).
-  POSTHOG_API_KEY: z.string().optional(),
-  POSTHOG_PROJECT_ID: z
-    .string()
-    .regex(/^\d+$/, {
-      error: 'POSTHOG_PROJECT_ID must be a positive integer',
-    })
-    .optional(),
-  POSTHOG_HOST: z
-    .string()
-    .regex(/^https:\/\/[^/]+$/, {
-      error:
-        'POSTHOG_HOST must be HTTPS with no trailing slash or path (e.g. https://eu.posthog.com)',
-    })
-    .optional(),
+/**
+ * Returns true when `version <= ceiling`, comparing the three numeric
+ * `MAJOR.MINOR.PATCH` segments. Inputs are shape-validated by the
+ * `/^\d+\.\d+\.\d+$/` regex before this runs, so each split yields exactly
+ * three numbers.
+ */
+function isVersionAtMost(version: string, ceiling: string): boolean {
+  const parts = version.split('.').map(Number);
+  const ceilingParts = ceiling.split('.').map(Number);
+  for (let i = 0; i < SEMVER_SEGMENT_COUNT; i++) {
+    if (parts[i] !== ceilingParts[i]) {
+      return parts[i] < ceilingParts[i];
+    }
+  }
+  return true;
+}
 
-  // Force-update gate (consumed by GET /api/v1/app/version)
-  MIN_IOS_VERSION: z
-    .string()
-    .regex(/^\d+\.\d+\.\d+$/)
-    .default('1.0.0'),
-  LATEST_IOS_VERSION: z
-    .string()
-    .regex(/^\d+\.\d+\.\d+$/)
-    .default('1.0.0'),
-  IOS_STORE_URL: z.url().default('https://apps.apple.com/app/id6758464920'),
-  MIN_WEB_VERSION: z
-    .string()
-    .regex(/^\d+\.\d+\.\d+$/)
-    .default('0.0.1'),
-  LATEST_WEB_VERSION: z
-    .string()
-    .regex(/^\d+\.\d+\.\d+$/)
-    .default('0.0.1'),
-});
+const envSchema = z
+  .object({
+    NODE_ENV: z
+      .enum(['development', 'production', 'preview', 'test'])
+      .default('development'),
+    PORT: z.coerce.number().default(3000),
+    SUPABASE_URL: z.string().min(1, { error: 'SUPABASE_URL is required' }),
+    SUPABASE_ANON_KEY: z
+      .string()
+      .min(1, { error: 'SUPABASE_ANON_KEY is required' }),
+    SUPABASE_SERVICE_ROLE_KEY: z
+      .string()
+      .min(1, { error: 'SUPABASE_SERVICE_ROLE_KEY is required' }),
+    TURNSTILE_SECRET_KEY: z
+      .string()
+      .min(1, { error: 'TURNSTILE_SECRET_KEY is required' }),
+    ENCRYPTION_MASTER_KEY: z
+      .string()
+      .length(64, {
+        error:
+          'ENCRYPTION_MASTER_KEY must be exactly 64 hex characters (32 bytes)',
+      })
+      .regex(/^[0-9a-f]+$/i, {
+        error: 'ENCRYPTION_MASTER_KEY must be a valid hex string',
+      }),
+    CORS_ORIGIN: z.string().optional(),
+    DEBUG_HTTP_FULL: z.string().optional(),
+    MAINTENANCE_MODE: z.string().optional(),
+    IP_BLACKLIST: z.string().optional(),
+
+    // PostHog person deletion (RGPD Art. 17). Requires a Personal API Key
+    // with `person:write` scope — NOT a project key (PostHog rejects project
+    // keys for person deletion).
+    POSTHOG_API_KEY: z.string().optional(),
+    POSTHOG_PROJECT_ID: z
+      .string()
+      .regex(/^\d+$/, {
+        error: 'POSTHOG_PROJECT_ID must be a positive integer',
+      })
+      .optional(),
+    POSTHOG_HOST: z
+      .string()
+      .regex(/^https:\/\/[^/]+$/, {
+        error:
+          'POSTHOG_HOST must be HTTPS with no trailing slash or path (e.g. https://eu.posthog.com)',
+      })
+      .optional(),
+
+    // Force-update gate (consumed by GET /api/v1/app/version)
+    MIN_IOS_VERSION: z
+      .string()
+      .regex(/^\d+\.\d+\.\d+$/)
+      .default('1.0.0'),
+    LATEST_IOS_VERSION: z
+      .string()
+      .regex(/^\d+\.\d+\.\d+$/)
+      .default('1.0.0'),
+    IOS_STORE_URL: z.url().default('https://apps.apple.com/app/id6758464920'),
+    MIN_WEB_VERSION: z
+      .string()
+      .regex(/^\d+\.\d+\.\d+$/)
+      .default('0.0.1'),
+    LATEST_WEB_VERSION: z
+      .string()
+      .regex(/^\d+\.\d+\.\d+$/)
+      .default('0.0.1'),
+  })
+  .refine(
+    (env) => isVersionAtMost(env.MIN_IOS_VERSION, env.LATEST_IOS_VERSION),
+    {
+      message: 'LATEST_IOS_VERSION must be >= MIN_IOS_VERSION',
+      path: ['LATEST_IOS_VERSION'],
+    },
+  )
+  .refine(
+    (env) => isVersionAtMost(env.MIN_WEB_VERSION, env.LATEST_WEB_VERSION),
+    {
+      message: 'LATEST_WEB_VERSION must be >= MIN_WEB_VERSION',
+      path: ['LATEST_WEB_VERSION'],
+    },
+  );
 
 export type Environment = z.infer<typeof envSchema>;
 


### PR DESCRIPTION
## Problème

Les variables d'env de la force-update gate (`MIN_IOS_VERSION`/`LATEST_IOS_VERSION`, `MIN_WEB_VERSION`/`LATEST_WEB_VERSION`) n'étaient validées que sur leur **forme** semver. Rien ne garantissait `MIN <= LATEST`.

Une faute de frappe opérateur mettant `MIN_IOS_VERSION` au-dessus de toute version publiée déclenche la force-update gate pour les clients sans build conforme disponible (`AppVersionStore.check()` compare `currentVersion < minVersion`).

## Fix

Deux refinements cross-field sur `envSchema` → le backend fail-fast au boot quand `MIN > LATEST`, pour iOS **et** web. Validé via `validateConfig` (wired dans `ConfigModule.forRoot`, reçoit `process.env`).

- Helper `isVersionAtMost` : compare les 3 segments numériques (`1.0.10 > 1.0.2`).
- Forme semver déjà garantie par regex avant le refine.

## Tests

`environment.spec.ts` : +5 (iOS below/equal/inverted, web inverted, compare numérique). 21/21 pass, `pnpm quality` clean.

## Note

L'invariant est un garde-fou de défense en profondeur (attrape la config auto-incohérente), pas une garantie absolue : `latestVersion` reste saisi à la main et n'est pas consommé par la gate iOS aujourd'hui.