### PR TITLE
fix(backend): invalidate cache before recalculate in budget-line use cases (PUL-239)

### DIFF
--- a/backend-nest/src/modules/budget-line/application/create-budget-line.use-case.ts
+++ b/backend-nest/src/modules/budget-line/application/create-budget-line.use-case.ts
@@ -57,8 +57,10 @@ export class CreateBudgetLineUseCase {
 
     const entity = await this.repo.insert(input);
 
-    await this.budgetRecalculation.recalculate(entity.budgetId);
+    // Cache invalidation BEFORE recalc — if recalc fails, the stale cached
+    // list won't be locked in as authoritative against the just-mutated row.
     await this.cacheService.invalidateForUser(user.id);
+    await this.budgetRecalculation.recalculate(entity.budgetId);
 
     this.logger.info(
       {

--- a/backend-nest/src/modules/budget-line/application/reset-budget-line-from-template.use-case.ts
+++ b/backend-nest/src/modules/budget-line/application/reset-budget-line-from-template.use-case.ts
@@ -42,8 +42,10 @@ export class ResetBudgetLineFromTemplateUseCase {
     const patch = this.buildResetPatch(templateLine);
     const entity = await this.repo.update(id, patch);
 
-    await this.budgetRecalculation.recalculate(entity.budgetId);
+    // Cache invalidation BEFORE recalc — if recalc fails, the stale cached
+    // list won't be locked in as authoritative against the just-mutated row.
     await this.cacheService.invalidateForUser(user.id);
+    await this.budgetRecalculation.recalculate(entity.budgetId);
 
     this.logger.info(
       {

--- a/backend-nest/src/modules/budget-line/application/update-budget-line.use-case.spec.ts
+++ b/backend-nest/src/modules/budget-line/application/update-budget-line.use-case.spec.ts
@@ -169,4 +169,18 @@ describe('UpdateBudgetLineUseCase', () => {
 
     expect(callOrder).toEqual(['repo', 'recalculate']);
   });
+
+  it('should invalidate cache even when recalculate rejects', async () => {
+    mockBudget.recalculate.mockRejectedValueOnce(new Error('recalc failed'));
+
+    await expect(
+      useCase.execute(
+        mockEntity.id,
+        { id: mockEntity.id, amount: 1500 },
+        mockUser,
+      ),
+    ).rejects.toThrow('recalc failed');
+
+    expect(mockCache.invalidateForUser).toHaveBeenCalledWith(mockUser.id);
+  });
 });

--- a/backend-nest/src/modules/budget-line/application/update-budget-line.use-case.ts
+++ b/backend-nest/src/modules/budget-line/application/update-budget-line.use-case.ts
@@ -43,8 +43,10 @@ export class UpdateBudgetLineUseCase {
 
     const entity = await this.repo.update(id, patch);
 
-    await this.budgetRecalculation.recalculate(entity.budgetId);
+    // Cache invalidation BEFORE recalc — if recalc fails, the stale cached
+    // list won't be locked in as authoritative against the just-mutated row.
     await this.cacheService.invalidateForUser(user.id);
+    await this.budgetRecalculation.recalculate(entity.budgetId);
 
     this.logger.info(
       { budgetLineId: id, userId: user.id, operation: 'budgetLine.update' },


### PR DESCRIPTION
## Summary

• Reorder cache invalidation **before** `recalculate()` in `create`, `update`, and `reset-from-template` budget-line use cases — if recalc throws, the cache is no longer left serving the stale list against the just-mutated row
• Aligns the 3 use cases with the documented pattern already used in `update-transaction`, `remove-budget-line`, `bulk-template-line-operations`
• Adds behavior test `should invalidate cache even when recalculate rejects` on `UpdateBudgetLineUseCase` (asserts the outcome, not call order)

## Type

fix

Closes PUL-239