### PR TITLE
fix(webapp): clean up orphan onboarding template when budget generation fails (PUL-131)

### DIFF
--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
@@ -11,7 +11,10 @@ import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 
 describe('ProfileSetupService', () => {
   let service: ProfileSetupService;
-  let mockApiClient: { post$: ReturnType<typeof vi.fn> };
+  let mockApiClient: {
+    post$: ReturnType<typeof vi.fn>;
+    deleteVoid$: ReturnType<typeof vi.fn>;
+  };
   let mockBudgetApi: {
     generateBudgets$: ReturnType<typeof vi.fn>;
     getAllBudgets$: ReturnType<typeof vi.fn>;
@@ -31,6 +34,7 @@ describe('ProfileSetupService', () => {
           data: { template: { id: 'template-123' } },
         }),
       ),
+      deleteVoid$: vi.fn().mockReturnValue(of(undefined)),
     };
 
     mockBudgetApi = {
@@ -282,6 +286,51 @@ describe('ProfileSetupService', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
       expect(mockBudgetApi.generateBudgets$).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('orphan template cleanup on generate failure', () => {
+    it('should delete the onboarding template when budget generation fails', async () => {
+      mockBudgetApi.generateBudgets$.mockReturnValue(
+        throwError(() => new Error('budget generation failed')),
+      );
+
+      const result = await service.createInitialBudget({
+        firstName: 'Test',
+        monthlyIncome: 3000,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockApiClient.deleteVoid$).toHaveBeenCalledWith(
+        '/budget-templates/template-123',
+      );
+    });
+
+    it('should still surface the budget error when template cleanup also fails', async () => {
+      mockBudgetApi.generateBudgets$.mockReturnValue(
+        throwError(() => new Error('budget generation failed')),
+      );
+      mockApiClient.deleteVoid$.mockReturnValue(
+        throwError(() => new Error('cleanup failed')),
+      );
+
+      const result = await service.createInitialBudget({
+        firstName: 'Test',
+        monthlyIncome: 3000,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should not delete the template when onboarding succeeds', async () => {
+      const result = await service.createInitialBudget({
+        firstName: 'Test',
+        monthlyIncome: 3000,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockApiClient.deleteVoid$).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.ts
@@ -87,6 +87,7 @@ export class ProfileSetupService {
       await firstValueFrom(this.#budgetApi.generateBudgets$(generateRequest));
     } catch (error: unknown) {
       this.#logger.error('Budget generation failed:', error);
+      await this.#cleanupOrphanTemplate(templateId);
       return {
         success: false,
         error: this.#transloco.translate('completeProfile.budgetGenerateError'),
@@ -120,5 +121,18 @@ export class ProfileSetupService {
       budgetTemplateCreateResponseSchema,
       budgetTemplateCreateFromOnboardingSchema,
     );
+  }
+
+  async #cleanupOrphanTemplate(templateId: string): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.#api.deleteVoid$(`/budget-templates/${templateId}`),
+      );
+    } catch (error: unknown) {
+      this.#logger.warn(
+        '[ProfileSetupService] Failed to clean up orphan onboarding template',
+        error,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Contexte

Re-audit de PUL-131 (cf. ticket ré-écrit). Le bug d'origine — rate limit DB « 1 template onboarding / 24h » bloquant le user — **n'existe plus** (supprimé par le refactor Clean Architecture #430). Ce qui reste réel : l'onboarding est non-atomique côté frontend.

`ProfileSetupService.createInitialBudget()` fait 2 écritures séquentielles :
1. `POST /budget-templates/from-onboarding` → crée le template
2. `POST /budgets/generate` → génère 12 budgets

Si l'étape 2 échoue après l'étape 1 : les budgets sont rollback côté backend, mais **le template restait orphelin** (aucun cleanup), et chaque retry recréait un nouveau template → fuite de templates orphelins.

## Changement

Nettoyage best-effort du template orphelin dans le `catch` de l'échec génération : `DELETE /budget-templates/:id`. Si le delete échoue aussi → `logger.warn`, l'erreur budget reste affichée à l'utilisateur, le retry est inchangé.

## Tests

3 tests unitaires ajoutés :
- delete appelé sur échec génération
- erreur toujours remontée si le cleanup échoue aussi
- pas de delete quand l'onboarding réussit

`vitest` : 16/16 sur le fichier, suite complète verte. `tsc`, `typecheck:spec`, `eslint` clean.

Closes PUL-131