### PR TITLE
fix(ios): stop self-inflicted logout on transient session-refresh failure (PUL-278)

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,6 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+archive = "rm -rf node_modules"
+run = "pnpm dev"
+setup = "PULPE_MAIN_WORKSPACE=\"$CONDUCTOR_ROOT_PATH\" ./sync-env.sh\npnpm install\n./scripts/install-skills.sh"

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,0 @@
-{
-    "scripts": {
-        "setup": "PULPE_MAIN_WORKSPACE=\"$CONDUCTOR_ROOT_PATH\" ./sync-env.sh\npnpm install\n./scripts/install-skills.sh",
-        "run": "pnpm dev",
-        "archive": "rm -rf node_modules"
-    }
-}

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -48,6 +48,15 @@ extension AppState {
                         )
                         await self?.logout(source: .system)
                     }
+                } catch is URLError {
+                    // Transient connectivity failure on a freshly-resumed radio. The session is
+                    // still valid server-side — content is already biometric-unlocked, so keep the
+                    // user authenticated and let the next successful network call (or the SDK's
+                    // auto-refresh) refresh the token. Logging out here would server-revoke a live
+                    // session and wipe Face ID over a momentary network blip (PUL-265 root cause).
+                    Logger.auth.warning(
+                        "handleEnterForeground: session refresh skipped — network unavailable, keeping session"
+                    )
                 } catch {
                     guard !Task.isCancelled else { return }
                     Logger.auth.warning(

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -58,7 +58,7 @@ extension AppState {
                         Logger.auth.debug("handleEnterForeground: background refresh cancelled")
                     } else {
                         Logger.auth.warning(
-                            "handleEnterForeground: session refresh skipped — network unavailable, keeping session"
+                            "handleEnterForeground: session refresh skipped — keeping session - \(error)"
                         )
                     }
                 } catch {

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -48,15 +48,19 @@ extension AppState {
                         )
                         await self?.logout(source: .system)
                     }
-                } catch is URLError {
-                    // Transient connectivity failure on a freshly-resumed radio. The session is
-                    // still valid server-side — content is already biometric-unlocked, so keep the
-                    // user authenticated and let the next successful network call (or the SDK's
-                    // auto-refresh) refresh the token. Logging out here would server-revoke a live
-                    // session and wipe Face ID over a momentary network blip (PUL-265 root cause).
-                    Logger.auth.warning(
-                        "handleEnterForeground: session refresh skipped — network unavailable, keeping session"
-                    )
+                } catch let error as URLError {
+                    // Keep the session: this URLError is either a transient connectivity blip on a
+                    // freshly-resumed radio (the session is still valid server-side — logging out
+                    // would server-revoke a live session and wipe Face ID, the PUL-265 root cause)
+                    // or a deliberate cancellation from a concurrent logout. Either way, do NOT log
+                    // out; the next successful network call / SDK auto-refresh refreshes the token.
+                    if error.code == .cancelled {
+                        Logger.auth.debug("handleEnterForeground: background refresh cancelled")
+                    } else {
+                        Logger.auth.warning(
+                            "handleEnterForeground: session refresh skipped — network unavailable, keeping session"
+                        )
+                    }
                 } catch {
                     guard !Task.isCancelled else { return }
                     Logger.auth.warning(

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -58,7 +58,7 @@ extension AppState {
                         Logger.auth.debug("handleEnterForeground: background refresh cancelled")
                     } else {
                         Logger.auth.warning(
-                            "handleEnterForeground: session refresh skipped — keeping session - \(error)"
+                            "handleEnterForeground: refresh skipped, keeping session - \(error, privacy: .public)"
                         )
                     }
                 } catch {

--- a/ios/Pulpe/App/AppState.swift
+++ b/ios/Pulpe/App/AppState.swift
@@ -350,7 +350,11 @@ final class AppState {
         _ authService: AuthService
     ) -> @Sendable () async throws -> UserInfo? {
         {
-            try await authService.validateSession()
+            // Strict variant: rethrows URLError so a transient/offline refresh failure is
+            // treated as "retry later" by the cold-start and foreground paths, never as a
+            // session loss. Swallowing it (old `validateSession`) forced a destructive logout
+            // on every flaky post-expiry refresh — the PUL-265 forced-logout root cause.
+            try await authService.validateSessionStrict()
         }
     }
 

--- a/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
+++ b/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
@@ -84,7 +84,7 @@ final class SessionLifecycleCoordinator {
         } catch let error as URLError {
             Logger.auth.warning("checkAuthState: network error during biometric login - \(error)")
             authDebug("AUTH_BIO_VALIDATE_RESULT", "network")
-            return .networkError("Connexion impossible, r\u{00E9}essaie")
+            return .networkError(AuthErrorMessages.connectionUnavailable)
         } catch let error as AuthServiceError {
             Logger.auth.error("checkAuthState: biometric session refresh failed - \(error)")
             await biometric.handleSessionExpired()
@@ -114,7 +114,7 @@ final class SessionLifecycleCoordinator {
             // rather than dropping the user to the login screen.
             Logger.auth.warning("checkAuthState: regular session fallback network error - \(error)")
             authDebug("AUTH_COLD_START_REGULAR_NETWORK", "reason=\(reason)")
-            return .networkError("Connexion impossible, r\u{00E9}essaie")
+            return .networkError(AuthErrorMessages.connectionUnavailable)
         } catch {
             Logger.auth.warning("checkAuthState: regular session fallback failed - \(error)")
             authDebug("AUTH_COLD_START_REGULAR_ERROR", "reason=\(reason)")
@@ -133,7 +133,7 @@ final class SessionLifecycleCoordinator {
             // Transient connectivity failure — not a session loss. Surface the retry UI.
             Logger.auth.warning("checkAuthState: regular session validation network error - \(error)")
             authDebug("AUTH_COLD_START_REGULAR_NETWORK", "source=checkAuthState")
-            return .networkError("Connexion impossible, r\u{00E9}essaie")
+            return .networkError(AuthErrorMessages.connectionUnavailable)
         } catch {
             Logger.auth.warning("checkAuthState: regular session validation failed - \(error)")
             authDebug("AUTH_COLD_START_REGULAR_ERROR", "source=checkAuthState")

--- a/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
+++ b/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
@@ -109,6 +109,12 @@ final class SessionLifecycleCoordinator {
                 authDebug("AUTH_COLD_START_REGULAR_MISSING", "reason=\(reason)")
                 return .unauthenticated
             }
+        } catch let error as URLError {
+            // Transient connectivity failure — not a session loss. Surface the retry UI
+            // rather than dropping the user to the login screen.
+            Logger.auth.warning("checkAuthState: regular session fallback network error - \(error)")
+            authDebug("AUTH_COLD_START_REGULAR_NETWORK", "reason=\(reason)")
+            return .networkError("Connexion impossible, r\u{00E9}essaie")
         } catch {
             Logger.auth.warning("checkAuthState: regular session fallback failed - \(error)")
             authDebug("AUTH_COLD_START_REGULAR_ERROR", "reason=\(reason)")
@@ -123,6 +129,11 @@ final class SessionLifecycleCoordinator {
                 authDebug("AUTH_COLD_START_REGULAR_VALID", "source=checkAuthState")
                 return .regularSession(user: user)
             }
+        } catch let error as URLError {
+            // Transient connectivity failure — not a session loss. Surface the retry UI.
+            Logger.auth.warning("checkAuthState: regular session validation network error - \(error)")
+            authDebug("AUTH_COLD_START_REGULAR_NETWORK", "source=checkAuthState")
+            return .networkError("Connexion impossible, r\u{00E9}essaie")
         } catch {
             Logger.auth.warning("checkAuthState: regular session validation failed - \(error)")
             authDebug("AUTH_COLD_START_REGULAR_ERROR", "source=checkAuthState")

--- a/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
+++ b/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
@@ -112,7 +112,7 @@ final class SessionLifecycleCoordinator {
         } catch let error as URLError {
             // Transient connectivity failure — not a session loss. Surface the retry UI
             // rather than dropping the user to the login screen.
-            Logger.auth.warning("checkAuthState: regular session fallback network error - \(error)")
+            Logger.auth.warning("checkAuthState: regular session fallback network error - \(error, privacy: .public)")
             authDebug("AUTH_COLD_START_REGULAR_NETWORK", "reason=\(reason)")
             return .networkError(AuthErrorMessages.connectionUnavailable)
         } catch {
@@ -131,7 +131,7 @@ final class SessionLifecycleCoordinator {
             }
         } catch let error as URLError {
             // Transient connectivity failure — not a session loss. Surface the retry UI.
-            Logger.auth.warning("checkAuthState: regular session validation network error - \(error)")
+            Logger.auth.warning("checkAuthState: regular session validation network error - \(error, privacy: .public)")
             authDebug("AUTH_COLD_START_REGULAR_NETWORK", "source=checkAuthState")
             return .networkError(AuthErrorMessages.connectionUnavailable)
         } catch {

--- a/ios/Pulpe/App/Auth/StartupCoordinator.swift
+++ b/ios/Pulpe/App/Auth/StartupCoordinator.swift
@@ -320,7 +320,7 @@ actor StartupCoordinator {
             // Transient connectivity failure (offline / cold radio on launch). The session is
             // not gone — surface the retry UI instead of dumping the user to the login screen
             // (which would force credential re-entry over a momentary network blip).
-            Logger.auth.warning("[STARTUP] Regular session validation network error: \(urlError)")
+            Logger.auth.warning("[STARTUP] Regular session validation network error: \(urlError, privacy: .public)")
             return .networkError(AuthErrorMessages.connectionUnavailable)
         } catch {
             Logger.auth.warning("[STARTUP] Regular session validation failed: \(error)")

--- a/ios/Pulpe/App/Auth/StartupCoordinator.swift
+++ b/ios/Pulpe/App/Auth/StartupCoordinator.swift
@@ -212,7 +212,7 @@ actor StartupCoordinator {
                 return .cancelled
             } else {
                 Logger.auth.warning("[STARTUP] Maintenance network error: \(error)")
-                return .networkError("Connexion impossible, réessaie")
+                return .networkError(AuthErrorMessages.connectionUnavailable)
             }
         } catch {
             Logger.auth.warning("[STARTUP] Maintenance check failed: \(error)")
@@ -265,7 +265,7 @@ actor StartupCoordinator {
             return .cancelled
         } else {
             Logger.auth.warning("[STARTUP] Biometric validation network error: \(error)")
-            return .networkError("Connexion impossible, réessaie")
+            return .networkError(AuthErrorMessages.connectionUnavailable)
         }
     }
 
@@ -321,7 +321,7 @@ actor StartupCoordinator {
             // not gone — surface the retry UI instead of dumping the user to the login screen
             // (which would force credential re-entry over a momentary network blip).
             Logger.auth.warning("[STARTUP] Regular session validation network error: \(urlError)")
-            return .networkError("Connexion impossible, réessaie")
+            return .networkError(AuthErrorMessages.connectionUnavailable)
         } catch {
             Logger.auth.warning("[STARTUP] Regular session validation failed: \(error)")
             // AnalyticsService is @MainActor — hop required from actor context

--- a/ios/Pulpe/App/Auth/StartupCoordinator.swift
+++ b/ios/Pulpe/App/Auth/StartupCoordinator.swift
@@ -308,6 +308,12 @@ actor StartupCoordinator {
         } catch is CancellationError {
             Logger.auth.debug("[STARTUP] Regular session validation cancelled")
             return .cancelled
+        } catch let urlError as URLError {
+            // Transient connectivity failure (offline / cold radio on launch). The session is
+            // not gone — surface the retry UI instead of dumping the user to the login screen
+            // (which would force credential re-entry over a momentary network blip).
+            Logger.auth.warning("[STARTUP] Regular session validation network error: \(urlError)")
+            return .networkError("Connexion impossible, réessaie")
         } catch {
             Logger.auth.warning("[STARTUP] Regular session validation failed: \(error)")
             // AnalyticsService is @MainActor — hop required from actor context

--- a/ios/Pulpe/App/Auth/StartupCoordinator.swift
+++ b/ios/Pulpe/App/Auth/StartupCoordinator.swift
@@ -309,6 +309,14 @@ actor StartupCoordinator {
             Logger.auth.debug("[STARTUP] Regular session validation cancelled")
             return .cancelled
         } catch let urlError as URLError {
+            // A superseded startup run cancels its in-flight `supabase.auth.session` request,
+            // which URLSession surfaces as `URLError(.cancelled)` (not `CancellationError`).
+            // Treat it as cancellation so the obsolete run doesn't apply a stale network route —
+            // mirrors the maintenance and biometric paths.
+            if urlError.code == .cancelled {
+                Logger.auth.debug("[STARTUP] Regular session validation URL request cancelled")
+                return .cancelled
+            }
             // Transient connectivity failure (offline / cold radio on launch). The session is
             // not gone — surface the retry UI instead of dumping the user to the login screen
             // (which would force credential re-entry over a momentary network blip).

--- a/ios/Pulpe/Core/Auth/AuthErrorMessages.swift
+++ b/ios/Pulpe/Core/Auth/AuthErrorMessages.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Centralized user-facing auth/session error messages (French).
+/// Keeps wording (and accents) consistent across the startup, foreground and biometric paths.
+enum AuthErrorMessages {
+    /// Shown when a session check fails due to a transient connectivity problem
+    /// (cold start, foreground refresh, biometric validation) — the session is not lost.
+    static let connectionUnavailable = "Connexion impossible, réessaie"
+}

--- a/ios/Pulpe/Core/Auth/AuthErrorMessages.swift
+++ b/ios/Pulpe/Core/Auth/AuthErrorMessages.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Centralized user-facing auth/session error messages (French).
 /// Keeps wording (and accents) consistent across the startup, foreground and biometric paths.
 enum AuthErrorMessages {

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -184,6 +184,11 @@ actor AuthService {
             return Self.userInfo(from: session.user, fallbackEmail: "")
         } catch let error as URLError {
             throw error
+        } catch is CancellationError {
+            // A superseded startup run cancels before/at the session suspension point. Propagate so
+            // the caller maps it to `.cancelled` (a no-op) instead of `.unauthenticated`, which
+            // would let an obsolete run clobber the newer one's state.
+            throw CancellationError()
         } catch {
             // `.public` (full error, not just localizedDescription) so a silent post-expiry
             // refresh regression shows the exact Supabase cause (e.g. AuthError.api) on a device
@@ -255,6 +260,10 @@ actor AuthService {
             return session.accessToken
         } catch let error as URLError {
             throw error
+        } catch is CancellationError {
+            // Propagate cancellation (e.g. a superseded request) rather than reporting it as
+            // "no usable session", which would push APIClient into a spurious logout.
+            throw CancellationError()
         } catch {
             Logger.auth.warning(
                 "resolveAccessTokenStrict: auth session unavailable - \(error.localizedDescription, privacy: .public)"

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -189,6 +189,11 @@ actor AuthService {
             // the caller maps it to `.cancelled` (a no-op) instead of `.unauthenticated`, which
             // would let an obsolete run clobber the newer one's state.
             throw CancellationError()
+        } catch AuthError.sessionMissing {
+            // Normal logged-out state (no stored session) — e.g. a fresh user or after an explicit
+            // logout. Not a warning; keep the real-error channel below clean for actual regressions.
+            Logger.auth.info("validateSessionStrict: no active session (logged out)")
+            return nil
         } catch {
             // `.public` (full error, not just localizedDescription) so a silent post-expiry
             // refresh regression shows the exact Supabase cause (e.g. AuthError.api) on a device

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -171,6 +171,27 @@ actor AuthService {
         }
     }
 
+    /// Like `validateSession()` but distinguishes a transient connectivity failure from a
+    /// genuine session loss. Throws on `URLError` (offline / timeout / connection lost on a
+    /// freshly-resumed radio) so callers can treat it as "retry later" instead of forcing a
+    /// destructive logout on a flaky connection. Returns nil only when the SDK confirms there
+    /// is no usable session (e.g. `AuthError.sessionMissing`, or a refresh the server rejected).
+    /// Mirrors `resolveAccessTokenStrict()` — the foreground/cold-start session checks use this
+    /// so a routine post-expiry refresh hiccup can no longer revoke the session (PUL-265 follow-up).
+    func validateSessionStrict() async throws -> UserInfo? {
+        do {
+            let session = try await supabase.auth.session
+            return Self.userInfo(from: session.user, fallbackEmail: "")
+        } catch let error as URLError {
+            throw error
+        } catch {
+            Logger.auth.warning(
+                "validateSessionStrict: auth session unavailable - \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+
     // MARK: - Logout
 
     /// Sign out of Supabase. Surfaces the underlying error so callers can decide how

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -185,8 +185,11 @@ actor AuthService {
         } catch let error as URLError {
             throw error
         } catch {
+            // `.public` (full error, not just localizedDescription) so a silent post-expiry
+            // refresh regression shows the exact Supabase cause (e.g. AuthError.api) on a device
+            // repro without leaking tokens.
             Logger.auth.warning(
-                "validateSessionStrict: auth session unavailable - \(error.localizedDescription, privacy: .public)"
+                "validateSessionStrict: auth session unavailable - \(error, privacy: .public)"
             )
             return nil
         }

--- a/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
+++ b/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
@@ -8,6 +8,14 @@ import Supabase
 /// owns persistence across launches and silent token refreshes — eliminating
 /// drift between custom keychain slots that previously triggered
 /// refresh-token-reuse detection on cold-start biometric paths (PUL-132).
+///
+/// Accessibility: `AfterFirstUnlockThisDeviceOnly` (matches the SDK's own default
+/// `KeychainLocalStorage`). The SDK rotates the refresh token on a background timer and
+/// must be able to PERSIST the rotated token even while the device is locked; with
+/// `WhenUnlockedThisDeviceOnly`, a locked-device write fails (`errSecInteractionNotAllowed`)
+/// and the SDK silently keeps the now-consumed token, so the next launch replays it and
+/// rotation reuse-detection revokes the whole family. `ThisDeviceOnly` keeps the token off
+/// iCloud Keychain / device migration.
 public struct PulpeAuthStorage: AuthLocalStorage {
     public static let sessionStorageKey = "supabase.auth.token"
 
@@ -26,7 +34,7 @@ public struct PulpeAuthStorage: AuthLocalStorage {
 
         let updateAttributes: [String: Any] = [
             kSecValueData as String: value,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]
 
         let updateStatus = SecItemUpdate(baseQuery as CFDictionary, updateAttributes as CFDictionary)
@@ -51,7 +59,7 @@ public struct PulpeAuthStorage: AuthLocalStorage {
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
             kSecValueData as String: value,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
         // errSecDuplicateItem: a concurrent writer (e.g. SDK auto-refresh timer)

--- a/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
+++ b/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
@@ -375,7 +375,7 @@ struct AppStateBackgroundLockTests {
         }
     }
 
-    // MARK: - PUL-XXX: Transient Refresh Failure Must NOT Force Logout
+    // MARK: - PUL-278: Transient Refresh Failure Must NOT Force Logout
 
     /// Regression: after the 1h access-token expiry, every reopen forces a network refresh.
     /// On app-resume the radio is frequently cold, so the refresh hits a transient URLError.

--- a/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
+++ b/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import Pulpe
 import Testing
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 @Suite(.serialized)
 @MainActor
 struct AppStateBackgroundLockTests {
@@ -290,7 +290,7 @@ struct AppStateBackgroundLockTests {
         }
     }
 
-    @Test func foregroundBiometricUnlock_sessionRefreshFailure_logsOut() async {
+    @Test func foregroundBiometricUnlock_genuineSessionLoss_logsOut() async {
         let sessionRefreshAttempted = AtomicFlag()
         let now = AtomicProperty(Date(timeIntervalSince1970: 0))
 
@@ -302,7 +302,10 @@ struct AppStateBackgroundLockTests {
             validateBiometricKey: { _ in true },
             validateRegularSession: {
                 sessionRefreshAttempted.set()
-                throw URLError(.userAuthenticationRequired)
+                // A GENUINE (non-network) session loss — e.g. the server rejected the refresh
+                // token. This must still log out. Only transient URLErrors are now spared
+                // (see `foregroundBiometricUnlock_transientNetworkError_keepsSessionAndBiometric`).
+                throw AuthServiceError.sessionExpired
             },
             nowProvider: { now.value }
         )
@@ -322,10 +325,10 @@ struct AppStateBackgroundLockTests {
         ) {
             sessionRefreshAttempted.value
         }
-        // When session refresh fails, user should be logged out
+        // When the session is genuinely gone, the user should be logged out
         await waitForCondition(
             timeout: .milliseconds(500),
-            "authState should be unauthenticated after session refresh failure"
+            "authState should be unauthenticated after a genuine session loss"
         ) {
             sut.authState == .unauthenticated
         }
@@ -370,6 +373,65 @@ struct AppStateBackgroundLockTests {
         ) {
             sut.authState == .unauthenticated
         }
+    }
+
+    // MARK: - PUL-XXX: Transient Refresh Failure Must NOT Force Logout
+
+    /// Regression: after the 1h access-token expiry, every reopen forces a network refresh.
+    /// On app-resume the radio is frequently cold, so the refresh hits a transient URLError.
+    /// Today `validateSession()` swallows it -> nil/throw -> `logout(source: .system)`, which
+    /// server-revokes the refresh token, wipes+disables biometric, and forces credential
+    /// re-entry. The session was actually still valid server-side — this is a self-inflicted,
+    /// permanent logout. A transient/offline failure must leave the (already biometric-unlocked)
+    /// session intact and defer the refresh; only a CONFIRMED server-side session loss may log out.
+    @Test func foregroundBiometricUnlock_transientNetworkError_keepsSessionAndBiometric() async {
+        let refreshAttempted = AtomicFlag()
+        let signOutCalled = AtomicFlag()
+        let now = AtomicProperty(Date(timeIntervalSince1970: 0))
+
+        let sut = AppState(
+            postAuthResolver: pinResolver,
+            biometricPreferenceStore: AppStateTestFactory.biometricEnabledStore(),
+            syncBiometricCredentials: { true },
+            resolveBiometricKey: { "restored-key" },
+            validateBiometricKey: { _ in true },
+            validateRegularSession: {
+                refreshAttempted.set()
+                // Transient connectivity failure on a freshly-resumed radio.
+                throw URLError(.notConnectedToInternet)
+            },
+            performSignOut: { _ in signOutCalled.set() },
+            nowProvider: { now.value }
+        )
+        sut.biometricEnabled = true
+        await authenticateViaPinEntry(sut)
+
+        sut.handleEnterBackground()
+        now.set(Date(timeIntervalSince1970: 7200)) // 2h — access token definitely expired
+        sut.prepareForForeground()
+
+        await sut.handleEnterForeground()
+
+        // Refresh must have been attempted...
+        await waitForCondition(timeout: .seconds(1), "refresh must be attempted") {
+            refreshAttempted.value
+        }
+        // ...and the (buggy) destructive logout, if it fires, runs right after the throw.
+        // Give it time to settle so the assertions below are not racing a pending logout.
+        try? await Task.sleep(for: .milliseconds(400))
+
+        #expect(
+            sut.authState == .authenticated,
+            "Transient refresh failure must NOT force logout — the session is still valid server-side"
+        )
+        #expect(
+            signOutCalled.value == false,
+            "Transient refresh failure must NOT revoke the refresh token server-side"
+        )
+        #expect(
+            sut.biometricEnabled == true,
+            "Transient refresh failure must NOT wipe/disable biometric"
+        )
     }
 
     @Test func foregroundAfterGracePeriod_biometricDisabled_requiresPinEntry() async {

--- a/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
+++ b/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
@@ -412,14 +412,12 @@ struct AppStateBackgroundLockTests {
 
         await sut.handleEnterForeground()
 
-        // Refresh must have been attempted...
-        await waitForCondition(timeout: .seconds(1), "refresh must be attempted") {
-            refreshAttempted.value
-        }
-        // ...and the (buggy) destructive logout, if it fires, runs right after the throw.
-        // Give it time to settle so the assertions below are not racing a pending logout.
-        try? await Task.sleep(for: .milliseconds(400))
+        // Deterministically wait for the fire-and-forget background refresh — and any logout it
+        // would trigger — to finish, instead of a timing-dependent sleep. The task is @MainActor
+        // isolated, so it cannot run until we suspend on `.value`; the read is race-free.
+        await sut.backgroundRefreshTask?.value
 
+        #expect(refreshAttempted.value == true, "session refresh must be attempted")
         #expect(
             sut.authState == .authenticated,
             "Transient refresh failure must NOT force logout — the session is still valid server-side"

--- a/ios/PulpeTests/App/AppStateBiometricColdStartTests.swift
+++ b/ios/PulpeTests/App/AppStateBiometricColdStartTests.swift
@@ -617,9 +617,9 @@ struct AppStateBiometricColdStartTests {
         let keychain = MockKeychainStore(lastUsedEmail: "returning@pulpe.app")
 
         UserDefaults.standard.set(true, forKey: "pulpe-has-launched-before")
-        // PUL-132: biometric path (which surfaces URLError as networkError) runs only
-        // on explicit-logout cold-start. Without this flag, validateBiometricSession
-        // is skipped and validateRegularSession's URLError maps to .unauthenticated.
+        // Explicit-logout cold-start so the biometric path runs (PUL-132). Both the biometric
+        // and the regular path now surface a transient URLError as `.networkError` (not a
+        // logout / credentials prompt), so the retry screen is shown either way.
         UserDefaults.standard.set(true, forKey: "pulpe-did-explicit-logout")
         defer {
             UserDefaults.standard.removeObject(forKey: "pulpe-has-launched-before")

--- a/ios/PulpeTests/App/Auth/StartupCoordinatorTests.swift
+++ b/ios/PulpeTests/App/Auth/StartupCoordinatorTests.swift
@@ -331,9 +331,12 @@ struct StartupCoordinatorTests {
             }
         )
 
-        // First attempt fails
+        // First attempt hits a transient network error (URLError) — this now surfaces the
+        // retry UI (.networkError), not a logout / credentials prompt.
         let firstResult = await sut.start(context: makeContext())
-        #expect(firstResult == .unauthenticated)
+        if case .networkError = firstResult {} else {
+            Issue.record("Expected .networkError on a transient first attempt, got \(firstResult)")
+        }
 
         // Retry succeeds
         let retryResult = await sut.retry(context: makeContext())

--- a/ios/PulpeTests/App/Auth/StartupCoordinatorTests.swift
+++ b/ios/PulpeTests/App/Auth/StartupCoordinatorTests.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable file_length
+// swiftlint:disable file_length type_body_length
 import Foundation
 @testable import Pulpe
 import Testing
@@ -345,6 +345,19 @@ struct StartupCoordinatorTests {
         } else {
             Issue.record("Expected authenticated on retry")
         }
+    }
+
+    @Test func regularValidation_urlCancelled_returnsCancelled() async {
+        // A superseded startup run cancels its in-flight supabase.auth.session request, which
+        // URLSession surfaces as URLError(.cancelled). It must map to .cancelled, NOT the stale
+        // .networkError retry route an obsolete run would otherwise apply.
+        let sut = makeCoordinator(
+            validateRegularSession: { throw URLError(.cancelled) }
+        )
+
+        let result = await sut.start(context: makeContext())
+
+        #expect(result == .cancelled)
     }
 
     @Test func cancel_whileRunning_returnsCancelled() async {


### PR DESCRIPTION
Closes **PUL-278**. Follow-up to PUL-265 (whose biometric-snapshot fix addressed a different symptom).

## Problem
After ~1 day of inactivity, reopening the app (cold or from background) logs the user out and forces credential re-entry — instead of just asking for Face ID. Reported as persisting for weeks despite PUL-265.

## Root cause (proven by test)
After the 1h access-token expiry, **every** reopen forces a network refresh. The foreground (`handleEnterForeground`) and cold-start (`StartupCoordinator.performRegularValidation`) paths treated **any** refresh failure — including a transient `URLError` that `AuthService.validateSession()` swallows to `nil` — as a definitive session loss and fired a destructive `logout(.system)`: `signOut(.local)` **server-revokes** the refresh token, biometric is **wiped + disabled**, and the user is dumped to the credentials screen. A single cold-radio blip on resume is therefore **permanent**.

- Supabase prod has **no** inactivity/timebox expiry (`sessions_timebox=0`, `sessions_inactivity_timeout=0`, verified via the Management API) → the session was still valid server-side. Not a server problem.
- The `APIClient` 401 path was already transient-safe (`resolveAccessTokenStrict`) — the foreground/cold-start paths were the asymmetric defect.
- PostHog (90d): 67 `login_completed` / 20 persons (one person **26×**) → forced-re-auth fingerprint.

## Fix (rotation stays ON — webapp invariant preserved)
- `AuthService.validateSessionStrict()` — rethrows `URLError`, returns `nil` only on confirmed loss.
- `handleEnterForeground` — `URLError` → keep the biometric-unlocked session, no logout/revoke.
- `StartupCoordinator` — `URLError` → `.networkError` (retry UI), not `.unauthenticated`.
- `SessionLifecycleCoordinator` — same transient policy on the fallback/regular paths.
- `PulpeAuthStorage` — `WhenUnlockedThisDeviceOnly` → `AfterFirstUnlockThisDeviceOnly` (the SDK's own default) so tokens rotated while the device is locked persist, closing the stale-token reuse-detection revocation path.

Genuine session loss (`AuthError` / confirmed `nil`) still logs out.

## Tests
- New `foregroundBiometricUnlock_transientNetworkError_keepsSessionAndBiometric` — **red→green** (asserts no logout, no `signOut`, biometric intact on a transient `URLError`).
- `foregroundBiometricUnlock_genuineSessionLoss_logsOut` — genuine loss still logs out.
- `StartupCoordinatorTests.retry_afterFailure_runsAgain` — transient `URLError` → `.networkError`.
- **155 tests / 8 suites pass, SwiftLint clean.**

## Manual verification (CA6 — TestFlight/device)
Sign in (Face ID on) → background → wait >60 min → enable Airplane Mode → reopen: should stay signed in, Face ID unlocks, session refreshes silently when connectivity returns. Never the credentials screen.

> Not covered by automated tests: the real multi-day timing and the locked-device keychain-write race (the accessibility change is justified by the SDK default + Apple guidance, not a unit test).