### PR TITLE
[codex] PUL-253 narrow logger key redaction

### DIFF
--- a/frontend/projects/webapp/src/app/core/logging/logger.spec.ts
+++ b/frontend/projects/webapp/src/app/core/logging/logger.spec.ts
@@ -111,24 +111,38 @@ describe('Logger', () => {
     });
 
     it('should mask sensitive object keys', () => {
-      const data = {
+      const sensitiveEntries: [string, unknown][] = [
+        ['password', 'secret123'],
+        ['apiKey', 'key-123'],
+        ['token', 'token-456'],
+        ['secret', 'secret-789'],
+        ['key', 'generic-key'],
+        ['anonKey', 'anon-key'],
+        ['api_key', 'snake-api-key'],
+        ['supabase_anon_key', 'snake-anon-key'],
+        ['service_role_key', 'service-role-key'],
+        ['supabase_service_role_key', 'prefixed-service-role-key'],
+        ['encryptionKey', 'encryption-key'],
+        ['clientKey', 'client-key'],
+        ['authKey', 'auth-key'],
+        ['masterKey', 'master-key'],
+        ['signingKey', 'signing-key'],
+      ];
+      const data: Record<string, unknown> = {
         username: 'john',
-        password: 'secret123',
-        apiKey: 'key-123',
-        token: 'token-456',
-        secret: 'secret-789',
-        anonKey: 'anon-key',
       };
+      for (const [key, value] of sensitiveEntries) {
+        data[key] = value;
+      }
+
       logger.debug('User data', data);
       const args =
         consoleDebugSpy.mock.calls[consoleDebugSpy.mock.calls.length - 1];
       const sanitized = args[1] as Record<string, unknown>;
       expect(sanitized['username']).toBe('john');
-      expect(sanitized['password']).toBe('***');
-      expect(sanitized['apiKey']).toBe('***');
-      expect(sanitized['token']).toBe('***');
-      expect(sanitized['secret']).toBe('***');
-      expect(sanitized['anonKey']).toBe('***');
+      for (const [key] of sensitiveEntries) {
+        expect(sanitized[key]).toBe('***');
+      }
     });
 
     it('should mask user identifier keys to prevent PII leakage', () => {
@@ -165,6 +179,29 @@ describe('Logger', () => {
       expect(sanitized['subject']).toBe('meeting agenda');
       expect(sanitized['subtitle']).toBe('chapter 1');
       expect(sanitized['substring']).toBe('foo');
+    });
+
+    it('should not mask non-sensitive keys that merely contain "key" as substring', () => {
+      const nonSensitiveEntries: [string, unknown][] = [
+        ['keyword', 'budget'],
+        ['keyboard', 'azerty'],
+        ['keyPath', 'settings.theme'],
+        ['idempotencyKey', 'request-123'],
+        ['cacheKey', 'dashboard-current-month'],
+        ['idempotency_key', 'request-456'],
+        ['cache_key', 'dashboard-next-month'],
+        ['objectKeys', ['id', 'name']],
+      ];
+      const data = Object.fromEntries(nonSensitiveEntries);
+
+      logger.debug('Non-sensitive key data', data);
+
+      const args =
+        consoleDebugSpy.mock.calls[consoleDebugSpy.mock.calls.length - 1];
+      const sanitized = args[1] as Record<string, unknown>;
+      for (const [key, value] of nonSensitiveEntries) {
+        expect(sanitized[key]).toEqual(value);
+      }
     });
 
     it('should handle nested objects', () => {

--- a/frontend/projects/webapp/src/app/core/logging/logger.ts
+++ b/frontend/projects/webapp/src/app/core/logging/logger.ts
@@ -11,6 +11,40 @@ export enum LogLevel {
   ERROR = 3,
 }
 
+const REDACTED_VALUE = '***';
+const KEY_SEPARATOR_PATTERN = /[_-]/g;
+
+const SENSITIVE_KEY_SUBSTRINGS = ['password', 'secret', 'token'] as const;
+const SENSITIVE_KEY_SUFFIXES = [
+  'apikey',
+  'anonkey',
+  'servicerolekey',
+  'privatekey',
+  'encryptionkey',
+  'clientkey',
+  'authkey',
+  'masterkey',
+  'signingkey',
+] as const;
+const SENSITIVE_EXACT_KEYS = new Set(['key', 'userid', 'user_id', 'sub']);
+
+function normalizeLogKey(key: string): string {
+  return key.toLowerCase().replace(KEY_SEPARATOR_PATTERN, '');
+}
+
+function isSensitiveLogKey(key: string): boolean {
+  const lowerKey = key.toLowerCase();
+  const normalizedKey = normalizeLogKey(key);
+
+  return (
+    SENSITIVE_KEY_SUBSTRINGS.some((substring) =>
+      lowerKey.includes(substring),
+    ) ||
+    SENSITIVE_KEY_SUFFIXES.some((suffix) => normalizedKey.endsWith(suffix)) ||
+    SENSITIVE_EXACT_KEYS.has(lowerKey)
+  );
+}
+
 /**
  * Centralized logging service for the application.
  * Provides environment-aware logging with automatic suppression in production.
@@ -125,21 +159,8 @@ export class Logger {
 
       for (const key in data) {
         if (Object.prototype.hasOwnProperty.call(data, key)) {
-          const lowerKey = key.toLowerCase();
-
-          // Mask sensitive keys
-          // Exact match on 'userid' / 'user_id' / 'sub' (JWT subject claim)
-          // avoids false positives on substrings like subject, subtitle, subscription, userIdentity.
-          if (
-            lowerKey.includes('password') ||
-            lowerKey.includes('secret') ||
-            lowerKey.includes('token') ||
-            lowerKey.includes('key') ||
-            lowerKey === 'userid' ||
-            lowerKey === 'user_id' ||
-            lowerKey === 'sub'
-          ) {
-            (sanitized as Record<string, unknown>)[key] = '***';
+          if (isSensitiveLogKey(key)) {
+            (sanitized as Record<string, unknown>)[key] = REDACTED_VALUE;
           } else {
             (sanitized as Record<string, unknown>)[key] = this.#sanitize(
               (data as Record<string, unknown>)[key],


### PR DESCRIPTION
## Summary

Fixes PUL-253 by narrowing the logger sanitizer's key-name redaction rule. `logger.ts` no longer masks every field whose name contains `key`; it now masks the intended key names and sensitive suffixes only.

## Root Cause

`lowerKey.includes('key')` was too broad and redacted harmless log fields such as `keyword`, `cacheKey`, `idempotencyKey`, `objectKeys`, and `keyPath`.

## Changes

- Replace the broad `includes('key')` condition with explicit matches for `apiKey`, `anonKey`, `*SecretKey`, and `*PrivateKey`.
- Add regression coverage proving non-sensitive `key` substrings are preserved.

## Validation

- `pnpm exec vitest run projects/webapp/src/app/core/logging/logger.spec.ts`
- `pnpm run typecheck:spec`
- Pre-commit `pnpm quality --filter=...[HEAD^]`
