### PR TITLE
ci: resilient Supabase CLI setup — cache + curl retry to survive release-CDN 504s

### DIFF
--- a/.github/actions/setup-supabase-cli/action.yml
+++ b/.github/actions/setup-supabase-cli/action.yml
@@ -1,0 +1,55 @@
+name: "Setup Supabase CLI"
+description: "Install the Supabase CLI resiliently — cache the binary and download via curl with retries so transient GitHub release-CDN 504s self-heal instead of failing the job"
+
+inputs:
+  version:
+    description: "Supabase CLI version (without leading v)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # Cache the binary keyed on version+arch. On a hit, the runner never touches
+    # GitHub's release CDN — which is where the intermittent 504 Gateway Timeouts
+    # originate. Shared across jobs, so only the first run per version downloads.
+    - name: Cache Supabase CLI
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/share/supabase-cli
+        key: supabase-cli-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
+    - name: Download Supabase CLI
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "$(uname -m)" in
+          x86_64) arch="amd64" ;;
+          aarch64 | arm64) arch="arm64" ;;
+          *) echo "::error::Unsupported architecture: $(uname -m)"; exit 1 ;;
+        esac
+        dest="$HOME/.local/share/supabase-cli"
+        mkdir -p "$dest"
+        url="https://github.com/supabase/cli/releases/download/v${{ inputs.version }}/supabase_linux_${arch}.tar.gz"
+        echo "Downloading Supabase CLI ${{ inputs.version }} from $url"
+        # --retry-all-errors makes curl retry on HTTP 5xx (e.g. the 504 the release
+        # CDN returns intermittently), not just on connection failures — the whole
+        # reason this action exists in place of supabase/setup-cli@v1.
+        curl -fSL --retry 6 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+          -o "$RUNNER_TEMP/supabase-cli.tar.gz" "$url"
+        # Tarball root is LICENSE, README.md, supabase — extract only the binary.
+        tar -xzf "$RUNNER_TEMP/supabase-cli.tar.gz" -C "$dest" supabase
+        rm -f "$RUNNER_TEMP/supabase-cli.tar.gz"
+
+    - name: Add Supabase CLI to PATH
+      shell: bash
+      run: |
+        set -euo pipefail
+        dest="$HOME/.local/share/supabase-cli"
+        chmod +x "$dest/supabase"
+        echo "$dest" >> "$GITHUB_PATH"
+
+    - name: Verify installation
+      shell: bash
+      run: supabase --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 🗄️ Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: ./.github/actions/setup-supabase-cli
         with:
           version: ${{ env.SUPABASE_CLI_VERSION }}
 
@@ -163,7 +163,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: 🗄️ Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: ./.github/actions/setup-supabase-cli
         with:
           version: ${{ env.SUPABASE_CLI_VERSION }}
 
@@ -237,7 +237,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: 🗄️ Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: ./.github/actions/setup-supabase-cli
         with:
           version: ${{ env.SUPABASE_CLI_VERSION }}
 
@@ -430,7 +430,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: 🗄️ Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: ./.github/actions/setup-supabase-cli
         with:
           version: ${{ env.SUPABASE_CLI_VERSION }}
 
@@ -645,7 +645,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 🗄️ Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: ./.github/actions/setup-supabase-cli
         with:
           version: ${{ env.SUPABASE_CLI_VERSION }}
 
@@ -715,7 +715,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 🗄️ Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: ./.github/actions/setup-supabase-cli
         with:
           version: ${{ env.SUPABASE_CLI_VERSION }}
 


### PR DESCRIPTION
## Problem

The 6 `setup-cli` jobs intermittently fail with `Unexpected HTTP response: 504`. `supabase/setup-cli@v1` downloads the CLI from GitHub's release CDN, which sporadically returns 504 Gateway Timeout. The action neither caches nor retries on HTTP 5xx → a single 504 fails the job. With 6 parallel downloads per run, the odds of catching one stay high while the CDN hiccups. Hit PUL-257's PR + `preview` repeatedly.

## Root cause (not us)

Confirmed external: identical workflow was green then red within an hour; the same 504 hit `preview` (a branch untouched by the trigger); failure is in the CLI *download* step, before any code runs; GitHub/Supabase status pages don't track sporadic per-asset CDN 504s.

## Fix

Replace the third-party action with a local composite action `./.github/actions/setup-supabase-cli` that:
- **caches** the binary keyed on `version+os+arch` → cache hit = zero CDN traffic (kills the root cause from the 2nd run on), and
- on a cache miss **downloads via `curl --retry-all-errors`** → a 504 self-heals instead of failing the job.

Behaviorally identical install: `supabase` on PATH, version still pinned via `SUPABASE_CLI_VERSION`. A `supabase --version` step verifies it in every job.

## Verified

- Release asset URL + tarball layout checked deterministically (binary `supabase` at tarball root).
- All 6 call sites have `actions/checkout` before the step → local action resolves.
- action.yml + ci.yml pass `yaml.safe_load` + `actionlint` (no new findings).
- **CI on this PR is the live proof** — first run is a cache miss, so it exercises the curl-download path in all 6 jobs and must stay green end-to-end.