### PR TITLE
fix(ios): surface error toast on bulk-check partial failure (PUL-259)

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
@@ -75,9 +75,16 @@ final class BudgetDetailsCoordinator {
                 showCheckToastIfNeeded(for: line, context: ctx, amountsHidden: amountsHidden)
             }
         case .confirmCheckAll(let line, let checkAll, let ctx, let amountsHidden):
-            let succeeded = await confirmToggle(for: line, checkAll: checkAll)
-            if succeeded {
+            switch await confirmToggle(for: line, checkAll: checkAll) {
+            case .lineNotToggled:
+                break
+            case .allChecked:
                 showCheckToastIfNeeded(for: line, context: ctx, amountsHidden: amountsHidden)
+            case .partialTransactionFailure:
+                ctx.toastManager.show(
+                    "Certaines transactions n'ont pas pu être pointées",
+                    type: .error
+                )
             }
         case .toggleTransaction(let tx):
             await toggleTransaction(tx)
@@ -209,16 +216,26 @@ final class BudgetDetailsCoordinator {
         return await performToggleBudgetLine(line)
     }
 
-    /// Confirms toggle after user answers the alert. Returns true if toggle succeeded.
+    /// Outcome of confirming a "check all" toggle from the alert. Lets the
+    /// dispatcher pick the right toast: the "Pointé" success toast when every
+    /// transaction reconciled, or an error toast when the bulk-check partially
+    /// failed (which also rolled the local apply back via reload).
+    enum CheckAllConfirmation {
+        case lineNotToggled
+        case allChecked
+        case partialTransactionFailure
+    }
+
+    /// Confirms toggle after user answers the alert.
     @discardableResult
-    func confirmToggle(for line: BudgetLine, checkAll: Bool) async -> Bool {
+    func confirmToggle(for line: BudgetLine, checkAll: Bool) async -> CheckAllConfirmation {
         defer { syncStore.resetCheckAllState() }
 
-        let succeeded = await performToggleBudgetLine(line)
-        if succeeded, checkAll {
-            await checkAllAllocatedTransactions(for: line.id)
-        }
-        return succeeded
+        guard await performToggleBudgetLine(line) else { return .lineNotToggled }
+        guard checkAll else { return .allChecked }
+
+        let hadFailure = await checkAllAllocatedTransactions(for: line.id)
+        return hadFailure ? .partialTransactionFailure : .allChecked
     }
 
     @discardableResult
@@ -249,11 +266,14 @@ final class BudgetDetailsCoordinator {
     }
 
     /// Toggle all unchecked transactions for a budget line in parallel.
-    private func checkAllAllocatedTransactions(for budgetLineId: String) async {
+    /// Returns `true` if at least one server call failed — the caller surfaces
+    /// the error toast; this method only reconciles local state via reload.
+    @discardableResult
+    private func checkAllAllocatedTransactions(for budgetLineId: String) async -> Bool {
         let unchecked = dataStore.transactions.filter {
             $0.budgetLineId == budgetLineId && !$0.isChecked
         }
-        guard !unchecked.isEmpty else { return }
+        guard !unchecked.isEmpty else { return false }
 
         for tx in unchecked {
             syncStore.markSyncing(txId: tx.id)
@@ -289,6 +309,7 @@ final class BudgetDetailsCoordinator {
         if hadFailure {
             await reloadCurrentBudget()
         }
+        return hadFailure
     }
 
     private func toggleTransaction(_ transaction: Transaction) async {

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorBulkCheckTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorBulkCheckTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Regression harness for PUL-259 — bulk-check ("check all") of a budget line's
+/// transactions must surface a feedback toast when some server calls fail.
+///
+/// Before the fix `checkAllAllocatedTransactions` set `hadFailure`, reloaded the
+/// budget (silently reverting the user's optimistic checks), but emitted no
+/// feedback — and because the line toggle itself succeeded, the dispatcher even
+/// fired the "Pointé" success toast, masking the partial failure. These tests
+/// inject the `TransactionServicing` / `BudgetLineServicing` seam so the failure
+/// is deterministic, and assert the dispatcher picks the error toast (not the
+/// success one) on partial failure, while keeping the success toast on the
+/// all-succeed path.
+@Suite(.serialized)
+@MainActor
+struct BudgetDetailsCoordinatorBulkCheckTests {
+    @Test
+    func confirmCheckAll_partialTransactionFailure_showsErrorToastNotSuccess() async throws {
+        let lineService = MockBudgetLineService()
+        let txService = MockTransactionService()
+        // tx-2 fails server-side; tx-1 succeeds → genuine partial failure.
+        txService.failingToggleIds = ["tx-2"]
+        let coord = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            budgetLineService: lineService,
+            transactionService: txService
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1", kind: .expense, isChecked: false)
+        let tx1 = TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "line-1", isChecked: false)
+        let tx2 = TestDataFactory.createTransaction(id: "tx-2", budgetLineId: "line-1", isChecked: false)
+        await coord.dispatch(.addBudgetLine(line))
+        await coord.dispatch(.addTransaction(tx1))
+        await coord.dispatch(.addTransaction(tx2))
+
+        let toastManager = ToastManager()
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.confirmCheckAll(line: line, checkAll: true, ctx, amountsHidden: false))
+
+        let toast = try #require(toastManager.currentToast)
+        #expect(toast.message == "Certaines transactions n'ont pas pu être pointées")
+        #expect(toast.type == .error)
+        // The success toast must not have overwritten the error.
+        #expect(!toast.message.hasPrefix("Pointé"))
+    }
+
+    @Test
+    func confirmCheckAll_allTransactionsSucceed_showsSuccessToast() async throws {
+        let lineService = MockBudgetLineService()
+        let txService = MockTransactionService()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            budgetLineService: lineService,
+            transactionService: txService
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1", amount: 100, kind: .expense, isChecked: false)
+        let tx1 = TestDataFactory.createTransaction(id: "tx-1", budgetLineId: "line-1", isChecked: false)
+        await coord.dispatch(.addBudgetLine(line))
+        await coord.dispatch(.addTransaction(tx1))
+
+        let toastManager = ToastManager()
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.confirmCheckAll(line: line, checkAll: true, ctx, amountsHidden: false))
+
+        let toast = try #require(toastManager.currentToast)
+        #expect(toast.message.hasPrefix("Pointé"))
+        #expect(toast.type == .success)
+    }
+}

--- a/ios/PulpeTests/Helpers/MockTransactionService.swift
+++ b/ios/PulpeTests/Helpers/MockTransactionService.swift
@@ -15,6 +15,9 @@ final class MockTransactionService: TransactionServicing {
     var stubbedToggle: Transaction?
     var stubbedCreated: Transaction?
     var stubbedUpdated: Transaction?
+    /// Transaction ids whose `toggleCheck` should throw — drives partial
+    /// bulk-check failures deterministically (PUL-259).
+    var failingToggleIds: Set<String> = []
 
     func deleteTransaction(id: String) async throws {
         deleteTransactionCallCount += 1
@@ -23,7 +26,8 @@ final class MockTransactionService: TransactionServicing {
     }
 
     func toggleCheck(id: String) async throws -> Transaction {
-        stubbedToggle ?? TestDataFactory.createTransaction(id: id)
+        if failingToggleIds.contains(id) { throw URLError(.badServerResponse) }
+        return stubbedToggle ?? TestDataFactory.createTransaction(id: id)
     }
 
     func createTransaction(_ data: TransactionCreate) async throws -> Transaction {


### PR DESCRIPTION
## Contexte

PUL-259. Découvert en review post-merge v0.35.0 du refactor BudgetDetails (PUL-209).

## Problème

`checkAllAllocatedTransactions` (bulk-check "pointer toutes les transactions" d'une ligne) avalait les échecs partiels : sur un échec serveur parmi N, il settait `hadFailure`, rechargeait le budget (annulant silencieusement les coches optimistes de l'user) mais **n'émettait aucun feedback**.

Deux nuances trouvées en creusant — au-delà du fix suggéré dans le ticket :

1. **`setError` est une impasse ici.** `syncStore.error` n'a qu'un seul consommateur : le projector ne le rend qu'en **écran terminal plein**, et uniquement si `budget == nil`. Pendant un bulk-check le budget est toujours chargé → `setError` mettrait un état jamais affiché. (Et la signature proposée `setError("string")` ne compile pas — ça prend un `Error`.)
2. **Le toast succès écrasait l'erreur.** Le toggle de la *ligne* réussit (seules des transactions échouent), donc `dispatchToggle` enchaînait sur le toast succès "Pointé" — qui aurait masqué tout toast d'erreur.

## Fix

Surface alignée avec la DA Pulpe = **toast**, comme le pattern succès existant (`showCheckToastIfNeeded`).

- `checkAllAllocatedTransactions(for:)` retourne `hadFailure: Bool`.
- `confirmToggle(for:checkAll:)` retourne un `CheckAllConfirmation` (`.lineNotToggled` / `.allChecked` / `.partialTransactionFailure`) pour que le dispatcher choisisse le bon toast.
- `dispatchToggle` :
  - `.allChecked` → toast succès "Pointé" (inchangé)
  - `.partialTransactionFailure` → `toastManager.show("Certaines transactions n'ont pas pu être pointées", type: .error)` au lieu du toast succès.

## Tests

`BudgetDetailsCoordinatorBulkCheckTests` (déterministes via le seam `TransactionServicing` + `failingToggleIds`) :
- `confirmCheckAll_partialTransactionFailure_showsErrorToastNotSuccess` — échec partiel → toast `.error`, pas "Pointé".
- `confirmCheckAll_allTransactionsSucceed_showsSuccessToast` — tout réussit → toast succès intact (non-régression).

`xcodebuild test` PulpeLocal : **37 tests / 4 suites verts** (BulkCheck + Mutation + SoftDelete + Toast — non-régression PUL-264 incluse). SwiftLint clean. Coordinator 339 LOC (< 350).

Closes PUL-259.
