### PR TITLE
feat(ios): point, edit & delete free transactions in budget detail (PUL-277)

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
@@ -6,10 +6,10 @@ import SwiftUI
 /// `ScrollView/LazyVStack`. Each row is a tap target that opens the
 /// transaction edit sheet (matching the budget-line detail flow).
 ///
-/// Visual: rows mirror `BudgetLineMixedRow` (kind tag · name · date
-/// subtitle · amount + currency suffix · chevron) with a leading inset that
-/// preserves the column rhythm of envelope rows. Free transactions are
-/// auto-counted, so there is no checkbox/`PointCircle` toggle.
+/// Visual: rows mirror `BudgetLineMixedRow` (point circle · kind tag · name ·
+/// date subtitle · amount + currency suffix · chevron). Pointing a free
+/// transaction is a personal reconciliation marker — like envelopes, it never
+/// changes any total — so the leading slot carries a real `PointCircle`.
 ///
 /// Accepts pre-shaped `FreeTransactionItem`s — the projection layer carries
 /// the `isSyncing` flag so the view stays free of `.contains` over a syncing
@@ -18,6 +18,7 @@ struct BudgetDetailsFreeTransactionsList: View {
     let items: [BudgetDetailsScreenState.FreeTransactionItem]
     let currency: SupportedCurrency
     let onTap: (Transaction) -> Void
+    let onTogglePointed: (Transaction) -> Void
 
     @State private var isExpanded = false
     private let collapsedItemCount = 3
@@ -58,7 +59,8 @@ struct BudgetDetailsFreeTransactionsList: View {
                     transaction: item.transaction,
                     isSyncing: item.isSyncing,
                     currency: currency,
-                    onTap: { onTap(item.transaction) }
+                    onTap: { onTap(item.transaction) },
+                    onTogglePointed: { onTogglePointed(item.transaction) }
                 )
                 .padding(.horizontal, DesignTokens.Spacing.lg)
                 .padding(.bottom, DesignTokens.Spacing.md)
@@ -89,20 +91,36 @@ struct BudgetDetailsFreeTransactionsList: View {
 
 // MARK: - Row
 
-/// Free-transaction row visually aligned with `BudgetLineMixedRow`: kind tag
-/// + name + date subtitle on the left, kind-tinted amount + currency suffix
-/// on the right, chevron. No `PointCircle` — free transactions are
-/// auto-counted, so the leading column reserves the same horizontal space
-/// as the envelope toggle to keep card rhythm consistent.
+/// Free-transaction row visually aligned with `BudgetLineMixedRow`: a leading
+/// `PointCircle` toggle, then kind tag + name + date subtitle on the left,
+/// kind-tinted amount + currency suffix on the right, chevron. Tapping the
+/// circle points/unpoints the transaction (`onTogglePointed`); tapping the row
+/// surface opens the edit sheet (`onTap`).
 private struct BudgetDetailsFreeTransactionRow: View {
     let transaction: Transaction
     let isSyncing: Bool
     let currency: SupportedCurrency
     let onTap: () -> Void
+    let onTogglePointed: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var triggerToggleFeedback = false
 
     private var kind: TransactionKind { transaction.kind }
     private var isIncome: Bool { kind == .income }
     private var isSaving: Bool { kind == .saving }
+    private var isPointed: Bool { transaction.isChecked }
+
+    /// PointCircle dot color — kind-based, mirroring `BudgetLineMixedRow.dotColor`
+    /// minus the over-budget branch (a free transaction has no envelope to
+    /// overshoot). Expenses use `financialExpense` so the pointed state stays
+    /// visually consistent with envelope rows.
+    private var dotColor: Color {
+        if isIncome { return .financialIncome }
+        if isSaving { return .financialSavings }
+        return .financialExpense
+    }
 
     /// Mirrors `BudgetLineMixedRow.amountColor` minus the consumption-driven
     /// branches (no envelope to overshoot). Expenses fall back to the neutral
@@ -126,26 +144,28 @@ private struct BudgetDetailsFreeTransactionRow: View {
 
     private var accessibilityLabel: String {
         let amount = transaction.amount.asCurrency(currency)
-        return "\(kind.label) · \(transaction.name) · \(amount) · \(transaction.transactionDate.dayMonthFormatted)"
+        let pointed = isPointed ? "Pointé" : "À pointer"
+        return "\(kind.label) · \(transaction.name) · \(amount) · \(transaction.transactionDate.dayMonthFormatted) · \(pointed)"
+    }
+
+    private func handleTogglePointed() {
+        triggerToggleFeedback.toggle()
+        onTogglePointed()
     }
 
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: DesignTokens.Spacing.xxs) {
-                // Empty leading slot keeps the same column origin as
-                // `BudgetLineMixedRow` (PointCircle width + leading xs) so
-                // free-tx and envelope rows share a clean vertical rhythm.
-                Color.clear
-                    .frame(
-                        width: DesignTokens.Checkbox.size,
-                        height: DesignTokens.Checkbox.size
-                    )
+                PointCircle(
+                    isPointed: isPointed,
+                    color: dotColor,
+                    isSyncing: isSyncing,
+                    onToggle: handleTogglePointed
+                )
 
                 centerColumn
 
                 Spacer(minLength: DesignTokens.Spacing.sm)
-
-                SyncIndicator(isSyncing: isSyncing)
 
                 amountColumn
 
@@ -156,12 +176,20 @@ private struct BudgetDetailsFreeTransactionRow: View {
             .padding(.trailing, DesignTokens.Spacing.md)
             .frame(maxWidth: .infinity, minHeight: DesignTokens.ListRow.minHeight, alignment: .leading)
             .contentShape(Rectangle())
+            .opacity(isPointed ? DesignTokens.Opacity.pointedDim : 1)
+            .animation(
+                reduceMotion ? nil : DesignTokens.Animation.gentleSpring,
+                value: isPointed
+            )
         }
         .buttonStyle(.plain)
         .background(Color.surfaceContainerLowest)
         .clipShape(RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.xl))
         .shadow(DesignTokens.Shadow.subtle)
-        .accessibilityElement(children: .ignore)
+        .sensoryFeedback(.success, trigger: triggerToggleFeedback)
+        // `.contain` keeps the inner PointCircle as its own focus node so VoiceOver
+        // can drive the pointed/unpointed toggle independently of the row's tap-to-open.
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Touche pour modifier")
         .accessibilityAddTraits(.isButton)
@@ -174,6 +202,7 @@ private struct BudgetDetailsFreeTransactionRow: View {
             Text(transaction.name)
                 .font(PulpeTypography.listRowTitle)
                 .foregroundStyle(Color.textPrimary)
+                .strikethrough(isPointed, color: Color.textTertiary)
                 .lineLimit(1)
                 .truncationMode(.tail)
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
@@ -145,7 +145,8 @@ private struct BudgetDetailsFreeTransactionRow: View {
     private var accessibilityLabel: String {
         let amount = transaction.amount.asCurrency(currency)
         let pointed = isPointed ? "Pointé" : "À pointer"
-        return "\(kind.label) · \(transaction.name) · \(amount) · \(transaction.transactionDate.dayMonthFormatted) · \(pointed)"
+        let date = transaction.transactionDate.dayMonthFormatted
+        return "\(kind.label) · \(transaction.name) · \(amount) · \(date) · \(pointed)"
     }
 
     private func handleTogglePointed() {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
@@ -192,7 +192,6 @@ private struct BudgetDetailsFreeTransactionRow: View {
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Touche pour modifier")
-        .accessibilityAddTraits(.isButton)
     }
 
     private var centerColumn: some View {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -219,6 +219,11 @@ struct BudgetDetailsView: View {
                         currency: userSettingsStore.currency,
                         onTap: { transaction in
                             router.push(.editTx(transactionId: transaction.id))
+                        },
+                        onTogglePointed: { transaction in
+                            Task {
+                                await coordinator.dispatch(.toggleTransaction(transaction))
+                            }
                         }
                     )
                 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/EditTransactionPage.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/EditTransactionPage.swift
@@ -26,6 +26,7 @@ struct EditTransactionPage: View {
     @State private var isLoading = false
     @State private var submitSuccessTrigger = false
     @State private var didAutofocus = false
+    @State private var showDeleteConfirmation = false
     @FocusState private var focusedField: AmountDescriptionField?
 
     private let conversionService = CurrencyConversionService.shared
@@ -73,6 +74,23 @@ struct EditTransactionPage: View {
         .pulpeStickyBottomCTA { saveButton(for: tx) }
         .navigationTitle("Modifier la transaction")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                headerMenu
+            }
+        }
+        .alert(
+            "Supprimer la transaction ?",
+            isPresented: $showDeleteConfirmation,
+            presenting: tx
+        ) { tx in
+            Button("Annuler", role: .cancel) {}
+            Button("Supprimer", role: .destructive) {
+                deleteTransaction(tx)
+            }
+        } message: { _ in
+            Text("Tu auras quelques secondes pour annuler.")
+        }
         .loadingOverlay(isLoading)
         .dismissKeyboardOnTap()
         .keyboardFieldNavigation(focus: $focusedField, order: [.amount, .description])
@@ -160,7 +178,32 @@ struct EditTransactionPage: View {
         .primaryButtonStyle(isEnabled: canSubmit)
     }
 
+    private var headerMenu: some View {
+        Menu {
+            Button(role: .destructive) {
+                showDeleteConfirmation = true
+            } label: {
+                Label("Supprimer", systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+        .accessibilityLabel("Plus d'options")
+    }
+
     // MARK: - Logic
+
+    /// Soft-deletes via the coordinator (same undo-toast machinery as budget
+    /// lines). We do NOT call `dismiss()`: removing the transaction empties
+    /// `transaction`, the `AutoPopView` branch fires, and the page pops once —
+    /// calling `dismiss()` here too would race that and risk a double-pop.
+    private func deleteTransaction(_ tx: Transaction) {
+        let ctx = ToastContext(
+            toastManager: toastManager,
+            presentationCurrency: userSettingsStore.currency
+        )
+        Task { await coordinator.dispatch(.softDeleteTransaction(tx, ctx)) }
+    }
 
     /// Re-fires when `tx.id` changes (i.e. on first appearance, never again
     /// during this push lifecycle since the transaction id is stable).

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorToggleTransactionTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorToggleTransactionTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Coverage for PUL-277 — pointing a *free* transaction (no `budgetLineId`)
+/// from the budget detail screen. The `.toggleTransaction` action and its
+/// optimistic-apply / rollback path already existed, but had no UI caller (and
+/// thus no test) before this feature wired a `PointCircle` onto free-transaction
+/// rows. These lock the persistence contract behind CA2: the toggle is applied
+/// optimistically and reverted when the server call fails.
+@Suite(.serialized)
+@MainActor
+struct BudgetDetailsCoordinatorToggleTransactionTests {
+    @Test
+    func toggleTransaction_freeTransaction_pointsOptimistically() async {
+        let txService = MockTransactionService()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            transactionService: txService
+        )
+        let freeTx = TestDataFactory.createTransaction(id: "tx-free", isChecked: false)
+        await coord.dispatch(.addTransaction(freeTx))
+
+        await coord.dispatch(.toggleTransaction(freeTx))
+
+        #expect(coord.dataStore.transactions.first?.isChecked == true)
+    }
+
+    @Test
+    func toggleTransaction_serverFailure_rollsBackToUnchecked() async {
+        let txService = MockTransactionService()
+        txService.failingToggleIds = ["tx-free"]
+        let coord = BudgetDetailsCoordinator(
+            budgetId: "test-budget",
+            transactionService: txService
+        )
+        let freeTx = TestDataFactory.createTransaction(id: "tx-free", isChecked: false)
+        await coord.dispatch(.addTransaction(freeTx))
+
+        await coord.dispatch(.toggleTransaction(freeTx))
+
+        #expect(coord.dataStore.transactions.first?.isChecked == false)
+    }
+}


### PR DESCRIPTION
## Summary

**Pointing (initial scope):**
• Free-transaction rows now show a `PointCircle` (was an empty slot) — pointable like budget lines and allocated transactions
• Pointing is a personal reconciliation marker: never changes any total or envelope consumption
• Pointed rows get strikethrough name + dim; folds the standalone `SyncIndicator` into the circle
• VoiceOver label Pointé/À pointer, 44pt tap target; "À pointer" filter already excluded pointed free tx

**Edit & delete (added scope):**
• Free transactions had no delete path — added a `•••` menu to the edit screen with destructive "Supprimer"
• Confirmation alert → soft-delete with undo toast, reusing the exact `.softDeleteTransaction` machinery + menu/alert pattern of the envelope detail page
• Tap still opens edit directly (1 tap); primary button stays "Enregistrer"; auto-pop on delete (no double-pop)
• Menu is unconditional → allocated transactions gain the same edit-screen delete entry point

UX decision (hybrid) chosen over an envelope-style detail screen (hollow for a leaf) and a big delete button under save (misclick risk). Details + acceptance criteria CA6–CA9 in PUL-277.

## Type

feat

Closes PUL-277