### PR TITLE
refactor(ios): derive tab-bar clearance from a single inset + device safe area

### DIFF
--- a/ios/Pulpe/App/MainTabView.swift
+++ b/ios/Pulpe/App/MainTabView.swift
@@ -10,17 +10,33 @@ struct MainTabView: View {
     @Environment(CurrentMonthStore.self) private var monthStore
     @State private var addTransactionBudgetId: AddTransactionItem?
     @State private var keyboardVisible = false
+    @State private var bottomSafeAreaInset: CGFloat = 0
     @Namespace private var tabSelectionNamespace
 
-    /// Vertical space the floating tab bar visually occupies above the system
-    /// bottom safe area. Pushed pages read this via `\.tabBarClearance` because
-    /// iOS 26 does not cascade `safeAreaInset` from a TabView through nested
-    /// `NavigationStack` destinations — they must re-reserve the bar's
-    /// height themselves. Collapses to 0 when the bar is hidden.
-    private static let tabBarClearanceHeight: CGFloat =
-        DesignTokens.FrameHeight.tabBar
-        + DesignTokens.Spacing.md
-        + DesignTokens.Spacing.xs
+    /// Gap between the floating tab bar's bottom edge and the physical screen
+    /// bottom. The bar ignores the bottom safe area (see `floatingTabBarOverlay`)
+    /// and sits this far above the true edge, hugging the rounded corners.
+    /// Single source of truth: both the bar's bottom padding and the content
+    /// clearance below derive from it, so they cannot drift apart.
+    private static let tabBarBottomInset = DesignTokens.Spacing.xxl
+
+    /// Breathing room reserved between scrolled content and the bar's top edge.
+    private static let tabBarContentSpacing = DesignTokens.Spacing.md
+
+    /// Bottom clearance each tab's content must reserve so it clears the floating
+    /// bar. Pushed pages read the published value via `\.tabBarClearance` because
+    /// iOS 26 does not cascade a `safeAreaInset` from a `TabView` through nested
+    /// `NavigationStack` destinations — they re-reserve it locally
+    /// (`clearsFloatingTabBar()`). Collapses to 0 when the bar is hidden.
+    ///
+    /// The bar's top sits `tabBarBottomInset + tabBar` above the physical bottom,
+    /// while content respects the safe area — and `safeAreaInset` already
+    /// reserves that inset — so it is subtracted here to avoid double-counting.
+    /// `max(0, …)` guards devices whose safe area alone already clears the bar.
+    private static func tabBarClearance(bottomSafeAreaInset: CGFloat) -> CGFloat {
+        let barTopAbovePhysicalBottom = tabBarBottomInset + DesignTokens.FrameHeight.tabBar
+        return max(0, barTopAbovePhysicalBottom + tabBarContentSpacing - bottomSafeAreaInset)
+    }
 
     /// Whether the floating tab bar should be hidden, given current state.
     /// Hidden when the keyboard is up, or when the active tab is drilled
@@ -48,7 +64,9 @@ struct MainTabView: View {
             templatePathDepth: state.templatePath.count,
             keyboardVisible: keyboardVisible
         )
-        let clearance: CGFloat = barHidden ? 0 : Self.tabBarClearanceHeight
+        let clearance: CGFloat = barHidden
+            ? 0
+            : Self.tabBarClearance(bottomSafeAreaInset: bottomSafeAreaInset)
 
         TabView(selection: $state.selectedTab) {
             SwiftUI.Tab(value: Tab.currentMonth) {
@@ -67,6 +85,14 @@ struct MainTabView: View {
             }
         }
         .pulpeBackground()
+        // Track the device's bottom safe-area inset so `tabBarClearance` reserves
+        // exactly the right space regardless of device (the bar is positioned from
+        // the physical bottom; content respects the safe area).
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.safeAreaInsets.bottom
+        } action: { newInset in
+            bottomSafeAreaInset = newInset
+        }
         // Publish the floating-bar reservation through the environment so each
         // tab's `NavigationStack` can re-apply the canonical safe-area pattern
         // locally — see `clearsFloatingTabBar()` below. The visible bar itself
@@ -106,12 +132,12 @@ struct MainTabView: View {
         floatingTabBar(selectedTab: selectedTab)
             .padding(.horizontal, DesignTokens.Spacing.lg)
             // Sit closer to the screen's bottom rounded corners: ignore the
-            // bottom safe area (home indicator) and pad a fixed gap from the
-            // true bottom edge, instead of floating above the full safe-area
-            // inset. `.ignoresSafeArea(edges:.bottom)` covers `.all` regions
-            // (incl. `.keyboard`), so the bar stays keyboard-independent during
-            // push/pop. The gap stays above the home-indicator pill.
-            .padding(.bottom, DesignTokens.Spacing.xxl)
+            // bottom safe area (home indicator) and pad `tabBarBottomInset` from
+            // the physical bottom edge, instead of floating above the full
+            // safe-area inset. `.ignoresSafeArea(edges:.bottom)` covers `.all`
+            // regions (incl. `.keyboard`), so the bar stays keyboard-independent
+            // during push/pop. The gap stays above the home-indicator pill.
+            .padding(.bottom, Self.tabBarBottomInset)
             .opacity(barHidden ? 0 : 1)
             .frame(height: barHidden ? 0 : nil)
             .allowsHitTesting(!barHidden)

--- a/ios/Pulpe/App/MainTabView.swift
+++ b/ios/Pulpe/App/MainTabView.swift
@@ -33,7 +33,9 @@ struct MainTabView: View {
     /// while content respects the safe area — and `safeAreaInset` already
     /// reserves that inset — so it is subtracted here to avoid double-counting.
     /// `max(0, …)` guards devices whose safe area alone already clears the bar.
-    private static func tabBarClearance(bottomSafeAreaInset: CGFloat) -> CGFloat {
+    /// Pure + `internal` so the formula's edge cases are unit-tested
+    /// (`MainTabViewClearanceTests`).
+    static func tabBarClearance(bottomSafeAreaInset: CGFloat) -> CGFloat {
         let barTopAbovePhysicalBottom = tabBarBottomInset + DesignTokens.FrameHeight.tabBar
         return max(0, barTopAbovePhysicalBottom + tabBarContentSpacing - bottomSafeAreaInset)
     }

--- a/ios/PulpeTests/App/MainTabViewLayoutTests.swift
+++ b/ios/PulpeTests/App/MainTabViewLayoutTests.swift
@@ -54,3 +54,47 @@ struct MainTabViewLayoutTests {
         #expect(result == scenario.hidden)
     }
 }
+
+/// Bar top above the physical bottom + the content spacing — the clearance to
+/// reserve when the device contributes no bottom safe area of its own. Derived
+/// from the same tokens the production formula uses (not magic).
+private let fullTabBarClearance: CGFloat =
+    DesignTokens.Spacing.xxl
+    + DesignTokens.FrameHeight.tabBar
+    + DesignTokens.Spacing.md
+
+/// Bottom clearance the floating bar reserves for content, given the device's
+/// bottom safe-area inset. The bar is placed from the physical bottom while
+/// content respects the safe area, so the formula subtracts the inset (already
+/// reserved by `safeAreaInset`) and clamps at zero.
+@Suite("MainTabView floating tab bar clearance")
+struct MainTabViewClearanceTests {
+    struct Case: Sendable, CustomTestStringConvertible {
+        let inset: CGFloat
+        let expected: CGFloat
+        let label: String
+
+        var testDescription: String { "\(label): inset=\(inset) → \(expected)" }
+    }
+
+    @Test(
+        "Clearance subtracts the device bottom inset, clamped at zero",
+        arguments: [
+            // No safe area (e.g. a device without a home indicator): reserve the
+            // full distance from the physical bottom to the bar top + spacing.
+            Case(inset: 0, expected: fullTabBarClearance, label: "no safe area"),
+            // Standard iPhone home-indicator inset: subtracted (content's own
+            // safeAreaInset already reserves it).
+            Case(inset: 34, expected: fullTabBarClearance - 34, label: "standard iPhone"),
+            // Inset exactly equal to the bar footprint: nothing left to reserve.
+            Case(inset: fullTabBarClearance, expected: 0, label: "boundary"),
+            // Safe area already clears the bar: never reserve a negative amount.
+            Case(inset: fullTabBarClearance + 50, expected: 0, label: "safe area exceeds bar footprint")
+        ]
+    )
+    func tabBarClearance_accountsForSafeAreaInset(testCase: Case) {
+        #expect(
+            MainTabView.tabBarClearance(bottomSafeAreaInset: testCase.inset) == testCase.expected
+        )
+    }
+}


### PR DESCRIPTION
## Contexte

Suite review sur #482 : `tabBarClearanceHeight` n'avait pas été mis à jour après le repositionnement de la tab bar flottante.

Depuis #482, la barre **ignore la safe area basse** et se place à un écart fixe du **vrai** bord bas. Mais la clearance (`tabBar + md + xs`) supposait encore l'ancienne position (relative à la safe area). Conséquences :
- le contenu et le FAB sur-réservaient ~14pt (écart contenu↔barre passé de `md` à ~26pt) ;
- barre et clearance vivaient dans 2 référentiels → risque de dérive silencieuse à chaque futur ajustement.

## Changement (1 fichier, `MainTabView`)

- **Source unique de vérité** `tabBarBottomInset` : la **même** constante alimente le padding bas de la barre ET la clearance → elles ne peuvent plus diverger.
- **Clearance device-correcte** : `max(0, barTop + md − insetSafeAreaBas)`, l'inset lu au runtime via `.onGeometryChange` (pattern déjà utilisé dans le repo). `max(0, …)` empêche toute sur-réservation, et une lecture nulle/erronée retombe sur l'ancien comportement (jamais de chevauchement).
- Doc-comments honnêtes en remplacement des périmés.

Résultat : le contenu et le FAB dégagent la barre avec l'écart `md` **voulu** (design d'origine), sur n'importe quel device. **Position de la barre inchangée** (reste là où validée en #482).

## Vérification

- ✅ `xcodebuild build -scheme PulpeLocal` → BUILD SUCCEEDED · SwiftLint clean · diff = 1 fichier
- ⚠️ Resserre l'espacement contenu/FAB de ~14pt (vers l'écart `md` voulu) — vérif visuelle non automatisable ici (auth/coffre de chiffrement). À regarder à l'œil avant merge ; l'écart est ajustable via le seul token `tabBarContentSpacing` si tu veux plus de respiration.
