### PR TITLE
fix(backend): close cross-account IDOR in apply_template_line_operations RPC (PUL-272)

### DIFF
--- a/backend-nest/supabase/migrations/20260610120000_secure_apply_template_line_operations.sql
+++ b/backend-nest/supabase/migrations/20260610120000_secure_apply_template_line_operations.sql
@@ -1,0 +1,343 @@
+-- Migration: harden apply_template_line_operations against cross-tenant writes (PUL-272).
+--
+-- Background: apply_template_line_operations is SECURITY DEFINER (OWNER postgres),
+-- so it bypasses RLS. Its only authorization check is template ownership
+-- (template.user_id = auth.uid()). The budget_line writes filtered solely on
+-- `budget_id = ANY(v_budget_ids)` without verifying those budgets belong to the
+-- caller. Because the function kept the default PUBLIC/anon/authenticated EXECUTE
+-- grant, any authenticated user could call it directly via PostgREST
+-- (POST /rest/v1/rpc/apply_template_line_operations) with their own template_id
+-- plus a victim's budget_id and inject/mutate budget_line rows in that victim's
+-- budget — an IDOR. The injected amounts, encrypted under the attacker's DEK,
+-- decrypt to 0 for the victim (silent corruption).
+--
+-- The NestJS path was never exposed (budget_ids are derived server-side from the
+-- authenticated user). The hole was exclusively the direct PostgREST vector.
+--
+-- Fix (mirrors the sibling create_template_with_lines hardening, 20260504120000):
+--   1. In-body ownership guard: every budget in budget_ids must belong to the
+--      caller (the real fix).
+--   2. REVOKE EXECUTE FROM PUBLIC, anon + scoped GRANT (belt-and-suspenders).
+--
+-- Function body is otherwise byte-for-byte identical to 20260508120100.
+
+CREATE OR REPLACE FUNCTION public.apply_template_line_operations(
+  template_id uuid,
+  budget_ids uuid[] DEFAULT ARRAY[]::uuid[],
+  delete_ids uuid[] DEFAULT ARRAY[]::uuid[],
+  updated_lines jsonb DEFAULT '[]'::jsonb,
+  created_lines jsonb DEFAULT '[]'::jsonb
+) RETURNS uuid[]
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_template_id uuid := template_id;
+  v_budget_ids uuid[] := COALESCE(budget_ids, ARRAY[]::uuid[]);
+  v_delete_ids uuid[] := COALESCE(delete_ids, ARRAY[]::uuid[]);
+  v_updated_lines jsonb := COALESCE(updated_lines, '[]'::jsonb);
+  v_created_lines jsonb := COALESCE(created_lines, '[]'::jsonb);
+  v_impacted uuid[] := ARRAY[]::uuid[];
+  v_new_ids uuid[];
+  v_update record;
+  v_create record;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.template t
+    WHERE t.id = v_template_id
+      AND t.user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Template % not found or access denied', v_template_id
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- PUL-272: cross-tenant write guard. SECURITY DEFINER bypasses RLS, so budget
+  -- ownership must be enforced explicitly here — template ownership above does
+  -- NOT imply the caller owns the budgets in budget_ids. Every budget must
+  -- belong to the caller; otherwise an authenticated user could pass another
+  -- user's budget_id (direct PostgREST call) and inject/mutate their budget_line
+  -- rows. unnest of an empty array yields no rows, so the template-only path
+  -- (no propagation) passes unaffected.
+  IF EXISTS (
+    SELECT 1
+    FROM unnest(v_budget_ids) AS b(id)
+    LEFT JOIN public.monthly_budget mb
+      ON mb.id = b.id AND mb.user_id = (SELECT auth.uid())
+    WHERE mb.id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Budget access denied'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- 1. UPDATE template_line rows from updated_lines payload (partial patch
+  --    semantics — only fields present in the JSONB are written).
+  --    Restrict to lines belonging to this template (defense in depth on top
+  --    of RLS — the function runs SECURITY DEFINER so RLS is bypassed).
+  FOR v_update IN
+    SELECT line FROM jsonb_array_elements(v_updated_lines) AS line
+  LOOP
+    UPDATE public.template_line tl
+    SET
+      name = CASE
+        WHEN v_update.line ? 'name'
+        THEN v_update.line->>'name'
+        ELSE tl.name
+      END,
+      amount = CASE
+        WHEN v_update.line ? 'amount'
+        THEN v_update.line->>'amount'
+        ELSE tl.amount
+      END,
+      kind = CASE
+        WHEN v_update.line ? 'kind'
+        THEN (v_update.line->>'kind')::public.transaction_kind
+        ELSE tl.kind
+      END,
+      recurrence = CASE
+        WHEN v_update.line ? 'recurrence'
+        THEN (v_update.line->>'recurrence')::public.transaction_recurrence
+        ELSE tl.recurrence
+      END,
+      original_amount = CASE
+        WHEN v_update.line ? 'original_amount'
+        THEN v_update.line->>'original_amount'
+        ELSE tl.original_amount
+      END,
+      original_currency = CASE
+        WHEN v_update.line ? 'original_currency'
+        THEN v_update.line->>'original_currency'
+        ELSE tl.original_currency
+      END,
+      target_currency = CASE
+        WHEN v_update.line ? 'target_currency'
+        THEN v_update.line->>'target_currency'
+        ELSE tl.target_currency
+      END,
+      exchange_rate = CASE
+        WHEN v_update.line ? 'exchange_rate'
+        THEN CASE
+          WHEN (v_update.line->>'exchange_rate') IS NULL
+            OR (v_update.line->>'exchange_rate') = ''
+          THEN NULL
+          ELSE (v_update.line->>'exchange_rate')::numeric
+        END
+        ELSE tl.exchange_rate
+      END,
+      description = CASE
+        WHEN v_update.line ? 'description'
+        THEN v_update.line->>'description'
+        ELSE tl.description
+      END,
+      updated_at = NOW()
+    WHERE tl.id = (v_update.line->>'id')::uuid
+      AND tl.template_id = v_template_id;
+  END LOOP;
+
+  -- 2. INSERT template_line rows from created_lines payload. Caller-supplied
+  --    `id` is used so the subsequent budget-line propagation can join on it.
+  FOR v_create IN
+    SELECT
+      (line->>'id')::uuid AS id,
+      line->>'name' AS name,
+      line->>'amount' AS amount,
+      (line->>'kind')::public.transaction_kind AS kind,
+      (line->>'recurrence')::public.transaction_recurrence AS recurrence,
+      line->>'original_amount' AS original_amount,
+      line->>'original_currency' AS original_currency,
+      line->>'target_currency' AS target_currency,
+      line->>'description' AS description,
+      CASE
+        WHEN (line->>'exchange_rate') IS NULL
+          OR (line->>'exchange_rate') = ''
+        THEN NULL
+        ELSE (line->>'exchange_rate')::numeric
+      END AS exchange_rate
+    FROM jsonb_array_elements(v_created_lines) AS line
+  LOOP
+    INSERT INTO public.template_line (
+      id, template_id, name, amount, kind, recurrence,
+      original_amount, original_currency, target_currency, exchange_rate,
+      description
+    ) VALUES (
+      v_create.id, v_template_id, v_create.name, v_create.amount,
+      v_create.kind, v_create.recurrence,
+      v_create.original_amount, v_create.original_currency,
+      v_create.target_currency, v_create.exchange_rate,
+      v_create.description
+    );
+  END LOOP;
+
+  -- 3. Propagate to budget_line when caller passed at least one budget.
+  IF COALESCE(array_length(v_budget_ids, 1), 0) > 0 THEN
+
+    IF COALESCE(array_length(v_delete_ids, 1), 0) > 0 THEN
+      WITH deleted_budget_lines AS (
+        DELETE FROM public.budget_line bl
+        WHERE bl.template_line_id = ANY(v_delete_ids)
+          AND bl.is_manually_adjusted = false
+          AND bl.budget_id = ANY(v_budget_ids)
+        RETURNING bl.budget_id
+      )
+      SELECT COALESCE(array_agg(DISTINCT budget_id), ARRAY[]::uuid[])
+      INTO v_new_ids
+      FROM deleted_budget_lines;
+
+      IF v_new_ids IS NOT NULL THEN
+        v_impacted := array_cat(v_impacted, v_new_ids);
+      END IF;
+    END IF;
+
+    FOR v_update IN
+      SELECT line FROM jsonb_array_elements(v_updated_lines) AS line
+    LOOP
+      WITH updated_budget_lines AS (
+        UPDATE public.budget_line bl
+        SET
+          name = CASE
+            WHEN v_update.line ? 'name'
+            THEN v_update.line->>'name'
+            ELSE bl.name
+          END,
+          amount = CASE
+            WHEN v_update.line ? 'amount'
+            THEN v_update.line->>'amount'
+            ELSE bl.amount
+          END,
+          kind = CASE
+            WHEN v_update.line ? 'kind'
+            THEN (v_update.line->>'kind')::public.transaction_kind
+            ELSE bl.kind
+          END,
+          recurrence = CASE
+            WHEN v_update.line ? 'recurrence'
+            THEN (v_update.line->>'recurrence')::public.transaction_recurrence
+            ELSE bl.recurrence
+          END,
+          original_amount = CASE
+            WHEN v_update.line ? 'original_amount'
+            THEN v_update.line->>'original_amount'
+            ELSE bl.original_amount
+          END,
+          original_currency = CASE
+            WHEN v_update.line ? 'original_currency'
+            THEN v_update.line->>'original_currency'
+            ELSE bl.original_currency
+          END,
+          target_currency = CASE
+            WHEN v_update.line ? 'target_currency'
+            THEN v_update.line->>'target_currency'
+            ELSE bl.target_currency
+          END,
+          exchange_rate = CASE
+            WHEN v_update.line ? 'exchange_rate'
+            THEN CASE
+              WHEN (v_update.line->>'exchange_rate') IS NULL
+                OR (v_update.line->>'exchange_rate') = ''
+              THEN NULL
+              ELSE (v_update.line->>'exchange_rate')::numeric
+            END
+            ELSE bl.exchange_rate
+          END,
+          updated_at = NOW()
+        WHERE bl.template_line_id = (v_update.line->>'id')::uuid
+          AND bl.is_manually_adjusted = false
+          AND bl.budget_id = ANY(v_budget_ids)
+        RETURNING bl.budget_id
+      )
+      SELECT COALESCE(array_agg(DISTINCT budget_id), ARRAY[]::uuid[])
+      INTO v_new_ids
+      FROM updated_budget_lines;
+
+      IF v_new_ids IS NOT NULL THEN
+        v_impacted := array_cat(v_impacted, v_new_ids);
+      END IF;
+    END LOOP;
+
+    FOR v_create IN
+      SELECT
+        (line->>'id')::uuid AS id,
+        line->>'name' AS name,
+        line->>'amount' AS amount,
+        (line->>'kind')::public.transaction_kind AS kind,
+        (line->>'recurrence')::public.transaction_recurrence AS recurrence,
+        line->>'original_amount' AS original_amount,
+        line->>'original_currency' AS original_currency,
+        line->>'target_currency' AS target_currency,
+        CASE
+          WHEN (line->>'exchange_rate') IS NULL
+            OR (line->>'exchange_rate') = ''
+          THEN NULL
+          ELSE (line->>'exchange_rate')::numeric
+        END AS exchange_rate
+      FROM jsonb_array_elements(v_created_lines) AS line
+    LOOP
+      WITH inserted_budget_lines AS (
+        INSERT INTO public.budget_line (
+          budget_id,
+          template_line_id,
+          name,
+          amount,
+          recurrence,
+          is_manually_adjusted,
+          kind,
+          original_amount,
+          original_currency,
+          target_currency,
+          exchange_rate,
+          created_at,
+          updated_at
+        )
+        SELECT
+          bid,
+          v_create.id,
+          v_create.name,
+          v_create.amount,
+          v_create.recurrence,
+          false,
+          v_create.kind,
+          v_create.original_amount,
+          v_create.original_currency,
+          v_create.target_currency,
+          v_create.exchange_rate,
+          NOW(),
+          NOW()
+        FROM unnest(v_budget_ids) AS bid
+        RETURNING budget_id
+      )
+      SELECT COALESCE(array_agg(DISTINCT budget_id), ARRAY[]::uuid[])
+      INTO v_new_ids
+      FROM inserted_budget_lines;
+
+      IF v_new_ids IS NOT NULL THEN
+        v_impacted := array_cat(v_impacted, v_new_ids);
+      END IF;
+    END LOOP;
+
+  END IF;
+
+  -- 4. DELETE template_line rows last so budget-line propagation step 3
+  --    could still observe them via the FK chain.
+  IF COALESCE(array_length(v_delete_ids, 1), 0) > 0 THEN
+    DELETE FROM public.template_line tl
+    WHERE tl.template_id = v_template_id
+      AND tl.id = ANY(v_delete_ids);
+  END IF;
+
+  RETURN (
+    SELECT COALESCE(array_agg(DISTINCT budget_id), ARRAY[]::uuid[])
+    FROM (
+      SELECT DISTINCT unnest(v_impacted) AS budget_id
+    ) aggregated
+  );
+END;
+$$;
+
+ALTER FUNCTION public.apply_template_line_operations(uuid, uuid[], uuid[], jsonb, jsonb) OWNER TO postgres;
+
+-- PUL-272: mirror the sibling create_template_with_lines hardening (20260504120000).
+-- Strip the default PUBLIC/anon EXECUTE grant and scope it to authenticated +
+-- service_role. Belt-and-suspenders on top of the in-body ownership guard.
+REVOKE EXECUTE ON FUNCTION public.apply_template_line_operations(uuid, uuid[], uuid[], jsonb, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.apply_template_line_operations(uuid, uuid[], uuid[], jsonb, jsonb) TO authenticated, service_role;

--- a/backend-nest/supabase/tests/README.md
+++ b/backend-nest/supabase/tests/README.md
@@ -12,6 +12,7 @@ DB="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 
 psql "$DB" -f supabase/tests/apply_template_line_operations_atomicity.sql
 psql "$DB" -f supabase/tests/apply_template_line_operations_failure_rollback.sql
+psql "$DB" -f supabase/tests/apply_template_line_operations_cross_user.sql
 psql "$DB" -f supabase/tests/create_budget_from_template_owner_only.sql
 psql "$DB" -f supabase/tests/toggle_transaction_check.sql
 psql "$DB" -f supabase/tests/enforce_template_limit_per_user.sql
@@ -25,6 +26,7 @@ Each script prints `NOTICE:  ALL ASSERTIONS PASSED` on success, or raises an exc
 |------|---------------------|----------|
 | `apply_template_line_operations_atomicity.sql` | `apply_template_line_operations` | partial-patch UPDATE preserves untouched fields, INSERT with caller-supplied id, DELETE, budget propagation (UPDATE/INSERT/DELETE), return value |
 | `apply_template_line_operations_failure_rollback.sql` | `apply_template_line_operations` | invalid enum cast raises, no template_line writes leak (atomicity guarantee) |
+| `apply_template_line_operations_cross_user.sql` | `apply_template_line_operations` | cross-tenant budget injection rejected with `Budget access denied` (P0001), zero leaked rows, own-budget propagation preserved (IDOR fix) — PUL-272 |
 | `create_budget_from_template_owner_only.sql` | `create_budget_from_template` | owner can create budget from own template, other user's template is rejected (Bug #2 fix) |
 | `toggle_transaction_check.sql` | `toggle_transaction_check` | toggle null↔now, ownership enforcement, ending_balance untouched (Option A regression guard) — HI-14 |
 | `enforce_template_limit_per_user.sql` | `enforce_template_limit_per_user` trigger | 6th template insert rejected with P0001/TEMPLATE_LIMIT_EXCEEDED, cross-user isolation — HI-30 |

--- a/backend-nest/supabase/tests/apply_template_line_operations_cross_user.sql
+++ b/backend-nest/supabase/tests/apply_template_line_operations_cross_user.sql
@@ -1,0 +1,125 @@
+-- Security regression test (PUL-272): apply_template_line_operations must reject
+-- cross-user budget injection (IDOR). The function is SECURITY DEFINER so it
+-- bypasses RLS; its only authorization check is template ownership. An
+-- authenticated attacker who owns their own template must NOT be able to write
+-- budget_line rows into another user's budget by passing the victim's budget_id
+-- in budget_ids.
+--
+-- TDD: against the pre-fix function this test FAILS — the ghost line is injected
+-- into the victim's budget and no exception is raised. After the
+-- 20260610120000_secure_apply_template_line_operations hardening migration it
+-- PASSES: the function raises 'Budget access denied' (P0001) and writes nothing.
+--
+-- Wraps in a transaction and rolls back at the end so DB state is unaffected.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_attacker_id          uuid := gen_random_uuid();
+  v_victim_id            uuid := gen_random_uuid();
+  v_attacker_template_id uuid := gen_random_uuid();
+  v_victim_template_id   uuid := gen_random_uuid();
+  v_attacker_budget_id   uuid := gen_random_uuid();
+  v_victim_budget_id     uuid := gen_random_uuid();
+  v_ghost_line_id        uuid := gen_random_uuid();
+  v_nominal_line_id      uuid := gen_random_uuid();
+  v_caught               boolean;
+  v_injected_count       int;
+BEGIN
+  -- Auth users (FK targets for template.user_id / monthly_budget.user_id).
+  INSERT INTO auth.users (id, email, encrypted_password, instance_id, aud, role)
+  VALUES
+    (v_attacker_id, 'attacker@local.test', 'fake',
+     '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated'),
+    (v_victim_id, 'victim@local.test', 'fake',
+     '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated');
+
+  -- The attacker is the authenticated requester.
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object('sub', v_attacker_id::text)::text,
+    true
+  );
+
+  -- Attacker owns their template — passes the only ownership guard (line 56).
+  INSERT INTO public.template (id, user_id, name, description, is_default)
+  VALUES (v_attacker_template_id, v_attacker_id, 'Attacker Template', '', false);
+
+  -- Victim owns their own template + budget. The attacker never had access.
+  INSERT INTO public.template (id, user_id, name, description, is_default)
+  VALUES (v_victim_template_id, v_victim_id, 'Victim Template', '', false);
+
+  -- Attacker's own budget (control case for the nominal path).
+  INSERT INTO public.monthly_budget (id, user_id, template_id, month, year, description)
+  VALUES (v_attacker_budget_id, v_attacker_id, v_attacker_template_id, 6, 2026, 'Attacker June');
+
+  -- Victim's budget (the cross-tenant target).
+  INSERT INTO public.monthly_budget (id, user_id, template_id, month, year, description)
+  VALUES (v_victim_budget_id, v_victim_id, v_victim_template_id, 7, 2026, 'Victim July');
+
+  -- ---------- ATTACK: inject a ghost budget_line into the victim's budget ----------
+  -- Attacker passes their OWN template_id (clears the ownership guard) but the
+  -- VICTIM's budget_id. The unconstrained INSERT propagation (function step 3)
+  -- would otherwise write a ghost budget_line into the victim's budget — with an
+  -- amount ciphertext encrypted under the attacker's DEK, so it decrypts to 0
+  -- for the victim (silent corruption).
+  v_caught := false;
+  BEGIN
+    PERFORM public.apply_template_line_operations(
+      template_id := v_attacker_template_id,
+      budget_ids := ARRAY[v_victim_budget_id]::uuid[],
+      created_lines := jsonb_build_array(
+        jsonb_build_object(
+          'id', v_ghost_line_id,
+          'name', 'GHOST',
+          'amount', 'CIPHERTEXT_ATTACKER_DEK',
+          'kind', 'expense',
+          'recurrence', 'fixed'
+        )
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_caught := true;
+    RAISE NOTICE 'PASS 1/3: cross-user injection rejected: %', SQLERRM;
+  END;
+
+  IF NOT v_caught THEN
+    RAISE EXCEPTION 'FAIL: cross-user call did not raise — IDOR is open';
+  END IF;
+
+  -- The victim's budget must contain zero injected lines (the function is atomic,
+  -- so even a rejected call must leave no partial write).
+  SELECT count(*) INTO v_injected_count
+  FROM public.budget_line WHERE budget_id = v_victim_budget_id;
+  IF v_injected_count <> 0 THEN
+    RAISE EXCEPTION 'FAIL: % ghost budget_line(s) leaked into victim budget', v_injected_count;
+  END IF;
+  RAISE NOTICE 'PASS 2/3: victim budget has zero injected lines';
+
+  -- ---------- NOMINAL: attacker propagating to their OWN budget still works ----------
+  PERFORM public.apply_template_line_operations(
+    template_id := v_attacker_template_id,
+    budget_ids := ARRAY[v_attacker_budget_id]::uuid[],
+    created_lines := jsonb_build_array(
+      jsonb_build_object(
+        'id', v_nominal_line_id,
+        'name', 'Legit Line',
+        'amount', 'CIPHERTEXT_OWN',
+        'kind', 'expense',
+        'recurrence', 'fixed'
+      )
+    )
+  );
+  SELECT count(*) INTO v_injected_count
+  FROM public.budget_line
+  WHERE budget_id = v_attacker_budget_id AND template_line_id = v_nominal_line_id;
+  IF v_injected_count <> 1 THEN
+    RAISE EXCEPTION 'FAIL: nominal own-budget propagation broken, count = %', v_injected_count;
+  END IF;
+  RAISE NOTICE 'PASS 3/3: nominal own-budget propagation intact';
+
+  RAISE NOTICE 'CROSS-USER IDOR GUARD: ALL ASSERTIONS PASSED';
+END $$;
+
+ROLLBACK;

--- a/backend-nest/supabase/tests/apply_template_line_operations_cross_user.sql
+++ b/backend-nest/supabase/tests/apply_template_line_operations_cross_user.sql
@@ -23,6 +23,7 @@ DECLARE
   v_attacker_budget_id   uuid := gen_random_uuid();
   v_victim_budget_id     uuid := gen_random_uuid();
   v_ghost_line_id        uuid := gen_random_uuid();
+  v_mixed_line_id        uuid := gen_random_uuid();
   v_nominal_line_id      uuid := gen_random_uuid();
   v_caught               boolean;
   v_injected_count       int;
@@ -42,7 +43,7 @@ BEGIN
     true
   );
 
