### PR TITLE
[codex] Fix onboarding footer positioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ claude-rules/
 coverage-report.json
 
 # Claude Code generated outputs
+.codex/
 .claude/output/
 .claude/analysis/
 .claude/ralph/

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts
@@ -735,11 +735,11 @@ import {
 
                 <pulpe-error-alert [message]="store.error()" class="mt-6" />
 
-                <div class="h-16 lg:h-10" aria-hidden="true"></div>
+                <div class="h-16 lg:h-36" aria-hidden="true"></div>
 
-                <!-- Sticky CTA: lives inside left column so it naturally spans form width on desktop. -->
+                <!-- Sticky CTA: lg -2rem mirrors the desktop md:p-8 page-content padding. -->
                 <div
-                  class="sticky bottom-0 z-10 -mx-4 sm:mx-0 pt-5 pb-[calc(20px+env(safe-area-inset-bottom))] lg:pb-5 border-t border-outline-variant/15 bg-surface"
+                  class="sticky bottom-0 lg:bottom-[-2rem] z-10 -mx-4 sm:mx-0 pt-5 pb-[calc(20px+env(safe-area-inset-bottom))] lg:pb-5 border-t border-outline-variant/15 bg-surface"
                 >
                   <pulpe-loading-button
                     [loading]="store.isLoading()"

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -62,7 +62,9 @@ for skill in "$WORKTREE"/.agents/skills/*; do
   ln -s "../../.agents/skills/$name" "$target"
   synced=$((synced + 1))
 done
-(( synced > 0 )) && echo "✓ Linked $synced skills into .claude/skills/"
+if (( synced > 0 )); then
+  echo "✓ Linked $synced skills into .claude/skills/"
+fi
 
 # 5. Worktree-only: recreate missing .claude/skills symlinks from main repo
 MAIN_REPO="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
@@ -81,4 +83,6 @@ for skill in "$MAIN_REPO"/.claude/skills/*; do
   linked=$((linked + 1))
 done
 
-(( linked > 0 )) && echo "✓ Linked $linked skills to worktree .claude/skills/"
+if (( linked > 0 )); then
+  echo "✓ Linked $linked skills to worktree .claude/skills/"
+fi


### PR DESCRIPTION
## Summary

- Keep the complete-profile onboarding CTA sticky while aligning the desktop footer with the bottom of the scroll container.
- Preserve the existing mobile behavior, which was already rendering correctly.
- Include the requested pending workspace change in `scripts/install-skills.sh`.
- Ignore local `.codex/` runtime configuration so permissive sandbox/approval settings are not committed.

## Root Cause

The desktop onboarding CTA lives inside a padded scroll container. A sticky `bottom: 0` aligned to the padded content area, so content could appear behind the footer or the footer could look visually lifted from the bottom depending on the compensation used.

## Safety Note

The previously committed `.codex/config.toml` contained local execution policy (`approval_policy = "never"`, `sandbox_mode = "danger-full-access"`). It has been removed from the PR and `.codex/` is now ignored.

## Validation

- `pnpm --dir frontend exec prettier --check projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts`
- `pnpm --dir frontend typecheck`
- pre-commit `pnpm quality --filter=...[HEAD^]`
- local Playwright visual/DOM checks for desktop and mobile onboarding footer positioning