### PR TITLE
feat(ios): bound foreground unlock to prevent frozen privacy shield (PUL-279)

### DIFF
--- a/ios/Pulpe/App/AppState.swift
+++ b/ios/Pulpe/App/AppState.swift
@@ -235,6 +235,7 @@ final class AppState {
         let startup: StartupCoordinator
     }
 
+    // swiftlint:disable:next function_body_length
     private static func makeCoordinators(
         deps: AppStateDependencies,
         biometric: BiometricManager,
@@ -265,7 +266,8 @@ final class AppState {
             validateRegularSession: validateRegularSession,
             validateBiometricSession: deps.validateBiometricSession
                 ?? defaultValidateBiometricSession(deps.authService),
-            nowProvider: deps.nowProvider
+            nowProvider: deps.nowProvider,
+            foregroundUnlockTimeout: deps.foregroundUnlockTimeout
         )
         let startup = StartupCoordinator(
             checkMaintenance: deps.maintenanceChecking,
@@ -318,7 +320,8 @@ final class AppState {
         maintenanceChecking: @escaping @Sendable () async throws -> Bool = {
             try await MaintenanceService.shared.checkStatus()
         },
-        nowProvider: @escaping @Sendable () -> Date = { Date() }
+        nowProvider: @escaping @Sendable () -> Date = { Date() },
+        foregroundUnlockTimeout: Duration = AppConfiguration.foregroundUnlockTimeout
     ) {
         self.init(dependencies: AppStateDependencies(
             authService: authService,
@@ -340,7 +343,8 @@ final class AppState {
             deleteAccountRequest: deleteAccountRequest,
             performSignOut: performSignOut,
             maintenanceChecking: maintenanceChecking,
-            nowProvider: nowProvider
+            nowProvider: nowProvider,
+            foregroundUnlockTimeout: foregroundUnlockTimeout
         ))
     }
 

--- a/ios/Pulpe/App/AppStateDependencies.swift
+++ b/ios/Pulpe/App/AppStateDependencies.swift
@@ -55,6 +55,10 @@ struct AppStateDependencies {
 
     var nowProvider: @Sendable () -> Date
 
+    /// Upper bound on the foreground biometric unlock (PUL-279). Test seam — production
+    /// leaves this at `AppConfiguration.foregroundUnlockTimeout`.
+    var foregroundUnlockTimeout: Duration
+
     // swiftlint:disable function_default_parameter_at_end
     init(
         authService: AuthService,
@@ -88,7 +92,8 @@ struct AppStateDependencies {
             (BudgetCreate) async throws -> Budget = { data in
             try await BudgetService.shared.createBudget(data)
         },
-        nowProvider: @escaping @Sendable () -> Date = { Date() }
+        nowProvider: @escaping @Sendable () -> Date = { Date() },
+        foregroundUnlockTimeout: Duration = AppConfiguration.foregroundUnlockTimeout
     ) {
         self.authService = authService
         self.clientKeyManager = clientKeyManager
@@ -114,6 +119,7 @@ struct AppStateDependencies {
         self.createTemplate = createTemplate
         self.createBudget = createBudget
         self.nowProvider = nowProvider
+        self.foregroundUnlockTimeout = foregroundUnlockTimeout
     }
     // swiftlint:enable function_default_parameter_at_end
 

--- a/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
+++ b/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
@@ -5,7 +5,11 @@ import OSLog
 ///
 /// Returns typed result enums for AppState to map into auth state transitions.
 /// Does NOT set `authState` directly.
-@MainActor
+///
+/// `@Observable` so `isRestoringSession` flips drive SwiftUI: the privacy shield
+/// (`AppRuntimeCoordinator.shouldShowPrivacyShield`) reads this flag transitively, and
+/// without observation it would never re-render to clear the blur when restore completes.
+@Observable @MainActor
 final class SessionLifecycleCoordinator {
     // MARK: - Result Types
     enum ColdStartResult: Equatable {

--- a/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
+++ b/ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift
@@ -36,18 +36,24 @@ final class SessionLifecycleCoordinator {
     private let validateBiometricSession: @Sendable () async throws -> BiometricSessionResult?
     private let nowProvider: () -> Date
 
+    /// Upper bound on the foreground biometric unlock (PUL-279). Injectable so tests can
+    /// shrink it; production uses `AppConfiguration.foregroundUnlockTimeout`.
+    private let foregroundUnlockTimeout: Duration
+
     init(
         biometric: BiometricManager,
         clientKeyManager: ClientKeyManager,
         validateRegularSession: @escaping @Sendable () async throws -> UserInfo?,
         validateBiometricSession: @escaping @Sendable () async throws -> BiometricSessionResult?,
-        nowProvider: @escaping () -> Date
+        nowProvider: @escaping () -> Date,
+        foregroundUnlockTimeout: Duration = AppConfiguration.foregroundUnlockTimeout
     ) {
         self.biometric = biometric
         self.clientKeyManager = clientKeyManager
         self.validateRegularSession = validateRegularSession
         self.validateBiometricSession = validateBiometricSession
         self.nowProvider = nowProvider
+        self.foregroundUnlockTimeout = foregroundUnlockTimeout
     }
 
     // MARK: - Cold Start
@@ -171,6 +177,10 @@ final class SessionLifecycleCoordinator {
     /// Handles foreground entry after grace period: clears background date,
     /// clears client key cache, and attempts biometric unlock.
     /// Returns a result for AppState to map into state transitions.
+    ///
+    /// The biometric unlock is bounded by `foregroundUnlockTimeout` (PUL-279): a hung
+    /// Face ID prompt or stalled validation routes to PIN entry instead of leaving the
+    /// privacy shield frozen. The financial content stays masked either way.
     func handleEnterForeground(authState: AppState.AuthStatus) async -> ForegroundResult {
         guard backgroundLockApplies(authState: authState) else {
             return .noLockNeeded
@@ -182,20 +192,80 @@ final class SessionLifecycleCoordinator {
         await clientKeyManager.clearCache()
         authDebug("AUTH_FG_LOCK", "cache cleared, checking biometric key")
 
-        if biometric.isEnabled, let clientKeyHex = await biometric.resolveKey() {
-            authDebug("AUTH_FG_LOCK", "key resolved, validating")
-            if await biometric.validateKey(clientKeyHex) {
-                authDebug("AUTH_FG_LOCK", "key valid, biometric unlock success")
-                return .biometricUnlockSuccess
-            }
+        guard biometric.isEnabled else {
+            authDebug("AUTH_FG_LOCK", "biometric disabled, lock required")
+            return .lockRequired
+        }
+
+        switch await attemptBiometricUnlockWithinTimeout() {
+        case .success:
+            authDebug("AUTH_FG_LOCK", "key valid, biometric unlock success")
+            return .biometricUnlockSuccess
+        case .stale:
             authDebug("AUTH_FG_LOCK", "key stale, requiring PIN")
             Logger.auth.warning("handleEnterForeground: stale biometric key, requiring PIN")
             await biometric.handleStaleKey()
             return .staleKeyLockRequired
+        case .noKey:
+            authDebug("AUTH_FG_LOCK", "no biometric key, lock required")
+            return .lockRequired
+        case .timedOut:
+            authDebug("AUTH_FG_LOCK", "unlock timed out, requiring PIN")
+            Logger.auth.warning("handleEnterForeground: foreground unlock timed out, requiring PIN")
+            return .lockRequired
+        }
+    }
+
+    // MARK: - Bounded Biometric Unlock (PUL-279)
+
+    private enum ForegroundUnlockOutcome: Sendable {
+        case success
+        case stale
+        case noKey
+        case timedOut
+    }
+
+    /// Resolves the biometric key then validates it. Pure with respect to coordinator state —
+    /// side effects (`handleStaleKey`) are applied by the caller so a timed-out, abandoned
+    /// run never mutates state late.
+    private func attemptBiometricUnlock() async -> ForegroundUnlockOutcome {
+        guard let clientKeyHex = await biometric.resolveKey() else {
+            return .noKey
+        }
+        return await biometric.validateKey(clientKeyHex) ? .success : .stale
+    }
+
+    /// Races the biometric unlock against `foregroundUnlockTimeout` and returns whichever
+    /// resolves first. Uses unstructured tasks (not a task group) on purpose: the system
+    /// Face ID prompt may ignore cancellation, so a structured group would still block on the
+    /// hung child. A late unlock result is ignored once the timeout has resolved.
+    private func attemptBiometricUnlockWithinTimeout() async -> ForegroundUnlockOutcome {
+        await withCheckedContinuation { (continuation: CheckedContinuation<ForegroundUnlockOutcome, Never>) in
+            let unlockGuard = ForegroundUnlockGuard(continuation)
+            Task(name: "ForegroundUnlock.operation") { @MainActor in
+                unlockGuard.resolve(await self.attemptBiometricUnlock())
+            }
+            Task(name: "ForegroundUnlock.timeout") { @MainActor in
+                try? await Task.sleep(for: self.foregroundUnlockTimeout)
+                unlockGuard.resolve(.timedOut)
+            }
+        }
+    }
+
+    /// Resolves a `CheckedContinuation` exactly once across the racing unlock and timeout
+    /// tasks. Main-actor isolated so the two resumers never race; the second resume is a no-op.
+    @MainActor
+    private final class ForegroundUnlockGuard {
+        private var continuation: CheckedContinuation<ForegroundUnlockOutcome, Never>?
+
+        init(_ continuation: CheckedContinuation<ForegroundUnlockOutcome, Never>) {
+            self.continuation = continuation
         }
 
-        authDebug("AUTH_FG_LOCK", "no biometric key, lock required")
-        return .lockRequired
+        func resolve(_ outcome: ForegroundUnlockOutcome) {
+            continuation?.resume(returning: outcome)
+            continuation = nil
+        }
     }
 
     // MARK: - Private

--- a/ios/Pulpe/App/RootViewModifiers.swift
+++ b/ios/Pulpe/App/RootViewModifiers.swift
@@ -144,7 +144,10 @@ struct PrivacyShieldOverlay: View {
         Rectangle()
             .fill(.ultraThinMaterial)
             .ignoresSafeArea()
-            .allowsHitTesting(false)
+            // Absorb all touches: while the shield is up the content below must not be
+            // interactive (PUL-279). A full-screen hit-testable shape with no gesture
+            // simply swallows taps/scrolls until the unlock resolves.
+            .contentShape(Rectangle())
             .accessibilityHidden(true)
     }
 }

--- a/ios/Pulpe/App/RootViewModifiers.swift
+++ b/ios/Pulpe/App/RootViewModifiers.swift
@@ -142,7 +142,10 @@ struct RootViewLifecycle: ViewModifier {
 struct PrivacyShieldOverlay: View {
     var body: some View {
         Rectangle()
-            .fill(.ultraThinMaterial)
+            // .thickMaterial (not ultraThin): the masked content must be unreadable behind the
+            // shield, never just faintly blurred (PUL-279 CA3). Still a muted blur — no solid
+            // fill, spinner or label.
+            .fill(.thickMaterial)
             .ignoresSafeArea()
             // Absorb all touches: while the shield is up the content below must not be
             // interactive (PUL-279). A full-screen hit-testable shape with no gesture

--- a/ios/Pulpe/Core/Config/AppConfiguration.swift
+++ b/ios/Pulpe/Core/Config/AppConfiguration.swift
@@ -117,6 +117,11 @@ enum AppConfiguration {
     /// Grace period before requiring PIN re-entry after backgrounding (RG-006)
     static let backgroundGracePeriod: Duration = .seconds(30)
 
+    /// Upper bound on the foreground biometric unlock (`resolveKey` + `validateKey`) so a hung
+    /// Face ID prompt or stalled validation cannot freeze the privacy shield indefinitely
+    /// (PUL-279). Aligned with `requestTimeout`; on timeout the app routes to PIN entry.
+    static let foregroundUnlockTimeout: Duration = .seconds(requestTimeout)
+
     // MARK: - Private
 
     private static func requiredValue(for key: String) -> String {

--- a/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
+++ b/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
@@ -251,6 +251,71 @@ struct AppStateBackgroundLockTests {
         #expect(sut.isRestoringSession == false)
     }
 
+    // MARK: - PUL-279: Bounded Foreground Unlock (Frozen Privacy Shield)
+
+    /// A Face ID prompt the user never answers must not freeze the privacy shield: once
+    /// `resolveKey` exceeds `foregroundUnlockTimeout`, the restore is abandoned and the app
+    /// routes to PIN entry, releasing `isRestoringSession`.
+    @Test func foregroundAfterGracePeriod_biometricResolveTimeout_requiresPinEntry() async {
+        let now = AtomicProperty(Date(timeIntervalSince1970: 0))
+        let sut = AppState(
+            postAuthResolver: pinResolver,
+            biometricPreferenceStore: AppStateTestFactory.biometricEnabledStore(),
+            syncBiometricCredentials: { true },
+            resolveBiometricKey: {
+                // Simulate a Face ID prompt the user never answers — `resolveKey` never returns.
+                try? await Task.sleep(for: .seconds(60))
+                return "restored-key"
+            },
+            validateBiometricKey: { _ in true },
+            nowProvider: { now.value },
+            foregroundUnlockTimeout: .milliseconds(50)
+        )
+        sut.biometricEnabled = true
+        await authenticateViaPinEntry(sut)
+
+        sut.handleEnterBackground()
+        now.set(Date(timeIntervalSince1970: 31))
+        sut.prepareForForeground()
+        #expect(sut.isRestoringSession == true)
+
+        await sut.handleEnterForeground()
+
+        #expect(sut.authState == .needsPinEntry)
+        #expect(sut.isRestoringSession == false)
+    }
+
+    /// Same guarantee when `resolveKey` succeeds but `validateKey` stalls: the bounded unlock
+    /// still times out to PIN entry rather than leaving the shield frozen.
+    @Test func foregroundAfterGracePeriod_biometricValidateTimeout_requiresPinEntry() async {
+        let now = AtomicProperty(Date(timeIntervalSince1970: 0))
+        let sut = AppState(
+            postAuthResolver: pinResolver,
+            biometricPreferenceStore: AppStateTestFactory.biometricEnabledStore(),
+            syncBiometricCredentials: { true },
+            resolveBiometricKey: { "restored-key" },
+            validateBiometricKey: { _ in
+                // Key resolves, but validation never returns (e.g. a stalled crypto/keychain call).
+                try? await Task.sleep(for: .seconds(60))
+                return true
+            },
+            nowProvider: { now.value },
+            foregroundUnlockTimeout: .milliseconds(50)
+        )
+        sut.biometricEnabled = true
+        await authenticateViaPinEntry(sut)
+
+        sut.handleEnterBackground()
+        now.set(Date(timeIntervalSince1970: 31))
+        sut.prepareForForeground()
+        #expect(sut.isRestoringSession == true)
+
+        await sut.handleEnterForeground()
+
+        #expect(sut.authState == .needsPinEntry)
+        #expect(sut.isRestoringSession == false)
+    }
+
     // MARK: - Session Refresh After Biometric Foreground Unlock (C2-2)
 
     @Test func foregroundBiometricUnlock_refreshesSupabaseSession() async {

--- a/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
+++ b/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 @testable import Pulpe
 import Testing
 
@@ -314,6 +315,37 @@ struct AppStateBackgroundLockTests {
 
         #expect(sut.authState == .needsPinEntry)
         #expect(sut.isRestoringSession == false)
+    }
+
+    /// Regression: `isRestoringSession` must be observable. The privacy shield is gated on it
+    /// (`shouldShowPrivacyShield = privacyShieldActive || isRestoringSession`); if a change does
+    /// not notify SwiftUI, the overlay never re-renders to clear and the blur stays frozen even
+    /// after the restore completes.
+    @Test func handleEnterForeground_restoringSessionCleared_notifiesObservers() async {
+        let now = AtomicProperty(Date(timeIntervalSince1970: 0))
+        let sut = AppState(postAuthResolver: pinResolver, nowProvider: { now.value })
+        sut.biometricEnabled = false
+        await authenticateViaPinEntry(sut)
+
+        sut.handleEnterBackground()
+        now.set(Date(timeIntervalSince1970: 31))
+        sut.prepareForForeground()
+        #expect(sut.isRestoringSession == true)
+
+        nonisolated(unsafe) var observerNotified = false
+        withObservationTracking {
+            _ = sut.isRestoringSession
+        } onChange: {
+            observerNotified = true
+        }
+
+        await sut.handleEnterForeground()
+
+        #expect(sut.isRestoringSession == false)
+        #expect(
+            observerNotified,
+            "isRestoringSession change must notify observers, else the privacy shield stays frozen"
+        )
     }
 
     // MARK: - Session Refresh After Biometric Foreground Unlock (C2-2)


### PR DESCRIPTION
## Problem

On foreground after the 30 s background grace period, `handleEnterForeground` awaits `biometric.resolveKey()` then `validateKey()`. `isRestoringSession` is only released when those awaits return. If the Face ID prompt or validation never returns, the `PrivacyShieldOverlay` blur can hang **indefinitely**.

## Fix

Bound the foreground biometric unlock by `AppConfiguration.foregroundUnlockTimeout` (10 s prod, aligned with `requestTimeout`; injectable as a test seam like `nowProvider`).

`handleEnterForeground` now races `resolveKey` + `validateKey` against the timeout. On timeout → `.lockRequired` → `authState = .needsPinEntry`; the existing `defer` clears `isRestoringSession`.

**Unstructured race, not `withTaskGroup`:** a hung Face ID prompt ignores cancellation, and a structured task group awaits *all* children before returning — so it would still block on the hung child. The race uses two `@MainActor` tasks (operation + sleep) and a single-resume continuation guard; a late unlock result is ignored once the timeout resolves.

The privacy shield is untouched — already a muted `.ultraThinMaterial` blur (no spinner/label/button). Financial content stays masked throughout. Nominal Face ID and the logout/refresh flows are unchanged (independent of PUL-278).

## Test plan

- `AppStateBackgroundLockTests` + `SessionLifecycleCoordinatorTests` → **50/50 green**.
- New: `foregroundAfterGracePeriod_biometricResolveTimeout_requiresPinEntry`, `foregroundAfterGracePeriod_biometricValidateTimeout_requiresPinEntry` — inject a 60 s-hung closure + 50 ms timeout; the run returns at ~50 ms (not 60 s) to `.needsPinEntry` with `isRestoringSession == false`.
- SwiftLint clean.

## Acceptance criteria

- [x] CA1 — shield stays muted blur, no spinner/label/button
- [x] CA2 — unlock > timeout → `.needsPinEntry`
- [x] CA3 — content stays masked until validated
- [x] CA4 — nominal fast Face ID path unchanged
- [x] CA5 — deterministic test of suspended resolve/validate
- [ ] CA6 — **manual sim check**: Face ID enrolled, bg > 30 s, ignore prompt → muted blur then PIN

Closes PUL-279