### PR TITLE
fix(ios): keyboard inset stranding on BudgetDetails after edit-tx pop (PUL-284)

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -255,6 +255,17 @@ struct BudgetDetailsView: View {
             prompt: "Rechercher..."
         )
         .searchPresentationToolbarBehavior(.avoidHidingContent)
+        // Reset the keyboard safe-area inset for this whole subtree — both
+        // overlays (sticky pager + FAB) inherit the reset. This screen has no
+        // bottom text input (the only field is the `.searchable` bar, which
+        // lives in the top nav-bar drawer), so ignoring the bottom keyboard
+        // inset hides nothing. Without this, a stale ~keyboard-height bottom
+        // inset inherited from a pushed, auto-focused child (EditTransactionPage)
+        // strands on pop — phantom over-scroll + FAB floating mid-page. Mirrors
+        // the existing guards on the tab bar (MainTabView) and sticky CTA
+        // (pulpeStickyBottomCTA). Must stay LAST so both overlays inherit it; if
+        // a bottom text field is ever added here, remove or scope this.
+        .ignoresSafeArea(.keyboard, edges: .bottom)
     }
 
     // MARK: - Routing


### PR DESCRIPTION
## Problème (PUL-284)

Bug de prod iOS, écran détail du budget. Après retour depuis l'écran d'édition d'une transaction (clavier ouvert), une **marge basse fantôme** (~hauteur clavier) apparaît : over-scroll sous la dernière ligne + **FAB `+` flottant au milieu** au lieu d'être ancré en bas à droite. Bug récurrent (plusieurs correctifs antérieurs n'avaient pas couvert cette surface).

## Cause racine

`BudgetDetailsView` et l'écran poussé `EditTransactionPage` partagent une seule `NavigationStack`. `EditTransactionPage` auto-focus le champ montant → le clavier gonfle l'inset bottom de safe-area de la stack. Au **Retour**, le clavier se ferme pendant le pop ; sur iOS 26 l'inset dégonflé n'est pas re-livré à `BudgetDetailsView` → l'inset (~hauteur clavier) **reste collé** sur sa `ScrollView`. Un seul inset coincé → les deux symptômes (over-scroll + FAB monté en `.overlay(alignment: .bottomTrailing)` ancré sur la safe area gonflée).

Les correctifs précédents avaient protégé la tab bar flottante (`MainTabView`) et le CTA collant (`pulpeStickyBottomCTA(avoidsKeyboard:)`), mais jamais le contenu scrollable du détail du budget (qui utilise un FAB, pas un CTA collant) → d'où la récurrence.

## Correctif (1 ligne)

`.ignoresSafeArea(.keyboard, edges: .bottom)` en **dernier** modificateur de `BudgetDetailsView.content`, pour que les deux overlays (pager + FAB) héritent du reset. L'écran n'a aucune saisie texte en bas (le champ `.searchable` est un tiroir en haut de la nav bar), donc ignorer l'inset clavier ne masque rien. Réutilise le pattern déjà éprouvé dans le repo (`MainTabView` ligne ~113, `pulpeStickyBottomCTA` dans `View+Extensions`).

## Vérification

- ✅ `xcodebuild build -scheme PulpeLocal` → BUILD SUCCEEDED
- ✅ SwiftLint clean ; diff = 1 fichier, 1 ligne (+ commentaire de précondition)
- ✅ Analyse multi-agent : 3 vérificateurs adverses → 0 réfutation ; remède canonique SwiftUI confirmé (forums Apple, même classe de bug iOS 16→26)
- ⚠️ **Pas de confirmation runtime automatisée** : ce bug de timing safe-area/clavier iOS 26 ne se reproduit pas de façon déterministe en harness XCUITest (testé 3 configs — voir commentaire PUL-284), et la vérif live locale est bloquée par le flux d'auth/coffre de chiffrement. **Validation finale = repro manuelle sur device/prod** (détail budget → toucher une transaction → clavier → Retour → plus de marge fantôme, FAB ancré en bas).
