### PR TITLE
[codex] Add budget-line RPC access validation

### DIFF
--- a/backend-nest/src/modules/budget-line/application/check-transactions.use-case.spec.ts
+++ b/backend-nest/src/modules/budget-line/application/check-transactions.use-case.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, jest } from 'bun:test';
+import { Test } from '@nestjs/testing';
+import { Buffer } from 'node:buffer';
+import { CheckTransactionsUseCase } from './check-transactions.use-case';
+import { BUDGET_LINE_REPOSITORY } from '../domain/ports/budget-line-repository.port';
+import { CacheService } from '@modules/cache/cache.service';
+import type { AuthenticatedUser } from '@common/decorators/user.decorator';
+import type { Transaction } from '@modules/transaction/domain/transaction.entity';
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'transaction-1',
+    budgetId: 'budget-1',
+    budgetLineId: 'line-1',
+    name: 'Courses',
+    amount: 75,
+    originalAmount: null,
+    originalCurrency: null,
+    targetCurrency: null,
+    exchangeRate: null,
+    kind: 'expense',
+    category: null,
+    transactionDate: '2026-01-01',
+    checkedAt: '2026-01-01T00:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+];
+
+const mockUser: AuthenticatedUser = {
+  id: 'user-1',
+  email: 'test@example.com',
+  accessToken: 'token',
+  clientKey: Buffer.from('key'),
+};
+
+describe('CheckTransactionsUseCase', () => {
+  let useCase: CheckTransactionsUseCase;
+  let mockRepo: {
+    validateAccess: ReturnType<typeof jest.fn>;
+    checkUncheckedTransactionsRpc: ReturnType<typeof jest.fn>;
+  };
+  let mockCache: { invalidateForUser: ReturnType<typeof jest.fn> };
+  let callOrder: string[];
+
+  beforeEach(async () => {
+    callOrder = [];
+    mockRepo = {
+      validateAccess: jest.fn().mockImplementation(async () => {
+        callOrder.push('validateAccess');
+      }),
+      checkUncheckedTransactionsRpc: jest.fn().mockImplementation(async () => {
+        callOrder.push('checkUncheckedTransactionsRpc');
+        return mockTransactions;
+      }),
+    };
+    mockCache = { invalidateForUser: jest.fn().mockResolvedValue(undefined) };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CheckTransactionsUseCase,
+        { provide: BUDGET_LINE_REPOSITORY, useValue: mockRepo },
+        { provide: CacheService, useValue: mockCache },
+        {
+          provide: `INFO_LOGGER:${CheckTransactionsUseCase.name}`,
+          useValue: {
+            info: () => {},
+            debug: () => {},
+            warn: () => {},
+            trace: () => {},
+          },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(CheckTransactionsUseCase);
+  });
+
+  it('should validate access before checking transactions via rpc', async () => {
+    const result = await useCase.execute('line-1', mockUser);
+
+    expect(result).toEqual(mockTransactions);
+    expect(mockRepo.validateAccess).toHaveBeenCalledWith('line-1', mockUser.id);
+    expect(callOrder).toEqual([
+      'validateAccess',
+      'checkUncheckedTransactionsRpc',
+    ]);
+    expect(mockCache.invalidateForUser).toHaveBeenCalledWith(mockUser.id);
+  });
+
+  it('should not call rpc when access validation fails', async () => {
+    mockRepo.validateAccess.mockRejectedValueOnce(new Error('Access denied'));
+
+    await expect(useCase.execute('line-1', mockUser)).rejects.toThrow(
+      'Access denied',
+    );
+
+    expect(mockRepo.checkUncheckedTransactionsRpc).not.toHaveBeenCalled();
+    expect(mockCache.invalidateForUser).not.toHaveBeenCalled();
+  });
+});

--- a/backend-nest/src/modules/budget-line/application/check-transactions.use-case.ts
+++ b/backend-nest/src/modules/budget-line/application/check-transactions.use-case.ts
@@ -19,6 +19,7 @@ export class CheckTransactionsUseCase {
   ) {}
 
   async execute(id: string, user: AuthenticatedUser): Promise<Transaction[]> {
+    await this.repo.validateAccess(id, user.id);
     const entities = await this.repo.checkUncheckedTransactionsRpc(id);
 
     await this.cacheService.invalidateForUser(user.id);

--- a/backend-nest/src/modules/budget-line/application/toggle-budget-line-check.use-case.spec.ts
+++ b/backend-nest/src/modules/budget-line/application/toggle-budget-line-check.use-case.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, jest } from 'bun:test';
+import { Test } from '@nestjs/testing';
+import { Buffer } from 'node:buffer';
+import { ToggleBudgetLineCheckUseCase } from './toggle-budget-line-check.use-case';
+import { BUDGET_LINE_REPOSITORY } from '../domain/ports/budget-line-repository.port';
+import { CacheService } from '@modules/cache/cache.service';
+import type { AuthenticatedUser } from '@common/decorators/user.decorator';
+import type { BudgetLine } from '../domain/budget-line.entity';
+
+const mockEntity: BudgetLine = {
+  id: 'line-1',
+  budgetId: 'budget-1',
+  templateLineId: null,
+  savingsGoalId: null,
+  name: 'Loyer',
+  amount: 1200,
+  originalAmount: null,
+  originalCurrency: null,
+  targetCurrency: null,
+  exchangeRate: null,
+  kind: 'expense',
+  recurrence: 'fixed',
+  isManuallyAdjusted: false,
+  checkedAt: '2026-01-01T00:00:00.000Z',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const mockUser: AuthenticatedUser = {
+  id: 'user-1',
+  email: 'test@example.com',
+  accessToken: 'token',
+  clientKey: Buffer.from('key'),
+};
+
+describe('ToggleBudgetLineCheckUseCase', () => {
+  let useCase: ToggleBudgetLineCheckUseCase;
+  let mockRepo: {
+    validateAccess: ReturnType<typeof jest.fn>;
+    toggleCheckRpc: ReturnType<typeof jest.fn>;
+  };
+  let mockCache: { invalidateForUser: ReturnType<typeof jest.fn> };
+  let callOrder: string[];
+
+  beforeEach(async () => {
+    callOrder = [];
+    mockRepo = {
+      validateAccess: jest.fn().mockImplementation(async () => {
+        callOrder.push('validateAccess');
+      }),
+      toggleCheckRpc: jest.fn().mockImplementation(async () => {
+        callOrder.push('toggleCheckRpc');
+        return mockEntity;
+      }),
+    };
+    mockCache = { invalidateForUser: jest.fn().mockResolvedValue(undefined) };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        ToggleBudgetLineCheckUseCase,
+        { provide: BUDGET_LINE_REPOSITORY, useValue: mockRepo },
+        { provide: CacheService, useValue: mockCache },
+        {
+          provide: `INFO_LOGGER:${ToggleBudgetLineCheckUseCase.name}`,
+          useValue: {
+            info: () => {},
+            debug: () => {},
+            warn: () => {},
+            trace: () => {},
+          },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(ToggleBudgetLineCheckUseCase);
+  });
+
+  it('should validate access before toggling the budget line via rpc', async () => {
+    const result = await useCase.execute('line-1', mockUser);
+
+    expect(result).toEqual(mockEntity);
+    expect(mockRepo.validateAccess).toHaveBeenCalledWith('line-1', mockUser.id);
+    expect(callOrder).toEqual(['validateAccess', 'toggleCheckRpc']);
+    expect(mockCache.invalidateForUser).toHaveBeenCalledWith(mockUser.id);
+  });
+
+  it('should not call rpc when access validation fails', async () => {
+    mockRepo.validateAccess.mockRejectedValueOnce(new Error('Access denied'));
+
+    await expect(useCase.execute('line-1', mockUser)).rejects.toThrow(
+      'Access denied',
+    );
+
+    expect(mockRepo.toggleCheckRpc).not.toHaveBeenCalled();
+    expect(mockCache.invalidateForUser).not.toHaveBeenCalled();
+  });
+});

--- a/backend-nest/src/modules/budget-line/application/toggle-budget-line-check.use-case.ts
+++ b/backend-nest/src/modules/budget-line/application/toggle-budget-line-check.use-case.ts
@@ -19,6 +19,7 @@ export class ToggleBudgetLineCheckUseCase {
   ) {}
 
   async execute(id: string, user: AuthenticatedUser): Promise<BudgetLine> {
+    await this.repo.validateAccess(id, user.id);
     const entity = await this.repo.toggleCheckRpc(id);
 
     await this.cacheService.invalidateForUser(user.id);

--- a/backend-nest/src/modules/budget-line/domain/ports/budget-line-repository.port.ts
+++ b/backend-nest/src/modules/budget-line/domain/ports/budget-line-repository.port.ts
@@ -11,6 +11,7 @@ export const BUDGET_LINE_REPOSITORY = Symbol('BUDGET_LINE_REPOSITORY');
 export interface BudgetLineRepositoryPort {
   findAll(): Promise<BudgetLine[]>;
   findById(id: string): Promise<BudgetLine>;
+  validateAccess(id: string, userId: string): Promise<void>;
   findByBudgetId(budgetId: string): Promise<BudgetLine[]>;
   fetchBudgetIdForLine(id: string): Promise<string | null>;
   insert(input: BudgetLineCreateInput): Promise<BudgetLine>;

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
@@ -166,9 +166,15 @@ describe('SupabaseBudgetLineRepository', () => {
       }));
       repo = new SupabaseBudgetLineRepository(provider, createMockEncryption());
 
-      await expect(repo.validateAccess('line-1', mockUser.id)).rejects.toThrow(
-        BusinessException,
-      );
+      try {
+        await repo.validateAccess('line-1', mockUser.id);
+        throw new Error('expected to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessException);
+        expect((error as BusinessException).code).toBe(
+          'ERR_BUDGET_LINE_NOT_FOUND',
+        );
+      }
     });
 
     it('should throw with context and cause when supabase returns an error', async () => {

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
@@ -171,9 +171,17 @@ describe('SupabaseBudgetLineRepository', () => {
         throw new Error('expected to throw');
       } catch (error) {
         expect(error).toBeInstanceOf(BusinessException);
-        expect((error as BusinessException).code).toBe(
-          'ERR_BUDGET_LINE_NOT_FOUND',
-        );
+        const businessError = error as BusinessException;
+        expect(businessError.code).toBe('ERR_BUDGET_LINE_NOT_FOUND');
+        expect(businessError.cause).toBeUndefined();
+        expect(businessError.loggingContext).toEqual({
+          operation: 'validateAccess',
+          entityId: 'line-1',
+          entityType: 'budget_line',
+          userId: mockUser.id,
+          supabaseError: null,
+          reason: 'user_mismatch',
+        });
       }
     });
 

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
@@ -134,6 +134,44 @@ describe('SupabaseBudgetLineRepository', () => {
     });
   });
 
+  describe('validateAccess', () => {
+    it('should resolve when budget line belongs to user', async () => {
+      const provider = createMockProvider(() => ({
+        select: () => ({
+          eq: () => ({
+            single: jest.fn().mockResolvedValue({
+              data: { ...mockRow, monthly_budget: { user_id: mockUser.id } },
+              error: null,
+            }),
+          }),
+        }),
+      }));
+      repo = new SupabaseBudgetLineRepository(provider, createMockEncryption());
+
+      await expect(repo.validateAccess('line-1', mockUser.id)).resolves.toBe(
+        undefined,
+      );
+    });
+
+    it('should throw when budget line belongs to another user', async () => {
+      const provider = createMockProvider(() => ({
+        select: () => ({
+          eq: () => ({
+            single: jest.fn().mockResolvedValue({
+              data: { ...mockRow, monthly_budget: { user_id: 'user-2' } },
+              error: null,
+            }),
+          }),
+        }),
+      }));
+      repo = new SupabaseBudgetLineRepository(provider, createMockEncryption());
+
+      await expect(repo.validateAccess('line-1', mockUser.id)).rejects.toThrow(
+        BusinessException,
+      );
+    });
+  });
+
   describe('insert', () => {
     it('should encrypt amount and return decrypted entity on success', async () => {
       const provider = createMockProvider(() => ({

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
@@ -170,6 +170,41 @@ describe('SupabaseBudgetLineRepository', () => {
         BusinessException,
       );
     });
+
+    it('should throw with context and cause when supabase returns an error', async () => {
+      const supabaseError = {
+        message: 'connection error',
+        code: 'PGRST_CONN',
+      };
+      const provider = createMockProvider(() => ({
+        select: () => ({
+          eq: () => ({
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: supabaseError,
+            }),
+          }),
+        }),
+      }));
+      repo = new SupabaseBudgetLineRepository(provider, createMockEncryption());
+
+      try {
+        await repo.validateAccess('line-1', mockUser.id);
+        throw new Error('expected to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessException);
+        const businessError = error as BusinessException;
+        expect(businessError.code).toBe('ERR_BUDGET_LINE_NOT_FOUND');
+        expect(businessError.cause).toBe(supabaseError);
+        expect(businessError.loggingContext).toEqual({
+          operation: 'validateAccess',
+          entityId: 'line-1',
+          entityType: 'budget_line',
+          userId: mockUser.id,
+          supabaseError,
+        });
+      }
+    });
   });
 
   describe('insert', () => {

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
@@ -166,23 +166,20 @@ describe('SupabaseBudgetLineRepository', () => {
       }));
       repo = new SupabaseBudgetLineRepository(provider, createMockEncryption());
 
-      try {
-        await repo.validateAccess('line-1', mockUser.id);
-        throw new Error('expected to throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(BusinessException);
-        const businessError = error as BusinessException;
-        expect(businessError.code).toBe('ERR_BUDGET_LINE_NOT_FOUND');
-        expect(businessError.cause).toBeUndefined();
-        expect(businessError.loggingContext).toEqual({
+      await expect(
+        repo.validateAccess('line-1', mockUser.id),
+      ).rejects.toMatchObject({
+        code: 'ERR_BUDGET_LINE_NOT_FOUND',
+        cause: undefined,
+        loggingContext: {
           operation: 'validateAccess',
           entityId: 'line-1',
           entityType: 'budget_line',
           userId: mockUser.id,
           supabaseError: null,
           reason: 'user_mismatch',
-        });
-      }
+        },
+      });
     });
 
     it('should throw with context and cause when supabase returns an error', async () => {
@@ -202,22 +199,19 @@ describe('SupabaseBudgetLineRepository', () => {
       }));
       repo = new SupabaseBudgetLineRepository(provider, createMockEncryption());
 
-      try {
-        await repo.validateAccess('line-1', mockUser.id);
-        throw new Error('expected to throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(BusinessException);
-        const businessError = error as BusinessException;
-        expect(businessError.code).toBe('ERR_BUDGET_LINE_NOT_FOUND');
-        expect(businessError.cause).toBe(supabaseError);
-        expect(businessError.loggingContext).toEqual({
+      await expect(
+        repo.validateAccess('line-1', mockUser.id),
+      ).rejects.toMatchObject({
+        code: 'ERR_BUDGET_LINE_NOT_FOUND',
+        cause: supabaseError,
+        loggingContext: {
           operation: 'validateAccess',
           entityId: 'line-1',
           entityType: 'budget_line',
           userId: mockUser.id,
           supabaseError,
-        });
-      }
+        },
+      });
     });
   });
 

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -80,6 +80,31 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
     return this.toEntity(data, dek);
   }
 
+  async validateAccess(id: string, userId: string): Promise<void> {
+    const supabase = this.supabaseProvider.client;
+    const { data, error } = await supabase
+      .from('budget_line')
+      .select('*, monthly_budget!inner(user_id)')
+      .eq('id', id)
+      .single();
+
+    if (error || !data) {
+      throw new BusinessException(ERROR_DEFINITIONS.BUDGET_LINE_NOT_FOUND, {
+        id,
+      });
+    }
+
+    const row = data as BudgetLineRow & {
+      monthly_budget: { user_id: string };
+    };
+
+    if (row.monthly_budget.user_id !== userId) {
+      throw new BusinessException(ERROR_DEFINITIONS.BUDGET_LINE_NOT_FOUND, {
+        id,
+      });
+    }
+  }
+
   async findByBudgetId(budgetId: string): Promise<BudgetLine[]> {
     const supabase = this.supabaseProvider.client;
     const { data, error } = await supabase

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -113,8 +113,8 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
       throw new BusinessException(
         ERROR_DEFINITIONS.BUDGET_LINE_NOT_FOUND,
         { id },
-        loggingContext,
-        { cause: error ?? undefined },
+        { ...loggingContext, reason: 'user_mismatch' },
+        { cause: undefined },
       );
     }
   }

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -84,7 +84,7 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
     const supabase = this.supabaseProvider.client;
     const { data, error } = await supabase
       .from('budget_line')
-      .select('*, monthly_budget!inner(user_id)')
+      .select('id, monthly_budget!inner(user_id)')
       .eq('id', id)
       .single();
 

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -88,10 +88,21 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
       .eq('id', id)
       .single();
 
+    const loggingContext = {
+      operation: 'validateAccess',
+      entityId: id,
+      entityType: 'budget_line',
+      userId,
+      supabaseError: error,
+    };
+
     if (error || !data) {
-      throw new BusinessException(ERROR_DEFINITIONS.BUDGET_LINE_NOT_FOUND, {
-        id,
-      });
+      throw new BusinessException(
+        ERROR_DEFINITIONS.BUDGET_LINE_NOT_FOUND,
+        { id },
+        loggingContext,
+        { cause: error ?? undefined },
+      );
     }
 
     const row = data as BudgetLineRow & {
@@ -99,9 +110,12 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
     };
 
     if (row.monthly_budget.user_id !== userId) {
-      throw new BusinessException(ERROR_DEFINITIONS.BUDGET_LINE_NOT_FOUND, {
-        id,
-      });
+      throw new BusinessException(
+        ERROR_DEFINITIONS.BUDGET_LINE_NOT_FOUND,
+        { id },
+        loggingContext,
+        { cause: error ?? undefined },
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- Add app-layer access validation before `toggle_budget_line_check` and `check_unchecked_transactions` RPC calls.
- Add `validateAccess(id, userId)` to the budget-line repository port and Supabase implementation.
- Cover both use cases with tests ensuring RPCs are not called when access validation fails.

## Context

PUL-250 was still relevant at the application layer. The SQL RPCs already enforce `auth.uid()` through `monthly_budget.user_id`, but the use cases previously called the RPCs directly without a defense-in-depth access check.

## Validation

- `bun test src/modules/budget-line/application/toggle-budget-line-check.use-case.spec.ts src/modules/budget-line/application/check-transactions.use-case.spec.ts src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts`
- `corepack pnpm --filter backend-nest type-check:full`
- `corepack pnpm --filter backend-nest lint`
- `corepack pnpm --filter backend-nest format:check`
- `corepack pnpm --filter backend-nest lint:arch`
- Pre-commit `pnpm quality` hook passed