### PR TITLE
[codex] Fix docs encryption service references

### DIFF
--- a/.claude/rules/05-workflows-and-processes/encryption-backend.md
+++ b/.claude/rules/05-workflows-and-processes/encryption-backend.md
@@ -40,7 +40,7 @@ Each column stores AES-256-GCM ciphertext encoded in base64, or `null`.
 
 ## Write Rule
 
-All financial amounts MUST be encrypted via `EncryptionService` before writing to the database. Use `prepareAmountData(amount, dek)` which returns `{ amount: encryptedCiphertext }`.
+All financial amounts MUST be encrypted via `ENCRYPTION_PORT` before writing to the database. Repositories inject `EncryptionPort` and call `prepareAmountData(amount, userId, clientKey)`, which returns `{ amount: encryptedCiphertext }`.
 
 Demo mode uses `DEMO_CLIENT_KEY_BUFFER` — same encryption pipeline as real users.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ paths: "**/*.ts"
 - **NEVER** destructive Supabase cmds (`db reset`, `db push --force`)
 - **ALWAYS** run `pnpm quality` before commit
 - **AFTER** DB schema change: `bun run generate-types:local` in backend
-- **ALWAYS** encrypt financial amounts (`amount`, `target_amount`, `ending_balance`) via `EncryptionService` before DB write. Columns `text` holding AES-256-GCM ciphertexts. (see `docs/ENCRYPTION.md`)
+- **ALWAYS** encrypt financial amounts (`amount`, `target_amount`, `ending_balance`) via `ENCRYPTION_PORT` before DB write. Columns `text` holding AES-256-GCM ciphertexts. (see `docs/ENCRYPTION.md`)
 
 ## Vocabulary
 

--- a/backend-nest/scripts/encrypt-seed-data.ts
+++ b/backend-nest/scripts/encrypt-seed-data.ts
@@ -10,7 +10,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { createCipheriv, hkdfSync, pbkdf2Sync, randomBytes } from 'node:crypto';
 
-// ── Constants (must match EncryptionService) ──────────────────────────
+// ── Constants (must match AesGcmCryptoService) ────────────────────────
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
@@ -20,7 +20,7 @@ const KDF_ITERATIONS = 600_000;
 const TEST_USER_ID = '11111111-1111-1111-8111-111111111111';
 const TEST_PIN = '1234';
 // Dev-only fixed salt — deterministic so re-runs after `supabase db reset` produce the same DEK.
-// NOT used in production; real users get a random salt via EncryptionService.#ensureUserSalt().
+// NOT used in production; real users get a random salt via AesGcmCryptoService.#ensureUserSalt().
 const SEED_SALT_HEX = 'deadbeefcafebabe1234567890abcdef';
 
 // ── Env ───────────────────────────────────────────────────────────────

--- a/backend-nest/src/modules/budget-template/infrastructure/persistence/schemas/rpc-payload.schemas.ts
+++ b/backend-nest/src/modules/budget-template/infrastructure/persistence/schemas/rpc-payload.schemas.ts
@@ -12,8 +12,8 @@ import {
 // Matches SQL access `line->>'name' | 'amount' | 'kind' | 'recurrence' |
 // 'description' | 'original_amount' | 'original_currency' | 'target_currency'
 // | 'exchange_rate'` (see migration 20260427120000_create_template_with_lines_fx_columns).
-// `amount` + `original_amount` are AES-256-GCM ciphertexts produced by
-// EncryptionService. `exchange_rate` is a finite positive number or null.
+// `amount` + `original_amount` are AES-256-GCM ciphertexts produced through
+// ENCRYPTION_PORT. `exchange_rate` is a finite positive number or null.
 // ----------------------------------------------------------------------------
 export const createTemplateLineRpcPayloadSchema = z
   .object({

--- a/backend-nest/src/modules/encryption/domain/ports/encryption.port.ts
+++ b/backend-nest/src/modules/encryption/domain/ports/encryption.port.ts
@@ -3,10 +3,10 @@ import type { Buffer } from 'node:buffer';
 /**
  * EncryptionPort — port interface used by application use cases for encryption operations.
  *
- * The concrete implementation is `EncryptionService`. Use cases inject this port via DI token
- * to keep the application layer decoupled from the concrete service. (See encryption.module.ts wiring.)
+ * The concrete implementation is `AesGcmCryptoService`. Consumers inject this port via the
+ * `ENCRYPTION_PORT` DI token to stay decoupled from the concrete service. (See encryption.module.ts wiring.)
  *
- * NOTE: this interface is the SUPPORTED surface — methods on EncryptionService not listed here
+ * NOTE: this interface is the SUPPORTED surface — methods on AesGcmCryptoService not listed here
  * are reserved for the encryption controller (recovery flows, PIN change, key wrap/unwrap, etc.).
  */
 export interface EncryptionPort {

--- a/docs/ENCRYPTION.md
+++ b/docs/ENCRYPTION.md
@@ -321,7 +321,7 @@ Si la validation échoue, le serveur refuse de démarrer.
 
 | Fichier | Rôle |
 |---------|------|
-| `encryption.service.ts` | Dérivation DEK, chiffrement/déchiffrement AES-GCM, wrap/unwrap DEK, cache, re-chiffrement |
+| `encryption/infrastructure/crypto/aes-gcm.crypto-service.ts` | Dérivation DEK, chiffrement/déchiffrement AES-GCM, wrap/unwrap DEK, cache, re-chiffrement |
 | `encryption-key.repository.ts` | CRUD de la table `user_encryption_key` (salt, wrapped_dek) |
 | `encryption.controller.ts` | Endpoints `/salt`, `/validate-key`, `/setup-recovery`, `/recover`, `/change-pin` |
 | `client-key-cleanup.interceptor.ts` | Efface le clientKey de la mémoire après chaque requête |


### PR DESCRIPTION
## Summary

Fixes PUL-256 by replacing stale `EncryptionService` references in active docs and backend comments after the Clean Architecture encryption refactor.

## Changes

- Update agent-facing encryption rules to point consumers at `ENCRYPTION_PORT`.
- Update the encryption docs backend file table to `encryption/infrastructure/crypto/aes-gcm.crypto-service.ts`.
- Align the `EncryptionPort` JSDoc and backend comments with `AesGcmCryptoService` / `ENCRYPTION_PORT`.

## Root cause

The Clean Architecture refactor renamed the former concrete service to `AesGcmCryptoService` and exposed it to cross-module consumers through the `ENCRYPTION_PORT` DI token, but a few active documentation references still used the old service name.

## Validation

- `rg -n "EncryptionService|encryption\.service\.ts|prepareAmountData\(amount, dek\)" .`
  - Remaining matches are historical references in `backend-nest/docs/CLEAN_ARCH_TIER_PLAN.md` and ADR-0008.
- `git diff --check`
- Pre-commit `pnpm quality` via lefthook passed.
