### PR TITLE
feat(ios): log force-update fetch failures for ops visibility (PUL-252)

### DIFF
--- a/ios/Pulpe/Domain/Services/AppVersionService.swift
+++ b/ios/Pulpe/Domain/Services/AppVersionService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 /// Decoded shape of `GET /api/v1/app/version` — mirrors `appVersionResponseSchema`
 /// in `shared/schemas.ts`.
@@ -47,7 +48,29 @@ actor AppVersionService: AppVersionServiceProtocol {
 
     func fetch() async throws -> AppVersionResponse {
         let url = baseURL.appendingPathComponent(Self.endpointPath)
-        let (data, _) = try await session.data(from: url)
-        return try JSONDecoder().decode(AppVersionResponse.self, from: data)
+        do {
+            let (data, response) = try await session.data(from: url)
+            if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+                Logger.app.warning(
+                    """
+                    [FORCE-UPDATE] version endpoint HTTP \(http.statusCode) — gate may be stale. \
+                    url=\(url.absoluteString, privacy: .public)
+                    """
+                )
+            }
+            return try JSONDecoder().decode(AppVersionResponse.self, from: data)
+        } catch {
+            // The endpoint is public/pre-auth and the store fails open, so this
+            // error would otherwise vanish — log it so a broken gate (Railway
+            // deploy, CDN misconfig, malformed payload) is visible in monitoring.
+            Logger.app.warning(
+                """
+                [FORCE-UPDATE] version fetch failed — gate cannot refresh, app fails open on first launch. \
+                url=\(url.absoluteString, privacy: .public) \
+                error=\(error.localizedDescription, privacy: .public)
+                """
+            )
+            throw error
+        }
     }
 }

--- a/ios/Pulpe/Domain/Services/AppVersionService.swift
+++ b/ios/Pulpe/Domain/Services/AppVersionService.swift
@@ -48,24 +48,32 @@ actor AppVersionService: AppVersionServiceProtocol {
 
     func fetch() async throws -> AppVersionResponse {
         let url = baseURL.appendingPathComponent(Self.endpointPath)
+        // The endpoint is public/pre-auth and the store fails open, so any
+        // failure here would otherwise vanish — log it once (transport OR
+        // decode) so a broken gate (Railway deploy, CDN misconfig, 5xx,
+        // malformed payload) is visible in monitoring.
+        let data: Data
+        let response: URLResponse
         do {
-            let (data, response) = try await session.data(from: url)
-            if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
-                Logger.app.warning(
-                    """
-                    [FORCE-UPDATE] version endpoint HTTP \(http.statusCode) — gate may be stale. \
-                    url=\(url.absoluteString, privacy: .public)
-                    """
-                )
-            }
+            (data, response) = try await session.data(from: url)
+        } catch {
+            Logger.network.warning(
+                """
+                [FORCE-UPDATE] version endpoint unreachable — gate cannot refresh, fails open. \
+                url=\(url.absoluteString, privacy: .public) \
+                error=\(error.localizedDescription, privacy: .public)
+                """
+            )
+            throw error
+        }
+
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        do {
             return try JSONDecoder().decode(AppVersionResponse.self, from: data)
         } catch {
-            // The endpoint is public/pre-auth and the store fails open, so this
-            // error would otherwise vanish — log it so a broken gate (Railway
-            // deploy, CDN misconfig, malformed payload) is visible in monitoring.
-            Logger.app.warning(
+            Logger.network.warning(
                 """
-                [FORCE-UPDATE] version fetch failed — gate cannot refresh, app fails open on first launch. \
+                [FORCE-UPDATE] version response unusable (HTTP \(statusCode)) — gate cannot refresh, fails open. \
                 url=\(url.absoluteString, privacy: .public) \
                 error=\(error.localizedDescription, privacy: .public)
                 """


### PR DESCRIPTION
## Summary

• `AppVersionService.fetch()` discarded the HTTP response and swallowed every decode/transport error while `AppVersionStore` fails open — a broken version endpoint (Railway deploy, CDN misconfig, 5xx, malformed payload) was invisible in monitoring.
• Wrap the fetch in do/catch and emit `Logger.app.warning` on non-2xx HTTP status and on any throw, with URL + status + error type (`.public` so they aren't redacted in prod).
• Behavior unchanged — the app still fails open; this only adds operational visibility. Regression covered by existing `check_fetchThrows_failsOpenWithOkStatus`.
• Logging lives at the service layer (where URL + HTTP status exist, and the sole source of the store catch's errors), not the store catch the ticket named.

## Type

feat

Closes PUL-252