### PR TITLE
fix(ios): coalesce BudgetDetails reloads via generation token (PUL-257)

### DIFF
--- a/ios/Pulpe/Domain/Services/BudgetService.swift
+++ b/ios/Pulpe/Domain/Services/BudgetService.swift
@@ -1,7 +1,16 @@
 import Foundation
 
+/// Read surface of `BudgetService` consumed by `BudgetDetailsCoordinator`'s
+/// reload paths. Lets the coordinator be driven by a test double so the
+/// reload-vs-optimistic-mutation race (PUL-257) can be asserted
+/// deterministically (see `MockBudgetService`).
+protocol BudgetServicing: Sendable {
+    func getBudgetWithDetails(id: String) async throws -> BudgetDetails
+    func getBudgetsSparse(fields: String, limit: Int?, year: Int?) async throws -> [BudgetSparse]
+}
+
 /// Service for budget-related API operations
-actor BudgetService {
+actor BudgetService: BudgetServicing {
     static let shared = BudgetService()
 
     // MARK: - Constants

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsAction.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsAction.swift
@@ -36,7 +36,6 @@ enum BudgetDetailsAction {
 
     // Transaction mutations
     case addTransaction(Transaction)
-    case updateTransaction(Transaction)
     case softDeleteTransaction(Transaction, ToastContext)
     case deleteTransaction(Transaction)
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
@@ -30,16 +30,6 @@ extension BudgetDetailsCoordinator {
         await reloadCurrentBudget()
     }
 
-    func updateTransaction(_ tx: Transaction) async {
-        if dataStore.transactions.contains(where: { $0.id == tx.id }) {
-            dataStore.updateTransaction(tx)
-            dataStore.recomputeMetrics()
-            dataStore.syncCache()
-            dataStore.invalidateAdjacentCache()
-        }
-        await reloadCurrentBudget()
-    }
-
     func deleteBudgetLine(_ line: BudgetLine) async {
         guard !(line.isRollover ?? false) else { return }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
@@ -15,13 +15,13 @@ final class BudgetDetailsCoordinator {
     let syncStore: SyncStateStore
     let mutationQueue: MutationQueue
 
-    @ObservationIgnored private let budgetService: BudgetService
+    @ObservationIgnored private let budgetService: any BudgetServicing
     @ObservationIgnored let budgetLineService: any BudgetLineServicing
     @ObservationIgnored let transactionService: any TransactionServicing
 
     init(
         budgetId: String,
-        budgetService: BudgetService = .shared,
+        budgetService: any BudgetServicing = BudgetService.shared,
         budgetLineService: any BudgetLineServicing = BudgetLineService.shared,
         transactionService: any TransactionServicing = TransactionService.shared,
         cache: BudgetDetailCache = .shared,
@@ -107,8 +107,6 @@ final class BudgetDetailsCoordinator {
         switch action {
         case .addTransaction(let tx):
             addTransaction(tx)
-        case .updateTransaction(let tx):
-            await updateTransaction(tx)
         case .softDeleteTransaction(let tx, let ctx):
             softDeleteTransaction(tx, context: ctx)
         case .deleteTransaction(let tx):
@@ -149,9 +147,10 @@ final class BudgetDetailsCoordinator {
         let loadStart = ContinuousClock.now
         defer { syncStore.setLoading(false) }
 
+        let generation = dataStore.mutationGeneration
         do {
             async let detailsTask = budgetService.getBudgetWithDetails(id: dataStore.budgetId)
-            async let budgetsTask = budgetService.getBudgetsSparse(fields: "month,year")
+            async let budgetsTask = budgetService.getBudgetsSparse(fields: "month,year", limit: nil, year: nil)
 
             let (details, budgets) = try await (detailsTask, budgetsTask)
 
@@ -159,7 +158,8 @@ final class BudgetDetailsCoordinator {
                 try await DesignTokens.Animation.ensureMinimumSkeletonTime(since: loadStart)
             }
 
-            dataStore.applyDetails(details)
+            // Drop the snapshot if an optimistic mutation landed mid-fetch (PUL-257).
+            dataStore.applyDetails(details, ifGenerationMatches: generation)
             dataStore.applyAllBudgets(budgets)
         } catch is CancellationError {
             // Task was cancelled, don't update error state
@@ -175,9 +175,16 @@ final class BudgetDetailsCoordinator {
         syncStore.clearError()
         defer { syncStore.setLoading(false) }
 
+        // Capture the generation BEFORE the fetch. If an optimistic mutation
+        // (toggle / add / update) lands while the network call is in flight,
+        // the snapshot is stale and `applyDetails(_:ifGenerationMatches:)` drops
+        // it rather than silently reverting that mutation (PUL-257). Guards the
+        // detached, non-cancellable reload fired after an edit save, which
+        // `.task(id:)` cancellation can't reach.
+        let generation = dataStore.mutationGeneration
         do {
             let details = try await budgetService.getBudgetWithDetails(id: dataStore.budgetId)
-            dataStore.applyDetails(details)
+            dataStore.applyDetails(details, ifGenerationMatches: generation)
         } catch is CancellationError {
             // Task was cancelled, don't update error state
         } catch {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/State/BudgetDataStore.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/State/BudgetDataStore.swift
@@ -33,6 +33,18 @@ final class BudgetDataStore {
     @ObservationIgnored private var cachedMetrics: BudgetFormulas.Metrics?
     @ObservationIgnored private var cachedRealizedMetrics: BudgetFormulas.RealizedMetrics?
 
+    // MARK: - Optimistic-mutation generation (PUL-257)
+
+    /// Monotonic counter bumped by every optimistic LOCAL source-state mutation
+    /// (and by `prepareNavigation`). A reload captures this BEFORE its network
+    /// fetch and re-checks it before applying the server snapshot via
+    /// `applyDetails(_:ifGenerationMatches:)`; if a mutation landed mid-flight
+    /// the stale snapshot is dropped instead of silently reverting the mutation.
+    /// `@ObservationIgnored` — pure bookkeeping, never drives the view.
+    @ObservationIgnored private(set) var mutationGeneration: Int = 0
+
+    private func bumpGeneration() { mutationGeneration &+= 1 }
+
     private let cache: BudgetDetailCache
 
     init(budgetId: String, cache: BudgetDetailCache = .shared) {
@@ -129,6 +141,18 @@ final class BudgetDataStore {
         )
     }
 
+    /// Apply a server snapshot only if no optimistic local mutation has landed
+    /// since `generation` was captured — i.e. the snapshot isn't stale (PUL-257).
+    /// Returns `true` when applied, `false` when dropped. Callers capture
+    /// `mutationGeneration` before their async fetch and pass it back here so a
+    /// reload that finishes after a concurrent mutation can't silently revert it.
+    @discardableResult
+    func applyDetails(_ details: BudgetDetails, ifGenerationMatches generation: Int) -> Bool {
+        guard mutationGeneration == generation else { return false }
+        applyDetails(details)
+        return true
+    }
+
     func applyAllBudgets(_ budgets: [BudgetSparse]) {
         allBudgets = budgets
         recomputeSortedBudgets()
@@ -154,48 +178,60 @@ final class BudgetDataStore {
             cachedMetrics = nil
             cachedRealizedMetrics = nil
         }
+        // Swapping the budget invalidates any in-flight reload of the previous
+        // month — bump so its stale snapshot is dropped on arrival (PUL-257).
+        bumpGeneration()
     }
 
     // Budget line collection mutations
     func appendBudgetLine(_ line: BudgetLine) {
         budgetLines.append(line)
+        bumpGeneration()
     }
 
     func updateBudgetLine(_ line: BudgetLine) {
         if let index = budgetLines.firstIndex(where: { $0.id == line.id }) {
             budgetLines[index] = line
         }
+        bumpGeneration()
     }
 
     func removeBudgetLine(id: String) {
         budgetLines.removeAll { $0.id == id }
+        bumpGeneration()
     }
 
     func setBudgetLines(_ lines: [BudgetLine]) {
         budgetLines = lines
+        bumpGeneration()
     }
 
     // Transaction collection mutations
     func appendTransaction(_ tx: Transaction) {
         transactions.append(tx)
+        bumpGeneration()
     }
 
     func updateTransaction(_ tx: Transaction) {
         if let index = transactions.firstIndex(where: { $0.id == tx.id }) {
             transactions[index] = tx
         }
+        bumpGeneration()
     }
 
     func removeTransaction(id: String) {
         transactions.removeAll { $0.id == id }
+        bumpGeneration()
     }
 
     func setTransactions(_ txs: [Transaction]) {
         transactions = txs
+        bumpGeneration()
     }
 
     func setBudget(_ value: Budget?) {
         budget = value
+        bumpGeneration()
     }
 
     // MARK: - Cache + metric helpers

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/State/BudgetDataStore.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/State/BudgetDataStore.swift
@@ -127,7 +127,10 @@ final class BudgetDataStore {
     }
 
     /// Apply fetched details to local state, recompute metrics, and update cache.
-    func applyDetails(_ details: BudgetDetails) {
+    /// Private: external callers must go through `applyDetails(_:ifGenerationMatches:)`
+    /// so a reload can never bypass the staleness guard and silently revert an
+    /// optimistic mutation (PUL-257).
+    private func applyDetails(_ details: BudgetDetails) {
         budget = details.budget
         budgetLines = details.budgetLines
         transactions = details.transactions

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorReloadRaceTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorReloadRaceTests.swift
@@ -104,6 +104,23 @@ struct BudgetDataStoreGenerationTests {
     }
 
     @Test
+    func prepareNavigation_bumpsGeneration() {
+        let budgetId = "gen-nav"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let store = BudgetDataStore(budgetId: budgetId)
+        let start = store.mutationGeneration
+
+        // Swapping the budget must bump so an in-flight reload of the previous
+        // month is dropped on arrival — the keystone of the detached-reload
+        // defense that `.task(id:)` cancellation can't reach (PUL-257 / PUL-258).
+        store.prepareNavigation(to: "gen-nav-other")
+
+        #expect(store.mutationGeneration == start + 1)
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+
+    @Test
     func applyDetails_withMatchingGeneration_applies() {
         let budgetId = "gen-match"
         BudgetDetailCache.shared.invalidate(budgetId: budgetId)

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorReloadRaceTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorReloadRaceTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Regression harness for PUL-257 — `reloadCurrentBudget()` had no coalescing,
+/// so a reload whose network fetch finished AFTER a concurrent optimistic
+/// mutation would blindly `applyDetails(...)` and silently revert it (lost
+/// toggle / add / edit on fast month-nav or a detached post-save reload).
+///
+/// The fix is a generation token on `BudgetDataStore`: every optimistic local
+/// mutation bumps `mutationGeneration`; a reload captures it before its fetch
+/// and drops the snapshot via `applyDetails(_:ifGenerationMatches:)` when a
+/// mutation landed mid-flight. A `MockBudgetService` gate reproduces the race
+/// deterministically — no sleeps, no flakiness. They fail on the pre-fix code.
+@Suite(.serialized)
+@MainActor
+struct BudgetDetailsCoordinatorReloadRaceTests {
+    @Test
+    func reload_staleSnapshotDuringConcurrentToggle_doesNotClobberMutation() async {
+        let budgetId = "pul257-stale"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let budgetService = MockBudgetService()
+        let lineService = MockBudgetLineService()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId,
+            budgetService: budgetService,
+            budgetLineService: lineService
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1", isChecked: false)
+        await coord.dispatch(.addBudgetLine(line))
+
+        // The reload's snapshot is STALE: captured before the toggle, line still
+        // unchecked. The server-confirmed toggle returns the line checked.
+        budgetService.stubbedDetails = BudgetDetails(
+            budget: TestDataFactory.createBudget(),
+            transactions: [],
+            budgetLines: [line]
+        )
+        lineService.stubbedToggle = line.toggled()
+        budgetService.gateDetails()
+
+        // Start the reload; it suspends inside getBudgetWithDetails.
+        let reload = Task { await coord.reloadCurrentBudget() }
+        await waitForCondition { budgetService.didEnterDetails }
+
+        // Mid-reload: the user toggles the line. Optimistic apply flips it
+        // checked and the server toggle completes — the mutation finishes
+        // "between" the reload's fetch start and its apply.
+        await coord.toggleBudgetLine(line)
+        #expect(coord.dataStore.budgetLines.first?.isChecked == true)
+
+        // Release the stale reload (its snapshot still has the line unchecked).
+        budgetService.releaseDetails()
+        await reload.value
+
+        // Fix: the stale snapshot is dropped → the toggle survives.
+        #expect(coord.dataStore.budgetLines.first?.isChecked == true)
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+
+    @Test
+    func reload_withoutConcurrentMutation_appliesServerSnapshot() async {
+        let budgetId = "pul257-fresh"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let budgetService = MockBudgetService()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId,
+            budgetService: budgetService
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1", isChecked: false)
+        await coord.dispatch(.addBudgetLine(line))
+
+        // No gate, no concurrent mutation: the server snapshot (line checked)
+        // must apply normally — the guard must not break the happy path.
+        budgetService.stubbedDetails = BudgetDetails(
+            budget: TestDataFactory.createBudget(),
+            transactions: [],
+            budgetLines: [line.toggled()]
+        )
+
+        await coord.reloadCurrentBudget()
+
+        #expect(coord.dataStore.budgetLines.first?.isChecked == true)
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+}
+
+/// Unit-level lock on the generation token mechanism that backs the fix above.
+@Suite(.serialized)
+@MainActor
+struct BudgetDataStoreGenerationTests {
+    @Test
+    func optimisticMutations_bumpGeneration() {
+        let store = BudgetDataStore(budgetId: "gen-bump")
+        let start = store.mutationGeneration
+
+        store.appendBudgetLine(TestDataFactory.createBudgetLine(id: "l1"))
+        store.appendTransaction(TestDataFactory.createTransaction(id: "t1"))
+        store.removeBudgetLine(id: "l1")
+
+        #expect(store.mutationGeneration == start + 3)
+    }
+
+    @Test
+    func applyDetails_withMatchingGeneration_applies() {
+        let budgetId = "gen-match"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let store = BudgetDataStore(budgetId: budgetId)
+        let captured = store.mutationGeneration
+
+        let details = BudgetDetails(
+            budget: TestDataFactory.createBudget(),
+            transactions: [TestDataFactory.createTransaction(id: "tx-1")],
+            budgetLines: []
+        )
+        let applied = store.applyDetails(details, ifGenerationMatches: captured)
+
+        #expect(applied)
+        #expect(store.transactions.contains { $0.id == "tx-1" })
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+
+    @Test
+    func applyDetails_withStaleGeneration_isDroppedAndPreservesMutation() {
+        let budgetId = "gen-stale"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let store = BudgetDataStore(budgetId: budgetId)
+        let captured = store.mutationGeneration
+
+        // An optimistic mutation lands after the generation was captured.
+        store.appendTransaction(TestDataFactory.createTransaction(id: "optimistic-tx"))
+
+        // A reload that started before the mutation tries to apply a snapshot
+        // that predates it (no transactions).
+        let staleDetails = BudgetDetails(
+            budget: TestDataFactory.createBudget(),
+            transactions: [],
+            budgetLines: []
+        )
+        let applied = store.applyDetails(staleDetails, ifGenerationMatches: captured)
+
+        #expect(!applied)
+        #expect(store.transactions.contains { $0.id == "optimistic-tx" })
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+}

--- a/ios/PulpeTests/Helpers/MockBudgetService.swift
+++ b/ios/PulpeTests/Helpers/MockBudgetService.swift
@@ -1,0 +1,56 @@
+import Foundation
+@testable import Pulpe
+
+/// Test double for `BudgetServicing`. Drives `BudgetDetailsCoordinator`'s reload
+/// paths so the reload-vs-optimistic-mutation race (PUL-257) can be asserted
+/// deterministically.
+///
+/// `@MainActor`-isolated (not an `actor`) on purpose: tests are `@MainActor`, so
+/// `didEnterDetails` / call counts are readable synchronously and pollable with
+/// `waitForCondition`. A `CheckedContinuation` gate lets a test suspend a reload
+/// mid-fetch, interleave an optimistic mutation, then release the stale snapshot.
+@MainActor
+final class MockBudgetService: BudgetServicing {
+    /// Snapshot returned by `getBudgetWithDetails` — the (possibly stale) server
+    /// state the reload will try to apply.
+    var stubbedDetails = BudgetDetails(
+        budget: TestDataFactory.createBudget(),
+        transactions: [],
+        budgetLines: []
+    )
+    var stubbedSparse: [BudgetSparse] = []
+    var detailsError: Error?
+
+    private(set) var getBudgetWithDetailsCallCount = 0
+    /// Flips true the moment a reload enters `getBudgetWithDetails`. Tests poll
+    /// this with `waitForCondition` to know the reload reached the gate.
+    private(set) var didEnterDetails = false
+
+    private var gateContinuation: CheckedContinuation<Void, Never>?
+    private var isGated = false
+
+    /// Suspend the next `getBudgetWithDetails` call until `releaseDetails()`.
+    func gateDetails() { isGated = true }
+
+    /// Resume a gated `getBudgetWithDetails` call.
+    func releaseDetails() {
+        gateContinuation?.resume()
+        gateContinuation = nil
+    }
+
+    func getBudgetWithDetails(id: String) async throws -> BudgetDetails {
+        getBudgetWithDetailsCallCount += 1
+        didEnterDetails = true
+        if isGated {
+            await withCheckedContinuation { continuation in
+                gateContinuation = continuation
+            }
+        }
+        if let detailsError { throw detailsError }
+        return stubbedDetails
+    }
+
+    func getBudgetsSparse(fields: String, limit: Int?, year: Int?) async throws -> [BudgetSparse] {
+        stubbedSparse
+    }
+}

--- a/ios/PulpeTests/Helpers/MockBudgetService.swift
+++ b/ios/PulpeTests/Helpers/MockBudgetService.swift
@@ -29,11 +29,16 @@ final class MockBudgetService: BudgetServicing {
     private var gateContinuation: CheckedContinuation<Void, Never>?
     private var isGated = false
 
-    /// Suspend the next `getBudgetWithDetails` call until `releaseDetails()`.
+    /// Arm a one-shot gate: the next `getBudgetWithDetails` call suspends until
+    /// `releaseDetails()`. One-shot by design — drive at most one gated call per
+    /// instance; `releaseDetails()` disarms so later calls pass through.
     func gateDetails() { isGated = true }
 
-    /// Resume a gated `getBudgetWithDetails` call.
+    /// Resume the gated `getBudgetWithDetails` call and disarm the gate, so any
+    /// later call on this instance returns immediately instead of suspending on
+    /// a continuation that would never resume.
     func releaseDetails() {
+        isGated = false
         gateContinuation?.resume()
         gateContinuation = nil
     }


### PR DESCRIPTION
## Problem

`BudgetDetailsCoordinator.reloadCurrentBudget()` / `loadDetails()` applied the fetched server snapshot via `dataStore.applyDetails(details)` **unconditionally**. A reload whose network fetch finishes *after* a concurrent optimistic mutation (toggle / add / edit) completes silently reverts that mutation — the classic "last `applyDetails` wins" race.

The originally suggested `Task?` + cancellation fix is **insufficient**: `EditTransactionPage` fires a detached, post-`dismiss()` reload (`Task { dispatch(.reloadCurrentBudget) }`) that escapes `.task(id:)` cancellation entirely.

## Fix — generation token

- `BudgetDataStore` carries a monotonic `mutationGeneration`, bumped by every optimistic **local** source-state mutation (append/update/remove/set lines & transactions, `setBudget`) and by `prepareNavigation`.
- `reloadCurrentBudget()` and `loadDetails()` capture the generation **before** the fetch, then apply via `applyDetails(_:ifGenerationMatches:)` which **drops the snapshot** if the generation moved mid-flight (a mutation landed in between). The store re-aligns on the next reload.
- Convergence reloads (post-`updateBudgetLine`, `checkAll` failure) are unaffected — they capture the generation *after* their own optimistic apply.

Also removes the dead `.updateTransaction(tx)` dispatch path (no view dispatched it) and adds a `BudgetServicing` seam so reloads can be gated in tests.

## Tests — deterministic, no sleeps

- `BudgetDetailsCoordinatorReloadRaceTests` — a `MockBudgetService` `CheckedContinuation` gate suspends a reload mid-fetch, an optimistic toggle is interleaved, the stale snapshot is released → the toggle survives. Plus a happy-path test (no concurrent mutation → snapshot applies).
- `BudgetDataStoreGenerationTests` — generation bumps per mutation + drop/apply by generation.
- Red→green by construction: pre-fix `applyDetails(details)` overwrites unconditionally → assertion fails.

Verified: 5 new tests + 38 existing coordinator tests + 11 architecture tests pass; SwiftLint clean; build succeeds.

Closes PUL-257.