### PR TITLE
fix(ios): keep soft-deleted rows hidden when a reload lands in the undo window (PUL-271)

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+SoftDelete.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+SoftDelete.swift
@@ -127,6 +127,33 @@ extension BudgetDetailsCoordinator {
         )
     }
 
+    // MARK: - Snapshot filtering
+
+    /// Strips rows still pending soft-deletion from a fetched server snapshot.
+    /// The server keeps them until the undo toast commits, so a reload landing
+    /// inside the undo window (pop-back restarting the screen's `.task`,
+    /// pull-to-refresh) would otherwise re-display every deleted row on apply
+    /// (PUL-271). Call AFTER the fetch returns: an undo landing mid-fetch pops
+    /// its item from the queue, and the restored row must survive the apply.
+    func filteringPendingSoftDeletions(from details: BudgetDetails) -> BudgetDetails {
+        guard !mutationQueue.isEmpty else { return details }
+        var lineIds = Set<String>()
+        var txIds = Set<String>()
+        for pending in mutationQueue.pendingSoftDeletions {
+            switch pending {
+            case .transaction(let tx):
+                txIds.insert(tx.id)
+            case .budgetLine(let line):
+                lineIds.insert(line.id)
+            }
+        }
+        return BudgetDetails(
+            budget: details.budget,
+            transactions: details.transactions.filter { !txIds.contains($0.id) },
+            budgetLines: details.budgetLines.filter { !lineIds.contains($0.id) }
+        )
+    }
+
     /// Finalize pending soft-deletions before the screen navigates to another
     /// month. Commits them against the still-current store and drops any stale
     /// error, so neither the undo/rollback paths nor an error banner can target

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
@@ -166,7 +166,8 @@ final class BudgetDetailsCoordinator {
             }
 
             // Drop the snapshot if an optimistic mutation landed mid-fetch (PUL-257).
-            dataStore.applyDetails(details, ifGenerationMatches: generation)
+            // Strip rows pending soft-deletion — the server still has them (PUL-271).
+            dataStore.applyDetails(filteringPendingSoftDeletions(from: details), ifGenerationMatches: generation)
             dataStore.applyAllBudgets(budgets)
         } catch is CancellationError {
             // Task was cancelled, don't update error state
@@ -191,7 +192,8 @@ final class BudgetDetailsCoordinator {
         let generation = dataStore.mutationGeneration
         do {
             let details = try await budgetService.getBudgetWithDetails(id: dataStore.budgetId)
-            dataStore.applyDetails(details, ifGenerationMatches: generation)
+            // Strip rows pending soft-deletion — the server still has them (PUL-271).
+            dataStore.applyDetails(filteringPendingSoftDeletions(from: details), ifGenerationMatches: generation)
         } catch is CancellationError {
             // Task was cancelled, don't update error state
         } catch {

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsSoftDeleteReloadTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsSoftDeleteReloadTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Regression harness for PUL-271 — a reload landing inside the undo window
+/// must not re-display rows pending soft-deletion.
+///
+/// Deleting a line from its detail page pops back to `BudgetDetailsView`,
+/// whose appearance-scoped `.task(id:)` restarts and dispatches
+/// `.reloadCurrentBudget`. The server still contains the row (its DELETE is
+/// deferred until the toast ends) and the PUL-257 generation guard passes —
+/// the soft-delete bumped the generation BEFORE the fetch started, not
+/// mid-flight. Pre-fix, `applyDetails` re-injected the row ~100ms after the
+/// pop, visibly resurrecting it while the undo toast was still up.
+///
+/// The fix filters the fetched snapshot against
+/// `mutationQueue.pendingSoftDeletions` before applying it, reading the queue
+/// AFTER the fetch returns so an undo landing mid-fetch keeps its restored row.
+@Suite(.serialized)
+@MainActor
+struct BudgetDetailsSoftDeleteReloadTests {
+    @Test
+    func reloadDuringUndoWindow_keepsSoftDeletedLineHiddenAndStillCommits() async {
+        let budgetId = "pul271-line"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let budgetService = MockBudgetService()
+        let lineService = MockBudgetLineService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId,
+            budgetService: budgetService,
+            budgetLineService: lineService
+        )
+        let deleted = TestDataFactory.createBudgetLine(id: "line-1")
+        let kept = TestDataFactory.createBudgetLine(id: "line-2")
+        await coord.dispatch(.addBudgetLine(deleted))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteBudgetLine(deleted, ctx))
+        #expect(coord.dataStore.budgetLines.isEmpty)
+
+        // Pop-back restarts the screen's `.task`, which reloads. The server
+        // snapshot still contains the deleted line — its DELETE is deferred —
+        // plus a second line that must prove the snapshot was applied, not
+        // skipped.
+        budgetService.stubbedDetails = BudgetDetails(
+            budget: TestDataFactory.createBudget(),
+            transactions: [],
+            budgetLines: [deleted, kept]
+        )
+        await coord.dispatch(.reloadCurrentBudget)
+
+        // The pending row stays hidden while the undo toast is up; the rest
+        // of the snapshot lands.
+        #expect(coord.dataStore.budgetLines.map(\.id) == ["line-2"])
+
+        // The toast's natural end must still commit the deferred DELETE.
+        toastManager.dismiss()
+        await waitForCondition { lineService.deleteBudgetLineCallCount == 1 }
+        #expect(lineService.deletedIds == ["line-1"])
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+
+    @Test
+    func reloadDuringUndoWindow_keepsSoftDeletedTransactionHidden() async {
+        let budgetId = "pul271-tx"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let budgetService = MockBudgetService()
+        let txService = MockTransactionService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId,
+            budgetService: budgetService,
+            transactionService: txService
+        )
+        let tx = TestDataFactory.createTransaction(id: "tx-1")
+        await coord.dispatch(.addTransaction(tx))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteTransaction(tx, ctx))
+        #expect(coord.dataStore.transactions.isEmpty)
+
+        budgetService.stubbedDetails = BudgetDetails(
+            budget: TestDataFactory.createBudget(),
+            transactions: [tx],
+            budgetLines: []
+        )
+        await coord.dispatch(.reloadCurrentBudget)
+
+        #expect(coord.dataStore.transactions.isEmpty)
+        // The snapshot itself was applied — only the pending row is stripped.
+        #expect(coord.dataStore.budget != nil)
+
+        toastManager.dismiss()
+        await waitForCondition { txService.deleteTransactionCallCount == 1 }
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+
+    @Test
+    func undoAfterReloadDuringUndoWindow_restoresLine() async {
+        let budgetId = "pul271-undo"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let budgetService = MockBudgetService()
+        let lineService = MockBudgetLineService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId,
+            budgetService: budgetService,
+            budgetLineService: lineService
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1")
+        await coord.dispatch(.addBudgetLine(line))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteBudgetLine(line, ctx))
+
+        budgetService.stubbedDetails = BudgetDetails(
+            budget: TestDataFactory.createBudget(),
+            transactions: [],
+            budgetLines: [line]
+        )
+        await coord.dispatch(.reloadCurrentBudget)
+        #expect(coord.dataStore.budgetLines.isEmpty)
+
+        // Undo after the filtered reload restores the line locally and never
+        // issues the server DELETE.
+        toastManager.executeUndo()
+        await waitForCondition { coord.dataStore.budgetLines.count == 1 }
+        #expect(coord.dataStore.budgetLines.first?.id == "line-1")
+        #expect(lineService.deleteBudgetLineCallCount == 0)
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+
+    @Test
+    func undoLandingMidFetch_keepsRestoredLineAfterApply() async {
+        let budgetId = "pul271-undo-race"
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+        let budgetService = MockBudgetService()
+        let lineService = MockBudgetLineService()
+        let toastManager = ToastManager()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId,
+            budgetService: budgetService,
+            budgetLineService: lineService
+        )
+        let line = TestDataFactory.createBudgetLine(id: "line-1")
+        await coord.dispatch(.addBudgetLine(line))
+
+        let ctx = ToastContext(toastManager: toastManager, presentationCurrency: .chf)
+        await coord.dispatch(.softDeleteBudgetLine(line, ctx))
+
+        budgetService.stubbedDetails = BudgetDetails(
+            budget: TestDataFactory.createBudget(),
+            transactions: [],
+            budgetLines: [line]
+        )
+        budgetService.gateDetails()
+
+        // The reload suspends inside the fetch; the user taps "Annuler" while
+        // it is in flight. The restored row must survive the apply — the
+        // pending filter reads the queue after the await (the undo already
+        // popped its item) and the undo's append bumps the generation anyway.
+        let reload = Task { await coord.dispatch(.reloadCurrentBudget) }
+        await waitForCondition { budgetService.didEnterDetails }
+
+        toastManager.executeUndo()
+        await waitForCondition { coord.dataStore.budgetLines.count == 1 }
+
+        budgetService.releaseDetails()
+        await reload.value
+
+        #expect(coord.dataStore.budgetLines.first?.id == "line-1")
+        #expect(lineService.deleteBudgetLineCallCount == 0)
+
+        BudgetDetailCache.shared.invalidate(budgetId: budgetId)
+    }
+}


