### PR TITLE
fix(ios): invalidate budget-list and dashboard caches after budget mutations (PUL-270)

### DIFF
--- a/.claude/rules/00-architecture/budget-details-feature-architecture.md
+++ b/.claude/rules/00-architecture/budget-details-feature-architecture.md
@@ -32,6 +32,7 @@ This feature uses a layered split that other complex iOS features should adopt w
 8. **Every file in this feature ≤ 350 LOC.** Hard error in CI after Phase 5.
 9. **All mutations route through `BudgetDetailsCoordinator.dispatch(_:)`.** Views never call `*Service.shared.*` directly for mutations.
 10. **`BudgetDetailsViewModel` does not exist.** It was retired in Phase 4 of the refactor.
+11. **Every mutation path terminates in `dataStore.syncCache()`** — the lone invalidation choke point: it syncs `BudgetDetailCache` AND fires `onMutation` (app-scoped store invalidation, PUL-270). Any new entry point that constructs the coordinator must call `bind(budgetListStore:dashboardStore:)` in its `.task`, or list/dashboard aggregates go stale on pop-back.
 
 ## When to apply this pattern to a new feature
 

--- a/.claude/rules/00-architecture/ios-architecture.md
+++ b/.claude/rules/00-architecture/ios-architecture.md
@@ -76,6 +76,7 @@ final class CurrentMonthStore: StoreProtocol {
 
     func loadIfNeeded() async   // Smart cache (30s TTL)
     func forceRefresh() async   // Bypass cache
+    func invalidateCache()      // Mark stale → next loadIfNeeded() refetches
 }
 ```
 
@@ -85,6 +86,11 @@ final class CurrentMonthStore: StoreProtocol {
 - Implement `StoreProtocol` for cache management
 - Constructor injection, `.shared` defaults
 - Inject via `.environment()` in views
+
+**Cross-store invalidation (PUL-270):**
+- Any mutation surface whose data overlaps an app-scoped store MUST call that store's `invalidateCache()` after the mutation — otherwise the TTL silently serves stale aggregates on the next screen.
+- A surface states ONE fact ("I mutated budget data") through a single `onMutation: (@MainActor () -> Void)?` seam fired by its mutation choke point — never a hand-enumerated store list at each mutation site. Wiring lives at app level (`PulpeApp.init`) or in the view's `.task` (`coordinator.bind(...)`).
+- Existing seams: `BudgetDataStore.onMutation` (fired by `syncCache()`), `CurrentMonthStore.onMutation` (fired by amount-changing mutations; toggles don't change aggregates).
 
 ## ViewModel Pattern (Feature-Level State)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,20 @@ jobs:
             sleep 1
             counter=$((counter + 1))
           done
+
+          # GoTrue boots last (DB migrations at startup) and the encryption
+          # integration/e2e specs probe /auth/v1/health (reachable = status < 500).
+          # Mirror that exact criterion here so tests never start before auth is up.
+          counter=0
+          until code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:54321/auth/v1/health); [ "$code" -ge 200 ] && [ "$code" -lt 500 ]; do
+            if [ $counter -gt $timeout ]; then
+              echo "❌ Supabase auth (GoTrue) not ready for tests"
+              supabase status
+              exit 1
+            fi
+            sleep 1
+            counter=$((counter + 1))
+          done
           echo "✅ Supabase ready for tests"
 
           # Export local Supabase keys as outputs (using heredoc for robust special character handling)

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -41,6 +41,14 @@ struct PulpeApp: App {
             userSettingsStore: userSettingsStore
         )
 
+        // Cross-store consistency (PUL-270): any amount-changing mutation on
+        // the dashboard marks the sibling stores projecting the same sparse
+        // aggregates stale, so their next loadIfNeeded() refetches.
+        currentMonthStore.onMutation = { [budgetListStore, dashboardStore] in
+            budgetListStore.invalidateCache()
+            dashboardStore.invalidateCache()
+        }
+
         // Wire currency persistence from `OnboardingBootstrapper` to `UserSettingsStore`.
         // Runs after PIN setup completes so the API call carries `X-Client-Key`.
         // Returns `true` only when the store's optimistic update was confirmed by the

--- a/ios/Pulpe/Domain/Store/BudgetListStore.swift
+++ b/ios/Pulpe/Domain/Store/BudgetListStore.swift
@@ -28,13 +28,13 @@ final class BudgetListStore: StoreProtocol {
 
     // MARK: - Services
 
-    private let budgetService: BudgetService
+    private let budgetService: any BudgetServicing
     private let widgetSyncService: WidgetDataSyncService
 
     // MARK: - Initialization
 
     init(
-        budgetService: BudgetService = .shared,
+        budgetService: any BudgetServicing = BudgetService.shared,
         widgetSyncService: WidgetDataSyncService = .shared,
         initialBudgets: [BudgetSparse] = []
     ) {
@@ -70,7 +70,7 @@ final class BudgetListStore: StoreProtocol {
 
             do {
                 let fields = "month,year,remaining,totalIncome,totalExpenses,rollover"
-                let fetchedBudgets = try await budgetService.getBudgetsSparse(fields: fields)
+                let fetchedBudgets = try await budgetService.getBudgetsSparse(fields: fields, limit: nil, year: nil)
 
                 // Check for cancellation before updating state
                 try Task.checkCancellation()
@@ -150,6 +150,11 @@ final class BudgetListStore: StoreProtocol {
 
     func addBudget(_ budget: Budget) {
         budgets.append(BudgetSparse(from: budget))
+        lastLoadTime = nil
+    }
+
+    /// Invalidates the cache so the next `loadIfNeeded()` will re-fetch.
+    func invalidateCache() {
         lastLoadTime = nil
     }
 }

--- a/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
+++ b/ios/Pulpe/Domain/Store/CurrentMonthStore.swift
@@ -102,6 +102,12 @@ final class CurrentMonthStore: StoreProtocol {
 
     private var lastLoadTime: Date?
 
+    /// Fired by every amount-changing mutation below (adds, updates, deletes —
+    /// not toggles). Lets the app invalidate sibling stores that project the
+    /// same budget aggregates (`BudgetListStore`, `DashboardStore`) without
+    /// this store knowing them — wired once in `PulpeApp.init` (PUL-270).
+    @ObservationIgnored var onMutation: (@MainActor () -> Void)?
+
     // Cache for expensive computed properties
     private var cachedMetrics: BudgetFormulas.Metrics?
     private var cachedRealizedMetrics: BudgetFormulas.RealizedMetrics?
@@ -565,6 +571,8 @@ extension CurrentMonthStore {
 
 extension CurrentMonthStore {
     func toggleBudgetLine(_ line: BudgetLine) async {
+        // Note: toggles don't fire `onMutation` — checking a line/transaction
+        // never changes the sparse aggregates sibling stores display.
         // Skip virtual rollover lines
         guard !(line.isRollover ?? false) else { return }
 
@@ -639,6 +647,7 @@ extension CurrentMonthStore {
         transactions.append(transaction)
         recomputeMetrics()
         syncWidgetAfterChange()
+        onMutation?()
     }
 
     func deleteTransaction(_ transaction: Transaction) async {
@@ -646,6 +655,7 @@ extension CurrentMonthStore {
         let originalTransactions = transactions
         transactions.removeAll { $0.id == transaction.id }
         recomputeMetrics()
+        onMutation?()
 
         do {
             try await transactionService.deleteTransaction(id: transaction.id)
@@ -669,6 +679,7 @@ extension CurrentMonthStore {
         let originalLines = budgetLines
         budgetLines.removeAll { $0.id == line.id }
         recomputeMetrics()
+        onMutation?()
 
         do {
             try await budgetLineService.deleteBudgetLine(id: line.id)
@@ -691,6 +702,7 @@ extension CurrentMonthStore {
             budgetLines[index] = line
             recomputeMetrics()
         }
+        onMutation?()
 
         // Refresh to get server state (needed for recalculations)
         await forceRefresh()
@@ -702,6 +714,7 @@ extension CurrentMonthStore {
             transactions[index] = transaction
             recomputeMetrics()
         }
+        onMutation?()
         await forceRefresh()
     }
 }

--- a/ios/Pulpe/Domain/Store/DashboardStore.swift
+++ b/ios/Pulpe/Domain/Store/DashboardStore.swift
@@ -32,7 +32,7 @@ final class DashboardStore: StoreProtocol {
 
     // MARK: - Services
 
-    private let budgetService: BudgetService
+    private let budgetService: any BudgetServicing
 
     // MARK: - Constants
 
@@ -41,7 +41,7 @@ final class DashboardStore: StoreProtocol {
 
     // MARK: - Initialization
 
-    init(budgetService: BudgetService = .shared, initialBudgets: [BudgetSparse] = []) {
+    init(budgetService: any BudgetServicing = BudgetService.shared, initialBudgets: [BudgetSparse] = []) {
         self.budgetService = budgetService
         self.sparseBudgets = initialBudgets
     }
@@ -87,8 +87,13 @@ final class DashboardStore: StoreProtocol {
                 let currentYear = Calendar.current.component(.year, from: Date())
 
                 // Fetch current year (all months including future) + recent history in parallel
-                async let currentYearBudgets = budgetService.getBudgetsSparse(year: currentYear)
+                async let currentYearBudgets = budgetService.getBudgetsSparse(
+                    fields: BudgetService.defaultSparseFields,
+                    limit: nil,
+                    year: currentYear
+                )
                 async let recentBudgets = budgetService.getBudgetsSparse(
+                    fields: BudgetService.defaultSparseFields,
                     limit: Self.maxHistoricalToFetch,
                     year: currentYear - 1
                 )

--- a/ios/Pulpe/Domain/Store/StoreProtocol.swift
+++ b/ios/Pulpe/Domain/Store/StoreProtocol.swift
@@ -18,6 +18,10 @@ protocol StoreProtocol: Observable {
     /// Forces a fresh data load, bypassing cache
     func forceRefresh() async
 
+    /// Invalidates the cache so the next `loadIfNeeded()` re-fetches — call
+    /// when a mutation elsewhere makes this store's data stale (PUL-270)
+    func invalidateCache()
+
     /// Clears all cached data — call when the user logs out
     func reset()
 }

--- a/ios/Pulpe/Domain/Store/UserSettingsStore.swift
+++ b/ios/Pulpe/Domain/Store/UserSettingsStore.swift
@@ -91,6 +91,11 @@ final class UserSettingsStore: StoreProtocol {
         if loadGeneration == currentGeneration { loadTask = nil }
     }
 
+    /// Invalidates the cache so the next `loadIfNeeded()` will re-fetch.
+    func invalidateCache() {
+        lastLoadTime = nil
+    }
+
     func reset() {
         loadTask?.cancel()
         loadTask = nil

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -6,6 +6,8 @@ struct BudgetDetailsView: View {
     @Environment(AppState.self) private var appState
     @Environment(BudgetDetailsRouter.self) private var router
     @Environment(UserSettingsStore.self) private var userSettingsStore
+    @Environment(BudgetListStore.self) private var budgetListStore
+    @Environment(DashboardStore.self) private var dashboardStore
     @Environment(\.amountsHidden) private var amountsHidden
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.tabBarClearance) private var tabBarClearance
@@ -100,6 +102,7 @@ struct BudgetDetailsView: View {
             }
         }
         .task(id: screenState.budgetId) {
+            coordinator.bind(budgetListStore: budgetListStore, dashboardStore: dashboardStore)
             if !screenState.hasAllBudgets {
                 await coordinator.dispatch(.loadDetails(force: false))
             } else {
@@ -300,6 +303,8 @@ struct BudgetDetailsView: View {
     .environment(AppState())
     .environment(BudgetDetailsRouter())
     .environment(UserSettingsStore())
+    .environment(BudgetListStore())
+    .environment(DashboardStore())
 }
 #Preview("Gestures Tip") {
     List {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
@@ -5,6 +5,19 @@ import Foundation
 /// All mutations follow the same shape: optimistic local apply, server call,
 /// rollback on error.
 extension BudgetDetailsCoordinator {
+    /// Late-binds the app-scoped stores projecting the same budget aggregates
+    /// (list + dashboard) so every mutation below marks them stale and their
+    /// next `loadIfNeeded()` refetches (PUL-270). Called from the view's
+    /// `.task` because `@Environment` is unavailable in `init` — same
+    /// precedent as `router.bind(to:)` in `MainTabView`. Strong captures on
+    /// purpose: both stores are app-scoped and outlive this coordinator.
+    func bind(budgetListStore: BudgetListStore, dashboardStore: DashboardStore) {
+        dataStore.onMutation = {
+            budgetListStore.invalidateCache()
+            dashboardStore.invalidateCache()
+        }
+    }
+
     func addBudgetLine(_ line: BudgetLine) {
         dataStore.appendBudgetLine(line)
         dataStore.recomputeMetrics()

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/State/BudgetDataStore.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/State/BudgetDataStore.swift
@@ -255,11 +255,18 @@ final class BudgetDataStore {
         cachedRealizedMetrics = nil
     }
 
+    /// Fired at the end of every successful `syncCache()` — the single choke
+    /// point all mutations go through (loads use `applyDetails` instead). Lets
+    /// the coordinator invalidate app-scoped stores (e.g. `BudgetListStore`)
+    /// without this State layer knowing about them (PUL-270).
+    @ObservationIgnored var onMutation: (@MainActor () -> Void)?
+
     /// Sync current in-memory state to the detail cache so popping back and
     /// re-entering doesn't flash stale data after an optimistic mutation.
     func syncCache() {
         guard let budget else { return }
         cache.store(budgetId: budgetId, budget: budget, budgetLines: budgetLines, transactions: transactions)
+        onMutation?()
     }
 
     /// Invalidate cached data for adjacent months so rollover values are

--- a/ios/PulpeTests/Domain/Store/CrossStoreSyncTests.swift
+++ b/ios/PulpeTests/Domain/Store/CrossStoreSyncTests.swift
@@ -53,6 +53,132 @@ struct DashboardStoreCacheInvalidationTests {
     }
 }
 
+// MARK: - BudgetListStore Cache Invalidation (PUL-270)
+
+@Suite(.serialized)
+@MainActor
+struct BudgetListStoreCacheInvalidationTests {
+    private let cache = BudgetDetailCache.shared
+
+    @Test
+    func detailMutation_thenPopBack_refetchesListAggregates() async {
+        cache.invalidateAll()
+
+        // List screen loaded → TTL fresh
+        let mockService = MockBudgetService()
+        mockService.stubbedSparse = [
+            TestDataFactory.createBudgetSparse(id: "budget-current", month: 2, year: 2025)
+        ]
+        let listStore = BudgetListStore(budgetService: mockService)
+        await listStore.forceRefresh()
+        #expect(mockService.getBudgetsSparseCallCount == 1, "Setup: initial list load")
+
+        // User opens detail and mutates (optimistic apply ends in syncCache())
+        let currentBudget = TestDataFactory.createBudget(id: "budget-current", month: 2, year: 2025)
+        cache.store(budgetId: "budget-current", budget: currentBudget, budgetLines: [], transactions: [])
+        // Dashboard store loaded too (300s TTL, projects the same sparse aggregates)
+        let dashboardMock = MockBudgetService()
+        let dashboardStore = DashboardStore(budgetService: dashboardMock)
+        await dashboardStore.forceRefresh()
+        let dashboardBaseline = dashboardMock.getBudgetsSparseCallCount
+
+        let coordinator = BudgetDetailsCoordinator(budgetId: "budget-current")
+        // mirrors BudgetDetailsView's .task
+        coordinator.bind(budgetListStore: listStore, dashboardStore: dashboardStore)
+        let tx = TestDataFactory.createTransaction(id: "new-tx", budgetId: "budget-current")
+        await coordinator.dispatch(.addTransaction(tx))
+
+        // Pop back within the 30s TTL: BudgetListView's .task re-fires loadIfNeeded()
+        await listStore.loadIfNeeded()
+        #expect(
+            mockService.getBudgetsSparseCallCount == 2,
+            "A detail mutation must invalidate the list TTL so pop-back refetches the aggregates (PUL-270)"
+        )
+
+        // Same mutation must also mark the dashboard stale (trend chart)
+        await dashboardStore.loadIfNeeded()
+        #expect(
+            dashboardMock.getBudgetsSparseCallCount > dashboardBaseline,
+            "A detail mutation must invalidate the dashboard TTL too (PUL-270)"
+        )
+    }
+
+    @Test
+    func invalidateCache_makesNextLoadIfNeededRefetch() async {
+        let mockService = MockBudgetService()
+        let store = BudgetListStore(budgetService: mockService)
+
+        await store.forceRefresh()
+        #expect(mockService.getBudgetsSparseCallCount == 1, "Setup: initial load")
+
+        // Cache valid: loadIfNeeded must skip the fetch (TTL gate — the bug's mechanism)
+        await store.loadIfNeeded()
+        #expect(mockService.getBudgetsSparseCallCount == 1, "Cache valid: loadIfNeeded should skip fetch")
+
+        store.invalidateCache()
+
+        await store.loadIfNeeded()
+        #expect(mockService.getBudgetsSparseCallCount == 2, "After invalidation, loadIfNeeded should re-fetch")
+    }
+}
+
+// MARK: - CurrentMonthStore Mutation Seam (PUL-270)
+
+@Suite(.serialized)
+@MainActor
+struct CurrentMonthStoreMutationSeamTests {
+    @Test
+    func addTransaction_firesOnMutation() {
+        let store = CurrentMonthStore()
+        nonisolated(unsafe) var fired = 0
+        store.onMutation = { fired += 1 }
+
+        store.addTransaction(TestDataFactory.createTransaction(id: "tx-seam"))
+
+        #expect(fired == 1, "Amount-changing dashboard mutation must fire onMutation")
+    }
+
+    @Test
+    func loadPath_doesNotFireOnMutation() async {
+        let store = CurrentMonthStore()
+        nonisolated(unsafe) var fired = 0
+        store.onMutation = { fired += 1 }
+
+        await store.forceRefresh()
+
+        #expect(fired == 0, "Loads must not fire onMutation (no over-invalidation)")
+    }
+}
+
+// MARK: - BudgetDataStore Mutation Seam (PUL-270)
+
+@Suite(.serialized)
+@MainActor
+struct BudgetDataStoreMutationSeamTests {
+    private let cache = BudgetDetailCache.shared
+
+    @Test
+    func syncCache_firesOnMutation_butLoadApplyDoesNot() {
+        cache.invalidateAll()
+
+        let budget = TestDataFactory.createBudget(id: "budget-seam", month: 2, year: 2025)
+        cache.store(budgetId: "budget-seam", budget: budget, budgetLines: [], transactions: [])
+        let dataStore = BudgetDataStore(budgetId: "budget-seam")
+
+        nonisolated(unsafe) var fired = 0
+        dataStore.onMutation = { fired += 1 }
+
+        // Mutation path: syncCache fires the seam exactly once
+        dataStore.syncCache()
+        #expect(fired == 1, "syncCache (mutation choke point) must fire onMutation")
+
+        // Load path: applying a server snapshot must NOT fire it (no over-invalidation)
+        let details = BudgetDetails(budget: budget, transactions: [], budgetLines: [])
+        dataStore.applyDetails(details, ifGenerationMatches: dataStore.mutationGeneration)
+        #expect(fired == 1, "applyDetails (load path) must not fire onMutation")
+    }
+}
+
 // MARK: - BudgetDetails Adjacent Cache Invalidation
 
 @Suite(.serialized)

--- a/ios/PulpeTests/Helpers/MockBudgetService.swift
+++ b/ios/PulpeTests/Helpers/MockBudgetService.swift
@@ -22,6 +22,7 @@ final class MockBudgetService: BudgetServicing {
     var detailsError: Error?
 
     private(set) var getBudgetWithDetailsCallCount = 0
+    private(set) var getBudgetsSparseCallCount = 0
     /// Flips true the moment a reload enters `getBudgetWithDetails`. Tests poll
     /// this with `waitForCondition` to know the reload reached the gate.
     private(set) var didEnterDetails = false
@@ -56,6 +57,7 @@ final class MockBudgetService: BudgetServicing {
     }
 
     func getBudgetsSparse(fields: String, limit: Int?, year: Int?) async throws -> [BudgetSparse] {
-        stubbedSparse
+        getBudgetsSparseCallCount += 1
+        return stubbedSparse
     }
 }


### PR DESCRIPTION
## Problème

Ajouter une transaction ou modifier une enveloppe depuis le détail d'un budget, puis revenir à la liste : les montants du mois restent périmés jusqu'à un pull-to-refresh manuel ([PUL-270](https://linear.app/pulpe/issue/PUL-270)).

## Root cause

La liste affiche des agrégats calculés serveur (`BudgetSparse.remaining/totalIncome/totalExpenses`). Au pop-back, le `.task` de `BudgetListView` se re-déclenche bien, mais `loadIfNeeded()` early-return tant que le TTL de 30 s n'est pas expiré — et aucune mutation du détail n'invalidait ce TTL. `BudgetListStore` était le seul store global sans `invalidateCache()`.

L'audit d'architecture a confirmé deux edges frères du même bug class, fermés ici aussi :
- les mutations depuis le dashboard (FAB + CurrentMonth) n'invalidaient jamais `BudgetListStore`
- `DashboardStore.invalidateCache()` n'avait aucun appelant en production (chart « Tendance » périmé jusqu'à 5 min)

## Fix

Chaque surface de mutation déclare un seul fait (« j'ai muté des données budget ») via un seam `onMutation`, jamais une liste de stores énumérée à la main :

- `BudgetDataStore.onMutation` — fired par `syncCache()`, le choke point de toutes les mutations BudgetDetails (les loads restent silencieux) ; bindé aux stores liste + dashboard dans le `.task` de la vue
- `CurrentMonthStore.onMutation` — fired par les mutations à impact montant (pas les toggles), câblé une fois dans `PulpeApp.init`
- `invalidateCache()` ajouté au contrat `StoreProtocol` — tout futur store doit répondre à la question d'invalidation
- Seams `any BudgetServicing` sur `BudgetListStore`/`DashboardStore` pour des tests déterministes

## Tests

- Repro rouge avant fix : `detailMutation_thenPopBack_refetchesListAggregates` — `(getBudgetsSparseCallCount → 1) == 2`, le TTL avale le refetch
- Tests contrat : seam fired par les mutations, pas par les loads (pas de sur-invalidation) ; `invalidateCache()` → refetch
- Suite complète : **1524 tests / 144 suites verts** ; gardes PUL-246/258/264 inchangés et verts
- Rules files MAJ (`ios-architecture.md`, `budget-details-feature-architecture.md`) pour documenter le pattern