### PR TITLE
feat(webapp): enforce force-update gate via web.minVersion (PUL-238)

### DIFF
--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -916,6 +916,11 @@
     "title": "Maintenance en cours",
     "message": "Le service est temporairement indisponible. Réessaie dans quelques instants."
   },
+  "forceUpdate": {
+    "title": "Mise à jour requise",
+    "message": "Une nouvelle version de Pulpe est disponible. Recharge la page pour reprendre là où tu en étais.",
+    "reload": "Recharger"
+  },
   "pageTitle": {
     "login": "Connexion",
     "signup": "Créer un compte",

--- a/frontend/projects/webapp/src/app/app.ts
+++ b/frontend/projects/webapp/src/app/app.ts
@@ -1,9 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
+import { ForceUpdateGate } from '@pattern/force-update';
+
 @Component({
   selector: 'pulpe-root',
-  imports: [RouterOutlet],
-  template: `<router-outlet />`,
+  imports: [RouterOutlet, ForceUpdateGate],
+  template: `
+    <router-outlet />
+    <pulpe-force-update-gate />
+  `,
 })
 export class App {}

--- a/frontend/projects/webapp/src/app/core/app-version/app-version-api.spec.ts
+++ b/frontend/projects/webapp/src/app/core/app-version/app-version-api.spec.ts
@@ -1,0 +1,105 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { REQUEST_ID_HEADER } from 'pulpe-shared';
+
+import { ApplicationConfiguration } from '../config/application-configuration';
+import { AppVersionApi } from './app-version-api';
+
+const VALID_PAYLOAD = {
+  success: true,
+  data: {
+    ios: { minVersion: '1.0.0', latestVersion: '1.0.2' },
+    web: { minVersion: '0.0.1', latestVersion: '0.35.0' },
+  },
+};
+
+describe('AppVersionApi', () => {
+  let service: AppVersionApi;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  const mockConfig = {
+    backendApiUrl: () => 'http://localhost:3000/api/v1',
+  };
+  const FIXED_REQUEST_ID = '00000000-0000-0000-0000-000000000000';
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue(FIXED_REQUEST_ID);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AppVersionApi,
+        { provide: ApplicationConfiguration, useValue: mockConfig },
+      ],
+    });
+
+    service = TestBed.inject(AppVersionApi);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('fetchVersion', () => {
+    it('should fetch and parse the version payload', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(VALID_PAYLOAD),
+      });
+
+      const result = await service.fetchVersion();
+
+      expect(result).toEqual(VALID_PAYLOAD);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/app/version',
+        { headers: { [REQUEST_ID_HEADER]: FIXED_REQUEST_ID } },
+      );
+    });
+
+    it('should throw when response is not ok', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(service.fetchVersion()).rejects.toThrow(
+        'App version check failed: 500',
+      );
+    });
+
+    it('should throw when the payload does not match the schema', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: {} }),
+      });
+
+      await expect(service.fetchVersion()).rejects.toThrow();
+    });
+
+    it('should deduplicate concurrent calls', async () => {
+      let resolvePromise: (value: unknown) => void;
+      mockFetch.mockReturnValue(
+        new Promise((resolve) => {
+          resolvePromise = resolve;
+        }),
+      );
+
+      const promise1 = service.fetchVersion();
+      const promise2 = service.fetchVersion();
+
+      resolvePromise!({
+        ok: true,
+        json: () => Promise.resolve(VALID_PAYLOAD),
+      });
+
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(result1).toEqual(VALID_PAYLOAD);
+      expect(result2).toEqual(VALID_PAYLOAD);
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/core/app-version/app-version-api.ts
+++ b/frontend/projects/webapp/src/app/core/app-version/app-version-api.ts
@@ -1,0 +1,55 @@
+import { inject, Injectable } from '@angular/core';
+
+import {
+  appVersionResponseSchema,
+  type AppVersionResponse,
+  REQUEST_ID_HEADER,
+} from 'pulpe-shared';
+
+import { ApplicationConfiguration } from '../config/application-configuration';
+import { NGROK_SKIP_HEADER } from '../config/ngrok.constants';
+
+/**
+ * Fetches the server-published minimum-supported-version payload.
+ * Uses native fetch instead of HttpClient: the endpoint is public (no auth)
+ * and the gate must work before interceptors/auth are fully initialized.
+ *
+ * No client-side TTL cache: the backend sends `Cache-Control: public,
+ * max-age=300`, so repeated checks within 5 minutes are served from the
+ * browser HTTP cache.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class AppVersionApi {
+  readonly #config = inject(ApplicationConfiguration);
+  #inFlight: Promise<AppVersionResponse> | null = null;
+
+  async fetchVersion(): Promise<AppVersionResponse> {
+    if (this.#inFlight) return this.#inFlight;
+
+    this.#inFlight = this.#fetchVersion().finally(() => {
+      this.#inFlight = null;
+    });
+
+    return this.#inFlight;
+  }
+
+  async #fetchVersion(): Promise<AppVersionResponse> {
+    const url = `${this.#config.backendApiUrl()}/app/version`;
+    const isNgrok = url.includes('ngrok');
+
+    const response = await fetch(url, {
+      headers: {
+        [REQUEST_ID_HEADER]: crypto.randomUUID(),
+        ...(isNgrok ? NGROK_SKIP_HEADER : {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`App version check failed: ${response.status}`);
+    }
+
+    return appVersionResponseSchema.parse(await response.json());
+  }
+}

--- a/frontend/projects/webapp/src/app/core/app-version/app-version-store.spec.ts
+++ b/frontend/projects/webapp/src/app/core/app-version/app-version-store.spec.ts
@@ -1,0 +1,141 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { AppVersionResponse } from 'pulpe-shared';
+
+import { Logger } from '@core/logging/logger';
+
+import { AppVersionApi } from './app-version-api';
+import { AppVersionStore } from './app-version-store';
+import { CURRENT_APP_VERSION } from './current-app-version';
+
+const createVersionResponse = (minVersion: string): AppVersionResponse => ({
+  success: true,
+  data: {
+    ios: { minVersion: '1.0.0', latestVersion: '1.0.0' },
+    web: { minVersion, latestVersion: '9.9.9' },
+  },
+});
+
+describe('AppVersionStore', () => {
+  let store: AppVersionStore;
+  let mockFetchVersion: ReturnType<typeof vi.fn>;
+
+  const mockLogger = {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockFetchVersion = vi.fn();
+    mockLogger.warn.mockReset();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: AppVersionApi,
+          useValue: { fetchVersion: mockFetchVersion },
+        },
+        { provide: CURRENT_APP_VERSION, useValue: '1.0.0' },
+        { provide: Logger, useValue: mockLogger },
+      ],
+    });
+
+    store = TestBed.inject(AppVersionStore);
+  });
+
+  describe('check', () => {
+    it('should require update when current version is below web.minVersion', async () => {
+      mockFetchVersion.mockResolvedValue(createVersionResponse('2.0.0'));
+
+      await store.check();
+
+      expect(store.isUpdateRequired()).toBe(true);
+    });
+
+    it('should not require update when current version meets web.minVersion', async () => {
+      mockFetchVersion.mockResolvedValue(createVersionResponse('1.0.0'));
+
+      await store.check();
+
+      expect(store.isUpdateRequired()).toBe(false);
+    });
+
+    it('should fail open when the first check errors', async () => {
+      mockFetchVersion.mockRejectedValue(new Error('Network error'));
+
+      await store.check();
+
+      expect(store.isUpdateRequired()).toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalledOnce();
+    });
+
+    it('should keep an already-shown gate when a later check errors', async () => {
+      mockFetchVersion.mockResolvedValue(createVersionResponse('2.0.0'));
+      await store.check();
+      expect(store.isUpdateRequired()).toBe(true);
+
+      mockFetchVersion.mockRejectedValue(new Error('Network error'));
+      await store.check();
+
+      expect(store.isUpdateRequired()).toBe(true);
+    });
+  });
+
+  describe('initialize', () => {
+    it('should check immediately on initialize', () => {
+      mockFetchVersion.mockResolvedValue(createVersionResponse('1.0.0'));
+
+      store.initialize();
+
+      expect(mockFetchVersion).toHaveBeenCalledOnce();
+    });
+
+    it('should re-check when the tab becomes visible', () => {
+      mockFetchVersion.mockResolvedValue(createVersionResponse('1.0.0'));
+      store.initialize();
+
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      expect(mockFetchVersion).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-check on pageshow restored from bfcache', () => {
+      mockFetchVersion.mockResolvedValue(createVersionResponse('1.0.0'));
+      store.initialize();
+
+      const event = new Event('pageshow');
+      Object.defineProperty(event, 'persisted', {
+        configurable: true,
+        value: true,
+      });
+      window.dispatchEvent(event);
+
+      expect(mockFetchVersion).toHaveBeenCalledTimes(2);
+    });
+
+    it('should only register listeners once across multiple initialize calls', () => {
+      mockFetchVersion.mockResolvedValue(createVersionResponse('1.0.0'));
+
+      store.initialize();
+      store.initialize();
+
+      expect(mockFetchVersion).toHaveBeenCalledOnce();
+    });
+
+    it('should remove event listeners on destroy', () => {
+      mockFetchVersion.mockResolvedValue(createVersionResponse('1.0.0'));
+      store.initialize();
+
+      TestBed.resetTestingModule();
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      expect(mockFetchVersion).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/core/app-version/app-version-store.ts
+++ b/frontend/projects/webapp/src/app/core/app-version/app-version-store.ts
@@ -1,0 +1,102 @@
+import { DOCUMENT } from '@angular/common';
+import {
+  computed,
+  DestroyRef,
+  inject,
+  Injectable,
+  signal,
+} from '@angular/core';
+
+import { Logger } from '@core/logging/logger';
+
+import { AppVersionApi } from './app-version-api';
+import { CURRENT_APP_VERSION } from './current-app-version';
+import { isVersionBelow } from './version-compare';
+
+type AppVersionStatus = 'unknown' | 'ok' | 'update-required';
+
+/**
+ * Force-update gate for the webapp (web analog of iOS `AppVersionStore`).
+ *
+ * Compares the running bundle version against the server-published
+ * `web.minVersion` on startup and whenever the tab returns to the foreground:
+ * `visibilitychange` for tab switches, `pageshow` for iOS Safari bfcache
+ * restores (which fire no `visibilitychange`).
+ *
+ * Fail-open on the first check so a version-endpoint outage never bricks the
+ * app. Once a status is known, later fetch errors keep it — going offline
+ * cannot dismiss an already-shown gate.
+ */
+@Injectable({ providedIn: 'root' })
+export class AppVersionStore {
+  readonly #api = inject(AppVersionApi);
+  readonly #logger = inject(Logger);
+  readonly #document = inject(DOCUMENT);
+  readonly #destroyRef = inject(DestroyRef);
+  readonly #currentVersion = inject(CURRENT_APP_VERSION);
+
+  readonly #status = signal<AppVersionStatus>('unknown');
+  readonly isUpdateRequired = computed(
+    () => this.#status() === 'update-required',
+  );
+
+  #isInitialized = false;
+
+  readonly #onVisibilityChange = (): void => {
+    if (this.#document.visibilityState === 'visible') {
+      void this.check();
+    }
+  };
+
+  readonly #onPageShow = (event: PageTransitionEvent): void => {
+    if (event.persisted) {
+      void this.check();
+    }
+  };
+
+  initialize(): void {
+    if (this.#isInitialized) return;
+    this.#isInitialized = true;
+
+    const win = this.#document.defaultView!;
+    this.#document.addEventListener(
+      'visibilitychange',
+      this.#onVisibilityChange,
+    );
+    win.addEventListener('pageshow', this.#onPageShow);
+
+    this.#destroyRef.onDestroy(() => {
+      this.#document.removeEventListener(
+        'visibilitychange',
+        this.#onVisibilityChange,
+      );
+      win.removeEventListener('pageshow', this.#onPageShow);
+    });
+
+    void this.check();
+  }
+
+  async check(): Promise<void> {
+    try {
+      const response = await this.#api.fetchVersion();
+      const minVersion = response.data.web.minVersion;
+      const isBelow = isVersionBelow(this.#currentVersion, minVersion);
+
+      this.#status.set(isBelow ? 'update-required' : 'ok');
+
+      if (isBelow) {
+        this.#logger.warn('[ForceUpdate] Bundle below minimum version', {
+          currentVersion: this.#currentVersion,
+          minVersion,
+        });
+      }
+    } catch (error) {
+      if (this.#status() === 'unknown') {
+        this.#status.set('ok');
+      }
+      this.#logger.warn('[ForceUpdate] Version check failed, failing open', {
+        error,
+      });
+    }
+  }
+}