### PR DESCRIPTION
## Symptôme

Supprimer une enveloppe depuis sa page détail → retour sur le détail du budget → l'enveloppe disparaît puis **réapparaît ~100 ms plus tard** et reste visible pendant toute la snackbar d'annulation.

## Root cause

Le pop-back relance le `.task(id:)` (appearance-scoped) de `BudgetDetailsView` → `.reloadCurrentBudget`. Le serveur contient encore la ligne (DELETE différé à la fin du toast) et la garde génération PUL-257 passe — le soft delete a bumpé la génération **avant** le début du fetch, pas mid-flight. `applyDetails` ré-injecte donc la ligne dans le store **et le cache**. Aucune couche ne filtrait `mutationQueue.pendingSoftDeletions`.

## Fix

`filteringPendingSoftDeletions(from:)` dans `BudgetDetailsCoordinator+SoftDelete` : filtre le snapshot fetché contre les IDs pending **avant** `applyDetails`, dans les deux chemins de reload (`reloadCurrentBudget` + `loadDetails`, couvre aussi le pull-to-refresh pendant la fenêtre d'undo). Queue lue **après** l'await : un undo mid-fetch garde sa ligne restaurée. Zéro changement au commit/undo — la queue reste source de vérité (contraintes PUL-264/PUL-258 préservées).

## Tests

`BudgetDetailsSoftDeleteReloadTests` — 4 tests déterministes (seams `MockBudgetService.stubbedDetails` + gate, zéro sleep), **rouges avant fix** (3/4, le 4ᵉ verrouille la protection génération existante) :

- reload pendant la fenêtre d'undo → ligne masquée, reste du snapshot appliqué, DELETE toujours commité au dismiss
- jumeau transaction
- undo après reload filtré → ligne restaurée, zéro DELETE serveur
- undo **pendant** le fetch (gate) → ligne restaurée survit à l'apply

Full suite : 1523/1523 ✔ · SwiftLint clean · invariant ≤350 LOC respecté (348)

Closes PUL-271