### PR TITLE
style(ios): lower floating tab bar closer to the bottom rounded corners

### DIFF
--- a/ios/Pulpe/App/MainTabView.swift
+++ b/ios/Pulpe/App/MainTabView.swift
@@ -105,12 +105,18 @@ struct MainTabView: View {
     private func floatingTabBarOverlay(selectedTab: Binding<Tab>, barHidden: Bool) -> some View {
         floatingTabBar(selectedTab: selectedTab)
             .padding(.horizontal, DesignTokens.Spacing.lg)
-            .padding(.bottom, DesignTokens.Spacing.xs)
+            // Sit closer to the screen's bottom rounded corners: ignore the
+            // bottom safe area (home indicator) and pad a fixed gap from the
+            // true bottom edge, instead of floating above the full safe-area
+            // inset. `.ignoresSafeArea(edges:.bottom)` covers `.all` regions
+            // (incl. `.keyboard`), so the bar stays keyboard-independent during
+            // push/pop. The gap stays above the home-indicator pill.
+            .padding(.bottom, DesignTokens.Spacing.xxl)
             .opacity(barHidden ? 0 : 1)
             .frame(height: barHidden ? 0 : nil)
             .allowsHitTesting(!barHidden)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .ignoresSafeArea(.keyboard, edges: .bottom)
+            .ignoresSafeArea(edges: .bottom)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Quoi

Descend la **tab bar flottante** d'environ 14pt pour qu'elle soit mieux alignée avec l'arrondi des angles bas de l'écran (épouse mieux la forme).

## Comment

Dans `MainTabView.floatingTabBarOverlay` : au lieu de flotter au-dessus de toute la safe area basse (~34pt home indicator) + `Spacing.xs`, la barre **ignore la safe area basse** et réserve un écart fixe `Spacing.xxl` (24pt) depuis le **vrai** bord bas de l'écran.

- `.ignoresSafeArea(edges: .bottom)` couvre les régions `.all` (dont `.keyboard`) → la barre reste **indépendante du clavier** pendant les push/pop (comportement inchangé).
- L'écart de 24pt reste au-dessus de la pastille du home indicator.
- La marge réservée pour le contenu (`tabBarClearance`) est inchangée et ne fait que gagner un peu d'air (le haut de la barre descend) → **rien n'est masqué**.

## Vérification

- ✅ `xcodebuild build -scheme PulpeLocal` → BUILD SUCCEEDED · SwiftLint clean · diff = 1 fichier
- ⚠️ Réglage purement **visuel** : à valider à l'œil sur device (le seul point à confirmer = l'écart de 24pt dégage bien la pastille du home indicator). Ajustable facilement : `xl` (20) plus bas, `lg` (16) symétrique avec les marges latérales, `xxxl` (32) plus haut.

Indépendant de PUL-284 (correctif d'inset clavier, PR #481).