--- a/frontend/projects/webapp/src/app/core/app-version/current-app-version.ts
+++ b/frontend/projects/webapp/src/app/core/app-version/current-app-version.ts
@@ -1,0 +1,15 @@
+import { InjectionToken } from '@angular/core';
+
+import { buildInfo } from '@env/build-info';
+
+/**
+ * Version of the currently running bundle. Indirected through DI so tests
+ * can pin a version without depending on the generated build-info file.
+ */
+export const CURRENT_APP_VERSION = new InjectionToken<string>(
+  'CURRENT_APP_VERSION',
+  {
+    providedIn: 'root',
+    factory: () => buildInfo.version,
+  },
+);

--- a/frontend/projects/webapp/src/app/core/app-version/index.ts
+++ b/frontend/projects/webapp/src/app/core/app-version/index.ts
@@ -1,0 +1,4 @@
+export { AppVersionApi } from './app-version-api';
+export { AppVersionStore } from './app-version-store';
+export { CURRENT_APP_VERSION } from './current-app-version';
+export { isVersionBelow } from './version-compare';

--- a/frontend/projects/webapp/src/app/core/app-version/version-compare.spec.ts
+++ b/frontend/projects/webapp/src/app/core/app-version/version-compare.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { isVersionBelow } from './version-compare';
+
+describe('isVersionBelow', () => {
+  it('should return true when current is below minimum', () => {
+    expect(isVersionBelow('0.34.0', '0.35.0')).toBe(true);
+  });
+
+  it('should return false when current equals minimum', () => {
+    expect(isVersionBelow('0.35.0', '0.35.0')).toBe(false);
+  });
+
+  it('should return false when current is above minimum', () => {
+    expect(isVersionBelow('1.0.0', '0.35.0')).toBe(false);
+  });
+
+  it('should compare segments numerically, not lexically', () => {
+    expect(isVersionBelow('1.0.10', '1.0.2')).toBe(false);
+    expect(isVersionBelow('1.0.2', '1.0.10')).toBe(true);
+  });
+
+  it('should compare major before minor and patch', () => {
+    expect(isVersionBelow('1.9.9', '2.0.0')).toBe(true);
+    expect(isVersionBelow('2.0.0', '1.9.9')).toBe(false);
+  });
+});

