### PR TITLE
refactor(backend): remove dead validateEnvironment() (PUL-255)

### DIFF
--- a/backend-nest/src/config/environment.spec.ts
+++ b/backend-nest/src/config/environment.spec.ts
@@ -209,4 +209,58 @@ describe('Environment Validation', () => {
       expect(() => validateConfig(config)).toThrow(/POSTHOG_PROJECT_ID/);
     });
   });
+
+  describe('force-update vars defaults', () => {
+    const baseConfig = {
+      NODE_ENV: 'production',
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_ANON_KEY: 'prod-anon-key',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+      TURNSTILE_SECRET_KEY: 'prod-turnstile-key',
+      ENCRYPTION_MASTER_KEY:
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    };
+
+    it('should apply default values when force-update vars are absent', () => {
+      const result = validateConfig(baseConfig);
+
+      expect(result.MIN_IOS_VERSION).toBe('1.0.0');
+      expect(result.LATEST_IOS_VERSION).toBe('1.0.0');
+      expect(result.IOS_STORE_URL).toBe(
+        'https://apps.apple.com/app/id6758464920',
+      );
+      expect(result.MIN_WEB_VERSION).toBe('0.0.1');
+      expect(result.LATEST_WEB_VERSION).toBe('0.0.1');
+    });
+
+    it('should use provided values over defaults when force-update vars are set', () => {
+      const config = {
+        ...baseConfig,
+        MIN_IOS_VERSION: '2.1.0',
+        LATEST_IOS_VERSION: '2.3.0',
+        IOS_STORE_URL: 'https://apps.apple.com/app/id1234567890',
+        MIN_WEB_VERSION: '1.5.0',
+        LATEST_WEB_VERSION: '1.6.0',
+      };
+
+      const result = validateConfig(config);
+
+      expect(result.MIN_IOS_VERSION).toBe('2.1.0');
+      expect(result.LATEST_IOS_VERSION).toBe('2.3.0');
+      expect(result.IOS_STORE_URL).toBe(
+        'https://apps.apple.com/app/id1234567890',
+      );
+      expect(result.MIN_WEB_VERSION).toBe('1.5.0');
+      expect(result.LATEST_WEB_VERSION).toBe('1.6.0');
+    });
+
+    it('should reject force-update version vars that are not semver', () => {
+      const config = {
+        ...baseConfig,
+        MIN_IOS_VERSION: '1.0',
+      };
+
+      expect(() => validateConfig(config)).toThrow(/MIN_IOS_VERSION/);
+    });
+  });
 });

--- a/backend-nest/src/config/environment.ts
+++ b/backend-nest/src/config/environment.ts
@@ -1,4 +1,3 @@
-import { ConfigService } from '@nestjs/config';
 import { z } from 'zod';
 
 const envSchema = z.object({
@@ -69,37 +68,6 @@ const envSchema = z.object({
 });
 
 export type Environment = z.infer<typeof envSchema>;
-
-export function validateEnvironment(configService: ConfigService): Environment {
-  const config = {
-    NODE_ENV: configService.get('NODE_ENV', 'development'),
-    PORT: configService.get('PORT', 3000),
-    SUPABASE_URL: configService.get('SUPABASE_URL'),
-    SUPABASE_ANON_KEY: configService.get('SUPABASE_ANON_KEY'),
-    SUPABASE_SERVICE_ROLE_KEY: configService.get('SUPABASE_SERVICE_ROLE_KEY'),
-    TURNSTILE_SECRET_KEY: configService.get('TURNSTILE_SECRET_KEY'),
-    ENCRYPTION_MASTER_KEY: configService.get('ENCRYPTION_MASTER_KEY'),
-    CORS_ORIGIN: configService.get('CORS_ORIGIN'),
-    DEBUG_HTTP_FULL: configService.get('DEBUG_HTTP_FULL'),
-    MAINTENANCE_MODE: configService.get('MAINTENANCE_MODE'),
-    IP_BLACKLIST: configService.get('IP_BLACKLIST'),
-    POSTHOG_API_KEY: configService.get('POSTHOG_API_KEY'),
-    POSTHOG_PROJECT_ID: configService.get('POSTHOG_PROJECT_ID'),
-    POSTHOG_HOST: configService.get('POSTHOG_HOST'),
-  };
-
-  const result = envSchema.safeParse(config);
-
-  if (!result.success) {
-    throw new Error(
-      `Environment validation failed:\n${result.error.issues
-        .map((issue) => `- ${issue.path.join('.')}: ${issue.message}`)
-        .join('\n')}`,
-    );
-  }
-
-  return result.data;
-}
 
 // Configuration validation function for NestJS ConfigModule
 export function validateConfig(config: Record<string, unknown>): Environment {


### PR DESCRIPTION
## Summary

• Remove dead `validateEnvironment()` from `config/environment.ts` — exported but zero callers, and out-of-sync with `envSchema` (missing the 5 force-update vars → always returned Zod defaults). Live `validateConfig()` (ConfigModule, app.module.ts) untouched.
• Drop now-unused `ConfigService` import.
• Add `force-update vars defaults` tests in `environment.spec.ts`: defaults applied when absent (`MIN_IOS_VERSION → '1.0.0'`, etc.), provided values override, non-semver rejected.

No runtime change — removed function was never invoked.

## Type

refactor