### PR TITLE
fix(ios): amount search matches displayed grouped value (PUL-247)

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/State/FiltersStore.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/State/FiltersStore.swift
@@ -141,7 +141,8 @@ final class FiltersStore {
     }
 
     /// Filters budget lines by name or by linked transaction names (accent and
-    /// case insensitive). O(n+m) with Dictionary indexing.
+    /// case insensitive). Amounts match the value **as displayed** to the user
+    /// (see `amountMatches`). O(n+m) with Dictionary indexing.
     static func filteredLines(
         _ lines: [BudgetLine],
         searchText: String,
@@ -154,12 +155,14 @@ final class FiltersStore {
             by: { $0.budgetLineId ?? "" }
         )
 
+        let amountNeedle = amountSearchKey(searchText)
+
         return lines.filter { line in
             line.name.localizedStandardContains(searchText) ||
-                "\(line.amount)".contains(searchText) ||
+                amountMatches(line.amount, needle: amountNeedle) ||
                 (transactionsByLineId[line.id]?.contains {
                     $0.name.localizedStandardContains(searchText) ||
-                        "\($0.amount)".contains(searchText)
+                        amountMatches($0.amount, needle: amountNeedle)
                 } ?? false)
         }
     }
@@ -182,10 +185,37 @@ final class FiltersStore {
         }
 
         guard !searchText.isEmpty else { return result }
+        let amountNeedle = amountSearchKey(searchText)
         return result.filter {
             $0.name.localizedStandardContains(searchText) ||
-                "\($0.amount)".contains(searchText)
+                amountMatches($0.amount, needle: amountNeedle)
         }
+    }
+
+    // MARK: - Amount search matching (PUL-247)
+
+    /// Canonicalises an amount string for search: maps the locale decimal
+    /// separator (`,` in fr-FR/EUR) to `.`, then keeps only digits and `.`.
+    /// This drops grouping separators (apostrophe, spaces, NBSP) and the currency
+    /// symbol, so the user's input and the displayed amount are compared on the
+    /// same footing regardless of locale. Returns `""` when no digit is present
+    /// (e.g. a lone space) so we never match every row.
+    private static func amountSearchKey(_ text: String) -> String {
+        let key = text
+            .replacingOccurrences(of: ",", with: ".")
+            .filter { $0.isNumber || $0 == "." }
+        return key.contains(where: \.isNumber) ? key : ""
+    }
+
+    /// Matches a needle against the amount **as the user sees it**. Both sides
+    /// are reduced to `amountSearchKey` form, which strips grouping and locale
+    /// decimal separators — so the displayed value's key is currency-independent
+    /// (`1'500.00` CHF and `1 500,00` EUR both reduce to `1500.00`). We therefore
+    /// format with an arbitrary fixed currency. Result: `1500`, `1'500`, `1 500`,
+    /// `1500.00` and `1 500,00` all match the `1500` amount.
+    private static func amountMatches(_ amount: Decimal, needle: String) -> Bool {
+        guard !needle.isEmpty else { return false }
+        return amountSearchKey(amount.asAmount(for: .chf)).contains(needle)
     }
 
     // MARK: - Instance forwarders (use store's current filters)

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/FiltersStoreTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/FiltersStoreTests.swift
@@ -304,6 +304,24 @@ struct FiltersStorePureTests {
         #expect(result.first?.id == "tx-2")
     }
 
+    @Test(arguments: ["1'500", "1 500", "1500,00"])
+    func combinedFilteredFreeTransactions_amountAsDisplayed_matches(query: String) {
+        // Free-transaction amount search also matches the displayed value (PUL-247).
+        let txs = [
+            TestDataFactory.createTransaction(id: "tx-1", name: "Coop", amount: 45),
+            TestDataFactory.createTransaction(id: "tx-2", name: "Migros", amount: 1500),
+        ]
+
+        let result = FiltersStore.combinedFilteredFreeTransactions(
+            txs,
+            searchText: query,
+            checkedFilter: .all
+        )
+
+        #expect(result.count == 1, "query \"\(query)\" should match only Migros (1500)")
+        #expect(result.first?.id == "tx-2")
+    }
+
     @Test
     func combinedFilteredFreeTransactions_bothFilters() {
         let txs = [
@@ -371,17 +389,51 @@ struct FiltersStorePureTests {
         #expect(result.count == 1)
     }
 
-    @Test
-    func filteredLines_amount_matchesExactAmount() {
+    /// Amount search must match the value **as displayed** to the user (PUL-247).
+    /// `1500` shows as `1'500.00` (CHF) / `1 500,00` (EUR); a user typing any of
+    /// the variants below — what they see — must find the `1500` line.
+    /// Every grouping/decimal variant the user might type — `1'500` (CHF
+    /// display), `1 500` / `1 500,00` (EUR display), `1500`, `1500.00` — must
+    /// find the `1500` line. The match is currency-independent by construction.
+    @Test(arguments: ["1500", "1'500", "1 500", "1500.00", "1500,00"])
+    func filteredLines_amountAsDisplayed_matches(query: String) {
         let lines = [
             TestDataFactory.createBudgetLine(id: "1", name: "Loyer", amount: 1500),
             TestDataFactory.createBudgetLine(id: "2", name: "Café", amount: 5),
         ]
 
-        let result = FiltersStore.filteredLines(lines, searchText: "1500", transactions: [])
+        let result = FiltersStore.filteredLines(lines, searchText: query, transactions: [])
+
+        #expect(result.count == 1, "query \"\(query)\" should match only the 1500 line")
+        #expect(result.first?.id == "1")
+    }
+
+    @Test
+    func filteredLines_amountWithSeparator_matchesLinkedTransaction() {
+        // Grouping separators must also match against linked transaction amounts (PUL-247).
+        let line = TestDataFactory.createBudgetLine(id: "line-x", name: "Courses", amount: 300)
+        let linkedTx = TestDataFactory.createTransaction(
+            id: "tx-linked",
+            budgetLineId: "line-x",
+            name: "Migros",
+            amount: 1500
+        )
+
+        let result = FiltersStore.filteredLines([line], searchText: "1'500", transactions: [linkedTx])
 
         #expect(result.count == 1)
-        #expect(result.first?.id == "1")
+        #expect(result.first?.id == "line-x")
+    }
+
+    @Test
+    func filteredLines_amountWrongValue_doesNotMatch() {
+        let lines = [
+            TestDataFactory.createBudgetLine(id: "1", name: "Loyer", amount: 1500),
+        ]
+
+        let result = FiltersStore.filteredLines(lines, searchText: "1600", transactions: [])
+
+        #expect(result.isEmpty)
     }
 
     @Test


### PR DESCRIPTION
## Summary

• Search by amount used the raw `Decimal` interpolation (`"\(line.amount)"` → `"1500"`), so a user typing the displayed value (`1'500` CHF / `1 500` EUR) matched nothing.
• Strip grouping separators (apostrophe `'`/`'`, space / NBSP / narrow-NBSP) from the search needle before comparing — `1500`, `1'500`, `1 500` all match `1500`.
• Applied to both `filteredLines` and `combinedFilteredFreeTransactions` (covers budget lines + linked + free transactions).
• 3 new deterministic tests (apostrophe, space, linked-tx) — fail on old code, green now. Full `FiltersStorePureTests`: 24/24 pass.

## Type

fix

Closes PUL-247