--- a/frontend/projects/webapp/src/app/core/app-version/version-compare.ts
+++ b/frontend/projects/webapp/src/app/core/app-version/version-compare.ts
@@ -1,0 +1,21 @@
+/**
+ * Numeric segment-by-segment comparison (`1.0.10` > `1.0.2`), web analog of
+ * the iOS gate's `String.isSemVerBelow`. Both inputs are strict `x.y.z`
+ * semver — enforced by `appVersionResponseSchema` server-side and the
+ * build-info generator client-side.
+ */
+export function isVersionBelow(current: string, minimum: string): boolean {
+  const currentParts = current.split('.').map(Number);
+  const minimumParts = minimum.split('.').map(Number);
+  const length = Math.max(currentParts.length, minimumParts.length);
+
+  for (let i = 0; i < length; i++) {
+    const currentPart = currentParts[i] ?? 0;
+    const minimumPart = minimumParts[i] ?? 0;
+    if (currentPart !== minimumPart) {
+      return currentPart < minimumPart;
+    }
+  }
+
+  return false;
+}

--- a/frontend/projects/webapp/src/app/core/core.ts
+++ b/frontend/projects/webapp/src/app/core/core.ts
@@ -29,6 +29,7 @@ import { provideAngularMaterial } from './angular-material';
 import { provideAuth } from './auth/auth-providers';
 import { AuthSessionService } from './auth/auth-session.service';
 import { PulpeTitleStrategy } from './routing/title-strategy';
