### PR TITLE
[codex] PUL-202 clarify currency metadata DB mapper

### DIFF
--- a/backend-nest/src/common/utils/currency-metadata.mapper.spec.ts
+++ b/backend-nest/src/common/utils/currency-metadata.mapper.spec.ts
@@ -4,25 +4,26 @@ import { BusinessException } from '@common/exceptions/business.exception';
 import { mapCurrencyNonAmountMetadataToDb } from './currency-metadata.mapper';
 
 function expectOriginalAmountGuard(input: never): void {
+  let caught: unknown;
   try {
-    mapCurrencyNonAmountMetadataToDb(input);
-    throw new Error('expected originalAmount guard to throw');
+    mapCurrencyNonAmountMetadataToDb(input, { userId: 'user-123' });
   } catch (error) {
-    expect(error).toBeInstanceOf(BusinessException);
-    const businessError = error as BusinessException;
-    expect(businessError.code).toBe(
-      ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR.code,
-    );
-    expect(businessError.message).toBe('Internal server error');
-    expect(businessError.loggingContext).toEqual({
-      operation: 'mapCurrencyNonAmountMetadataToDb',
-      violation: 'originalAmount present',
-    });
-    expect(businessError.cause).toBeInstanceOf(Error);
-    expect((businessError.cause as Error).message).toBe(
-      'originalAmount must be encrypted separately with encryptOptionalAmount',
-    );
+    caught = error;
   }
+
+  expect(caught).toBeInstanceOf(BusinessException);
+  const businessError = caught as BusinessException;
+  expect(businessError.code).toBe(ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR.code);
+  expect(businessError.message).toBe('Internal server error');
+  expect(businessError.loggingContext).toEqual({
+    operation: 'mapCurrencyNonAmountMetadataToDb',
+    violation: 'originalAmount present',
+    userId: 'user-123',
+  });
+  expect(businessError.cause).toBeInstanceOf(Error);
+  expect((businessError.cause as Error).message).toBe(
+    'originalAmount must be encrypted separately with encryptOptionalAmount',
+  );
 }
 
 describe('mapCurrencyNonAmountMetadataToDb', () => {

--- a/backend-nest/src/common/utils/currency-metadata.mapper.spec.ts
+++ b/backend-nest/src/common/utils/currency-metadata.mapper.spec.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect } from 'bun:test';
-import { mapCurrencyMetadataToDb } from './currency-metadata.mapper';
+import { mapCurrencyNonAmountMetadataToDb } from './currency-metadata.mapper';
 
-describe('mapCurrencyMetadataToDb', () => {
+describe('mapCurrencyNonAmountMetadataToDb', () => {
   it('should return an empty object when no currency fields are provided', () => {
-    const result = mapCurrencyMetadataToDb({});
+    const result = mapCurrencyNonAmountMetadataToDb({});
 
     expect(result).toEqual({});
   });
 
   it('should emit only the original_currency key when only originalCurrency is set', () => {
-    const result = mapCurrencyMetadataToDb({ originalCurrency: 'EUR' });
+    const result = mapCurrencyNonAmountMetadataToDb({
+      originalCurrency: 'EUR',
+    });
 
     expect(result).toEqual({ original_currency: 'EUR' });
     expect(result).not.toHaveProperty('target_currency');
@@ -17,7 +19,9 @@ describe('mapCurrencyMetadataToDb', () => {
   });
 
   it('should emit only the target_currency key when only targetCurrency is set', () => {
-    const result = mapCurrencyMetadataToDb({ targetCurrency: 'CHF' });
+    const result = mapCurrencyNonAmountMetadataToDb({
+      targetCurrency: 'CHF',
+    });
 
     expect(result).toEqual({ target_currency: 'CHF' });
     expect(result).not.toHaveProperty('original_currency');
@@ -25,7 +29,7 @@ describe('mapCurrencyMetadataToDb', () => {
   });
 
   it('should emit only the exchange_rate key when only exchangeRate is set', () => {
-    const result = mapCurrencyMetadataToDb({ exchangeRate: 1.08 });
+    const result = mapCurrencyNonAmountMetadataToDb({ exchangeRate: 1.08 });
 
     expect(result).toEqual({ exchange_rate: 1.08 });
     expect(result).not.toHaveProperty('original_currency');
@@ -33,7 +37,7 @@ describe('mapCurrencyMetadataToDb', () => {
   });
 
   it('should emit all three keys when the full currency metadata is provided', () => {
-    const result = mapCurrencyMetadataToDb({
+    const result = mapCurrencyNonAmountMetadataToDb({
       originalCurrency: 'EUR',
       targetCurrency: 'CHF',
       exchangeRate: 1.05,
@@ -47,7 +51,7 @@ describe('mapCurrencyMetadataToDb', () => {
   });
 
   it('should preserve explicit null as null (clearing intent)', () => {
-    const result = mapCurrencyMetadataToDb({
+    const result = mapCurrencyNonAmountMetadataToDb({
       originalCurrency: null,
       exchangeRate: null,
     });
@@ -57,5 +61,36 @@ describe('mapCurrencyMetadataToDb', () => {
       exchange_rate: null,
     });
     expect(result).not.toHaveProperty('target_currency');
+  });
+
+  it('should reject originalAmount at runtime when callers bypass types', () => {
+    expect(() =>
+      mapCurrencyNonAmountMetadataToDb({
+        originalAmount: 120,
+      } as never),
+    ).toThrow('originalAmount must be encrypted separately');
+  });
+
+  it('should reject present originalAmount even when its value is undefined', () => {
+    expect(() =>
+      mapCurrencyNonAmountMetadataToDb({
+        originalAmount: undefined,
+      } as never),
+    ).toThrow('originalAmount must be encrypted separately');
+  });
+
+  it('should reject originalAmount at compile time', () => {
+    type WideCurrencyPatch = {
+      originalAmount?: number | null;
+      originalCurrency?: Parameters<
+        typeof mapCurrencyNonAmountMetadataToDb
+      >[0]['originalCurrency'];
+    };
+    const patch: WideCurrencyPatch = {};
+    const compileTimeOnly = () =>
+      // @ts-expect-error originalAmount must be encrypted before DB mapping.
+      mapCurrencyNonAmountMetadataToDb(patch);
+
+    expect(typeof compileTimeOnly).toBe('function');
   });
 });

--- a/backend-nest/src/common/utils/currency-metadata.mapper.spec.ts
+++ b/backend-nest/src/common/utils/currency-metadata.mapper.spec.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect } from 'bun:test';
+import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
+import { BusinessException } from '@common/exceptions/business.exception';
 import { mapCurrencyNonAmountMetadataToDb } from './currency-metadata.mapper';
+
+function expectOriginalAmountGuard(input: never): void {
+  try {
+    mapCurrencyNonAmountMetadataToDb(input);
+    throw new Error('expected originalAmount guard to throw');
+  } catch (error) {
+    expect(error).toBeInstanceOf(BusinessException);
+    const businessError = error as BusinessException;
+    expect(businessError.code).toBe(
+      ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR.code,
+    );
+    expect(businessError.message).toBe('Internal server error');
+    expect(businessError.loggingContext).toEqual({
+      operation: 'mapCurrencyNonAmountMetadataToDb',
+      violation: 'originalAmount present',
+    });
+    expect(businessError.cause).toBeInstanceOf(Error);
+    expect((businessError.cause as Error).message).toBe(
+      'originalAmount must be encrypted separately with encryptOptionalAmount',
+    );
+  }
+}
 
 describe('mapCurrencyNonAmountMetadataToDb', () => {
   it('should return an empty object when no currency fields are provided', () => {
@@ -64,19 +88,15 @@ describe('mapCurrencyNonAmountMetadataToDb', () => {
   });
 
   it('should reject originalAmount at runtime when callers bypass types', () => {
-    expect(() =>
-      mapCurrencyNonAmountMetadataToDb({
-        originalAmount: 120,
-      } as never),
-    ).toThrow('originalAmount must be encrypted separately');
+    expectOriginalAmountGuard({
+      originalAmount: 120,
+    } as never);
   });
 
   it('should reject present originalAmount even when its value is undefined', () => {
-    expect(() =>
-      mapCurrencyNonAmountMetadataToDb({
-        originalAmount: undefined,
-      } as never),
-    ).toThrow('originalAmount must be encrypted separately');
+    expectOriginalAmountGuard({
+      originalAmount: undefined,
+    } as never);
   });
 
   it('should reject originalAmount at compile time', () => {
@@ -91,6 +111,8 @@ describe('mapCurrencyNonAmountMetadataToDb', () => {
       // @ts-expect-error originalAmount must be encrypted before DB mapping.
       mapCurrencyNonAmountMetadataToDb(patch);
 
+    // Keep a runtime reference so TypeScript checks the closure without calling
+    // it; the regression guard is the @ts-expect-error above.
     expect(typeof compileTimeOnly).toBe('function');
   });
 });

--- a/backend-nest/src/common/utils/currency-metadata.mapper.ts
+++ b/backend-nest/src/common/utils/currency-metadata.mapper.ts
@@ -54,6 +54,10 @@ type CurrencyNonAmountDbColumns = Omit<
   'original_amount'
 >;
 
+interface CurrencyMetadataMappingContext {
+  userId?: string;
+}
+
 /**
  * Maps non-amount currency metadata DTO fields to their DB column names.
  *
@@ -67,6 +71,7 @@ type CurrencyNonAmountDbColumns = Omit<
  */
 export function mapCurrencyNonAmountMetadataToDb(
   dto: CurrencyNonAmountMetadataDto,
+  context: CurrencyMetadataMappingContext = {},
 ): Partial<CurrencyNonAmountDbColumns> {
   if ('originalAmount' in dto) {
     const cause = new Error(
@@ -78,6 +83,7 @@ export function mapCurrencyNonAmountMetadataToDb(
       {
         operation: 'mapCurrencyNonAmountMetadataToDb',
         violation: 'originalAmount present',
+        ...(context.userId && { userId: context.userId }),
       },
       { cause },
     );

--- a/backend-nest/src/common/utils/currency-metadata.mapper.ts
+++ b/backend-nest/src/common/utils/currency-metadata.mapper.ts
@@ -33,30 +33,46 @@ export function mapCurrencyMetadataToApi(
   };
 }
 
-interface CurrencyMetadataDto {
+interface CurrencyNonAmountMetadataDto {
   originalCurrency?: SupportedCurrency | null;
   targetCurrency?: SupportedCurrency | null;
   exchangeRate?: number | null;
+  originalAmount?: never;
 }
 
-interface CurrencyMetadataDb {
+interface CurrencyMetadataDbColumns {
+  original_amount: string | null;
   original_currency: string | null;
   target_currency: string | null;
   exchange_rate: number | null;
 }
 
+type CurrencyNonAmountDbColumns = Omit<
+  CurrencyMetadataDbColumns,
+  'original_amount'
+>;
+
 /**
- * Maps currency metadata DTO fields to their DB column names.
+ * Maps non-amount currency metadata DTO fields to their DB column names.
+ *
+ * `original_amount` is intentionally excluded because it is ciphertext. Callers
+ * must encrypt `originalAmount` separately with ENCRYPTION_PORT.encryptOptionalAmount.
  *
  * Returns only the keys that are explicitly defined in the input DTO — so
  * spreading the result onto a PATCH update object never clobbers untouched
  * columns. Missing keys are omitted; explicit `null` / `undefined` values
  * normalize to `null` for the columns the caller did mention.
  */
-export function mapCurrencyMetadataToDb(
-  dto: CurrencyMetadataDto,
-): Partial<CurrencyMetadataDb> {
-  const out: Partial<CurrencyMetadataDb> = {};
+export function mapCurrencyNonAmountMetadataToDb(
+  dto: CurrencyNonAmountMetadataDto,
+): Partial<CurrencyNonAmountDbColumns> {
+  if ('originalAmount' in dto) {
+    throw new Error(
+      'originalAmount must be encrypted separately with encryptOptionalAmount',
+    );
+  }
+
+  const out: Partial<CurrencyNonAmountDbColumns> = {};
   if (dto.originalCurrency !== undefined) {
     out.original_currency = dto.originalCurrency ?? null;
   }

--- a/backend-nest/src/common/utils/currency-metadata.mapper.ts
+++ b/backend-nest/src/common/utils/currency-metadata.mapper.ts
@@ -1,4 +1,6 @@
 import { type SupportedCurrency, supportedCurrencySchema } from 'pulpe-shared';
+import { ERROR_DEFINITIONS } from '@common/constants/error-definitions';
+import { BusinessException } from '@common/exceptions/business.exception';
 
 interface DecryptedCurrencyMetadataDbRow {
   original_amount?: number | null;
@@ -67,8 +69,17 @@ export function mapCurrencyNonAmountMetadataToDb(
   dto: CurrencyNonAmountMetadataDto,
 ): Partial<CurrencyNonAmountDbColumns> {
   if ('originalAmount' in dto) {
-    throw new Error(
+    const cause = new Error(
       'originalAmount must be encrypted separately with encryptOptionalAmount',
+    );
+    throw new BusinessException(
+      ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
+      undefined,
+      {
+        operation: 'mapCurrencyNonAmountMetadataToDb',
+        violation: 'originalAmount present',
+      },
+      { cause },
     );
   }
 

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -8,7 +8,7 @@ import {
   type EncryptionPort,
 } from '@modules/encryption/encryption.tokens';
 import type { AuthenticatedUser } from '@common/decorators/user.decorator';
-import { mapCurrencyMetadataToDb } from '@common/utils/currency-metadata.mapper';
+import { mapCurrencyNonAmountMetadataToDb } from '@common/utils/currency-metadata.mapper';
 import type { Transaction } from '@modules/transaction/domain/transaction.entity';
 import type { BudgetLineRepositoryPort } from '../../domain/ports/budget-line-repository.port';
 import type {
@@ -444,7 +444,7 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
       name: input.name,
       amount: encryptedAmount,
       original_amount: encryptedOriginalAmount,
-      ...mapCurrencyMetadataToDb({
+      ...mapCurrencyNonAmountMetadataToDb({
         originalCurrency: input.originalCurrency,
         targetCurrency: input.targetCurrency,
         exchangeRate: input.exchangeRate,
@@ -481,7 +481,7 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
 
     Object.assign(
       updateData,
-      mapCurrencyMetadataToDb({
+      mapCurrencyNonAmountMetadataToDb({
         originalCurrency: patch.originalCurrency,
         targetCurrency: patch.targetCurrency,
         exchangeRate: patch.exchangeRate,

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -444,11 +444,14 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
       name: input.name,
       amount: encryptedAmount,
       original_amount: encryptedOriginalAmount,
-      ...mapCurrencyNonAmountMetadataToDb({
-        originalCurrency: input.originalCurrency,
-        targetCurrency: input.targetCurrency,
-        exchangeRate: input.exchangeRate,
-      }),
+      ...mapCurrencyNonAmountMetadataToDb(
+        {
+          originalCurrency: input.originalCurrency,
+          targetCurrency: input.targetCurrency,
+          exchangeRate: input.exchangeRate,
+        },
+        { userId: user.id },
+      ),
       kind: input.kind,
       recurrence: input.recurrence,
       is_manually_adjusted: input.isManuallyAdjusted ?? false,
@@ -481,11 +484,14 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
 
     Object.assign(
       updateData,
-      mapCurrencyNonAmountMetadataToDb({
-        originalCurrency: patch.originalCurrency,
-        targetCurrency: patch.targetCurrency,
-        exchangeRate: patch.exchangeRate,
-      }),
+      mapCurrencyNonAmountMetadataToDb(
+        {
+          originalCurrency: patch.originalCurrency,
+          targetCurrency: patch.targetCurrency,
+          exchangeRate: patch.exchangeRate,
+        },
+        { userId: user.id },
+      ),
     );
 
     updateData.updated_at = new Date().toISOString();

--- a/backend-nest/src/modules/budget-template/infrastructure/persistence/supabase-budget-template.repository.ts
+++ b/backend-nest/src/modules/budget-template/infrastructure/persistence/supabase-budget-template.repository.ts
@@ -634,11 +634,14 @@ export class SupabaseBudgetTemplateRepository implements BudgetTemplateRepositor
       name: input.name,
       amount: encryptedAmount,
       original_amount: encryptedOriginalAmount,
-      ...mapCurrencyNonAmountMetadataToDb({
-        originalCurrency: input.originalCurrency,
-        targetCurrency: input.targetCurrency,
-        exchangeRate: input.exchangeRate,
-      }),
+      ...mapCurrencyNonAmountMetadataToDb(
+        {
+          originalCurrency: input.originalCurrency,
+          targetCurrency: input.targetCurrency,
+          exchangeRate: input.exchangeRate,
+        },
+        { userId: user.id },
+      ),
       kind: input.kind,
       recurrence: input.recurrence,
       description: input.description,
@@ -677,11 +680,14 @@ export class SupabaseBudgetTemplateRepository implements BudgetTemplateRepositor
 
     Object.assign(
       updateData,
-      mapCurrencyNonAmountMetadataToDb({
-        originalCurrency: patch.originalCurrency,
-        targetCurrency: patch.targetCurrency,
-        exchangeRate: patch.exchangeRate,
-      }),
+      mapCurrencyNonAmountMetadataToDb(
+        {
+          originalCurrency: patch.originalCurrency,
+          targetCurrency: patch.targetCurrency,
+          exchangeRate: patch.exchangeRate,
+        },
+        { userId: user.id },
+      ),
     );
 
     return updateData;

--- a/backend-nest/src/modules/budget-template/infrastructure/persistence/supabase-budget-template.repository.ts
+++ b/backend-nest/src/modules/budget-template/infrastructure/persistence/supabase-budget-template.repository.ts
@@ -9,7 +9,7 @@ import {
   type EncryptionPort,
 } from '@modules/encryption/encryption.tokens';
 import type { AuthenticatedUser } from '@common/decorators/user.decorator';
-import { mapCurrencyMetadataToDb } from '@common/utils/currency-metadata.mapper';
+import { mapCurrencyNonAmountMetadataToDb } from '@common/utils/currency-metadata.mapper';
 import type {
   BudgetTemplate,
   BudgetTemplateUpdatePatch,
@@ -634,7 +634,7 @@ export class SupabaseBudgetTemplateRepository implements BudgetTemplateRepositor
       name: input.name,
       amount: encryptedAmount,
       original_amount: encryptedOriginalAmount,
-      ...mapCurrencyMetadataToDb({
+      ...mapCurrencyNonAmountMetadataToDb({
         originalCurrency: input.originalCurrency,
         targetCurrency: input.targetCurrency,
         exchangeRate: input.exchangeRate,
@@ -677,7 +677,7 @@ export class SupabaseBudgetTemplateRepository implements BudgetTemplateRepositor
 
     Object.assign(
       updateData,
-      mapCurrencyMetadataToDb({
+      mapCurrencyNonAmountMetadataToDb({
         originalCurrency: patch.originalCurrency,
         targetCurrency: patch.targetCurrency,
         exchangeRate: patch.exchangeRate,

--- a/backend-nest/src/modules/transaction/infrastructure/persistence/supabase-transaction.repository.ts
+++ b/backend-nest/src/modules/transaction/infrastructure/persistence/supabase-transaction.repository.ts
@@ -8,7 +8,7 @@ import {
   type EncryptionPort,
 } from '@modules/encryption/encryption.tokens';
 import type { AuthenticatedUser } from '@common/decorators/user.decorator';
-import { mapCurrencyMetadataToDb } from '@common/utils/currency-metadata.mapper';
+import { mapCurrencyNonAmountMetadataToDb } from '@common/utils/currency-metadata.mapper';
 import type { TransactionRepositoryPort } from '../../domain/ports/transaction-repository.port';
 import type {
   Transaction,
@@ -574,7 +574,7 @@ export class SupabaseTransactionRepository implements TransactionRepositoryPort 
       transaction_date: input.transactionDate,
       category: input.category ?? null,
       checked_at: input.checkedAt ?? null,
-      ...mapCurrencyMetadataToDb({
+      ...mapCurrencyNonAmountMetadataToDb({
         originalCurrency: input.originalCurrency,
         targetCurrency: input.targetCurrency,
         exchangeRate: input.exchangeRate,
@@ -607,7 +607,7 @@ export class SupabaseTransactionRepository implements TransactionRepositoryPort 
 
     Object.assign(
       updateData,
-      mapCurrencyMetadataToDb({
+      mapCurrencyNonAmountMetadataToDb({
         originalCurrency: patch.originalCurrency,
         targetCurrency: patch.targetCurrency,
         exchangeRate: patch.exchangeRate,

--- a/backend-nest/src/modules/transaction/infrastructure/persistence/supabase-transaction.repository.ts
+++ b/backend-nest/src/modules/transaction/infrastructure/persistence/supabase-transaction.repository.ts
@@ -574,11 +574,14 @@ export class SupabaseTransactionRepository implements TransactionRepositoryPort 
       transaction_date: input.transactionDate,
       category: input.category ?? null,
       checked_at: input.checkedAt ?? null,
-      ...mapCurrencyNonAmountMetadataToDb({
-        originalCurrency: input.originalCurrency,
-        targetCurrency: input.targetCurrency,
-        exchangeRate: input.exchangeRate,
-      }),
+      ...mapCurrencyNonAmountMetadataToDb(
+        {
+          originalCurrency: input.originalCurrency,
+          targetCurrency: input.targetCurrency,
+          exchangeRate: input.exchangeRate,
+        },
+        { userId: user.id },
+      ),
     };
   }
 
@@ -607,11 +610,14 @@ export class SupabaseTransactionRepository implements TransactionRepositoryPort 
 
     Object.assign(
       updateData,
-      mapCurrencyNonAmountMetadataToDb({
-        originalCurrency: patch.originalCurrency,
-        targetCurrency: patch.targetCurrency,
-        exchangeRate: patch.exchangeRate,
-      }),
+      mapCurrencyNonAmountMetadataToDb(
+        {
+          originalCurrency: patch.originalCurrency,
+          targetCurrency: patch.targetCurrency,
+          exchangeRate: patch.exchangeRate,
+        },
+        { userId: user.id },
+      ),
     );
 
     updateData.updated_at = new Date().toISOString();


### PR DESCRIPTION
## What changed

- Renamed the DB helper to `mapCurrencyNonAmountMetadataToDb` to make the `original_amount` exclusion explicit.
- Added a `never`-typed `originalAmount` input guard and an `Omit<..., 'original_amount'>` return shape.
- Added runtime protection for callers that bypass TypeScript and deterministic tests for the mapper contract.
- Updated budget line, transaction, and template repository call sites.

## Why

`original_amount` is encrypted ciphertext and must stay handled at the repository encryption boundary via `encryptOptionalAmount`. The previous helper name suggested it mapped all FX metadata, which could let future callers silently omit `original_amount`.

## Validation

- `pnpm build:shared`
- `bun test src/common/utils/currency-metadata.mapper.spec.ts`
- `bun run quality`
- pre-commit `quality` hook passed during commit

Note: lint still reports existing complexity/size warnings, with 0 errors.