-  -- Attacker owns their template — passes the only ownership guard (line 56).
+  -- Attacker owns their template — clears the template-ownership guard.
   INSERT INTO public.template (id, user_id, name, description, is_default)
   VALUES (v_attacker_template_id, v_attacker_id, 'Attacker Template', '', false);
 
@@ -81,7 +82,7 @@ BEGIN
     );
   EXCEPTION WHEN OTHERS THEN
     v_caught := true;
-    RAISE NOTICE 'PASS 1/3: cross-user injection rejected: %', SQLERRM;
+    RAISE NOTICE 'PASS 1/4: cross-user injection rejected: %', SQLERRM;
   END;
 
   IF NOT v_caught THEN
@@ -95,7 +96,44 @@ BEGIN
   IF v_injected_count <> 0 THEN
     RAISE EXCEPTION 'FAIL: % ghost budget_line(s) leaked into victim budget', v_injected_count;
   END IF;
-  RAISE NOTICE 'PASS 2/3: victim budget has zero injected lines';
+  RAISE NOTICE 'PASS 2/4: victim budget has zero injected lines';
+
+  -- ---------- ATTACK 2: mixed array [own budget, victim budget] ----------
+  -- The strongest bypass attempt: smuggle the victim's budget alongside the
+  -- attacker's own. A naive guard ("at least one owned budget" / filter-then-write)
+  -- would write to the owned budget and silently drop the victim's. The guard must
+  -- instead reject the WHOLE call and — being atomic — write nothing, not even to
+  -- the attacker's own budget.
+  v_caught := false;
+  BEGIN
+    PERFORM public.apply_template_line_operations(
+      template_id := v_attacker_template_id,
+      budget_ids := ARRAY[v_attacker_budget_id, v_victim_budget_id]::uuid[],
+      created_lines := jsonb_build_array(
+        jsonb_build_object(
+          'id', v_mixed_line_id,
+          'name', 'GHOST_MIXED',
+          'amount', 'CIPHERTEXT_ATTACKER_DEK',
+          'kind', 'expense',
+          'recurrence', 'fixed'
+        )
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_caught := true;
+    RAISE NOTICE 'PASS 3/4: mixed own+victim array rejected: %', SQLERRM;
+  END;
+
+  IF NOT v_caught THEN
+    RAISE EXCEPTION 'FAIL: mixed own+victim array did not raise — guard checks "any owned" instead of "all owned"';
+  END IF;
+
+  -- Atomic rollback: zero rows written, including the attacker's OWN budget.
+  SELECT count(*) INTO v_injected_count
+  FROM public.budget_line WHERE template_line_id = v_mixed_line_id;
+  IF v_injected_count <> 0 THEN
+    RAISE EXCEPTION 'FAIL: % row(s) written despite rejected mixed call (non-atomic)', v_injected_count;
+  END IF;
 
   -- ---------- NOMINAL: attacker propagating to their OWN budget still works ----------
   PERFORM public.apply_template_line_operations(
@@ -117,7 +155,7 @@ BEGIN
   IF v_injected_count <> 1 THEN
     RAISE EXCEPTION 'FAIL: nominal own-budget propagation broken, count = %', v_injected_count;
   END IF;
-  RAISE NOTICE 'PASS 3/3: nominal own-budget propagation intact';
+  RAISE NOTICE 'PASS 4/4: nominal own-budget propagation intact';
 
   RAISE NOTICE 'CROSS-USER IDOR GUARD: ALL ASSERTIONS PASSED';
 END $$;


### PR DESCRIPTION
## Problème (PUL-272)

`apply_template_line_operations` est `SECURITY DEFINER` (contourne la RLS) et ne vérifiait que l'**ownership du template**. Les écritures sur `budget_line` filtraient uniquement sur `budget_id = ANY(budget_ids)` sans vérifier que ces budgets appartiennent à l'appelant — et la fonction conservait le `GRANT EXECUTE` par défaut à `PUBLIC`/`anon`/`authenticated`.

→ Tout utilisateur authentifié pouvait appeler la fonction directement via PostgREST (`POST /rest/v1/rpc/apply_template_line_operations`), en bypassant NestJS, avec son propre `template_id` (passe le seul garde) + le `budget_id` d'une **victime**, pour injecter/muter des `budget_line` dans le budget d'un autre compte. Les montants, chiffrés sous la DEK de l'attaquant, se déchiffrent à **0** chez la victime → corruption silencieuse.

État vulnérable confirmé sur la DB locale avant fix : aucun garde budget, `proacl` = `{=X, anon=X, authenticated=X, service_role=X}`.

## Fix

1. **Garde d'appartenance budget** (le vrai correctif), inséré **avant toute écriture**, juste après le check template : chaque budget de `budget_ids` doit appartenir à `(SELECT auth.uid())`, sinon `RAISE EXCEPTION 'Budget access denied'` (P0001). `unnest` d'un tableau vide ne produit aucune ligne → le chemin template-only (sans propagation) passe sans changement.
2. **`REVOKE EXECUTE FROM PUBLIC, anon` + `GRANT TO authenticated, service_role`** (belt-and-suspenders), miroir du durcissement du frère `create_template_with_lines` (`20260504120000`).

Corps de fonction byte-identique à `20260508120100` pour le reste.

## Tests (TDD, repro-first)

Nouveau `apply_template_line_operations_cross_user.sql` :
- 🔴 échoue contre la fonction pré-fix (`IDOR is open` — la ligne fantôme est injectée)
- 🟢 après migration : rejet `Budget access denied` + **zéro ligne injectée** chez la victime + chemin nominal own-budget intact

Non-régression : `apply_template_line_operations_atomicity` + `failure_rollback` restent verts.

## Vérifs

- Caller nominal = `AuthenticatedSupabaseProvider.client` (JWT user) → `auth.uid()` = appelant, le garde ne casse jamais la propagation sur ses propres budgets.
- Review adversariale indépendante : SAFE sur tous les axes (budget_ids mixte sien+victime rejeté, array vide, NULL `auth.uid()` fail-closed, NULL-owner rejeté, DELETE/UPDATE/INSERT couverts).
- `database.types.ts` : regen no-op (signature/retour inchangés).

## CA

- [x] CA1 — appel cross-user → `Budget access denied` (P0001)
- [x] CA2 — chemin nominal NestJS fonctionnel
- [x] CA3 — test de régression cross-user (repro d'abord, puis fix)
- [x] CA4 — `EXECUTE` révoqué pour `anon` ; types regen no-op
- [x] CA5 — 2 tests SQL existants verts