+import { AppVersionStore } from './app-version/app-version-store';
 import { ApplicationConfiguration } from './config/application-configuration';
 import { PostHogService } from './analytics/posthog';
 import { AnalyticsService } from './analytics/analytics';
@@ -147,6 +148,7 @@ export function provideCore({ routes }: CoreOptions) {
       const storageMigrationRunner = inject(StorageMigrationRunnerService);
       const clientKeyService = inject(ClientKeyService);
       const resumeRefresh = inject(ResumeRefreshService);
+      const appVersionStore = inject(AppVersionStore);
       const injector = inject(Injector);
       const logger = inject(Logger);
 
@@ -164,6 +166,9 @@ export function provideCore({ routes }: CoreOptions) {
 
       // 1. Charger la configuration d'abord (requise par PostHog et Auth)
       await applicationConfig.initialize();
+
+      // 1b. Force-update gate : non-bloquant, fail-open (requiert backendApiUrl)
+      appVersionStore.initialize();
 
       // 2. Logger les informations complètes après chargement
       logAppInfo(applicationConfig, logger);

--- a/frontend/projects/webapp/src/app/pattern/force-update/force-update-gate.spec.ts
+++ b/frontend/projects/webapp/src/app/pattern/force-update/force-update-gate.spec.ts
@@ -1,0 +1,66 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed, type ComponentFixture } from '@angular/core/testing';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import { AppVersionStore } from '@core/app-version';
+import { PAGE_RELOAD } from '@core/page-reload';
+
+import { ForceUpdateGate } from './force-update-gate';
+
+describe('ForceUpdateGate', () => {
+  let fixture: ComponentFixture<ForceUpdateGate>;
+  const reloadSpy = vi.fn();
+  const isUpdateRequiredSignal = signal(false);
+
+  beforeEach(async () => {
+    reloadSpy.mockReset();
+    isUpdateRequiredSignal.set(false);
+
+    await TestBed.configureTestingModule({
+      imports: [ForceUpdateGate],
+      providers: [
+        provideZonelessChangeDetection(),
+        ...provideTranslocoForTest(),
+        {
+          provide: AppVersionStore,
+          useValue: { isUpdateRequired: isUpdateRequiredSignal.asReadonly() },
+        },
+        { provide: PAGE_RELOAD, useValue: reloadSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ForceUpdateGate);
+    await fixture.whenStable();
+  });
+
+  it('should render nothing when no update is required', () => {
+    const wall = fixture.nativeElement.querySelector(
+      '[data-testid="force-update-reload-button"]',
+    );
+
+    expect(wall).toBeNull();
+  });
+
+  it('should render the blocking wall when an update is required', async () => {
+    isUpdateRequiredSignal.set(true);
+    await fixture.whenStable();
+
+    const wall = fixture.nativeElement.querySelector('[role="alertdialog"]');
+
+    expect(wall).not.toBeNull();
+    expect(wall.textContent).toContain('Mise à jour requise');
+  });
+
+  it('should reload the page when the reload button is clicked', async () => {
+    isUpdateRequiredSignal.set(true);
+    await fixture.whenStable();
+
+    const button = fixture.nativeElement.querySelector(
+      '[data-testid="force-update-reload-button"]',
+    );
+    button.click();
+
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/projects/webapp/src/app/pattern/force-update/force-update-gate.ts
+++ b/frontend/projects/webapp/src/app/pattern/force-update/force-update-gate.ts
@@ -1,0 +1,60 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+
+import { TranslocoPipe } from '@jsverse/transloco';
+
+import { AppVersionStore } from '@core/app-version';
+import { PAGE_RELOAD } from '@core/page-reload';
+
+/**
+ * Non-dismissable "update required" wall rendered above every route when the
+ * running bundle is older than the server-published `web.minVersion`.
+ * On web, updating = reloading the page to fetch the fresh index.html.
+ */
+@Component({
+  selector: 'pulpe-force-update-gate',
+  imports: [MatButtonModule, TranslocoPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (isUpdateRequired()) {
+      <div
+        class="pulpe-entry-shell pulpe-gradient fixed inset-0 z-[9999]"
+        role="alertdialog"
+        aria-modal="true"
+        [attr.aria-label]="'forceUpdate.title' | transloco"
+      >
+        <div
+          class="pulpe-entry-card w-full max-w-lg items-center gap-6 text-center"
+        >
+          <h1 class="text-headline-large text-on-surface">
+            {{ 'forceUpdate.title' | transloco }}
+          </h1>
+
+          <p class="text-body-large text-on-surface-variant">
+            {{ 'forceUpdate.message' | transloco }}
+          </p>
+
+          <button
+            matButton="filled"
+            type="button"
+            data-testid="force-update-reload-button"
+            class="mt-4"
+            (click)="reloadPage()"
+          >
+            {{ 'forceUpdate.reload' | transloco }}
+          </button>
+        </div>
+      </div>
+    }
+  `,
+})
+export class ForceUpdateGate {
+  readonly #store = inject(AppVersionStore);
+  readonly #reload = inject(PAGE_RELOAD);
+
+  protected readonly isUpdateRequired = this.#store.isUpdateRequired;
+
+  protected reloadPage(): void {
+    this.#reload();
+  }
+}

--- a/frontend/projects/webapp/src/app/pattern/force-update/index.ts
+++ b/frontend/projects/webapp/src/app/pattern/force-update/index.ts
@@ -1,0 +1,1 @@
+export { ForceUpdateGate } from './force-update-gate';


### PR DESCRIPTION
## Résumé

La webapp Angular consomme enfin `GET /api/v1/app/version` (PUL-235 n'avait livré que le contrat serveur). Quand le bundle courant est plus vieux que `web.minVersion`, un mur non-dismissable « Mise à jour requise » bloque toutes les routes avec un CTA « Recharger » qui re-fetch le bundle frais.

Kill switch dormant : `MIN_WEB_VERSION` vaut `0.0.1` par défaut, la gate ne s'affiche jamais tant qu'on ne la bump pas volontairement sur Railway.

## Implémentation

- `core/app-version/` — `AppVersionApi` (fetch natif public, parse Zod `appVersionResponseSchema`, dédup in-flight, cache HTTP navigateur via le `Cache-Control: max-age=300` du backend), `AppVersionStore` (signal store), `isVersionBelow` (comparaison numérique segment par segment, analog de `String.isSemVerBelow` iOS), token `CURRENT_APP_VERSION` sur `buildInfo.version`
- `pattern/force-update/` — `ForceUpdateGate`, rendu dans `App` root au-dessus du `router-outlet` (style `pulpe-entry-shell`/`pulpe-entry-card`, même DA que la page maintenance)
- Déclenchement : au boot (après chargement config, non-bloquant) + `visibilitychange` (tab switch desktop) + `pageshow persisted` (bfcache iOS Safari, qui ne fire pas `visibilitychange`)
- Sémantique identique à la gate iOS : fail-open au premier check (panne endpoint ≠ app briquée), sticky ensuite (passer offline ne dismisse pas une gate affichée)

## Vérification

- 1976 tests unitaires verts (17 nouveaux : store, comparaison semver, API, composant)
- Vérification runtime Playwright contre `ng serve` (endpoint stubé) — 7/7 :
  - gate visible desktop + mobile, copy correcte
  - Échap / clic extérieur ne la dismisse pas
  - « Recharger » recharge la page (et la gate revient si le serveur sert toujours une version périmée)
  - pas de gate quand la version est à jour, pas de gate sur erreur 500 (fail-open)
  - re-check au `visibilitychange` : bump de `minVersion` pendant que l'onglet est ouvert → gate apparaît au retour au premier plan
- `pnpm quality` 10/10