### PR TITLE
[codex] Fix budget line delete error mapping

### DIFF
--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
@@ -201,17 +201,28 @@ describe('SupabaseBudgetLineRepository', () => {
       await expect(repo.delete('line-1')).resolves.toBeUndefined();
     });
 
-    it('should throw when deletion fails', async () => {
+    it('should throw BUDGET_LINE_DELETE_FAILED with cause when deletion fails', async () => {
+      const dbError = { code: '08006', message: 'connection lost' };
       const provider = createMockProvider(() => ({
         delete: () => ({
           eq: jest.fn().mockResolvedValue({
-            error: { message: 'Delete failed' },
+            error: dbError,
           }),
         }),
       }));
       repo = new SupabaseBudgetLineRepository(provider, createMockEncryption());
 
-      await expect(repo.delete('line-1')).rejects.toThrow(BusinessException);
+      try {
+        await repo.delete('line-1');
+        throw new Error('expected to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessException);
+        const businessError = error as BusinessException;
+        expect(businessError.code).toBe('ERR_BUDGET_LINE_DELETE_FAILED');
+        expect(businessError.getStatus()).toBe(500);
+        expect(businessError.cause).toBe(dbError);
+        expect(businessError.loggingContext.supabaseError).toBe(dbError);
+      }
     });
   });
 

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -232,7 +232,7 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
 
     if (error) {
       throw new BusinessException(
-        ERROR_DEFINITIONS.BUDGET_LINE_NOT_FOUND,
+        ERROR_DEFINITIONS.BUDGET_LINE_DELETE_FAILED,
         { id },
         {
           operation: 'deleteBudgetLine',
@@ -240,6 +240,7 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
           entityType: 'budget_line',
           supabaseError: error,
         },
+        { cause: error },
       );
     }
   }


### PR DESCRIPTION
## Summary

Fixes PUL-249 by changing `SupabaseBudgetLineRepository.delete()` so Supabase delete failures are reported as `BUDGET_LINE_DELETE_FAILED` instead of `BUDGET_LINE_NOT_FOUND`.

## Root cause

The repository mapped every Supabase error during `delete().eq()` to a 404 not-found error and did not pass `{ cause: error }`, so transient database or RLS failures were indistinguishable from missing rows and lost their cause chain.

## Changes

- Map Supabase delete errors to `ERR_BUDGET_LINE_DELETE_FAILED` / HTTP 500.
- Preserve the original Supabase error with `{ cause: error }`.
- Add a regression test that asserts the error code, status, cause, and logging context.

## Validation

- `bun test src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts`
- `bun run type-check:full`
- `bun run lint` (passes with existing warnings)
- `bun run lint:arch`
- `bun run format:check`
- Pre-commit `pnpm quality --filter=...[HEAD^]` via lefthook