### PR TITLE
fix(backend): include force-update vars in validateEnvironment (PUL-260)

### DIFF
--- a/backend-nest/src/config/environment.spec.ts
+++ b/backend-nest/src/config/environment.spec.ts
@@ -1,5 +1,12 @@
+import type { ConfigService } from '@nestjs/config';
 import { describe, expect, it } from 'bun:test';
-import { validateConfig } from './environment';
+import { validateConfig, validateEnvironment } from './environment';
+
+const createConfigService = (values: Record<string, unknown>): ConfigService =>
+  ({
+    get: (key: string, defaultValue?: unknown) =>
+      key in values ? values[key] : defaultValue,
+  }) as unknown as ConfigService;
 
 describe('Environment Validation', () => {
   describe('SUPABASE_SERVICE_ROLE_KEY', () => {
@@ -269,6 +276,62 @@ describe('Environment Validation', () => {
       };
 
       expect(() => validateConfig(config)).not.toThrow();
+    });
+  });
+
+  describe('validateEnvironment force-update vars', () => {
+    const baseValues = {
+      NODE_ENV: 'production',
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_ANON_KEY: 'prod-anon-key',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+      TURNSTILE_SECRET_KEY: 'prod-turnstile-key',
+      ENCRYPTION_MASTER_KEY:
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    };
+
+    it('should return the force-update vars set on the ConfigService', () => {
+      const configService = createConfigService({
+        ...baseValues,
+        MIN_IOS_VERSION: '1.2.0',
+        LATEST_IOS_VERSION: '1.5.0',
+        IOS_STORE_URL: 'https://apps.apple.com/app/id123',
+        MIN_WEB_VERSION: '0.1.0',
+        LATEST_WEB_VERSION: '0.3.0',
+      });
+
+      const result = validateEnvironment(configService);
+
+      expect(result.MIN_IOS_VERSION).toBe('1.2.0');
+      expect(result.LATEST_IOS_VERSION).toBe('1.5.0');
+      expect(result.IOS_STORE_URL).toBe('https://apps.apple.com/app/id123');
+      expect(result.MIN_WEB_VERSION).toBe('0.1.0');
+      expect(result.LATEST_WEB_VERSION).toBe('0.3.0');
+    });
+
+    it('should fall back to schema defaults when force-update vars are absent', () => {
+      const configService = createConfigService(baseValues);
+
+      const result = validateEnvironment(configService);
+
+      expect(result.MIN_IOS_VERSION).toBe('1.0.0');
+      expect(result.LATEST_IOS_VERSION).toBe('1.0.0');
+      expect(result.IOS_STORE_URL).toBe(
+        'https://apps.apple.com/app/id6758464920',
+      );
+      expect(result.MIN_WEB_VERSION).toBe('0.0.1');
+      expect(result.LATEST_WEB_VERSION).toBe('0.0.1');
+    });
+
+    it('should throw when a force-update var is invalid', () => {
+      const configService = createConfigService({
+        ...baseValues,
+        MIN_IOS_VERSION: 'not-a-semver',
+      });
+
+      expect(() => validateEnvironment(configService)).toThrow(
+        /MIN_IOS_VERSION/,
+      );
     });
   });
 });

--- a/backend-nest/src/config/environment.ts
+++ b/backend-nest/src/config/environment.ts
@@ -120,6 +120,11 @@ export function validateEnvironment(configService: ConfigService): Environment {
     POSTHOG_API_KEY: configService.get('POSTHOG_API_KEY'),
     POSTHOG_PROJECT_ID: configService.get('POSTHOG_PROJECT_ID'),
     POSTHOG_HOST: configService.get('POSTHOG_HOST'),
+    MIN_IOS_VERSION: configService.get('MIN_IOS_VERSION'),
+    LATEST_IOS_VERSION: configService.get('LATEST_IOS_VERSION'),
+    IOS_STORE_URL: configService.get('IOS_STORE_URL'),
+    MIN_WEB_VERSION: configService.get('MIN_WEB_VERSION'),
+    LATEST_WEB_VERSION: configService.get('LATEST_WEB_VERSION'),
   };
 
   const result = envSchema.safeParse(config);


### PR DESCRIPTION
## Problem

`validateEnvironment()` built its `config` object by hand and omitted the 5 force-update vars — `MIN_IOS_VERSION`, `LATEST_IOS_VERSION`, `IOS_STORE_URL`, `MIN_WEB_VERSION`, `LATEST_WEB_VERSION`. Zod then applied schema *defaults* instead of the operator-configured values, so the typed `Environment` returned was silently wrong. `validateConfig()` (used by NestJS ConfigModule) was unaffected — `main.ts` reads via `configService.get()` directly, so runtime worked, but the type contract lied.

## Fix

Pass the 5 vars through from `ConfigService` in `validateEnvironment()`.

## Tests

Added `validateEnvironment force-update vars` block — behavior-focused:
- returns the values set on `ConfigService` (the regression guard: pre-fix this returned schema defaults)
- falls back to schema defaults when the vars are absent
- throws when a force-update var is invalid

`bun test environment.spec.ts` → 24 pass / 0 fail. Typecheck + eslint clean.

Closes PUL-260.