### PR TITLE
feat(spread): parité iOS — tracker réalisé + détail txn + lisser un existant (PUL-17)

### DIFF
--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -93,6 +93,8 @@ custom_rules:
       - ".*/Features/Budgets/BudgetList/BudgetListView\\+YearComponents\\.swift"
       - ".*/Features/Budgets/BudgetDetails/BudgetDetailHero\\.swift"
       - ".*/Features/Budgets/BudgetDetails/BudgetLineDetailPage\\.swift"
+      # PUL-17 spread progress tracker bar (filled capsule, not a chip).
+      - ".*/Features/Budgets/BudgetDetails/Spread/SpreadTrackerHeader\\.swift"
       - ".*/Features/Budgets/BudgetDetails/BudgetLineDetailPage\\+Hero\\.swift"
       - ".*/Features/Onboarding/Components/OnboardingProgressIndicator\\.swift"
       - ".*/Features/Onboarding/Steps/BudgetPreviewFlowBars\\.swift"

--- a/ios/Pulpe/Core/Network/Endpoints.swift
+++ b/ios/Pulpe/Core/Network/Endpoints.swift
@@ -32,6 +32,7 @@ enum Endpoint {
     case budgetLinesCreate
     case budgetLinesSpread
     case budgetLinesSpreadOccurrences(spreadGroupId: String)
+    case budgetLineSpreadFromLine(id: String)
     case budgetLine(id: String)
     case budgetLineToggle(id: String)
     case budgetLineResetFromTemplate(id: String)
@@ -42,6 +43,7 @@ enum Endpoint {
     case transactionsCreate
     case transaction(id: String)
     case transactionToggle(id: String)
+    case transactionSpreadFromTxn(id: String)
 
     // MARK: - Templates
 
@@ -99,6 +101,7 @@ enum Endpoint {
         case .budgetLinesCreate: return "/budget-lines"
         case .budgetLinesSpread: return "/budget-lines/spread"
         case .budgetLinesSpreadOccurrences(let id): return "/budget-lines/spread/\(id)"
+        case .budgetLineSpreadFromLine(let id): return "/budget-lines/\(id)/spread"
         case .budgetLine(let id): return "/budget-lines/\(id)"
         case .budgetLineToggle(let id): return "/budget-lines/\(id)/toggle-check"
         case .budgetLineResetFromTemplate(let id): return "/budget-lines/\(id)/reset-from-template"
@@ -108,6 +111,7 @@ enum Endpoint {
         case .transactionsCreate: return "/transactions"
         case .transaction(let id): return "/transactions/\(id)"
         case .transactionToggle(let id): return "/transactions/\(id)/toggle-check"
+        case .transactionSpreadFromTxn(let id): return "/transactions/\(id)/spread"
 
         // Templates
         case .templates: return "/budget-templates"
@@ -139,7 +143,8 @@ enum Endpoint {
 
     var method: HTTPMethod {
         switch self {
-        case .budgets, .budgetLines, .budgetLinesCreate, .budgetLinesSpread, .transactionsCreate, .templates,
+        case .budgets, .budgetLines, .budgetLinesCreate, .budgetLinesSpread,
+             .budgetLineSpreadFromLine, .transactionSpreadFromTxn, .transactionsCreate, .templates,
              .templateLines, .templateFromOnboarding, .templateLinesBulk,
              .budgetLineToggle, .budgetLineResetFromTemplate, .transactionToggle,
              .encryptionValidateKey, .encryptionSetupRecovery, .encryptionRegenerateRecovery, .encryptionRecover,

--- a/ios/Pulpe/Domain/Formulas/SpreadProgress.swift
+++ b/ios/Pulpe/Domain/Formulas/SpreadProgress.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// PUL-17 — per-occurrence display metadata for a spread group, computed
+/// CLIENT-SIDE (no stored fields). Mirrors the web `SpreadOccurrenceViewModel` /
+/// `buildSpreadOccurrenceViewModels` so iOS and webapp resolve the same
+/// past/current/realized state.
+///
+/// Two distinct axes:
+/// - DISPLAY (`isPast` / `isCurrent`): vs the VIEWED budget period — drives
+///   dimming and the "Ce mois" / "Ici" marker.
+/// - REALIZATION (`isClosed`): vs TODAY's live period — a month genuinely
+///   elapsed, independent of which month is being viewed. Drives the tracker
+///   cumulé so viewing a FUTURE budget never fabricates progress.
+struct SpreadOccurrenceItem: Identifiable, Sendable {
+    let occurrence: SpreadOccurrence
+    let isPast: Bool
+    let isCurrent: Bool
+    let isChecked: Bool
+    let isClosed: Bool
+
+    var id: String { occurrence.id }
+}
+
+/// PUL-17 — derived progress of a smoothed expense. All fields are pure
+/// functions of the occurrence list (mirrors the web `SpreadTracker`):
+/// `cumulatedAmount` sums REALIZED occurrences only (closed OR pointé) of their
+/// realized amount (consommé if sub-transactions, else prévu) — never
+/// `index × perMonth`.
+struct SpreadTracker: Equatable, Sendable {
+    let count: Int
+    let currentIndex: Int
+    let cumulatedAmount: Decimal
+    let totalAmount: Decimal
+    let perMonthAmount: Decimal
+    let progressPercent: Double
+}
+
+/// Pure derivation of the spread occurrence items + progress tracker. Port of
+/// the web `spread-occurrence.view-model.ts` builders — kept in `Domain/Formulas`
+/// (not the view) so it stays unit-testable and identical across platforms.
+enum SpreadProgress {
+    /// Builds the per-occurrence items, sorted by period ascending. Display
+    /// flags (`isPast` / `isCurrent`) are payDay-aware vs `referencePeriod` (the
+    /// VIEWED budget); realization (`isClosed`) is vs `livePeriod` (today).
+    static func buildItems(
+        occurrences: [SpreadOccurrence],
+        referencePeriod: BudgetPeriod,
+        livePeriod: BudgetPeriod
+    ) -> [SpreadOccurrenceItem] {
+        occurrences
+            .map { occurrence in
+                let comparison = BudgetPeriodCalculator.comparePeriods(occurrence.period, referencePeriod)
+                return SpreadOccurrenceItem(
+                    occurrence: occurrence,
+                    isPast: comparison < 0,
+                    isCurrent: comparison == 0,
+                    isChecked: occurrence.isChecked,
+                    isClosed: BudgetPeriodCalculator.comparePeriods(occurrence.period, livePeriod) < 0
+                )
+            }
+            .sorted {
+                BudgetPeriodCalculator.comparePeriods($0.occurrence.period, $1.occurrence.period) < 0
+            }
+    }
+
+    /// Derives the progress tracker from the items, or `nil` for an empty group.
+    /// - `currentIndex`: 1-based rank of the VIEWED month among the occurrences
+    ///   (count of past || current). 0 when the viewed month precedes them all.
+    /// - `cumulatedAmount`: Σ realized amount over REALIZED items (closed || checked).
+    /// - `totalAmount`: Σ of every occurrence amount (= the source total T).
+    /// - `perMonthAmount`: the viewed month's amount, else the last tranche.
+    /// - `progressPercent`: realized / total, clamped to [0, 100].
+    static func buildTracker(from items: [SpreadOccurrenceItem]) -> SpreadTracker? {
+        guard !items.isEmpty else { return nil }
+
+        let currentIndex = items.enumerated().reduce(0) { rank, entry in
+            (entry.element.isPast || entry.element.isCurrent) ? entry.offset + 1 : rank
+        }
+        let cumulatedAmount = items
+            .filter { $0.isClosed || $0.isChecked }
+            .reduce(Decimal.zero) { $0 + $1.occurrence.realizedAmount }
+        let totalAmount = items.reduce(Decimal.zero) { $0 + $1.occurrence.amount }
+        let perMonthAmount = items.first(where: { $0.isCurrent })?.occurrence.amount
+            ?? items.last?.occurrence.amount
+            ?? Decimal.zero
+
+        let progressPercent: Double
+        if totalAmount > 0 {
+            let ratio = NSDecimalNumber(decimal: cumulatedAmount / totalAmount).doubleValue * 100
+            progressPercent = min(100, max(0, ratio))
+        } else {
+            progressPercent = 0
+        }
+
+        return SpreadTracker(
+            count: items.count,
+            currentIndex: currentIndex,
+            cumulatedAmount: cumulatedAmount,
+            totalAmount: totalAmount,
+            perMonthAmount: perMonthAmount,
+            progressPercent: progressPercent
+        )
+    }
+}

--- a/ios/Pulpe/Domain/Models/BudgetLineSpread.swift
+++ b/ios/Pulpe/Domain/Models/BudgetLineSpread.swift
@@ -64,6 +64,22 @@ struct BudgetLineSpreadCreate: Encodable, Sendable {
     }
 }
 
+/// One target month for a total-preserving "lisser un existant" (PUL-17 v1.1).
+/// The client sends only the periods; the server reads the source's total T and
+/// redistributes it into T/N (splitTotalPreserving), then deletes the source.
+struct SpreadFromExistingPeriod: Encodable, Sendable {
+    let year: Int
+    let month: Int
+}
+
+/// Request body for the from-existing spread endpoints
+/// (`POST /budget-lines/:id/spread`, `POST /transactions/:id/spread`). N ≥ 2 —
+/// lisser sur 1 mois est un no-op. The window starts at M0 toward the future
+/// only (never rewrites a closed month).
+struct SpreadFromExistingCreate: Encodable, Sendable {
+    let periods: [SpreadFromExistingPeriod]
+}
+
 /// A month with no default template, skipped during fan-out (no budget created,
 /// no line inserted).
 struct SpreadSkippedMonth: Decodable, Sendable, Hashable {

--- a/ios/Pulpe/Domain/Models/BudgetLineSpread.swift
+++ b/ios/Pulpe/Domain/Models/BudgetLineSpread.swift
@@ -23,7 +23,11 @@ enum SpreadAmountKind: String, Encodable, Sendable {
 /// - `mode == .total`: `totalAmount` set, the server divides it cents-preservingly.
 /// A single frozen FX trio (figé) covers every month; the `*OriginalAmount` mirror
 /// of the active amount is present only in full-FX (multi-currency) spreads.
-/// The `spreadGroupId` is generated server-side.
+///
+/// `spreadGroupId` is the client-minted idempotency key (PUL-17): one stable uuid
+/// per create intent, replayed verbatim on every retry so the server REPLAYS the
+/// existing group instead of duplicating it (cf. docs/SPREAD.md « Idempotence »).
+/// Lowercased to mirror the web's `crypto.randomUUID()` byte-for-byte.
 struct BudgetLineSpreadCreate: Encodable, Sendable {
     let name: String
     let kind: TransactionKind
@@ -36,6 +40,7 @@ struct BudgetLineSpreadCreate: Encodable, Sendable {
     let originalCurrency: SupportedCurrency?
     let targetCurrency: SupportedCurrency?
     let exchangeRate: Decimal?
+    let spreadGroupId: String
 
     init(
         name: String,
@@ -48,7 +53,8 @@ struct BudgetLineSpreadCreate: Encodable, Sendable {
         totalOriginalAmount: Decimal? = nil,
         originalCurrency: SupportedCurrency? = nil,
         targetCurrency: SupportedCurrency? = nil,
-        exchangeRate: Decimal? = nil
+        exchangeRate: Decimal? = nil,
+        spreadGroupId: String = UUID().uuidString.lowercased()
     ) {
         self.name = name
         self.kind = kind
@@ -61,6 +67,7 @@ struct BudgetLineSpreadCreate: Encodable, Sendable {
         self.originalCurrency = originalCurrency
         self.targetCurrency = targetCurrency
         self.exchangeRate = exchangeRate
+        self.spreadGroupId = spreadGroupId
     }
 }
 

--- a/ios/Pulpe/Domain/Models/SpreadOccurrence.swift
+++ b/ios/Pulpe/Domain/Models/SpreadOccurrence.swift
@@ -16,6 +16,12 @@ struct SpreadOccurrence: Decodable, Identifiable, Sendable {
     let kind: TransactionKind
     let checkedAt: Date?
     let originalAmount: Decimal?
+    /// Réalisé (PUL-17 tracker): `consumed` = Σ of this occurrence's
+    /// sub-transactions (decrypted server-side); `transactionCount` lets the
+    /// client pick consommé vs prévu. Both default to 0 — the wire field is
+    /// `.default(0)` (additive contract), so a payload omitting them decodes to 0.
+    let consumed: Decimal
+    let transactionCount: Int
 
     /// Stable identity for `ForEach` — one line per budget, so the line id is unique.
     var id: String { budgetLineId }
@@ -25,4 +31,34 @@ struct SpreadOccurrence: Decodable, Identifiable, Sendable {
 
     /// `{year, month}` period this occurrence lives in, for payDay-aware comparison.
     var period: BudgetPeriod { BudgetPeriod(month: month, year: year) }
+
+    /// The amount that actually counts for this month: the real consommé once
+    /// any sub-transaction exists, else the planned prévu tranche. Mirrors the
+    /// web `spreadOccurrenceRealizedAmount`.
+    var realizedAmount: Decimal { transactionCount > 0 ? consumed : amount }
+}
+
+extension SpreadOccurrence {
+    private enum CodingKeys: String, CodingKey {
+        case budgetLineId, budgetId, month, year, name, amount, kind
+        case checkedAt, originalAmount, consumed, transactionCount
+    }
+
+    // Custom decoder so `consumed`/`transactionCount` fall back to 0 when a
+    // payload omits them (additive `.default(0)` contract). Lives in an
+    // extension to preserve the struct's memberwise initializer for tests.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        budgetLineId = try container.decode(String.self, forKey: .budgetLineId)
+        budgetId = try container.decode(String.self, forKey: .budgetId)
+        month = try container.decode(Int.self, forKey: .month)
+        year = try container.decode(Int.self, forKey: .year)
+        name = try container.decode(String.self, forKey: .name)
+        amount = try container.decode(Decimal.self, forKey: .amount)
+        kind = try container.decode(TransactionKind.self, forKey: .kind)
+        checkedAt = try container.decodeIfPresent(Date.self, forKey: .checkedAt)
+        originalAmount = try container.decodeIfPresent(Decimal.self, forKey: .originalAmount)
+        consumed = try container.decodeIfPresent(Decimal.self, forKey: .consumed) ?? 0
+        transactionCount = try container.decodeIfPresent(Int.self, forKey: .transactionCount) ?? 0
+    }
 }

--- a/ios/Pulpe/Domain/Services/BudgetLineService.swift
+++ b/ios/Pulpe/Domain/Services/BudgetLineService.swift
@@ -8,6 +8,10 @@ protocol BudgetLineServicing: Sendable {
     func toggleCheck(id: String) async throws -> BudgetLine
     func createSpread(_ data: BudgetLineSpreadCreate) async throws -> BudgetLineSpreadResponse
     func getSpreadOccurrences(spreadGroupId: String) async throws -> [SpreadOccurrence]
+    func spreadExistingBudgetLine(
+        id: String,
+        periods: [SpreadFromExistingPeriod]
+    ) async throws -> BudgetLineSpreadResponse
 }
 
 /// Service for budget line API operations
@@ -48,6 +52,20 @@ actor BudgetLineService: BudgetLineServicing {
     /// Lot C). Drives the read-only occurrences sheet.
     func getSpreadOccurrences(spreadGroupId: String) async throws -> [SpreadOccurrence] {
         try await apiClient.request(.budgetLinesSpreadOccurrences(spreadGroupId: spreadGroupId), method: .get)
+    }
+
+    /// Lisse une prévision EXISTANTE en préservant son total (PUL-17 v1.1) :
+    /// le serveur lit le total T de la source, le redistribue en T/N sur les
+    /// `periods`, puis supprime la source — le tout dans une seule transaction.
+    func spreadExistingBudgetLine(
+        id: String,
+        periods: [SpreadFromExistingPeriod]
+    ) async throws -> BudgetLineSpreadResponse {
+        try await apiClient.request(
+            .budgetLineSpreadFromLine(id: id),
+            body: SpreadFromExistingCreate(periods: periods),
+            method: .post
+        )
     }
 
     /// Update a budget line

--- a/ios/Pulpe/Domain/Services/TransactionService.swift
+++ b/ios/Pulpe/Domain/Services/TransactionService.swift
@@ -8,6 +8,10 @@ protocol TransactionServicing: Sendable {
     func toggleCheck(id: String) async throws -> Transaction
     func createTransaction(_ data: TransactionCreate) async throws -> Transaction
     func updateTransaction(id: String, data: TransactionUpdate) async throws -> Transaction
+    func spreadExistingTransaction(
+        id: String,
+        periods: [SpreadFromExistingPeriod]
+    ) async throws -> BudgetLineSpreadResponse
 }
 
 /// Service for transaction API operations
@@ -45,6 +49,21 @@ actor TransactionService: TransactionServicing {
     /// Delete a transaction
     func deleteTransaction(id: String) async throws {
         try await apiClient.requestVoid(.transaction(id: id), method: .delete)
+    }
+
+    /// Lisse une transaction libre EXISTANTE en préservant son total (PUL-17
+    /// v1.1). Le serveur lit le total T, le redistribue en T/N sur les `periods`,
+    /// puis supprime la transaction source — une seule transaction. Retourne les
+    /// `budget_line` créées (les occurrences sont des prévisions, pas des réels).
+    func spreadExistingTransaction(
+        id: String,
+        periods: [SpreadFromExistingPeriod]
+    ) async throws -> BudgetLineSpreadResponse {
+        try await apiClient.request(
+            .transactionSpreadFromTxn(id: id),
+            body: SpreadFromExistingCreate(periods: periods),
+            method: .post
+        )
     }
 
     // MARK: - Actions

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -22,6 +22,13 @@ struct AddBudgetLineSheet: View {
     @State private var mode: BudgetLineCreationMode = .once
     @State private var amountMode: SpreadAmountMode = .total
     @State private var spreadCalculator: SpreadCalculator
+    /// Idempotency key for the spread create (PUL-17), minted ONCE per sheet
+    /// presentation (= per create intent) and reused on every submit retry so a
+    /// double-tap or a retry after a post-commit failure replays the same group
+    /// instead of duplicating it. `.sheet(item:)` rebuilds this view per
+    /// presentation, so a fresh intent always gets a fresh key. Lowercased to
+    /// mirror the web's `crypto.randomUUID()`.
+    @State private var spreadGroupId = UUID().uuidString.lowercased()
 
     private let dependencies: AddBudgetLineDependencies
     private let conversionService = CurrencyConversionService.shared
@@ -252,7 +259,8 @@ struct AddBudgetLineSheet: View {
                     kind: kind,
                     amount: amount,
                     mode: amountMode,
-                    conversion: conversion
+                    conversion: conversion,
+                    spreadGroupId: spreadGroupId
                 )
             )
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Routing.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Routing.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// Push + sheet destination builders for `BudgetDetailsView`, split out to keep
+/// the main view file under the feature's 350-LOC budget (same precedent as the
+/// `BudgetLineDetailPage` ↔ `+Hero` split). The members used here
+/// (`coordinator`, `router`, `userSettingsStore`, `toastContext`) are declared
+/// non-private on the view for this reason.
+extension BudgetDetailsView {
+    @ViewBuilder
+    func pushDestination(for route: BudgetLinePushRoute) -> some View {
+        switch route {
+        case .lineDetail(let lineId):
+            BudgetLineDetailPage(
+                lineId: lineId,
+                onEditLine: { line in router.present(.editBudgetLine(line)) }
+            )
+        case .addAllocatedTx(let lineId):
+            AddAllocatedTransactionPage(lineId: lineId)
+        case .editTx(let transactionId):
+            EditTransactionPage(transactionId: transactionId)
+        }
+    }
+
+    @ViewBuilder
+    func sheetContent(for destination: BudgetDetailDestination) -> some View {
+        switch destination {
+        case .addBudgetLine:
+            // Anchor the spread on the OPENED budget's period, not the device month (PUL-17).
+            let openBudget = coordinator.dataStore.budget
+            AddBudgetLineSheet(
+                budgetId: coordinator.dataStore.budgetId,
+                anchorMonth: openBudget?.month ?? Calendar.current.component(.month, from: Date()),
+                anchorYear: openBudget?.year ?? Calendar.current.component(.year, from: Date())
+            ) { budgetLine in
+                Task { await coordinator.dispatch(.addBudgetLine(budgetLine)) }
+            }
+        case .editBudgetLine(let line):
+            EditBudgetLineSheet(budgetLine: line, userCurrency: userSettingsStore.currency) { updatedLine in
+                Task { await coordinator.dispatch(.updateBudgetLine(updatedLine)) }
+            }
+        case .previousBudget(let item):
+            PreviousBudgetSheet(budgetId: item.id)
+        case .realizedBalance:
+            RealizedBalanceSheet(
+                metrics: coordinator.dataStore.metrics,
+                realizedMetrics: coordinator.dataStore.realizedMetrics
+            )
+        case .spreadOccurrences(let spreadGroupId):
+            // The VIEWED budget's period anchors the display axis (past/current,
+            // "Ce mois" vs "Ici"); the live period (today) drives realization.
+            let openBudget = coordinator.dataStore.budget
+            SpreadOccurrencesSheet(
+                spreadGroupId: spreadGroupId,
+                referencePeriod: BudgetPeriod(
+                    month: openBudget?.month ?? Calendar.current.component(.month, from: Date()),
+                    year: openBudget?.year ?? Calendar.current.component(.year, from: Date())
+                ),
+                payDayOfMonth: userSettingsStore.payDayOfMonth,
+                currency: userSettingsStore.currency
+            )
+        case .spreadExisting(let source):
+            SpreadExistingSheet(source: source, currency: userSettingsStore.currency) { periods in
+                let ctx = toastContext
+                Task {
+                    switch source.sourceType {
+                    case .budgetLine:
+                        await coordinator.dispatch(
+                            .spreadBudgetLineFromExisting(lineId: source.id, periods: periods, ctx)
+                        )
+                    case .transaction:
+                        await coordinator.dispatch(
+                            .spreadTransactionFromExisting(txId: source.id, periods: periods, ctx)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -10,6 +10,7 @@ struct BudgetDetailsView: View {
     @Environment(UserSettingsStore.self) var userSettingsStore
     @Environment(BudgetListStore.self) private var budgetListStore
     @Environment(DashboardStore.self) private var dashboardStore
+    @Environment(CurrentMonthStore.self) private var currentMonthStore
     @Environment(\.amountsHidden) private var amountsHidden
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.tabBarClearance) private var tabBarClearance
@@ -104,7 +105,11 @@ struct BudgetDetailsView: View {
             }
         }
         .task(id: screenState.budgetId) {
-            coordinator.bind(budgetListStore: budgetListStore, dashboardStore: dashboardStore)
+            coordinator.bind(
+                budgetListStore: budgetListStore,
+                dashboardStore: dashboardStore,
+                currentMonthStore: currentMonthStore
+            )
             if !screenState.hasAllBudgets {
                 await coordinator.dispatch(.loadDetails(force: false))
             } else {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -4,14 +4,16 @@ import TipKit
 struct BudgetDetailsView: View {
     let budgetId: String
     @Environment(AppState.self) private var appState
-    @Environment(BudgetDetailsRouter.self) private var router
-    @Environment(UserSettingsStore.self) private var userSettingsStore
+    // Non-private: shared with the `BudgetDetailsView+Routing` extension file
+    // (same precedent as `BudgetLineDetailPage` ↔ its `+Hero` extension).
+    @Environment(BudgetDetailsRouter.self) var router
+    @Environment(UserSettingsStore.self) var userSettingsStore
     @Environment(BudgetListStore.self) private var budgetListStore
     @Environment(DashboardStore.self) private var dashboardStore
     @Environment(\.amountsHidden) private var amountsHidden
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.tabBarClearance) private var tabBarClearance
-    @State private var coordinator: BudgetDetailsCoordinator
+    @State var coordinator: BudgetDetailsCoordinator
     @State private var projector: BudgetDetailsProjector
 
     @State private var searchText = ""
@@ -59,7 +61,7 @@ struct BudgetDetailsView: View {
         )
     }
 
-    private var toastContext: ToastContext {
+    var toastContext: ToastContext {
         ToastContext(
             toastManager: appState.toastManager,
             presentationCurrency: userSettingsStore.currency
@@ -271,56 +273,6 @@ struct BudgetDetailsView: View {
         // (pulpeStickyBottomCTA). Must stay LAST so both overlays inherit it; if
         // a bottom text field is ever added here, remove or scope this.
         .ignoresSafeArea(.keyboard, edges: .bottom)
-    }
-
-    // MARK: - Routing
-
-    @ViewBuilder
-    private func pushDestination(for route: BudgetLinePushRoute) -> some View {
-        switch route {
-        case .lineDetail(let lineId):
-            BudgetLineDetailPage(
-                lineId: lineId,
-                onEditLine: { line in router.present(.editBudgetLine(line)) }
-            )
-        case .addAllocatedTx(let lineId):
-            AddAllocatedTransactionPage(lineId: lineId)
-        case .editTx(let transactionId):
-            EditTransactionPage(transactionId: transactionId)
-        }
-    }
-
-    @ViewBuilder
-    private func sheetContent(for destination: BudgetDetailDestination) -> some View {
-        switch destination {
-        case .addBudgetLine:
-            // Anchor the spread on the OPENED budget's period, not the device month (PUL-17).
-            let openBudget = coordinator.dataStore.budget
-            AddBudgetLineSheet(
-                budgetId: coordinator.dataStore.budgetId,
-                anchorMonth: openBudget?.month ?? Calendar.current.component(.month, from: Date()),
-                anchorYear: openBudget?.year ?? Calendar.current.component(.year, from: Date())
-            ) { budgetLine in
-                Task { await coordinator.dispatch(.addBudgetLine(budgetLine)) }
-            }
-        case .editBudgetLine(let line):
-            EditBudgetLineSheet(budgetLine: line, userCurrency: userSettingsStore.currency) { updatedLine in
-                Task { await coordinator.dispatch(.updateBudgetLine(updatedLine)) }
-            }
-        case .previousBudget(let item):
-            PreviousBudgetSheet(budgetId: item.id)
-        case .realizedBalance:
-            RealizedBalanceSheet(
-                metrics: coordinator.dataStore.metrics,
-                realizedMetrics: coordinator.dataStore.realizedMetrics
-            )
-        case .spreadOccurrences(let spreadGroupId):
-            SpreadOccurrencesSheet(
-                spreadGroupId: spreadGroupId,
-                payDayOfMonth: userSettingsStore.payDayOfMonth,
-                currency: userSettingsStore.currency
-            )
-        }
     }
 }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -290,6 +290,7 @@ struct BudgetDetailsView: View {
     .environment(UserSettingsStore())
     .environment(BudgetListStore())
     .environment(DashboardStore())
+    .environment(CurrentMonthStore())
 }
 #Preview("Gestures Tip") {
     List {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage+Hero.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage+Hero.swift
@@ -86,30 +86,6 @@ extension BudgetLineDetailPage {
         .accessibilityLabel("\(Int(percentage.rounded()))% utilisé")
     }
 
-    /// Row-affordance opening the read-only occurrences sheet (PUL-17 Lot C).
-    /// A dedicated Button — NOT the whole detail row — so the gesture stays
-    /// explicit. Presented via the feature router's sheet slot.
-    func spreadAffordance(spreadGroupId: UUID) -> some View {
-        Button {
-            router.present(.spreadOccurrences(spreadGroupId: spreadGroupId.uuidString))
-        } label: {
-            PulpeChip(
-                icon: "calendar",
-                label: "Dépense lissée",
-                style: .muted,
-                trailing: {
-                    Image(systemName: "chevron.right")
-                        .font(PulpeTypography.metricMini)
-                        .foregroundStyle(Color.textTertiary)
-                }
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .contentShape(Rectangle())
-        .plainPressedButtonStyle()
-        .accessibilityLabel("Voir les mois de la dépense lissée")
-    }
-
     func titleWithKindDot(line: BudgetLine) -> some View {
         HStack(spacing: DesignTokens.Spacing.sm) {
             Circle()

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage.swift
@@ -76,9 +76,11 @@ struct BudgetLineDetailPage: View {
                 .padding(.bottom, DesignTokens.Spacing.md)
 
             if let spreadGroupId = line.spreadGroupId {
-                spreadAffordance(spreadGroupId: spreadGroupId)
-                    .padding(.horizontal, DesignTokens.Spacing.lg)
-                    .padding(.bottom, DesignTokens.Spacing.md)
+                SpreadAffordanceButton {
+                    router.present(.spreadOccurrences(spreadGroupId: spreadGroupId.uuidString))
+                }
+                .padding(.horizontal, DesignTokens.Spacing.lg)
+                .padding(.bottom, DesignTokens.Spacing.md)
             }
 
             transactionsList(line: line, transactions: transactions)
@@ -162,6 +164,14 @@ private extension BudgetLineDetailPage {
                 Label("Modifier", systemImage: "pencil")
             }
 
+            if canSpread(line) {
+                Button {
+                    presentSpread(for: line)
+                } label: {
+                    Label("Lisser sur plusieurs mois", systemImage: "calendar")
+                }
+            }
+
             Button(role: .destructive) {
                 showDeleteConfirmation = true
             } label: {
@@ -171,6 +181,28 @@ private extension BudgetLineDetailPage {
             Image(systemName: "ellipsis.circle")
         }
         .accessibilityLabel("Plus d'options")
+    }
+
+    /// A prévision is spreadable only when it's a one-off expense/épargne that
+    /// isn't already lissée and isn't a rollover row (PUL-17 v1.1, total-preserving).
+    func canSpread(_ line: BudgetLine) -> Bool {
+        line.kind != .income
+            && line.recurrence == .oneOff
+            && line.spreadGroupId == nil
+            && !(line.isRollover ?? false)
+    }
+
+    func presentSpread(for line: BudgetLine) {
+        guard let budget = coordinator.dataStore.budget else { return }
+        router.present(.spreadExisting(SpreadExistingSource(
+            id: line.id,
+            sourceType: .budgetLine,
+            kind: line.kind,
+            name: line.name,
+            total: line.amount,
+            month: budget.month,
+            year: budget.year
+        )))
     }
 
     func deleteBudgetLine(_ line: BudgetLine) {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsAction.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsAction.swift
@@ -33,11 +33,16 @@ enum BudgetDetailsAction {
     case updateBudgetLine(BudgetLine)
     case softDeleteBudgetLine(BudgetLine, ToastContext)
     case deleteBudgetLine(BudgetLine)
+    /// Lisser une prévision existante (total préservé) — supprime la source +
+    /// fan-out, puis reconcilie le budget courant (PUL-17 v1.1).
+    case spreadBudgetLineFromExisting(lineId: String, periods: [SpreadFromExistingPeriod], ToastContext)
 
     // Transaction mutations
     case addTransaction(Transaction)
     case softDeleteTransaction(Transaction, ToastContext)
     case deleteTransaction(Transaction)
+    /// Lisser une transaction libre existante (total préservé) (PUL-17 v1.1).
+    case spreadTransactionFromExisting(txId: String, periods: [SpreadFromExistingPeriod], ToastContext)
 
     // Side-effect: emit "Pointé" toast after a successful toggle
     case showCheckToastIfNeeded(BudgetLine, ToastContext, amountsHidden: Bool)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
@@ -170,7 +170,8 @@ extension BudgetDetailsCoordinator {
         // cache is wiped to force a server-authoritative refetch rather than serve
         // this budget's optimistic copy.
         dataStore.syncCache()
-        dataStore.invalidateAdjacentCache()
+        // `invalidateAllCache()` already wipes adjacent budgets too, so no separate
+        // `invalidateAdjacentCache()` is needed on this cross-budget path.
         dataStore.invalidateAllCache()
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
@@ -163,9 +163,14 @@ extension BudgetDetailsCoordinator {
             dataStore.appendBudgetLine(m0Line)
         }
         dataStore.recomputeMetrics()
+        // `syncCache()` first: it's the mutation choke point that fires `onMutation`
+        // (invalidates the list/dashboard stores, PUL-270). Its cache WRITE is
+        // deliberately superseded by `invalidateAll()` below — a cross-month spread
+        // restructures N budgets the coordinator doesn't own, so every detail cache
+        // is wiped to force a server-authoritative refetch rather than serve this
+        // budget's optimistic copy.
         dataStore.syncCache()
         dataStore.invalidateAdjacentCache()
-        // Cross-budget: a spread touches N months the coordinator doesn't own.
         BudgetDetailCache.shared.invalidateAll()
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
@@ -165,12 +165,12 @@ extension BudgetDetailsCoordinator {
         dataStore.recomputeMetrics()
         // `syncCache()` first: it's the mutation choke point that fires `onMutation`
         // (invalidates the list/dashboard stores, PUL-270). Its cache WRITE is
-        // deliberately superseded by `invalidateAll()` below — a cross-month spread
-        // restructures N budgets the coordinator doesn't own, so every detail cache
-        // is wiped to force a server-authoritative refetch rather than serve this
-        // budget's optimistic copy.
+        // deliberately superseded by `invalidateAllCache()` below — a cross-month
+        // spread restructures N budgets the coordinator doesn't own, so every detail
+        // cache is wiped to force a server-authoritative refetch rather than serve
+        // this budget's optimistic copy.
         dataStore.syncCache()
         dataStore.invalidateAdjacentCache()
-        BudgetDetailCache.shared.invalidateAll()
+        dataStore.invalidateAllCache()
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
@@ -11,10 +11,18 @@ extension BudgetDetailsCoordinator {
     /// `.task` because `@Environment` is unavailable in `init` — same
     /// precedent as `router.bind(to:)` in `MainTabView`. Strong captures on
     /// purpose: both stores are app-scoped and outlive this coordinator.
-    func bind(budgetListStore: BudgetListStore, dashboardStore: DashboardStore) {
+    func bind(
+        budgetListStore: BudgetListStore,
+        dashboardStore: DashboardStore,
+        currentMonthStore: CurrentMonthStore
+    ) {
         dataStore.onMutation = {
             budgetListStore.invalidateCache()
             dashboardStore.invalidateCache()
+            // A budget-detail mutation can change the current month's aggregates
+            // (a cross-month spread especially) — invalidate it too so the
+            // CurrentMonth tab refetches instead of serving a stale 30s-TTL copy.
+            currentMonthStore.invalidateCache()
         }
     }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
@@ -109,4 +109,63 @@ extension BudgetDetailsCoordinator {
         }
         return updated
     }
+
+    // MARK: - Spread from existing (PUL-17 v1.1)
+
+    /// Lisse une prévision existante (total préservé). The server deletes the
+    /// source line and fans out N tranches in one transaction; on success we drop
+    /// the source locally, graft the M0 tranche that landed in THIS budget, and
+    /// invalidate the cross-budget caches the coordinator doesn't own. Applied
+    /// AFTER the server confirms (no optimistic rollback): a failure leaves the
+    /// source intact and the detail page open.
+    func spreadBudgetLineFromExisting(
+        lineId: String,
+        periods: [SpreadFromExistingPeriod],
+        context: ToastContext
+    ) async {
+        do {
+            let response = try await budgetLineService.spreadExistingBudgetLine(id: lineId, periods: periods)
+            applySpreadFromExisting(removingLineId: lineId, removingTransactionId: nil, response: response)
+            context.toastManager.show("C'est lissé sur \(periods.count) mois")
+        } catch {
+            syncStore.setError(error)
+            context.toastManager.show("Le lissage n'a pas pu aboutir", type: .error)
+        }
+    }
+
+    /// Lisse une transaction libre existante (total préservé). Same shape; the
+    /// source is a transaction (removed locally), the N tranches are budget lines.
+    func spreadTransactionFromExisting(
+        txId: String,
+        periods: [SpreadFromExistingPeriod],
+        context: ToastContext
+    ) async {
+        do {
+            let response = try await transactionService.spreadExistingTransaction(id: txId, periods: periods)
+            applySpreadFromExisting(removingLineId: nil, removingTransactionId: txId, response: response)
+            context.toastManager.show("C'est lissé sur \(periods.count) mois")
+        } catch {
+            syncStore.setError(error)
+            context.toastManager.show("Le lissage n'a pas pu aboutir", type: .error)
+        }
+    }
+
+    private func applySpreadFromExisting(
+        removingLineId: String?,
+        removingTransactionId: String?,
+        response: BudgetLineSpreadResponse
+    ) {
+        if let lineId = removingLineId { dataStore.removeBudgetLine(id: lineId) }
+        if let txId = removingTransactionId { dataStore.removeTransaction(id: txId) }
+        // Graft the tranche that landed in the currently-open budget (M0) so the
+        // screen updates immediately — same seam as the additive `onAdd`.
+        if let m0Line = response.lines.first(where: { $0.budgetId == dataStore.budgetId }) {
+            dataStore.appendBudgetLine(m0Line)
+        }
+        dataStore.recomputeMetrics()
+        dataStore.syncCache()
+        dataStore.invalidateAdjacentCache()
+        // Cross-budget: a spread touches N months the coordinator doesn't own.
+        BudgetDetailCache.shared.invalidateAll()
+    }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator+Mutations.swift
@@ -131,6 +131,9 @@ extension BudgetDetailsCoordinator {
         periods: [SpreadFromExistingPeriod],
         context: ToastContext
     ) async {
+        syncStore.setLoading(true)
+        syncStore.clearError()
+        defer { syncStore.setLoading(false) }
         do {
             let response = try await budgetLineService.spreadExistingBudgetLine(id: lineId, periods: periods)
             applySpreadFromExisting(removingLineId: lineId, removingTransactionId: nil, response: response)
@@ -148,6 +151,9 @@ extension BudgetDetailsCoordinator {
         periods: [SpreadFromExistingPeriod],
         context: ToastContext
     ) async {
+        syncStore.setLoading(true)
+        syncStore.clearError()
+        defer { syncStore.setLoading(false) }
         do {
             let response = try await transactionService.spreadExistingTransaction(id: txId, periods: periods)
             applySpreadFromExisting(removingLineId: nil, removingTransactionId: txId, response: response)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Coordinator/BudgetDetailsCoordinator.swift
@@ -38,8 +38,7 @@ final class BudgetDetailsCoordinator {
 
     // MARK: - Dispatch
 
-    /// Single mutation entrypoint. Routes by action category to keep each
-    /// branch under the cyclomatic-complexity budget.
+    /// Single mutation entrypoint. Routes by action category.
     func dispatch(_ action: BudgetDetailsAction) async {
         if await dispatchLoadOrFilter(action) { return }
         if await dispatchToggle(action) { return }
@@ -104,6 +103,8 @@ final class BudgetDetailsCoordinator {
             softDeleteBudgetLine(line, context: ctx)
         case .deleteBudgetLine(let line):
             await deleteBudgetLine(line)
+        case .spreadBudgetLineFromExisting(let lineId, let periods, let ctx):
+            await spreadBudgetLineFromExisting(lineId: lineId, periods: periods, context: ctx)
         default:
             return false
         }
@@ -118,6 +119,8 @@ final class BudgetDetailsCoordinator {
             softDeleteTransaction(tx, context: ctx)
         case .deleteTransaction(let tx):
             await deleteTransaction(tx)
+        case .spreadTransactionFromExisting(let txId, let periods, let ctx):
+            await spreadTransactionFromExisting(txId: txId, periods: periods, context: ctx)
         default:
             return false
         }
@@ -183,12 +186,9 @@ final class BudgetDetailsCoordinator {
         syncStore.clearError()
         defer { syncStore.setLoading(false) }
 
-        // Capture the generation BEFORE the fetch. If an optimistic mutation
-        // (toggle / add / update) lands while the network call is in flight,
-        // the snapshot is stale and `applyDetails(_:ifGenerationMatches:)` drops
-        // it rather than silently reverting that mutation (PUL-257). Guards the
-        // detached, non-cancellable reload fired after an edit save, which
-        // `.task(id:)` cancellation can't reach.
+        // Capture the generation BEFORE the fetch so an optimistic mutation
+        // landing mid-flight drops the stale snapshot instead of reverting it
+        // (PUL-257) — guards the detached reload fired after an edit save.
         let generation = dataStore.mutationGeneration
         do {
             let details = try await budgetService.getBudgetWithDetails(id: dataStore.budgetId)
@@ -225,10 +225,8 @@ final class BudgetDetailsCoordinator {
         return await performToggleBudgetLine(line)
     }
 
-    /// Outcome of confirming a "check all" toggle from the alert. Lets the
-    /// dispatcher pick the right toast: the "Pointé" success toast when every
-    /// transaction reconciled, or an error toast when the bulk-check partially
-    /// failed (which also rolled the local apply back via reload).
+    /// Outcome of confirming a "check all" toggle — drives the success vs
+    /// partial-failure toast.
     enum CheckAllConfirmation {
         case lineNotToggled
         case allChecked

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/EditTransactionPage.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/EditTransactionPage.swift
@@ -13,6 +13,8 @@ struct EditTransactionPage: View {
     let transactionId: String
 
     @Environment(BudgetDetailsCoordinator.self) private var coordinator
+    @Environment(BudgetDetailsProjector.self) private var projector
+    @Environment(BudgetDetailsRouter.self) private var router
     @Environment(\.dismiss) private var dismiss
     @Environment(ToastManager.self) private var toastManager
     @Environment(UserSettingsStore.self) private var userSettingsStore
@@ -51,6 +53,36 @@ struct EditTransactionPage: View {
         )
     }
 
+    /// The spread group of this transaction's parent budget line, if it belongs
+    /// to a "Lisser" expense — drives the occurrences affordance (PUL-17). A
+    /// transaction never carries `spreadGroupId` itself; its lissé-ness derives
+    /// from its parent line, resolved via the projector's O(1) `lineById` index.
+    private func parentSpreadGroupId(for tx: Transaction) -> UUID? {
+        guard let lineId = tx.budgetLineId else { return nil }
+        return projector.screenState.lineById[lineId]?.spreadGroupId
+    }
+
+    /// A FREE transaction (no parent line) that isn't income can be redistributed
+    /// into a total-preserving spread (PUL-17 v1.1). An allocated transaction
+    /// derives its lissé-ness from its parent line — it shows the occurrences
+    /// affordance instead, never this action.
+    private func canSpread(_ tx: Transaction) -> Bool {
+        tx.budgetLineId == nil && tx.kind != .income
+    }
+
+    private func presentSpread(for tx: Transaction) {
+        guard let budget = coordinator.dataStore.budget else { return }
+        router.present(.spreadExisting(SpreadExistingSource(
+            id: tx.id,
+            sourceType: .transaction,
+            kind: tx.kind,
+            name: tx.name,
+            total: tx.amount,
+            month: budget.month,
+            year: budget.year
+        )))
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -76,7 +108,7 @@ struct EditTransactionPage: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                headerMenu
+                headerMenu(for: tx)
             }
         }
         .alert(
@@ -113,6 +145,12 @@ struct EditTransactionPage: View {
     @ViewBuilder
     private func formContent(for tx: Transaction) -> some View {
         VStack(spacing: DesignTokens.Spacing.xxl) {
+            if let spreadGroupId = parentSpreadGroupId(for: tx) {
+                SpreadAffordanceButton {
+                    router.present(.spreadOccurrences(spreadGroupId: spreadGroupId.uuidString))
+                }
+            }
+
             KindToggle(selection: $kind)
 
             if userSettingsStore.showCurrencySelectorEffective && isAlternateCurrency {
@@ -178,8 +216,16 @@ struct EditTransactionPage: View {
         .primaryButtonStyle(isEnabled: canSubmit)
     }
 
-    private var headerMenu: some View {
+    @ViewBuilder
+    private func headerMenu(for tx: Transaction) -> some View {
         Menu {
+            if canSpread(tx) {
+                Button {
+                    presentSpread(for: tx)
+                } label: {
+                    Label("Lisser sur plusieurs mois", systemImage: "calendar")
+                }
+            }
             Button(role: .destructive) {
                 showDeleteConfirmation = true
             } label: {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Routing/BudgetDetailDestination.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Routing/BudgetDetailDestination.swift
@@ -9,8 +9,8 @@ struct PreviousBudgetItem: Identifiable {
 /// Source of a total-preserving "lisser un existant" (PUL-17 v1.1): an existing
 /// prévision (`budgetLine`) or a free `transaction`, with its locked total and
 /// anchor month (M0). `kind` (expense/saving) drives the sheet's accent color.
-struct SpreadExistingSource: Identifiable, Hashable {
-    enum SourceType: Hashable { case budgetLine, transaction }
+struct SpreadExistingSource: Identifiable, Hashable, Sendable {
+    enum SourceType: Hashable, Sendable { case budgetLine, transaction }
 
     let id: String
     let sourceType: SourceType

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Routing/BudgetDetailDestination.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Routing/BudgetDetailDestination.swift
@@ -6,6 +6,21 @@ struct PreviousBudgetItem: Identifiable {
     let id: String
 }
 
+/// Source of a total-preserving "lisser un existant" (PUL-17 v1.1): an existing
+/// prévision (`budgetLine`) or a free `transaction`, with its locked total and
+/// anchor month (M0). `kind` (expense/saving) drives the sheet's accent color.
+struct SpreadExistingSource: Identifiable, Hashable {
+    enum SourceType: Hashable { case budgetLine, transaction }
+
+    let id: String
+    let sourceType: SourceType
+    let kind: TransactionKind
+    let name: String
+    let total: Decimal
+    let month: Int
+    let year: Int
+}
+
 /// Sheet destinations for `BudgetDetailsView`.
 ///
 /// Single source of truth for sheet presentation. Apple's guidance is to
@@ -19,6 +34,8 @@ enum BudgetDetailDestination: Identifiable {
     case realizedBalance
     /// Read-only timeline of every month a "Lisser" expense touches (PUL-17 Lot C).
     case spreadOccurrences(spreadGroupId: String)
+    /// Total-preserving "lisser un existant" config sheet (PUL-17 v1.1).
+    case spreadExisting(SpreadExistingSource)
 
     var id: String {
         switch self {
@@ -27,6 +44,7 @@ enum BudgetDetailDestination: Identifiable {
         case .previousBudget(let item): "previousBudget-\(item.id)"
         case .realizedBalance: "realizedBalance"
         case .spreadOccurrences(let groupId): "spreadOccurrences-\(groupId)"
+        case .spreadExisting(let source): "spreadExisting-\(source.id)"
         }
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/AddBudgetLineSpreadLogic.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/AddBudgetLineSpreadLogic.swift
@@ -10,12 +10,16 @@ enum AddBudgetLineSpreadLogic {
     /// Form inputs for one spread submit. FX is already resolved once upstream
     /// (`conversion`) so a single frozen `exchangeRate` covers every month. `mode`
     /// decides whether `amount` is read as a per-month figure or the TOTAL.
+    /// `spreadGroupId` is the idempotency key minted ONCE by the sheet per create
+    /// intent (`@State`) — required (no default) so the retry-driving view must
+    /// pass its stable id, never mint a fresh one per attempt.
     struct SubmitInput {
         let name: String
         let kind: TransactionKind
         let amount: Decimal
         let mode: SpreadAmountMode
         let conversion: CurrencyConversion?
+        let spreadGroupId: String
     }
 
     /// Builds the `POST /budget-lines/spread` intent: the converted amount, the
@@ -45,7 +49,8 @@ enum AddBudgetLineSpreadLogic {
             totalOriginalAmount: isTotal ? originalAmount : nil,
             originalCurrency: input.conversion?.originalCurrency,
             targetCurrency: input.conversion?.targetCurrency,
-            exchangeRate: input.conversion?.exchangeRate
+            exchangeRate: input.conversion?.exchangeRate,
+            spreadGroupId: input.spreadGroupId
         )
     }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadAffordanceButton.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadAffordanceButton.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// PUL-17 — the "Dépense lissée → voir les mois" affordance: a dedicated Button
+/// (never a whole detail row) wrapping a `.muted` PulpeChip + chevron. Shared by
+/// the budget-line detail page AND the transaction detail page so both surfaces
+/// of a spread expense reach the occurrences timeline in lockstep. The caller
+/// provides the action (it owns the router + the spread group id).
+struct SpreadAffordanceButton: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            PulpeChip(
+                icon: "calendar",
+                label: "Dépense lissée",
+                style: .muted,
+                trailing: {
+                    Image(systemName: "chevron.right")
+                        .font(PulpeTypography.metricMini)
+                        .foregroundStyle(Color.textTertiary)
+                }
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .contentShape(Rectangle())
+        .plainPressedButtonStyle()
+        .accessibilityLabel("Voir les mois de la dépense lissée")
+    }
+}

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculator.swift
@@ -41,15 +41,15 @@ final class SpreadExistingCalculator {
     }
 
     /// M0 is never deselectable; other months toggle in/out of the window.
-    var isLocked: (SpreadMonth) -> Bool {
-        { [start] month in month.ordinal == start.ordinal }
+    func isLocked(_ month: SpreadMonth) -> Bool {
+        month.ordinal == start.ordinal
     }
 
     // MARK: - Validation
 
     var validationMessage: String? {
         if end.ordinal < start.ordinal { return "Le mois de fin précède le mois de début" }
-        if windowMonths.count > Self.maxMonths { return "36 mois maximum" }
+        if selectedCount > Self.maxMonths { return "36 mois maximum" }
         if selectedCount < Self.minMonths { return "Choisis au moins deux mois" }
         return nil
     }
@@ -60,6 +60,10 @@ final class SpreadExistingCalculator {
 
     func setEnd(_ month: SpreadMonth) {
         end = month
+        // A temporarily-invalid window (end before start → empty range) must not
+        // wipe the user's deselections; only purge ordinals that fell out of a
+        // valid window.
+        guard end.ordinal >= start.ordinal else { return }
         let windowOrdinals = Set(windowMonths.map(\.ordinal))
         deselectedOrdinals.formIntersection(windowOrdinals)
     }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculator.swift
@@ -48,7 +48,9 @@ final class SpreadExistingCalculator {
     // MARK: - Validation
 
     var validationMessage: String? {
-        if end.ordinal < start.ordinal { return "Le mois de fin précède le mois de début" }
+        // `<=`: end == start leaves only the locked M0 in the window, so the grid
+        // offers nothing to toggle — point at the date, not at "choose two months".
+        if end.ordinal <= start.ordinal { return "Le mois de fin doit suivre le mois de début" }
         if selectedCount > Self.maxMonths { return "36 mois maximum" }
         if selectedCount < Self.minMonths { return "Choisis au moins deux mois" }
         return nil

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculator.swift
@@ -62,10 +62,11 @@ final class SpreadExistingCalculator {
 
     func setEnd(_ month: SpreadMonth) {
         end = month
-        // A temporarily-invalid window (end before start → empty range) must not
-        // wipe the user's deselections; only purge ordinals that fell out of a
-        // valid window.
-        guard end.ordinal >= start.ordinal else { return }
+        // A temporarily-invalid window must not wipe the user's deselections; only
+        // purge ordinals that fell out of a VALID window. Strict `>`: end == start
+        // leaves only the locked M0 in the window, so intersecting against {M0}
+        // would clear every deselection the user made.
+        guard end.ordinal > start.ordinal else { return }
         let windowOrdinals = Set(windowMonths.map(\.ordinal))
         deselectedOrdinals.formIntersection(windowOrdinals)
     }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculator.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculator.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Reactive state for "lisser une dépense existante" (PUL-17 v1.1 — total
+/// preserving). Distinct from the additive `SpreadCalculator` (amount × N): here
+/// the source total `T` is LOCKED and redistributed into `T/N` via
+/// `SpreadSplit.splitTotalPreserving`.
+///
+/// The source month M0 (`start`) is fixed — only `end` moves (forward only).
+/// Every month in `[M0, end]` starts selected; any month EXCEPT M0 can be
+/// deselected (M0 always carries a tranche). N ≥ 2 — lisser sur un seul mois est
+/// un no-op.
+@Observable @MainActor
+final class SpreadExistingCalculator {
+    /// Backend cap (mirrors `MAX_SPREAD_TRANCHES`).
+    static let maxMonths = SpreadCalculator.maxMonths
+    static let minMonths = 2
+
+    let start: SpreadMonth
+    private(set) var end: SpreadMonth
+    private(set) var deselectedOrdinals: Set<Int> = []
+
+    init(anchorMonth: Int, anchorYear: Int) {
+        let anchor = SpreadMonth(year: anchorYear, month: anchorMonth)
+        self.start = anchor
+        // Default window: M0 + 2 (3 months) — same default as the additive flow.
+        self.end = SpreadMonth.from(ordinal: anchor.ordinal + 2)
+    }
+
+    // MARK: - Derived state
+
+    var windowMonths: [SpreadMonth] { SpreadMonth.range(from: start, to: end) }
+
+    var selectedMonths: [SpreadMonth] {
+        windowMonths.filter { !deselectedOrdinals.contains($0.ordinal) }
+    }
+
+    var selectedCount: Int { selectedMonths.count }
+
+    func isSelected(_ month: SpreadMonth) -> Bool {
+        !deselectedOrdinals.contains(month.ordinal)
+    }
+
+    /// M0 is never deselectable; other months toggle in/out of the window.
+    var isLocked: (SpreadMonth) -> Bool {
+        { [start] month in month.ordinal == start.ordinal }
+    }
+
+    // MARK: - Validation
+
+    var validationMessage: String? {
+        if end.ordinal < start.ordinal { return "Le mois de fin précède le mois de début" }
+        if windowMonths.count > Self.maxMonths { return "36 mois maximum" }
+        if selectedCount < Self.minMonths { return "Choisis au moins deux mois" }
+        return nil
+    }
+
+    var isValid: Bool { validationMessage == nil }
+
+    // MARK: - Mutations
+
+    func setEnd(_ month: SpreadMonth) {
+        end = month
+        let windowOrdinals = Set(windowMonths.map(\.ordinal))
+        deselectedOrdinals.formIntersection(windowOrdinals)
+    }
+
+    func toggle(_ month: SpreadMonth) {
+        guard month.ordinal != start.ordinal else { return }
+        if deselectedOrdinals.contains(month.ordinal) {
+            deselectedOrdinals.remove(month.ordinal)
+        } else {
+            deselectedOrdinals.insert(month.ordinal)
+        }
+    }
+
+    // MARK: - Total-preserving split
+
+    /// Per-month tranches for `total`, exact to the cent (remainder on the first
+    /// months). Empty until the window is valid (N ≥ 2).
+    func split(total: Decimal) -> [Decimal] {
+        guard selectedCount >= Self.minMonths else { return [] }
+        return SpreadSplit.splitTotalPreserving(total: total, partCount: selectedCount)
+    }
+
+    /// Representative "X par mois" — the base (non-remainder) tranche.
+    func perMonth(total: Decimal) -> Decimal {
+        split(total: total).last ?? 0
+    }
+
+    /// Name of the last month carrying a remainder cent, or `nil` for an exact
+    /// split. Surfaced as the honesty hint ("quelques centimes en plus").
+    func remainderMonthName(total: Decimal) -> String? {
+        let parts = split(total: total)
+        guard let base = parts.last else { return nil }
+        let remainderCount = parts.filter { $0 != base }.count
+        guard remainderCount > 0 else { return nil }
+        return selectedMonths.prefix(remainderCount).last?.name
+    }
+
+    /// The chosen periods (ascending, M0 included), for the API call.
+    func periods() -> [SpreadFromExistingPeriod] {
+        selectedMonths.map { SpreadFromExistingPeriod(year: $0.year, month: $0.month) }
+    }
+}

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+/// PUL-17 v1.1 — "lisser une dépense existante" sheet (total-preserving).
+///
+/// The source total is LOCKED (read-only): the user picks the end month + the
+/// months to skip, and `T` is redistributed into `T/N` via the calculator's
+/// `SpreadSplit` (M0 included, drops to ~T/N). Mirrors the web
+/// `SpreadExistingDialog`. On submit it emits the chosen `periods` and dismisses;
+/// the caller routes them to the coordinator (which deletes the source + fans out).
+struct SpreadExistingSheet: View {
+    let source: SpreadExistingSource
+    let currency: SupportedCurrency
+    let onSpread: ([SpreadFromExistingPeriod]) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var calculator: SpreadExistingCalculator
+    @State private var isPickingEnd = false
+
+    init(
+        source: SpreadExistingSource,
+        currency: SupportedCurrency,
+        onSpread: @escaping ([SpreadFromExistingPeriod]) -> Void
+    ) {
+        self.source = source
+        self.currency = currency
+        self.onSpread = onSpread
+        self._calculator = State(
+            initialValue: SpreadExistingCalculator(anchorMonth: source.month, anchorYear: source.year)
+        )
+    }
+
+    private var accentColor: Color { Color.financialColor(for: source.kind) }
+    private var yearRange: ClosedRange<Int> { calculator.start.year...(calculator.start.year + 4) }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xl) {
+                    lockedTotalCard
+                    helpText
+                    monthRangeRow
+                    monthsGrid
+                    echo
+                }
+                .padding(.horizontal, DesignTokens.Spacing.xl)
+                .padding(.top, DesignTokens.Spacing.lg)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .pulpeBackground()
+            .pulpeStickyBottomCTA { submitButton }
+            .navigationTitle("Lisser la dépense")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { SheetCloseButton() }
+            }
+            .sheet(isPresented: $isPickingEnd) {
+                SpreadMonthPickerSheet(
+                    title: "Dernier mois",
+                    initial: calculator.end,
+                    yearRange: yearRange,
+                    accentColor: accentColor
+                ) { calculator.setEnd($0) }
+            }
+        }
+        .standardSheetPresentation(detents: [.medium, .large])
+    }
+
+    // MARK: - Locked total
+
+    private var lockedTotalCard: some View {
+        HStack {
+            Label("Montant total", systemImage: "lock.fill")
+                .font(PulpeTypography.subheadline)
+                .foregroundStyle(Color.onSurfaceVariant)
+            Spacer()
+            Text(source.total.asCurrency(currency))
+                .font(PulpeTypography.headline)
+                .foregroundStyle(Color.textPrimary)
+                .monospacedDigit()
+                .sensitiveAmount()
+        }
+        .padding(.horizontal, DesignTokens.Spacing.lg)
+        .padding(.vertical, DesignTokens.Spacing.md)
+        .frame(maxWidth: .infinity)
+        .background(Color.surfaceContainer, in: .rect(cornerRadius: DesignTokens.CornerRadius.button))
+        .accessibilityElement(children: .combine)
+    }
+
+    private var helpText: some View {
+        Text(
+            "On répartit ce montant à parts égales sur les mois que tu choisis, "
+                + "à partir de ce mois-ci. Désélectionne ceux à sauter."
+        )
+            .font(PulpeTypography.caption)
+            .foregroundStyle(Color.onSurfaceVariant)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: - De (locked) → À (picker)
+
+    private var monthRangeRow: some View {
+        HStack(spacing: DesignTokens.Spacing.md) {
+            lockedFromField
+            endPickerButton
+        }
+    }
+
+    private var lockedFromField: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxs) {
+            Text("De")
+                .font(PulpeTypography.caption)
+                .foregroundStyle(Color.onSurfaceVariant)
+            Text(calculator.start.longName)
+                .font(PulpeTypography.subheadline)
+                .foregroundStyle(Color.textSecondary)
+        }
+        .padding(.horizontal, DesignTokens.Spacing.lg)
+        .padding(.vertical, DesignTokens.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.surfaceContainer, in: .rect(cornerRadius: DesignTokens.CornerRadius.button))
+        .accessibilityLabel("De : \(calculator.start.longName)")
+    }
+
+    private var endPickerButton: some View {
+        Button { isPickingEnd = true } label: {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxs) {
+                Text("À")
+                    .font(PulpeTypography.caption)
+                    .foregroundStyle(Color.onSurfaceVariant)
+                HStack {
+                    Text(calculator.end.longName)
+                        .font(PulpeTypography.subheadline)
+                        .foregroundStyle(Color.textPrimary)
+                    Spacer(minLength: 0)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(PulpeTypography.metricMini)
+                        .foregroundStyle(Color.textTertiary)
+                }
+            }
+            .padding(.horizontal, DesignTokens.Spacing.lg)
+            .padding(.vertical, DesignTokens.Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.surfaceContainerHigh, in: .rect(cornerRadius: DesignTokens.CornerRadius.button))
+        }
+        .frame(minHeight: DesignTokens.TapTarget.minimum)
+        .contentShape(.rect(cornerRadius: DesignTokens.CornerRadius.button))
+        .plainPressedButtonStyle()
+        .accessibilityLabel("À : \(calculator.end.longName)")
+    }
+
+    // MARK: - Months grid
+
+    private let columns = [GridItem(.adaptive(minimum: 96), spacing: DesignTokens.Spacing.sm)]
+
+    @ViewBuilder
+    private var monthsGrid: some View {
+        let months = calculator.windowMonths
+        if !months.isEmpty {
+            LazyVGrid(columns: columns, alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+                ForEach(months) { month in
+                    monthChip(month)
+                }
+            }
+            .animation(.snappy(duration: DesignTokens.Animation.fast), value: calculator.windowMonths)
+        }
+    }
+
+    private func monthChip(_ month: SpreadMonth) -> some View {
+        let isOn = calculator.isSelected(month)
+        return Button {
+            withAnimation(.snappy(duration: DesignTokens.Animation.fast)) { calculator.toggle(month) }
+        } label: {
+            PulpeChip(label: month.name, style: isOn ? .solid : .outlined)
+                .strikethrough(!isOn, color: Color.onSurfaceVariant)
+        }
+        .disabled(calculator.isLocked(month))
+        .plainPressedButtonStyle()
+        .accessibilityLabel(month.longName)
+        .accessibilityValue(isOn ? "Sélectionné" : "Désélectionné")
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+
+    // MARK: - Echo
+
+    @ViewBuilder
+    private var echo: some View {
+        if let message = calculator.validationMessage {
+            ErrorBanner(message: message)
+        } else {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+                Text(disclosure)
+                    .font(PulpeTypography.subheadline)
+                    .foregroundStyle(Color.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .sensitiveAmount()
+
+                if let remainder = calculator.remainderMonthName(total: source.total) {
+                    Text("Le mois de \(remainder) porte quelques centimes de plus.")
+                        .font(PulpeTypography.caption)
+                        .foregroundStyle(Color.onSurfaceVariant)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.horizontal, DesignTokens.Spacing.lg)
+            .padding(.vertical, DesignTokens.Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.surfaceContainerLow, in: .rect(cornerRadius: DesignTokens.CornerRadius.button))
+        }
+    }
+
+    private var disclosure: String {
+        let count = calculator.selectedCount
+        let perMonth = calculator.perMonth(total: source.total).asCurrency(currency)
+        let total = source.total.asCurrency(currency)
+        switch source.sourceType {
+        case .transaction:
+            return "On transforme cette dépense de \(total) en un plan lissé : "
+                + "\(perMonth) par mois sur \(count) mois. Le réel est remplacé par le plan."
+        case .budgetLine:
+            return "On répartit cette prévision de \(total) en \(perMonth) par mois sur \(count) mois."
+        }
+    }
+
+    // MARK: - Submit
+
+    private var submitButton: some View {
+        Button {
+            guard calculator.isValid else { return }
+            onSpread(calculator.periods())
+            dismiss()
+        } label: {
+            Text("Lisser la dépense")
+        }
+        .disabled(!calculator.isValid)
+        .primaryButtonStyle(isEnabled: calculator.isValid)
+    }
+}
+
+#Preview {
+    SpreadExistingSheet(
+        source: SpreadExistingSource(
+            id: "line-1",
+            sourceType: .budgetLine,
+            kind: .expense,
+            name: "Assurance auto",
+            total: 1200,
+            month: 6,
+            year: 2026
+        ),
+        currency: .chf
+    ) { _ in }
+}

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -30,7 +30,10 @@ struct SpreadExistingSheet: View {
     }
 
     private var accentColor: Color { Color.financialColor(for: source.kind) }
-    private var yearRange: ClosedRange<Int> { calculator.start.year...(calculator.start.year + 4) }
+    // M0 is locked, so the window is [M0, M0+35] at most (36-month cap). The
+    // worst case (M0 = December) ends in `start.year + 3`; +4 over-exposed a year
+    // of months the validation would reject.
+    private var yearRange: ClosedRange<Int> { calculator.start.year...(calculator.start.year + 3) }
 
     var body: some View {
         NavigationStack {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -236,7 +236,6 @@ struct SpreadExistingSheet: View {
 
     private var submitButton: some View {
         Button {
-            guard calculator.isValid else { return }
             onSpread(calculator.periods())
             dismiss()
         } label: {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -15,6 +15,7 @@ struct SpreadExistingSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var calculator: SpreadExistingCalculator
     @State private var isPickingEnd = false
+    @State private var isSubmitting = false
 
     init(
         source: SpreadExistingSource,
@@ -237,6 +238,11 @@ struct SpreadExistingSheet: View {
 
     private var submitButton: some View {
         Button {
+            // The sheet dismisses synchronously, but the dismiss animation isn't
+            // instant — a fast double-tap would otherwise spawn two dispatches on
+            // the same source (the 2nd hits a 404 after the 1st deletes it).
+            guard !isSubmitting else { return }
+            isSubmitting = true
             onSpread(calculator.periods())
             dismiss()
         } label: {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -185,6 +185,7 @@ struct SpreadExistingSheet: View {
         .plainPressedButtonStyle()
         .accessibilityLabel(month.longName)
         .accessibilityValue(isOn ? "Sélectionné" : "Désélectionné")
+        .accessibilityHint(calculator.isLocked(month) ? "Mois de départ, non modifiable" : "")
         .accessibilityAddTraits(isOn ? .isSelected : [])
     }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -217,7 +217,10 @@ struct SpreadExistingSheet: View {
         let total = source.total.asCurrency(currency)
         switch source.sourceType {
         case .transaction:
-            return "On transforme cette dépense de \(total) en un plan lissé : "
+            // Source kind drives the noun — a spread saving must read "épargne",
+            // not "dépense" (same accord as the additive successMessage).
+            let noun = source.kind == .saving ? "épargne" : "dépense"
+            return "On transforme cette \(noun) de \(total) en un plan lissé : "
                 + "\(perMonth) par mois sur \(count) mois. Le réel est remplacé par le plan."
         case .budgetLine:
             return "On répartit cette prévision de \(total) en \(perMonth) par mois sur \(count) mois."

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -30,6 +30,11 @@ struct SpreadExistingSheet: View {
     }
 
     private var accentColor: Color { Color.financialColor(for: source.kind) }
+    // Source kind drives the noun — a spread saving must read "épargne", not
+    // "dépense" (same accord as the `disclosure` body and the additive flow).
+    private var spreadTitle: String {
+        source.kind == .saving ? "Lisser l'épargne" : "Lisser la dépense"
+    }
     // M0 is locked, so the window is [M0, M0+35] at most (36-month cap). The
     // worst case (M0 = December) ends in `start.year + 3`; +4 over-exposed a year
     // of months the validation would reject.
@@ -51,7 +56,7 @@ struct SpreadExistingSheet: View {
             .scrollBounceBehavior(.basedOnSize)
             .pulpeBackground()
             .pulpeStickyBottomCTA { submitButton }
-            .navigationTitle("Lisser la dépense")
+            .navigationTitle(spreadTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { SheetCloseButton() }
@@ -235,7 +240,7 @@ struct SpreadExistingSheet: View {
             onSpread(calculator.periods())
             dismiss()
         } label: {
-            Text("Lisser la dépense")
+            Text(spreadTitle)
         }
         .disabled(!calculator.isValid)
         .primaryButtonStyle(isEnabled: calculator.isValid)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -248,8 +248,8 @@ struct SpreadExistingSheet: View {
         } label: {
             Text(spreadTitle)
         }
-        .disabled(!calculator.isValid)
-        .primaryButtonStyle(isEnabled: calculator.isValid)
+        .disabled(!calculator.isValid || isSubmitting)
+        .primaryButtonStyle(isEnabled: calculator.isValid && !isSubmitting)
     }
 }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadOccurrenceRow.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadOccurrenceRow.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// PUL-17 — one occurrence row in the "Dépense lissée" timeline.
+///
+/// Month label + amount, OR — when the month has real sub-transactions
+/// (`transactionCount > 0`) — the realized composite "consommé / prévu barré"
+/// (the plan was replaced by the real spend; one shared currency symbol). Past
+/// (vs the VIEWED month) = dimmed + non-interactive; checked = full-row
+/// strike-through; the viewed-period row carries a "Ce mois" / "Ici" marker.
+/// All amounts are 2-decimal (`asAmount`/`asCurrency`) per the budget-detail rule.
+struct SpreadOccurrenceRow: View {
+    let item: SpreadOccurrenceItem
+    let currency: SupportedCurrency
+    /// `true` when the viewed budget IS the live current period → "Ce mois";
+    /// otherwise the marked row is just the viewed month → "Ici".
+    let isCurrentPeriod: Bool
+
+    private var occurrence: SpreadOccurrence { item.occurrence }
+
+    var body: some View {
+        HStack(spacing: DesignTokens.Spacing.md) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxs) {
+                Text(monthLabel)
+                    .font(PulpeTypography.listRowTitle)
+                    .foregroundStyle(item.isChecked ? Color.secondary : Color.textPrimary)
+                    .strikethrough(item.isChecked, color: .secondary)
+
+                if item.isCurrent {
+                    Text(isCurrentPeriod ? "Ce mois" : "Ici")
+                        .font(PulpeTypography.metricMini)
+                        .foregroundStyle(Color.pulpePrimary)
+                }
+            }
+
+            Spacer(minLength: DesignTokens.Spacing.sm)
+
+            amountView
+        }
+        .padding(.vertical, DesignTokens.Spacing.xs)
+        .opacity(item.isPast ? DesignTokens.Opacity.disabled : 1)
+        .allowsHitTesting(!item.isPast)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var amountView: some View {
+        if occurrence.transactionCount > 0 {
+            // Réalisé : consommé en avant, prévu barré, un seul symbole. Les deux
+            // nombres en 2 décimales (ligne) — un prévu 24.99 ne doit jamais
+            // s'afficher barré "25" à côté d'un réalisé 24.99.
+            HStack(alignment: .firstTextBaseline, spacing: DesignTokens.Spacing.xs) {
+                Text(occurrence.consumed.asAmount(for: currency))
+                    .font(PulpeTypography.amountCard)
+                    .foregroundStyle(Color.textPrimary)
+                Text("/")
+                    .font(PulpeTypography.metricMini)
+                    .foregroundStyle(Color.textTertiary)
+                Text(occurrence.amount.asAmount(for: currency))
+                    .font(PulpeTypography.metricMini)
+                    .foregroundStyle(Color.textTertiary)
+                    .strikethrough(true, color: Color.textTertiary)
+                Text(currency.symbol)
+                    .font(PulpeTypography.amountCard)
+                    .foregroundStyle(Color.textPrimary)
+            }
+            .monospacedDigit()
+            .sensitiveAmount()
+        } else {
+            Text(occurrence.amount.asCurrency(currency))
+                .font(PulpeTypography.amountCard)
+                .monospacedDigit()
+                .foregroundStyle(item.isChecked ? Color.secondary : Color.textPrimary)
+                .strikethrough(item.isChecked, color: .secondary)
+                .sensitiveAmount()
+        }
+    }
+
+    private var monthLabel: String {
+        "\(Formatters.monthName(for: occurrence.month)) \(occurrence.year)"
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [monthLabel]
+        if occurrence.transactionCount > 0 {
+            parts.append(
+                "\(occurrence.consumed.asCurrency(currency)) consommés sur "
+                    + "\(occurrence.amount.asCurrency(currency)) prévus"
+            )
+        } else {
+            parts.append(occurrence.amount.asCurrency(currency))
+        }
+        if item.isCurrent { parts.append(isCurrentPeriod ? "ce mois" : "ici") }
+        if item.isChecked { parts.append("pointé") }
+        if item.isPast { parts.append("passé") }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadOccurrencesSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadOccurrencesSheet.swift
@@ -2,32 +2,41 @@ import SwiftUI
 
 // MARK: - ViewModel
 
-/// Loads the read-only occurrences of a "Lisser" expense (PUL-17 Lot C).
+/// Loads the read-only occurrences of a "Lisser" expense (PUL-17 Lot C) and
+/// derives the realized progress (tracker + per-occurrence display flags) via
+/// the pure `SpreadProgress` formula.
 ///
-/// Mirrors `PreviousBudgetSheetViewModel`: fetches once via the service, exposes
-/// loading / error / data, and pre-computes which occurrences are past vs current
-/// using the payDay-aware `BudgetPeriodCalculator`. Past/current is resolved
-/// client-side (not a naive calendar compare) so a custom pay day shifts the
-/// "Ce mois" marker exactly like the rest of the app.
+/// Two reference frames are threaded in: `referencePeriod` (the VIEWED budget)
+/// drives the display axis (past/current/marker), and `livePeriod` (today,
+/// payDay-aware) drives the realization axis (`isClosed` → the tracker cumulé).
+/// `isCurrentPeriod` distinguishes "Ce mois" (viewed IS the live period) from
+/// "Ici" (just the month being looked at).
 @Observable @MainActor
 final class SpreadOccurrencesSheetViewModel {
-    private(set) var occurrences: [SpreadOccurrence] = []
+    private(set) var items: [SpreadOccurrenceItem] = []
+    private(set) var tracker: SpreadTracker?
     private(set) var isLoading = true
     private(set) var error: Error?
 
-    let spreadGroupId: String
+    let isCurrentPeriod: Bool
+
+    private let spreadGroupId: String
     private let service: any BudgetLineServicing
-    private let currentPeriod: BudgetPeriod
+    private let referencePeriod: BudgetPeriod
+    private let livePeriod: BudgetPeriod
 
     init(
         spreadGroupId: String,
+        referencePeriod: BudgetPeriod,
         payDayOfMonth: Int?,
         service: any BudgetLineServicing = BudgetLineService.shared,
         now: Date = Date()
     ) {
         self.spreadGroupId = spreadGroupId
         self.service = service
-        self.currentPeriod = BudgetPeriodCalculator.periodForDate(now, payDayOfMonth: payDayOfMonth)
+        self.referencePeriod = referencePeriod
+        self.livePeriod = BudgetPeriodCalculator.periodForDate(now, payDayOfMonth: payDayOfMonth)
+        self.isCurrentPeriod = BudgetPeriodCalculator.comparePeriods(referencePeriod, livePeriod) == 0
     }
 
     func load() async {
@@ -37,45 +46,39 @@ final class SpreadOccurrencesSheetViewModel {
 
         do {
             let fetched = try await service.getSpreadOccurrences(spreadGroupId: spreadGroupId)
-            occurrences = fetched.sorted { lhs, rhs in
-                BudgetPeriodCalculator.comparePeriods(lhs.period, rhs.period) < 0
-            }
+            items = SpreadProgress.buildItems(
+                occurrences: fetched,
+                referencePeriod: referencePeriod,
+                livePeriod: livePeriod
+            )
+            tracker = SpreadProgress.buildTracker(from: items)
         } catch is CancellationError {
             // Task cancelled — keep current state.
         } catch {
             self.error = error
         }
     }
-
-    /// `true` when the occurrence's period precedes the current budget period
-    /// (payDay-aware). Past occurrences are dimmed and non-interactive.
-    func isPast(_ occurrence: SpreadOccurrence) -> Bool {
-        BudgetPeriodCalculator.comparePeriods(occurrence.period, currentPeriod) < 0
-    }
-
-    /// `true` for the occurrence living in the current budget period.
-    func isCurrent(_ occurrence: SpreadOccurrence) -> Bool {
-        BudgetPeriodCalculator.comparePeriods(occurrence.period, currentPeriod) == 0
-    }
-
-    func monthLabel(_ occurrence: SpreadOccurrence) -> String {
-        "\(Formatters.monthName(for: occurrence.month)) \(occurrence.year)"
-    }
 }
 
 // MARK: - View
 
-/// Read-only month-by-month timeline of a "Lisser" expense (PUL-17 Lot C).
-/// Clones the `PreviousBudgetSheet` scaffolding: NavigationStack + List + close
-/// button + `.standardSheetPresentation(detents:)`.
+/// Read-only month-by-month timeline of a "Lisser" expense (PUL-17 Lot C),
+/// fronted by the realized progress tracker. Clones the `PreviousBudgetSheet`
+/// scaffolding: NavigationStack + List + close button + standard presentation.
 struct SpreadOccurrencesSheet: View {
     @State private var viewModel: SpreadOccurrencesSheetViewModel
     let currency: SupportedCurrency
 
-    init(spreadGroupId: String, payDayOfMonth: Int?, currency: SupportedCurrency) {
+    init(
+        spreadGroupId: String,
+        referencePeriod: BudgetPeriod,
+        payDayOfMonth: Int?,
+        currency: SupportedCurrency
+    ) {
         self._viewModel = State(
             initialValue: SpreadOccurrencesSheetViewModel(
                 spreadGroupId: spreadGroupId,
+                referencePeriod: referencePeriod,
                 payDayOfMonth: payDayOfMonth
             )
         )
@@ -85,9 +88,9 @@ struct SpreadOccurrencesSheet: View {
     var body: some View {
         NavigationStack {
             Group {
-                if viewModel.isLoading && viewModel.occurrences.isEmpty {
+                if viewModel.isLoading && viewModel.items.isEmpty {
                     LoadingView(message: "Chargement...")
-                } else if let error = viewModel.error, viewModel.occurrences.isEmpty {
+                } else if let error = viewModel.error, viewModel.items.isEmpty {
                     ErrorView(error: error) { await viewModel.load() }
                 } else {
                     content
@@ -107,15 +110,19 @@ struct SpreadOccurrencesSheet: View {
 
     private var content: some View {
         List {
+            if let tracker = viewModel.tracker {
+                Section {
+                    SpreadTrackerHeader(tracker: tracker, currency: currency)
+                        .listRowBackground(Color.clear)
+                }
+            }
+
             Section {
-                ForEach(viewModel.occurrences) { occurrence in
+                ForEach(viewModel.items) { item in
                     SpreadOccurrenceRow(
-                        monthLabel: viewModel.monthLabel(occurrence),
-                        amount: occurrence.amount,
+                        item: item,
                         currency: currency,
-                        isPast: viewModel.isPast(occurrence),
-                        isChecked: occurrence.isChecked,
-                        isCurrent: viewModel.isCurrent(occurrence)
+                        isCurrentPeriod: viewModel.isCurrentPeriod
                     )
                     .listRowBackground(Color.clear)
                 }
@@ -127,62 +134,10 @@ struct SpreadOccurrencesSheet: View {
     }
 }
 
-// MARK: - Row
-
-/// One occurrence row — month label + amount. Display-only.
-/// Past = dimmed + non-interactive; checked = struck-through + secondary; the two
-/// compose. The current period carries a "Ce mois" marker.
-private struct SpreadOccurrenceRow: View {
-    let monthLabel: String
-    let amount: Decimal
-    let currency: SupportedCurrency
-    let isPast: Bool
-    let isChecked: Bool
-    let isCurrent: Bool
-
-    var body: some View {
-        HStack(spacing: DesignTokens.Spacing.md) {
-            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxs) {
-                Text(monthLabel)
-                    .font(PulpeTypography.listRowTitle)
-                    .foregroundStyle(isChecked ? Color.secondary : Color.textPrimary)
-                    .strikethrough(isChecked, color: .secondary)
-
-                if isCurrent {
-                    Text("Ce mois")
-                        .font(PulpeTypography.metricMini)
-                        .foregroundStyle(Color.pulpePrimary)
-                }
-            }
-
-            Spacer(minLength: DesignTokens.Spacing.sm)
-
-            Text(amount.asCurrency(currency))
-                .font(PulpeTypography.amountCard)
-                .monospacedDigit()
-                .foregroundStyle(isChecked ? Color.secondary : Color.textPrimary)
-                .strikethrough(isChecked, color: .secondary)
-                .sensitiveAmount()
-        }
-        .padding(.vertical, DesignTokens.Spacing.xs)
-        .opacity(isPast ? DesignTokens.Opacity.disabled : 1)
-        .allowsHitTesting(!isPast)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel)
-    }
-
-    private var accessibilityLabel: String {
-        var parts = [monthLabel, amount.asCurrency(currency)]
-        if isCurrent { parts.append("ce mois") }
-        if isChecked { parts.append("pointé") }
-        if isPast { parts.append("passé") }
-        return parts.joined(separator: ", ")
-    }
-}
-
 #Preview {
     SpreadOccurrencesSheet(
         spreadGroupId: "preview-group",
+        referencePeriod: BudgetPeriod(month: 6, year: 2026),
         payDayOfMonth: nil,
         currency: .chf
     )

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadTrackerHeader.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadTrackerHeader.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// PUL-17 — progress tracker header for the "Dépense lissée" sheet: a position
+/// line, the realized cumulé/total, a `pulpePrimary` bar filled to
+/// `progressPercent`, and the per-month tranche.
+///
+/// All amounts use `asCurrency` (2 decimals) per
+/// `feedback_two_decimals_ios_budget_detail` — the budget-detail surface forbids
+/// `asCompactCurrency`, so this intentionally diverges from the web 0-decimal
+/// aggregation. Mirrors the web `SpreadOccurrencesList` tracker block otherwise.
+struct SpreadTrackerHeader: View {
+    let tracker: SpreadTracker
+    let currency: SupportedCurrency
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            HStack(alignment: .firstTextBaseline, spacing: DesignTokens.Spacing.sm) {
+                Text(positionLabel)
+                    .font(PulpeTypography.headline)
+                    .foregroundStyle(Color.textPrimary)
+
+                Spacer(minLength: DesignTokens.Spacing.sm)
+
+                Text(cumulatedLabel)
+                    .font(PulpeTypography.metricLabel)
+                    .foregroundStyle(Color.textSecondary)
+                    .monospacedDigit()
+                    .sensitiveAmount()
+            }
+
+            progressBar
+
+            Text("\(tracker.perMonthAmount.asCurrency(currency)) par mois")
+                .font(PulpeTypography.metricMini)
+                .foregroundStyle(Color.textTertiary)
+                .monospacedDigit()
+                .sensitiveAmount()
+        }
+        .padding(.vertical, DesignTokens.Spacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var progressBar: some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.progressTrack)
+
+            ProgressBarShape(progress: CGFloat(tracker.progressPercent / 100))
+                .fill(Color.pulpePrimary)
+        }
+        .frame(height: DesignTokens.ProgressBar.thickHeight)
+        .accessibilityHidden(true)
+    }
+
+    private var positionLabel: String {
+        tracker.currentIndex == 0
+            ? "Commence le mois prochain"
+            : "\(ordinal) mois sur \(tracker.count)"
+    }
+
+    private var ordinal: String {
+        tracker.currentIndex == 1 ? "1er" : "\(tracker.currentIndex)e"
+    }
+
+    private var cumulatedLabel: String {
+        "\(tracker.cumulatedAmount.asCurrency(currency)) sur \(tracker.totalAmount.asCurrency(currency))"
+    }
+
+    private var accessibilityLabel: String {
+        "\(positionLabel), \(cumulatedLabel), \(tracker.perMonthAmount.asCurrency(currency)) par mois"
+    }
+}
+
+#Preview {
+    SpreadTrackerHeader(
+        tracker: SpreadTracker(
+            count: 6,
+            currentIndex: 2,
+            cumulatedAmount: 200,
+            totalAmount: 600,
+            perMonthAmount: 100,
+            progressPercent: 33.3
+        ),
+        currency: .chf
+    )
+    .padding()
+    .frame(maxWidth: .infinity)
+    .background(Color.appBackground)
+}

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/State/BudgetDataStore.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/State/BudgetDataStore.swift
@@ -276,6 +276,14 @@ final class BudgetDataStore {
         if let nextId = nextBudgetId { cache.invalidate(budgetId: nextId) }
     }
 
+    /// Wipe EVERY budget's detail cache. Used after a cross-month spread, which
+    /// restructures N budgets this store doesn't own — each must refetch the
+    /// server-authoritative state. Keeps the cache singleton behind the store so
+    /// the coordinator never reaches `BudgetDetailCache.shared` directly (Rule 11).
+    func invalidateAllCache() {
+        cache.invalidateAll()
+    }
+
     /// Drop the current budget id from the cache. Used when prefetched data
     /// is known stale (e.g. after a server reload error path).
     func clearCacheBudgetEntry() {

--- a/ios/PulpeTests/Domain/Formulas/SpreadProgressTests.swift
+++ b/ios/PulpeTests/Domain/Formulas/SpreadProgressTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// PUL-17 — locks the client-side spread progress derivation against the web
+/// `spread-occurrence.view-model.ts` spec: the two axes (display `isPast`/
+/// `isCurrent` vs the VIEWED period, realization `isClosed` vs TODAY), and the
+/// tracker (cumulé over realized-only, total, position, per-month, percent).
+@Suite("SpreadProgress")
+struct SpreadProgressTests {
+    private func occ(
+        month: Int,
+        year: Int = 2026,
+        amount: Decimal,
+        consumed: Decimal = 0,
+        transactionCount: Int = 0,
+        checkedAt: Date? = nil
+    ) -> SpreadOccurrence {
+        SpreadOccurrence(
+            budgetLineId: "bl-\(year)-\(month)",
+            budgetId: "b-\(year)-\(month)",
+            month: month,
+            year: year,
+            name: "Assurance",
+            amount: amount,
+            kind: .expense,
+            checkedAt: checkedAt,
+            originalAmount: nil,
+            consumed: consumed,
+            transactionCount: transactionCount
+        )
+    }
+
+    private func period(_ month: Int, _ year: Int = 2026) -> BudgetPeriod {
+        BudgetPeriod(month: month, year: year)
+    }
+
+    private func makeItems(_ occurrences: [SpreadOccurrence], ref: Int, live: Int) -> [SpreadOccurrenceItem] {
+        SpreadProgress.buildItems(
+            occurrences: occurrences,
+            referencePeriod: period(ref),
+            livePeriod: period(live)
+        )
+    }
+
+    private func tracker(_ occurrences: [SpreadOccurrence], ref: Int, live: Int) -> SpreadTracker? {
+        SpreadProgress.buildTracker(from: makeItems(occurrences, ref: ref, live: live))
+    }
+
+    // MARK: - buildItems
+
+    @Test func buildItems_sortsByPeriodAscending() {
+        let occurrences = [occ(month: 7, amount: 100), occ(month: 5, amount: 100), occ(month: 6, amount: 100)]
+        let items = makeItems(occurrences, ref: 6, live: 6)
+        #expect(items.map(\.occurrence.month) == [5, 6, 7])
+    }
+
+    @Test func buildItems_pastAndCurrent_areRelativeToReferencePeriod() {
+        let occurrences = [occ(month: 5, amount: 100), occ(month: 6, amount: 100), occ(month: 7, amount: 100)]
+        let items = makeItems(occurrences, ref: 6, live: 6)
+        #expect(items[0].isPast)
+        #expect(items[1].isCurrent)
+        #expect(!items[2].isPast && !items[2].isCurrent)
+    }
+
+    @Test func buildItems_isClosed_isRelativeToLivePeriod_notReference() {
+        // Viewing a FUTURE budget (reference = 8) while today is month 6.
+        let occurrences = [occ(month: 5, amount: 100), occ(month: 7, amount: 100)]
+        let items = makeItems(occurrences, ref: 8, live: 6)
+        let allPast = items.allSatisfy(\.isPast)
+        #expect(allPast)            // both precede the viewed month 8
+        #expect(items[0].isClosed)  // 5 genuinely elapsed vs today (6)
+        #expect(!items[1].isClosed) // 7 has not
+    }
+
+    // MARK: - buildTracker
+
+    @Test func buildTracker_returnsNil_forEmpty() {
+        #expect(SpreadProgress.buildTracker(from: []) == nil)
+    }
+
+    @Test func buildTracker_currentIndex_countsPastAndCurrent() {
+        let result = tracker((5...7).map { occ(month: $0, amount: 100) }, ref: 6, live: 6)
+        #expect(result?.count == 3)
+        #expect(result?.currentIndex == 2)
+    }
+
+    @Test func buildTracker_currentIndexZero_whenViewedPrecedesAll() {
+        let occurrences = [occ(month: 6, amount: 100), occ(month: 7, amount: 100)]
+        #expect(tracker(occurrences, ref: 4, live: 4)?.currentIndex == 0)
+    }
+
+    @Test func buildTracker_total_isSumOfAllAmounts() {
+        let occurrences = (1...4).map { occ(month: $0, amount: 100) }
+        #expect(tracker(occurrences, ref: 2, live: 2)?.totalAmount == 400)
+    }
+
+    @Test func buildTracker_cumulated_sumsRealizedOverClosedOrChecked() {
+        // Today = month 6.
+        let occurrences = [
+            occ(month: 4, amount: 100, consumed: 120, transactionCount: 1), // closed + realized → 120
+            occ(month: 5, amount: 100),                                      // closed, no tx → prévu 100
+            occ(month: 6, amount: 100),                                      // current → excluded
+            occ(month: 7, amount: 100, checkedAt: Date()),                   // future but pointé → prévu 100
+            occ(month: 8, amount: 100),                                      // future → excluded
+        ]
+        let result = tracker(occurrences, ref: 6, live: 6)
+        #expect(result?.cumulatedAmount == 320)
+        #expect(result?.totalAmount == 500)
+    }
+
+    @Test func buildTracker_realizedUsesConsumed_onlyWhenTransactionsExist() {
+        // Closed month with 0 transactions → prévu (100), not consumed (0).
+        let occurrences = [occ(month: 4, amount: 100, consumed: 0, transactionCount: 0)]
+        #expect(tracker(occurrences, ref: 6, live: 6)?.cumulatedAmount == 100)
+    }
+
+    @Test func buildTracker_progressPercent_isCumulatedOverTotalClamped() {
+        let occurrences = (4...7).map { occ(month: $0, amount: 100) } // 4,5 closed vs live 6
+        #expect(tracker(occurrences, ref: 6, live: 6)?.progressPercent == 50)
+    }
+
+    @Test func buildTracker_perMonth_isCurrentAmount_elseLast() {
+        let withCurrent = [occ(month: 5, amount: 100), occ(month: 6, amount: 222), occ(month: 7, amount: 100)]
+        #expect(tracker(withCurrent, ref: 6, live: 6)?.perMonthAmount == 222)
+
+        let noCurrent = [occ(month: 5, amount: 100), occ(month: 6, amount: 100), occ(month: 7, amount: 333)]
+        #expect(tracker(noCurrent, ref: 2, live: 2)?.perMonthAmount == 333)
+    }
+}

--- a/ios/PulpeTests/Domain/Services/BudgetLineSpreadRequestTests.swift
+++ b/ios/PulpeTests/Domain/Services/BudgetLineSpreadRequestTests.swift
@@ -209,6 +209,37 @@ struct BudgetLineSpreadRequestTests {
         #expect(decoded.totalOriginalAmount == nil)
     }
 
+    // MARK: - Idempotency key on the wire (PUL-17)
+
+    @Test
+    func createSpread_sendsClientSpreadGroupIdUnderTheSpreadGroupIdKey() async throws {
+        let recorder = RequestRecorder()
+        InterceptingURLProtocol.requestHandler = { request in
+            recorder.record(request)
+            return (makeHTTPResponse(for: request, statusCode: 200), Self.successResponseData())
+        }
+        defer { InterceptingURLProtocol.requestHandler = nil }
+
+        let groupId = "b7e8f9a0-1c2d-4e3f-8a9b-0c1d2e3f4a5b"
+        let body = BudgetLineSpreadCreate(
+            name: "Impôts",
+            kind: .expense,
+            mode: .perMonth,
+            months: [SpreadMonthRef(year: 2026, month: 6)],
+            perMonthAmount: 80,
+            spreadGroupId: groupId
+        )
+
+        let apiClient = makeAPIClient()
+        let _: BudgetLineSpreadResponse = try await apiClient.request(
+            .budgetLinesSpread, body: body, method: .post
+        )
+
+        let decoded = try #require(recorder.decodedBody)
+        // The idempotency key rides on the wire under the `spreadGroupId` JSON key.
+        #expect(decoded.spreadGroupId == groupId)
+    }
+
     // MARK: - Response decoding
 
     @Test
@@ -379,6 +410,7 @@ private struct DecodedSpreadBody: Decodable {
     let originalCurrency: String?
     let targetCurrency: String?
     let exchangeRate: Decimal?
+    let spreadGroupId: String
 }
 
 private struct TranchePair: Equatable {

--- a/ios/PulpeTests/Domain/Store/CrossStoreSyncTests.swift
+++ b/ios/PulpeTests/Domain/Store/CrossStoreSyncTests.swift
@@ -83,8 +83,16 @@ struct BudgetListStoreCacheInvalidationTests {
         let dashboardBaseline = dashboardMock.getBudgetsSparseCallCount
 
         let coordinator = BudgetDetailsCoordinator(budgetId: "budget-current")
-        // mirrors BudgetDetailsView's .task
-        coordinator.bind(budgetListStore: listStore, dashboardStore: dashboardStore)
+        // CurrentMonthStore (concrete service, not mock-injectable) backs the
+        // CurrentMonth tab; bind() must wire it into the same onMutation closure
+        // whose execution the list + dashboard assertions below already prove.
+        let currentMonthStore = CurrentMonthStore()
+        // mirrors BudgetDetailsView's .task — wires all three app-scoped stores
+        coordinator.bind(
+            budgetListStore: listStore,
+            dashboardStore: dashboardStore,
+            currentMonthStore: currentMonthStore
+        )
         let tx = TestDataFactory.createTransaction(id: "new-tx", budgetId: "budget-current")
         await coordinator.dispatch(.addTransaction(tx))
 

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSpreadFromExistingTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSpreadFromExistingTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// PUL-17 v1.1 — the coordinator's "lisser un existant" flow: calls the right
+/// service, removes the source AFTER the server confirms, grafts the M0 tranche
+/// that landed in THIS budget, and leaves the source intact on failure.
+@Suite("BudgetDetailsCoordinator — spread from existing", .serialized)
+@MainActor
+struct SpreadFromExistingCoordinatorTests {
+    private let budgetId = "test-budget"
+
+    private func period(_ month: Int) -> SpreadFromExistingPeriod {
+        SpreadFromExistingPeriod(year: 2026, month: month)
+    }
+
+    private func toast() -> (ToastManager, ToastContext) {
+        let manager = ToastManager()
+        return (manager, ToastContext(toastManager: manager, presentationCurrency: .chf))
+    }
+
+    @Test
+    func spreadBudgetLineFromExisting_callsService_withIdAndPeriods() async {
+        let mockLine = MockBudgetLineService()
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId, budgetLineService: mockLine, transactionService: MockTransactionService()
+        )
+        await coord.dispatch(.addBudgetLine(TestDataFactory.createBudgetLine(id: "line-1", budgetId: budgetId)))
+        let (_, ctx) = toast()
+
+        await coord.dispatch(.spreadBudgetLineFromExisting(lineId: "line-1", periods: [period(6), period(7)], ctx))
+
+        #expect(mockLine.spreadFromLineCalls.count == 1)
+        #expect(mockLine.spreadFromLineCalls.first?.id == "line-1")
+        #expect(mockLine.spreadFromLineCalls.first?.periods.count == 2)
+    }
+
+    @Test
+    func spreadBudgetLineFromExisting_onSuccess_removesSource_graftsM0_andToasts() async {
+        let mockLine = MockBudgetLineService()
+        mockLine.stubbedSpreadResponse = BudgetLineSpreadResponse(
+            spreadGroupId: UUID(),
+            lines: [
+                TestDataFactory.createBudgetLine(id: "tranche-m0", budgetId: budgetId),
+                TestDataFactory.createBudgetLine(id: "tranche-m1", budgetId: "other-budget"),
+            ],
+            createdBudgets: [],
+            skippedMonths: []
+        )
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId, budgetLineService: mockLine, transactionService: MockTransactionService()
+        )
+        await coord.dispatch(.addBudgetLine(TestDataFactory.createBudgetLine(id: "line-1", budgetId: budgetId)))
+        let (manager, ctx) = toast()
+
+        await coord.dispatch(.spreadBudgetLineFromExisting(lineId: "line-1", periods: [period(6), period(7)], ctx))
+
+        let ids = Set(coord.dataStore.budgetLines.map(\.id))
+        #expect(!ids.contains("line-1"))      // source removed
+        #expect(ids.contains("tranche-m0"))   // M0 tranche grafted (same budget)
+        #expect(!ids.contains("tranche-m1"))  // other-budget tranche NOT grafted here
+        #expect(manager.currentToast?.message == "C'est lissé sur 2 mois")
+    }
+
+    @Test
+    func spreadBudgetLineFromExisting_onError_keepsSource_andShowsErrorToast() async {
+        let mockLine = MockBudgetLineService()
+        mockLine.spreadError = URLError(.badServerResponse)
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId, budgetLineService: mockLine, transactionService: MockTransactionService()
+        )
+        await coord.dispatch(.addBudgetLine(TestDataFactory.createBudgetLine(id: "line-1", budgetId: budgetId)))
+        let (manager, ctx) = toast()
+
+        await coord.dispatch(.spreadBudgetLineFromExisting(lineId: "line-1", periods: [period(6), period(7)], ctx))
+
+        let sourceIntact = coord.dataStore.budgetLines.contains { $0.id == "line-1" }
+        #expect(sourceIntact)  // untouched
+        #expect(manager.currentToast?.message == "Le lissage n'a pas pu aboutir")
+    }
+
+    @Test
+    func spreadTransactionFromExisting_onSuccess_removesTransaction_graftsLine() async {
+        let mockTx = MockTransactionService()
+        mockTx.stubbedSpreadResponse = BudgetLineSpreadResponse(
+            spreadGroupId: UUID(),
+            lines: [TestDataFactory.createBudgetLine(id: "tranche-m0", budgetId: budgetId)],
+            createdBudgets: [],
+            skippedMonths: []
+        )
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId, budgetLineService: MockBudgetLineService(), transactionService: mockTx
+        )
+        await coord.dispatch(.addTransaction(
+            TestDataFactory.createTransaction(id: "tx-1", budgetId: budgetId, budgetLineId: nil)
+        ))
+        let (manager, ctx) = toast()
+
+        await coord.dispatch(.spreadTransactionFromExisting(txId: "tx-1", periods: [period(6), period(7)], ctx))
+
+        #expect(coord.dataStore.transactions.isEmpty)
+        let graftedM0 = coord.dataStore.budgetLines.contains { $0.id == "tranche-m0" }
+        #expect(graftedM0)
+        #expect(mockTx.spreadFromTxnCalls.first?.id == "tx-1")
+        #expect(manager.currentToast?.message == "C'est lissé sur 2 mois")
+    }
+}

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSpreadFromExistingTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/BudgetDetailsCoordinatorSpreadFromExistingTests.swift
@@ -104,4 +104,23 @@ struct SpreadFromExistingCoordinatorTests {
         #expect(mockTx.spreadFromTxnCalls.first?.id == "tx-1")
         #expect(manager.currentToast?.message == "C'est lissé sur 2 mois")
     }
+
+    @Test
+    func spreadTransactionFromExisting_onError_keepsSource_andShowsErrorToast() async {
+        let mockTx = MockTransactionService()
+        mockTx.spreadError = URLError(.badServerResponse)
+        let coord = BudgetDetailsCoordinator(
+            budgetId: budgetId, budgetLineService: MockBudgetLineService(), transactionService: mockTx
+        )
+        await coord.dispatch(.addTransaction(
+            TestDataFactory.createTransaction(id: "tx-1", budgetId: budgetId, budgetLineId: nil)
+        ))
+        let (manager, ctx) = toast()
+
+        await coord.dispatch(.spreadTransactionFromExisting(txId: "tx-1", periods: [period(6), period(7)], ctx))
+
+        let sourceIntact = coord.dataStore.transactions.contains { $0.id == "tx-1" }
+        #expect(sourceIntact)
+        #expect(manager.currentToast?.message == "Le lissage n'a pas pu aboutir")
+    }
 }

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/AddBudgetLineSpreadLogicTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/AddBudgetLineSpreadLogicTests.swift
@@ -16,6 +16,9 @@ import Testing
 @Suite("AddBudgetLine spread submit wiring")
 @MainActor
 struct AddBudgetLineSpreadLogicTests {
+    /// A fixed idempotency key for the wiring tests that don't assert it specifically.
+    private static let testGroupId = "a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d"
+
     // MARK: - buildCreate: per-month amount + one month ref per selected month, same-currency
 
     @Test
@@ -25,7 +28,7 @@ struct AddBudgetLineSpreadLogicTests {
 
         let data = AddBudgetLineSpreadLogic.buildCreate(
             calculator: calculator,
-            input: .init(name: "  Impôts  ", kind: .expense, amount: 80, mode: .perMonth, conversion: nil)
+            input: .init(name: "  Impôts  ", kind: .expense, amount: 80, mode: .perMonth, conversion: nil, spreadGroupId: Self.testGroupId)
         )
 
         #expect(data.name == "Impôts")
@@ -51,7 +54,7 @@ struct AddBudgetLineSpreadLogicTests {
 
         let data = AddBudgetLineSpreadLogic.buildCreate(
             calculator: calculator,
-            input: .init(name: "Loyer", kind: .expense, amount: 500, mode: .perMonth, conversion: nil)
+            input: .init(name: "Loyer", kind: .expense, amount: 500, mode: .perMonth, conversion: nil, spreadGroupId: Self.testGroupId)
         )
 
         #expect(data.months.map { TranchePair($0.year, $0.month) } == [
@@ -68,7 +71,7 @@ struct AddBudgetLineSpreadLogicTests {
 
         let data = AddBudgetLineSpreadLogic.buildCreate(
             calculator: calculator,
-            input: .init(name: "Vacances", kind: .expense, amount: 90, mode: .total, conversion: nil)
+            input: .init(name: "Vacances", kind: .expense, amount: 90, mode: .total, conversion: nil, spreadGroupId: Self.testGroupId)
         )
 
         #expect(data.mode == .total)
@@ -94,7 +97,7 @@ struct AddBudgetLineSpreadLogicTests {
 
         let data = AddBudgetLineSpreadLogic.buildCreate(
             calculator: calculator,
-            input: .init(name: "Assurance", kind: .expense, amount: 100, mode: .total, conversion: conversion)
+            input: .init(name: "Assurance", kind: .expense, amount: 100, mode: .total, conversion: conversion, spreadGroupId: Self.testGroupId)
         )
 
         // FX figé: the converted total + the original total ride at request level.
@@ -124,7 +127,7 @@ struct AddBudgetLineSpreadLogicTests {
 
         let data = AddBudgetLineSpreadLogic.buildCreate(
             calculator: calculator,
-            input: .init(name: "Assurance", kind: .expense, amount: 100, mode: .perMonth, conversion: conversion)
+            input: .init(name: "Assurance", kind: .expense, amount: 100, mode: .perMonth, conversion: conversion, spreadGroupId: Self.testGroupId)
         )
 
         // One exchangeRate + one perMonthOriginalAmount at request level (FX figé).
@@ -138,6 +141,46 @@ struct AddBudgetLineSpreadLogicTests {
         #expect(data.perMonthOriginalAmount == 100)
         #expect(data.totalAmount == nil)
         #expect(data.totalOriginalAmount == nil)
+    }
+
+    // MARK: - Idempotency key (PUL-17): carried into the DTO + reused across retries
+
+    @Test
+    func buildCreate_carriesTheIntentSpreadGroupId() {
+        let calculator = SpreadCalculator(anchorMonth: 6, anchorYear: 2026)
+        let intentId = "b7e8f9a0-1c2d-4e3f-8a9b-0c1d2e3f4a5b"
+
+        let perMonth = AddBudgetLineSpreadLogic.buildCreate(
+            calculator: calculator,
+            input: .init(name: "Impôts", kind: .expense, amount: 80, mode: .perMonth,
+                         conversion: nil, spreadGroupId: intentId)
+        )
+        let total = AddBudgetLineSpreadLogic.buildCreate(
+            calculator: calculator,
+            input: .init(name: "Vacances", kind: .expense, amount: 90, mode: .total,
+                         conversion: nil, spreadGroupId: intentId)
+        )
+
+        #expect(perMonth.spreadGroupId == intentId)
+        #expect(total.spreadGroupId == intentId)
+    }
+
+    @Test
+    func buildCreate_reusesTheSameSpreadGroupId_onRetryOfTheSameIntent() {
+        // The sheet mints ONE key per intent (@State) and reuses it on retry;
+        // buildCreate must be a faithful conduit — same SubmitInput → same key on
+        // every attempt, so a retry replays the group instead of duplicating it.
+        let calculator = SpreadCalculator(anchorMonth: 6, anchorYear: 2026)
+        let input = AddBudgetLineSpreadLogic.SubmitInput(
+            name: "Impôts", kind: .expense, amount: 80, mode: .perMonth,
+            conversion: nil, spreadGroupId: "b7e8f9a0-1c2d-4e3f-8a9b-0c1d2e3f4a5b"
+        )
+
+        let firstAttempt = AddBudgetLineSpreadLogic.buildCreate(calculator: calculator, input: input)
+        let retry = AddBudgetLineSpreadLogic.buildCreate(calculator: calculator, input: input)
+
+        #expect(firstAttempt.spreadGroupId == input.spreadGroupId)
+        #expect(retry.spreadGroupId == firstAttempt.spreadGroupId)
     }
 
     // MARK: - Submit wiring: createSpread called + invalidation fired
@@ -160,7 +203,7 @@ struct AddBudgetLineSpreadLogicTests {
         // Mirror exactly what `AddBudgetLineSheet.addSpread()` does.
         let data = AddBudgetLineSpreadLogic.buildCreate(
             calculator: calculator,
-            input: .init(name: "Impôts", kind: .expense, amount: 80, mode: .perMonth, conversion: nil)
+            input: .init(name: "Impôts", kind: .expense, amount: 80, mode: .perMonth, conversion: nil, spreadGroupId: Self.testGroupId)
         )
         let response = try await dependencies.createSpread(data)
         dependencies.invalidateCrossBudgetCaches(BudgetListStore())

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculatorTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculatorTests.swift
@@ -85,12 +85,15 @@ struct SpreadExistingCalculatorTests {
         #expect(calc.isValid)
     }
 
-    /// A transiently-inverted window (end before start) must not silently wipe
-    /// the user's deselections — they survive until a valid window prunes them.
-    @Test func setEnd_invertedWindow_preservesDeselections() {
+    /// A transiently-invalid window (end before OR equal to start) must not
+    /// silently wipe the user's deselections — they survive until a valid window
+    /// prunes them. `end == start` is the boundary: the window is just the locked
+    /// M0, so intersecting against it would otherwise clear everything.
+    @Test func setEnd_invalidWindow_preservesDeselections() {
         let calc = make()  // Jun 2026 → [6, 7, 8]
         calc.toggle(SpreadMonth(year: 2026, month: 7))  // deselect July
         calc.setEnd(SpreadMonth(year: 2026, month: 5))  // end < start → invalid
+        calc.setEnd(calc.start)                          // end == start → invalid
         calc.setEnd(SpreadMonth(year: 2026, month: 8))  // back to a valid window
         #expect(!calc.isSelected(SpreadMonth(year: 2026, month: 7)))
         #expect(calc.selectedCount == 2)

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculatorTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculatorTests.swift
@@ -63,6 +63,30 @@ struct SpreadExistingCalculatorTests {
         #expect(calc.validationMessage == "36 mois maximum")
     }
 
+    /// The cap is on the tranches actually sent (`selectedCount`), not the raw
+    /// window span: a 37-month window with one month skipped is 36 tranches and
+    /// must pass — the server would accept it.
+    @Test func validation_oversizedWindow_validOnceDeselectedUnderCap() {
+        let calc = make(month: 1, year: 2026)
+        calc.setEnd(SpreadMonth(year: 2029, month: 1))  // Jan 2026…Jan 2029 = 37 months
+        #expect(calc.validationMessage == "36 mois maximum")
+        calc.toggle(SpreadMonth(year: 2026, month: 2))  // → 36 tranches
+        #expect(calc.selectedCount == 36)
+        #expect(calc.validationMessage == nil)
+        #expect(calc.isValid)
+    }
+
+    /// A transiently-inverted window (end before start) must not silently wipe
+    /// the user's deselections — they survive until a valid window prunes them.
+    @Test func setEnd_invertedWindow_preservesDeselections() {
+        let calc = make()  // Jun 2026 → [6, 7, 8]
+        calc.toggle(SpreadMonth(year: 2026, month: 7))  // deselect July
+        calc.setEnd(SpreadMonth(year: 2026, month: 5))  // end < start → invalid
+        calc.setEnd(SpreadMonth(year: 2026, month: 8))  // back to a valid window
+        #expect(!calc.isSelected(SpreadMonth(year: 2026, month: 7)))
+        #expect(calc.selectedCount == 2)
+    }
+
     @Test func perMonth_isBaseTranche() {
         let calc = make()  // 3 months → 100/3 base 33.33 (remainder on M0)
         #expect(calc.perMonth(total: 100) == Decimal(string: "33.33"))

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculatorTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculatorTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// PUL-17 v1.1 — the total-preserving "lisser un existant" calculator: M0-locked
+/// window, N ≥ 2, and the split-driven echo (per-month base + remainder month).
+@Suite("SpreadExistingCalculator")
+@MainActor
+struct SpreadExistingCalculatorTests {
+    private func make(month: Int = 6, year: Int = 2026) -> SpreadExistingCalculator {
+        SpreadExistingCalculator(anchorMonth: month, anchorYear: year)
+    }
+
+    @Test func defaultWindow_isThreeMonthsFromAnchor() {
+        let calc = make()
+        #expect(calc.windowMonths.map(\.month) == [6, 7, 8])
+        #expect(calc.selectedCount == 3)
+    }
+
+    @Test func m0_isLocked_andNotDeselectable() {
+        let calc = make()
+        #expect(calc.isLocked(calc.start))
+        calc.toggle(calc.start)
+        #expect(calc.isSelected(calc.start))
+        #expect(calc.selectedCount == 3)
+    }
+
+    @Test func toggle_deselectsNonAnchorMonth() {
+        let calc = make()
+        let july = SpreadMonth(year: 2026, month: 7)
+        calc.toggle(july)
+        #expect(!calc.isSelected(july))
+        #expect(calc.selectedCount == 2)
+    }
+
+    @Test func setEnd_extendsWindow_andPrunesOutOfRangeDeselections() {
+        let calc = make()
+        calc.toggle(SpreadMonth(year: 2026, month: 8))
+        #expect(calc.selectedCount == 2)
+        calc.setEnd(SpreadMonth(year: 2026, month: 7))
+        #expect(calc.windowMonths.map(\.month) == [6, 7])
+        #expect(calc.selectedCount == 2)   // August deselection pruned
+    }
+
+    @Test func validation_invertedWindow() {
+        let calc = make()
+        calc.setEnd(SpreadMonth(year: 2026, month: 5))
+        #expect(calc.validationMessage == "Le mois de fin précède le mois de début")
+        #expect(!calc.isValid)
+    }
+
+    @Test func validation_singleMonth_requiresTwo() {
+        let calc = make()
+        calc.toggle(SpreadMonth(year: 2026, month: 7))
+        calc.toggle(SpreadMonth(year: 2026, month: 8))
+        #expect(calc.selectedCount == 1)
+        #expect(calc.validationMessage == "Choisis au moins deux mois")
+    }
+
+    @Test func validation_exceeds36Months() {
+        let calc = make(month: 1, year: 2026)
+        calc.setEnd(SpreadMonth(year: 2029, month: 12))
+        #expect(calc.validationMessage == "36 mois maximum")
+    }
+
+    @Test func perMonth_isBaseTranche() {
+        let calc = make()  // 3 months → 100/3 base 33.33 (remainder on M0)
+        #expect(calc.perMonth(total: 100) == Decimal(string: "33.33"))
+    }
+
+    @Test func remainderMonthName_namesLastRemainderMonth() {
+        let calc = make()  // [Juin, Juillet, Août], 100/3 → 1 cent on Juin
+        #expect(calc.remainderMonthName(total: 100) == "Juin")
+    }
+
+    @Test func remainderMonthName_nilForExactSplit() {
+        let calc = make()
+        calc.setEnd(SpreadMonth(year: 2026, month: 9))  // 4 months, 100/4 = 25 exact
+        #expect(calc.remainderMonthName(total: 100) == nil)
+    }
+
+    @Test func periods_areAscending_includingM0() {
+        let calc = make()
+        let periods = calc.periods()
+        #expect(periods.map(\.month) == [6, 7, 8])
+        let allIn2026 = periods.allSatisfy { $0.year == 2026 }
+        #expect(allIn2026)
+    }
+}

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculatorTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/SpreadExistingCalculatorTests.swift
@@ -45,7 +45,16 @@ struct SpreadExistingCalculatorTests {
     @Test func validation_invertedWindow() {
         let calc = make()
         calc.setEnd(SpreadMonth(year: 2026, month: 5))
-        #expect(calc.validationMessage == "Le mois de fin précède le mois de début")
+        #expect(calc.validationMessage == "Le mois de fin doit suivre le mois de début")
+        #expect(!calc.isValid)
+    }
+
+    /// `end == start` leaves only the locked M0 in the window — the grid offers
+    /// nothing to toggle, so the message must point at the date, not at the grid.
+    @Test func validation_endEqualsStart_pointsAtTheDate() {
+        let calc = make()
+        calc.setEnd(calc.start)
+        #expect(calc.validationMessage == "Le mois de fin doit suivre le mois de début")
         #expect(!calc.isValid)
     }
 

--- a/ios/PulpeTests/Helpers/MockBudgetLineService.swift
+++ b/ios/PulpeTests/Helpers/MockBudgetLineService.swift
@@ -21,6 +21,7 @@ final class MockBudgetLineService: BudgetLineServicing {
     var spreadError: Error?
     private(set) var createdSpreads: [BudgetLineSpreadCreate] = []
     private(set) var requestedOccurrenceGroupIds: [String] = []
+    private(set) var spreadFromLineCalls: [(id: String, periods: [SpreadFromExistingPeriod])] = []
 
     func deleteBudgetLine(id: String) async throws {
         deleteBudgetLineCallCount += 1
@@ -47,5 +48,19 @@ final class MockBudgetLineService: BudgetLineServicing {
         requestedOccurrenceGroupIds.append(spreadGroupId)
         if let spreadError { throw spreadError }
         return stubbedSpreadOccurrences
+    }
+
+    func spreadExistingBudgetLine(
+        id: String,
+        periods: [SpreadFromExistingPeriod]
+    ) async throws -> BudgetLineSpreadResponse {
+        spreadFromLineCalls.append((id: id, periods: periods))
+        if let spreadError { throw spreadError }
+        return stubbedSpreadResponse ?? BudgetLineSpreadResponse(
+            spreadGroupId: UUID(),
+            lines: [],
+            createdBudgets: [],
+            skippedMonths: []
+        )
     }
 }

--- a/ios/PulpeTests/Helpers/MockTransactionService.swift
+++ b/ios/PulpeTests/Helpers/MockTransactionService.swift
@@ -18,6 +18,10 @@ final class MockTransactionService: TransactionServicing {
     /// Transaction ids whose `toggleCheck` should throw — drives partial
     /// bulk-check failures deterministically (PUL-259).
     var failingToggleIds: Set<String> = []
+    // Spread-from-existing (PUL-17 v1.1) — stubbed response + recorded inputs.
+    var stubbedSpreadResponse: BudgetLineSpreadResponse?
+    var spreadError: Error?
+    private(set) var spreadFromTxnCalls: [(id: String, periods: [SpreadFromExistingPeriod])] = []
 
     func deleteTransaction(id: String) async throws {
         deleteTransactionCallCount += 1
@@ -36,5 +40,19 @@ final class MockTransactionService: TransactionServicing {
 
     func updateTransaction(id: String, data: TransactionUpdate) async throws -> Transaction {
         stubbedUpdated ?? TestDataFactory.createTransaction(id: id)
+    }
+
+    func spreadExistingTransaction(
+        id: String,
+        periods: [SpreadFromExistingPeriod]
+    ) async throws -> BudgetLineSpreadResponse {
+        spreadFromTxnCalls.append((id: id, periods: periods))
+        if let spreadError { throw spreadError }
+        return stubbedSpreadResponse ?? BudgetLineSpreadResponse(
+            spreadGroupId: UUID(),
+            lines: [],
+            createdBudgets: [],
+            skippedMonths: []
+        )
     }
 }


### PR DESCRIPTION
Parité iOS complète pour **PUL-17** (lissage de dépense). **Empilée sur #480** (partie web) — base = `worktree-pul-17-lisser-depense`. GitHub retargettera la base vers `preview` au merge de #480.

## Blocs

**1 — Tracker réalisé** (pur client — le backend renvoie déjà `consumed`/`transactionCount`)
- `SpreadOccurrence` décode `consumed`/`transactionCount`
- `Domain/Formulas/SpreadProgress.swift` : port du `buildSpreadTracker` web — 2 axes (affichage `isPast`/`isCurrent` vs mois **vu**, réalisation `isClosed` vs mois **live**)
- `SpreadOccurrencesSheet` : header tracker (position · cumulé/total · barre `pulpePrimary` · /mois) + composite « consommé / prévu barré » + marqueur Ici/Ce mois

**2 — Détail transaction** (le cul-de-sac signalé)
- `SpreadAffordanceButton` partagé entre `BudgetLineDetailPage` et `EditTransactionPage` (ligne parente résolue via le projector) → la timeline des occurrences est joignable depuis une transaction d'une dépense lissée

**3 — Lisser un existant (total préservé)**
- `SpreadSplit` (split en centimes Σ=T) + `SpreadExistingCalculator` (M0 verrouillé, N≥2) + `SpreadExistingSheet`
- Entrées « Lisser sur plusieurs mois » : menu prévision + toolbar transaction libre · endpoints `POST /budget-lines/:id/spread` + `/transactions/:id/spread` · coordinator (supprime la source après succès, greffe la tranche M0, invalide cross-budget)

## Vérification
- Suite iOS complète : **1620 tests verts** (+33 nouveaux : SpreadProgress, SpreadSplit, SpreadExistingCalculator, coordinator from-existing)
- `swiftlint --strict` clean · arch LOC ≤350/fichier (routing extrait dans `BudgetDetailsView+Routing`)
- Build `PulpeLocal` OK

## Notes
- 2-décimales partout sur le budget-detail (divergence assumée vs agrégation 0-déc du web)
- iOS = 2 surfaces de détail (ligne + transaction) ; pas de surface grid/card comme le web

Linear : PUL-17