### PR TITLE
test(ios): cover checkedTickHash projection invariant (PUL-246)

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsProjector.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsProjector.swift
@@ -315,11 +315,11 @@ final class BudgetDetailsProjector {
         }
     }
 
-    /// Cheap, order-independent hash of every `isChecked` flag in source.
-    /// Stable as long as the set of `(id, isChecked)` pairs is stable, so it
-    /// only changes when a check flips. Used as the `value:` of the list
-    /// `.animation(_:value:)` modifier without allocating a new array per
-    /// body re-eval.
+    /// Cheap hash of every `(id, isChecked)` pair, in source order — changes
+    /// if-and-only-if a check flips, as long as source order is stable. The
+    /// toggle path mutates in place (`BudgetDataStore.updateBudgetLine`) so it
+    /// is; a wholesale reorder would also bump it, worst case one harmless
+    /// extra `gentleSpring`. Drives the list `.animation(_:value:)`.
     private static func makeCheckedTickHash(
         budgetLines: [BudgetLine],
         transactions: [Transaction]

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/Projection/BudgetDetailsScreenStateProjectionTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/Projection/BudgetDetailsScreenStateProjectionTests.swift
@@ -314,4 +314,63 @@ struct BudgetDetailsScreenStateProjectionTests {
         #expect(state.free.map(\.transaction.id) == ["free"])
         #expect(state.transactionsByLineId["line-1"]?.map(\.id) == ["allocated"])
     }
+
+    // MARK: - Checked tick hash
+
+    /// `checkedTickHash` is the `value:` of the list-level `.animation(_:value:)`
+    /// in `BudgetDetailsView`. Its contract: change if-and-only-if some item's
+    /// `isChecked` flag flips. A hash that never changes silently kills pointage
+    /// animations; one that changes on unrelated edits thrashes them.
+
+    private func checkedTickHash(for stack: StoreStack) -> Int {
+        BudgetDetailsProjector.project(
+            dataStore: stack.data,
+            filtersStore: stack.filters,
+            syncStore: stack.sync,
+            searchText: ""
+        ).checkedTickHash
+    }
+
+    @Test
+    func checkedTickHash_reprojectedWithSameSource_staysStable() {
+        let stack = makeStores()
+        stack.data.appendBudgetLine(TestDataFactory.createBudgetLine(id: "line-1", isChecked: true))
+        stack.data.appendTransaction(TestDataFactory.createTransaction(id: "tx-1", isChecked: false))
+
+        #expect(checkedTickHash(for: stack) == checkedTickHash(for: stack))
+    }
+
+    @Test
+    func checkedTickHash_budgetLineCheckFlips_changes() {
+        let unchecked = makeStores()
+        unchecked.data.appendBudgetLine(TestDataFactory.createBudgetLine(id: "line-1", isChecked: false))
+
+        let checked = makeStores()
+        checked.data.appendBudgetLine(TestDataFactory.createBudgetLine(id: "line-1", isChecked: true))
+
+        #expect(checkedTickHash(for: unchecked) != checkedTickHash(for: checked))
+    }
+
+    @Test
+    func checkedTickHash_transactionCheckFlips_changes() {
+        let unchecked = makeStores()
+        unchecked.data.appendTransaction(TestDataFactory.createTransaction(id: "tx-1", isChecked: false))
+
+        let checked = makeStores()
+        checked.data.appendTransaction(TestDataFactory.createTransaction(id: "tx-1", isChecked: true))
+
+        #expect(checkedTickHash(for: unchecked) != checkedTickHash(for: checked))
+    }
+
+    @Test
+    func checkedTickHash_nonCheckedFieldChanges_staysStable() {
+        let base = makeStores()
+        base.data.appendBudgetLine(TestDataFactory.createBudgetLine(id: "line-1", name: "Loyer", amount: 1000, isChecked: false))
+
+        // Same id + same isChecked, but name and amount differ — hash must ignore them.
+        let edited = makeStores()
+        edited.data.appendBudgetLine(TestDataFactory.createBudgetLine(id: "line-1", name: "Loyer révisé", amount: 1200, isChecked: false))
+
+        #expect(checkedTickHash(for: base) == checkedTickHash(for: edited))
+    }
 }


### PR DESCRIPTION
## Contexte

PUL-246 : `BudgetDetailsScreenState.checkedTickHash` — l'`Int` qui pilote le `value:` du `.animation(_:value:)` au niveau liste (animations de pointage) — n'était couvert par aucun test. Contrat : changer **si-et-seulement-si** un `isChecked` flippe.

## Changements

**Tests** (`BudgetDetailsScreenStateProjectionTests.swift`, +59) — 4 cas Swift Testing :
- reprojection sur même source → hash stable
- flip `isChecked` d'une `budget_line` → hash change
- flip `isChecked` d'une `transaction` → hash change
- edit non-pertinent (name/amount, même id + isChecked) → hash stable (garde anti-thrash)

**Doc-comment** (`BudgetDetailsProjector.swift`, +10/-5) — `makeCheckedTickHash` prétendait "order-independent" alors que `Hasher.combine` est order-**dependent**. Corrigé pour décrire le vrai contrat : stable tant que l'ordre source est stable, ce que le toggle in-place (`BudgetDataStore.updateBudgetLine`) garantit. Pas de changement de logique — l'ordre-dépendance n'est pas atteignable via le chemin qui pilote l'animation.

## Vérification

`xcodebuild test -only-testing:PulpeTests/BudgetDetailsScreenStateProjectionTests` → **14/14 pass**, `** TEST SUCCEEDED **`.