### PR TITLE
feat(savings-goals): iOS surface (PUL-12)

### DIFF
--- a/ios/Pulpe/App/MainTabView.swift
+++ b/ios/Pulpe/App/MainTabView.swift
@@ -304,6 +304,9 @@ struct CurrentMonthTab: View {
     var body: some View {
         NavigationStack {
             CurrentMonthView()
+                .navigationDestination(for: SavingsGoalDestination.self) { _ in
+                    SavingsGoalsListView()
+                }
         }
         .clearsFloatingTabBar()
     }

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -22,6 +22,7 @@ struct PulpeApp: App {
     @State private var dashboardStore: DashboardStore
     @State private var userSettingsStore: UserSettingsStore
     @State private var featureFlagsStore: FeatureFlagsStore
+    @State private var savingsGoalStore: SavingsGoalStore
     @State private var runtimeCoordinator: AppRuntimeCoordinator
     @State private var deepLinkDestination: DeepLinkDestination?
     @State private var appVersionStore = AppVersionStore()
@@ -33,12 +34,14 @@ struct PulpeApp: App {
         let dashboardStore = DashboardStore()
         let featureFlagsStore = FeatureFlagsStore()
         let userSettingsStore = UserSettingsStore(featureFlags: featureFlagsStore)
+        let savingsGoalStore = SavingsGoalStore()
 
         appState.sessionDataResetter = LiveSessionDataResetter(
             currentMonthStore: currentMonthStore,
             budgetListStore: budgetListStore,
             dashboardStore: dashboardStore,
-            userSettingsStore: userSettingsStore
+            userSettingsStore: userSettingsStore,
+            savingsGoalStore: savingsGoalStore
         )
 
         // Cross-store consistency (PUL-270): any amount-changing mutation on
@@ -64,6 +67,7 @@ struct PulpeApp: App {
         _dashboardStore = State(initialValue: dashboardStore)
         _userSettingsStore = State(initialValue: userSettingsStore)
         _featureFlagsStore = State(initialValue: featureFlagsStore)
+        _savingsGoalStore = State(initialValue: savingsGoalStore)
         _runtimeCoordinator = State(initialValue: AppRuntimeCoordinator(
             appState: appState,
             currentMonthStore: currentMonthStore,
@@ -96,6 +100,7 @@ struct PulpeApp: App {
                     .environment(dashboardStore)
                     .environment(userSettingsStore)
                     .environment(featureFlagsStore)
+                    .environment(savingsGoalStore)
                     .environment(appVersionStore)
                     .overlay(alignment: .topLeading) {
                         ToastOverlayWindowHost(toastManager: appState.toastManager)

--- a/ios/Pulpe/App/SessionDataResetting.swift
+++ b/ios/Pulpe/App/SessionDataResetting.swift
@@ -13,17 +13,20 @@ final class LiveSessionDataResetter: SessionDataResetting {
     private let budgetListStore: BudgetListStore
     private let dashboardStore: DashboardStore
     private let userSettingsStore: UserSettingsStore
+    private let savingsGoalStore: SavingsGoalStore
 
     init(
         currentMonthStore: CurrentMonthStore,
         budgetListStore: BudgetListStore,
         dashboardStore: DashboardStore,
-        userSettingsStore: UserSettingsStore
+        userSettingsStore: UserSettingsStore,
+        savingsGoalStore: SavingsGoalStore
     ) {
         self.currentMonthStore = currentMonthStore
         self.budgetListStore = budgetListStore
         self.dashboardStore = dashboardStore
         self.userSettingsStore = userSettingsStore
+        self.savingsGoalStore = savingsGoalStore
     }
 
     func resetStores() {
@@ -31,5 +34,6 @@ final class LiveSessionDataResetter: SessionDataResetting {
         budgetListStore.reset()
         dashboardStore.reset()
         userSettingsStore.reset()
+        savingsGoalStore.reset()
     }
 }

--- a/ios/Pulpe/Core/Network/Endpoints.swift
+++ b/ios/Pulpe/Core/Network/Endpoints.swift
@@ -54,6 +54,11 @@ enum Endpoint {
     case templateLine(templateId: String, lineId: String)
     case templateLinesBulk(templateId: String)
 
+    // MARK: - Savings Goals
+
+    case savingsGoals
+    case savingsGoal(id: String)
+
     // MARK: - Currency
 
     case currencyRate(base: SupportedCurrency, target: SupportedCurrency)
@@ -116,6 +121,10 @@ enum Endpoint {
         case .templateLine(let templateId, let lineId): return "/budget-templates/\(templateId)/lines/\(lineId)"
         case .templateLinesBulk(let templateId): return "/budget-templates/\(templateId)/lines/bulk-operations"
 
+        // Savings Goals
+        case .savingsGoals: return "/savings-goals"
+        case .savingsGoal(let id): return "/savings-goals/\(id)"
+
         // Currency
         case .currencyRate: return "/currency/rate"
 
@@ -145,6 +154,7 @@ enum Endpoint {
         case .validateSession, .userProfile, .budget, .budgetDetails, .budgetsExport,
              .budgetLine, .transaction, .template, .templateUsage, .templateLine,
              .transactionsByBudget, .budgetsSparse,
+             .savingsGoals, .savingsGoal,
              .encryptionVaultStatus, .encryptionSalt,
              .userSettings, .currencyRate:
             return .get

--- a/ios/Pulpe/Domain/Models/BudgetLine.swift
+++ b/ios/Pulpe/Domain/Models/BudgetLine.swift
@@ -119,6 +119,11 @@ struct BudgetLineUpdate: Encodable {
     var kind: TransactionKind?
     var isManuallyAdjusted: Bool?
     var checkedAt: Date?
+    /// Tri-state savings-goal link: `.none` omits the key (no change),
+    /// `.some(nil)` sends explicit `null` (untag), `.some(id)` sets the link.
+    /// Only the saving-line editor sets this — every other PATCH leaves the
+    /// tag untouched.
+    var savingsGoalId: String??
     var originalAmount: Decimal?
     var originalCurrency: SupportedCurrency?
     var targetCurrency: SupportedCurrency?

--- a/ios/Pulpe/Domain/Models/BudgetTemplate.swift
+++ b/ios/Pulpe/Domain/Models/BudgetTemplate.swift
@@ -27,6 +27,9 @@ struct TemplateLine: Codable, Identifiable, Hashable, Sendable {
     let createdAt: Date
     let updatedAt: Date
 
+    // Savings goal link (PUL-12) — the primary tagging surface lives on the template
+    var savingsGoalId: String?
+
     // Currency conversion metadata
     var originalAmount: Decimal?
     var originalCurrency: SupportedCurrency?
@@ -67,6 +70,7 @@ struct TemplateLineCreate: Encodable {
     let kind: TransactionKind
     let recurrence: TransactionRecurrence
     let description: String
+    let savingsGoalId: String?
     let originalAmount: Decimal?
     let originalCurrency: SupportedCurrency?
     let targetCurrency: SupportedCurrency?
@@ -78,6 +82,7 @@ struct TemplateLineCreate: Encodable {
         kind: TransactionKind,
         recurrence: TransactionRecurrence,
         description: String = "",
+        savingsGoalId: String? = nil,
         originalAmount: Decimal? = nil,
         originalCurrency: SupportedCurrency? = nil,
         targetCurrency: SupportedCurrency? = nil,
@@ -88,6 +93,7 @@ struct TemplateLineCreate: Encodable {
         self.kind = kind
         self.recurrence = recurrence
         self.description = description
+        self.savingsGoalId = savingsGoalId
         self.originalAmount = originalAmount
         self.originalCurrency = originalCurrency
         self.targetCurrency = targetCurrency
@@ -101,6 +107,8 @@ struct TemplateLineUpdate: Encodable {
     var kind: TransactionKind?
     var recurrence: TransactionRecurrence?
     var description: String?
+    /// Tri-state savings-goal link — see `BudgetLineUpdate.savingsGoalId`.
+    var savingsGoalId: String??
     var originalAmount: Decimal?
     var originalCurrency: SupportedCurrency?
     var targetCurrency: SupportedCurrency?
@@ -135,6 +143,8 @@ struct TemplateLineUpdateWithId: Encodable {
     var kind: TransactionKind?
     var recurrence: TransactionRecurrence?
     var description: String?
+    /// Tri-state savings-goal link — see `BudgetLineUpdate.savingsGoalId`.
+    var savingsGoalId: String??
     var originalAmount: Decimal?
     var originalCurrency: SupportedCurrency?
     var targetCurrency: SupportedCurrency?

--- a/ios/Pulpe/Domain/Models/SavingsGoal.swift
+++ b/ios/Pulpe/Domain/Models/SavingsGoal.swift
@@ -57,6 +57,17 @@ struct SavingsGoalUpdate: Encodable {
     var status: SavingsGoalStatus?
 }
 
+// MARK: - Kind guard
+
+extension TransactionKind {
+    /// Only a `saving` prévision may carry a savings-goal link. Mirrors the
+    /// backend kind-guard (`kind ≠ saving ⇒ savingsGoalId = null`), so a line
+    /// whose kind moved away from `saving` is untagged.
+    func savingsGoalLink(_ selection: String?) -> String? {
+        self == .saving ? selection : nil
+    }
+}
+
 // MARK: - ISO date helper
 
 /// Converts between the API's `YYYY-MM-DD` `targetDate` strings and `Date`.

--- a/ios/Pulpe/Domain/Models/SavingsGoal.swift
+++ b/ios/Pulpe/Domain/Models/SavingsGoal.swift
@@ -7,6 +7,14 @@ enum SavingsGoalStatus: String, Codable, Sendable, CaseIterable {
     case active = "ACTIVE"
     case completed = "COMPLETED"
     case paused = "PAUSED"
+
+    var label: String {
+        switch self {
+        case .active: "Actif"
+        case .completed: "Atteint"
+        case .paused: "En pause"
+        }
+    }
 }
 
 /// A long-term savings goal (PUL-12).

--- a/ios/Pulpe/Domain/Models/SavingsGoal.swift
+++ b/ios/Pulpe/Domain/Models/SavingsGoal.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Status of a savings goal. In v1 the status is purely a label — it never
+/// touches the linked prévisions (see `docs/SAVINGS.md` §6). COMPLETED is
+/// reversible.
+enum SavingsGoalStatus: String, Codable, Sendable, CaseIterable {
+    case active = "ACTIVE"
+    case completed = "COMPLETED"
+    case paused = "PAUSED"
+}
+
+/// A long-term savings goal (PUL-12).
+///
+/// `targetAmount` is encrypted at rest on the backend and returned decrypted.
+/// `targetDate` is a bare ISO date (`YYYY-MM-DD`), not a datetime — it is kept as
+/// a `String` to match the API exactly and avoid the ISO8601 *datetime* decoder
+/// (which would reject `2027-01-01`). FX fields are dormant in v1 (account
+/// currency only) and come back `null`.
+struct SavingsGoal: Codable, Identifiable, Hashable, Sendable {
+    let id: String
+    let userId: String?
+    let name: String
+    let targetAmount: Decimal
+    let targetDate: String
+    let status: SavingsGoalStatus
+    let createdAt: Date
+    let updatedAt: Date
+
+    // Currency conversion metadata (dormant in v1 — always null)
+    var originalTargetAmount: Decimal?
+    var originalCurrency: SupportedCurrency?
+    var targetCurrency: SupportedCurrency?
+    var exchangeRate: Decimal?
+
+    /// The `targetDate` parsed into a `Date` for display / editing, or `nil` if
+    /// the API ever returns a malformed value.
+    var targetDateValue: Date? {
+        SavingsGoalDateFormatter.parse(targetDate)
+    }
+}
+
+// MARK: - Create/Update DTOs
+
+struct SavingsGoalCreate: Encodable {
+    let name: String
+    let targetAmount: Decimal
+    let targetDate: String
+    let status: SavingsGoalStatus
+}
+
+/// Partial update — only the set fields are sent (Swift synthesises
+/// `encodeIfPresent` for optionals, so `nil` fields are omitted from the body).
+struct SavingsGoalUpdate: Encodable {
+    var name: String?
+    var targetAmount: Decimal?
+    var targetDate: String?
+    var status: SavingsGoalStatus?
+}
+
+// MARK: - ISO date helper
+
+/// Converts between the API's `YYYY-MM-DD` `targetDate` strings and `Date`.
+/// Fixed Gregorian/UTC/POSIX so it never drifts with the device locale.
+enum SavingsGoalDateFormatter {
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    static func parse(_ string: String) -> Date? {
+        formatter.date(from: string)
+    }
+
+    static func string(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+}

--- a/ios/Pulpe/Domain/Services/SavingsGoalService.swift
+++ b/ios/Pulpe/Domain/Services/SavingsGoalService.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Read/write surface of `SavingsGoalService`. A protocol so `SavingsGoalStore`
+/// can be driven by a test double.
+protocol SavingsGoalServicing: Sendable {
+    func getAll() async throws -> [SavingsGoal]
+    func get(id: String) async throws -> SavingsGoal
+    func create(_ data: SavingsGoalCreate) async throws -> SavingsGoal
+    func update(id: String, data: SavingsGoalUpdate) async throws -> SavingsGoal
+    func delete(id: String) async throws
+}
+
+/// Service for savings-goal API operations (PUL-12). The backend wraps responses
+/// in `{ success, data }`; `APIClient` unwraps that automatically.
+actor SavingsGoalService: SavingsGoalServicing {
+    static let shared = SavingsGoalService()
+
+    private let apiClient: APIClient
+
+    private init(apiClient: APIClient = .shared) {
+        self.apiClient = apiClient
+    }
+
+    func getAll() async throws -> [SavingsGoal] {
+        try await apiClient.request(.savingsGoals, method: .get)
+    }
+
+    func get(id: String) async throws -> SavingsGoal {
+        try await apiClient.request(.savingsGoal(id: id), method: .get)
+    }
+
+    func create(_ data: SavingsGoalCreate) async throws -> SavingsGoal {
+        try await apiClient.request(.savingsGoals, body: data, method: .post)
+    }
+
+    func update(id: String, data: SavingsGoalUpdate) async throws -> SavingsGoal {
+        try await apiClient.request(.savingsGoal(id: id), body: data, method: .patch)
+    }
+
+    func delete(id: String) async throws {
+        try await apiClient.requestVoid(.savingsGoal(id: id), method: .delete)
+    }
+}

--- a/ios/Pulpe/Domain/Store/SavingsGoalStore.swift
+++ b/ios/Pulpe/Domain/Store/SavingsGoalStore.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Caches the user's savings goals (PUL-12). Backs both the goals list/form and
+/// the "Objectif" picker in the prévision editors, so it is injected at app root.
+///
+/// Goal CRUD never changes budget aggregates (a goal is metadata; DELETE only
+/// unlinks lines, it never alters amounts), so — unlike the dashboard stores —
+/// it does not invalidate sibling stores.
+@Observable @MainActor
+final class SavingsGoalStore: StoreProtocol {
+    // MARK: - State
+
+    private(set) var goals: [SavingsGoal] = []
+    private(set) var isLoading = false
+    private(set) var error: APIError?
+
+    var hasError: Bool {
+        error != nil && goals.isEmpty
+    }
+
+    // MARK: - Cache Metadata
+
+    private(set) var hasLoadedOnce = false
+    private var lastLoadTime: Date?
+    private var loadTask: Task<Void, Never>?
+    private var loadGeneration = 0
+
+    // MARK: - Services
+
+    private let service: any SavingsGoalServicing
+
+    init(service: any SavingsGoalServicing = SavingsGoalService.shared) {
+        self.service = service
+    }
+
+    // MARK: - Smart Loading (StoreProtocol)
+
+    func loadIfNeeded() async {
+        if let lastLoad = lastLoadTime,
+           Date().timeIntervalSince(lastLoad) < AppConfiguration.shortCacheValidity {
+            return
+        }
+        await forceRefresh()
+    }
+
+    func forceRefresh() async {
+        loadTask?.cancel()
+        loadGeneration += 1
+        let currentGeneration = loadGeneration
+
+        let task = Task(name: "SavingsGoals.load") {
+            isLoading = true
+            error = nil
+            defer { isLoading = false }
+
+            do {
+                let fetched = try await service.getAll()
+                try Task.checkCancellation()
+                goals = fetched.sortedForDisplay()
+                lastLoadTime = Date()
+                hasLoadedOnce = true
+            } catch is CancellationError {
+                // Cancelled — keep existing state.
+            } catch let apiError as APIError {
+                self.error = apiError
+            } catch {
+                self.error = .networkError(error)
+            }
+        }
+
+        loadTask = task
+        await task.value
+        if loadGeneration == currentGeneration { loadTask = nil }
+    }
+
+    // MARK: - Mutations
+
+    /// Creates a goal and inserts it into the cached list on success.
+    @discardableResult
+    func create(_ data: SavingsGoalCreate) async throws -> SavingsGoal {
+        let created = try await service.create(data)
+        goals = (goals + [created]).sortedForDisplay()
+        return created
+    }
+
+    /// Updates a goal (incl. status changes) and replaces it in the cache.
+    @discardableResult
+    func update(id: String, data: SavingsGoalUpdate) async throws -> SavingsGoal {
+        let updated = try await service.update(id: id, data: data)
+        if let index = goals.firstIndex(where: { $0.id == id }) {
+            goals[index] = updated
+        }
+        goals = goals.sortedForDisplay()
+        return updated
+    }
+
+    /// Deletes a goal (the backend unlinks its prévisions; none are deleted).
+    func delete(id: String) async throws {
+        try await service.delete(id: id)
+        goals.removeAll { $0.id == id }
+    }
+
+    func invalidateCache() {
+        lastLoadTime = nil
+    }
+
+    func reset() {
+        loadTask?.cancel()
+        loadTask = nil
+        loadGeneration = 0
+        goals = []
+        hasLoadedOnce = false
+        lastLoadTime = nil
+        error = nil
+    }
+}
+
+// MARK: - Display ordering
+
+private extension Array where Element == SavingsGoal {
+    /// ACTIVE first, then PAUSED, then COMPLETED; alphabetical within a status.
+    func sortedForDisplay() -> [SavingsGoal] {
+        sorted { lhs, rhs in
+            if lhs.status.sortRank != rhs.status.sortRank {
+                return lhs.status.sortRank < rhs.status.sortRank
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+}
+
+private extension SavingsGoalStatus {
+    var sortRank: Int {
+        switch self {
+        case .active: return 0
+        case .paused: return 1
+        case .completed: return 2
+        }
+    }
+}

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -11,6 +11,7 @@ struct AddBudgetLineSheet: View {
     @State private var name = ""
     @State private var amount: Decimal?
     @State private var kind: TransactionKind = .expense
+    @State private var savingsGoalId: String?
     @State private var isChecked = false
     @State private var isLoading = false
     @State private var error: Error?
@@ -78,6 +79,9 @@ struct AddBudgetLineSheet: View {
             )
             .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
             descriptionField
+            if kind == .saving {
+                SavingsGoalPickerField(selection: $savingsGoalId)
+            }
             CheckedToggle(isOn: $isChecked, tintColor: kind.color)
 
             if let error {
@@ -90,6 +94,10 @@ struct AddBudgetLineSheet: View {
         }
         .sensoryFeedback(.success, trigger: submitSuccessTrigger)
         .onAppear { inputCurrency = userSettingsStore.currency }
+        .onChange(of: kind) { _, newKind in
+            // Mirror the backend kind-guard: only savings can carry a goal.
+            if newKind != .saving { savingsGoalId = nil }
+        }
     }
 
     // MARK: - Description
@@ -147,6 +155,7 @@ struct AddBudgetLineSheet: View {
                 amount: conversion?.convertedAmount ?? amount,
                 kind: kind,
                 recurrence: .oneOff,
+                savingsGoalId: kind.savingsGoalLink(savingsGoalId),
                 checkedAt: isChecked ? Date() : nil,
                 originalAmount: conversion?.originalAmount,
                 originalCurrency: conversion?.originalCurrency,
@@ -181,4 +190,5 @@ struct AddBudgetLineDependencies: Sendable {
     }
     .environment(ToastManager())
     .environment(UserSettingsStore())
+    .environment(SavingsGoalStore())
 }

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -220,16 +220,21 @@ struct CurrentMonthView: View {
                         .staggeredEntrance(isVisible: hasAppeared, index: 3)
                     }
 
-                    // 5. Savings progress
-                    if store.savingsSummary.hasSavings {
-                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
-                            Text("Épargne")
-                                .pulpeSectionHeader()
+                    // 5. Savings progress + goals entry
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+                        Text("Épargne")
+                            .pulpeSectionHeader()
 
+                        if store.savingsSummary.hasSavings {
                             SavingsSummaryCard(summary: store.savingsSummary)
                         }
-                        .staggeredEntrance(isVisible: hasAppeared, index: 4)
+
+                        NavigationLink(value: SavingsGoalDestination.list) {
+                            SavingsGoalsEntryRow(hasSavings: store.savingsSummary.hasSavings)
+                        }
+                        .buttonStyle(.plain)
                     }
+                    .staggeredEntrance(isVisible: hasAppeared, index: 4)
                 }
                 .padding(.horizontal, DesignTokens.Spacing.lg)
                 .padding(.top, DesignTokens.Spacing.lg)

--- a/ios/Pulpe/Features/SavingsGoals/SavingsGoalFormSheet.swift
+++ b/ios/Pulpe/Features/SavingsGoals/SavingsGoalFormSheet.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+
+/// Create / edit a savings goal (PUL-12). `goal == nil` → create.
+/// In edit mode it also drives status changes (Actif / En pause / Atteint —
+/// COMPLETED is reversible) and deletion (the backend unlinks prévisions; none
+/// are deleted). Target amount is in the account currency (no currency selector
+/// in v1, CA27).
+struct SavingsGoalFormSheet: View {
+    let goal: SavingsGoal?
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(ToastManager.self) private var toastManager
+    @Environment(SavingsGoalStore.self) private var store
+
+    @State private var name: String
+    @State private var amount: Decimal?
+    @State private var amountText: String
+    @State private var targetDate: Date
+    @State private var status: SavingsGoalStatus
+    @State private var isLoading = false
+    @State private var error: Error?
+    @State private var showDeleteConfirmation = false
+    @FocusState private var focusedField: AmountDescriptionField?
+
+    private let currency: SupportedCurrency
+    private let accentColor = TransactionKind.saving.color
+
+    init(goal: SavingsGoal?, userCurrency: SupportedCurrency) {
+        self.goal = goal
+        self.currency = userCurrency
+        _name = State(initialValue: goal?.name ?? "")
+        _status = State(initialValue: goal?.status ?? .active)
+
+        let amount = goal?.targetAmount
+        _amount = State(initialValue: amount)
+        let amountString = amount.map {
+            Formatters.amountInput(for: userCurrency).string(from: $0 as NSDecimalNumber) ?? ""
+        } ?? ""
+        _amountText = State(initialValue: amountString)
+
+        let defaultDate = Calendar.current.date(byAdding: .year, value: 1, to: Date()) ?? Date()
+        _targetDate = State(initialValue: goal?.targetDateValue ?? defaultDate)
+    }
+
+    private var isEditing: Bool { goal != nil }
+
+    private var canSubmit: Bool {
+        guard let amount, amount > 0 else { return false }
+        return !name.trimmingCharacters(in: .whitespaces).isEmpty && !isLoading
+    }
+
+    var body: some View {
+        SheetFormContainer(
+            title: isEditing ? "Modifier l'objectif" : "Nouvel objectif",
+            isLoading: isLoading,
+            focus: $focusedField,
+            focusOrder: [.amount, .description]
+        ) {
+            HeroAmountField(
+                amount: $amount,
+                amountText: $amountText,
+                focus: $focusedField,
+                field: .amount,
+                currency: currency,
+                accentColor: accentColor
+            )
+            nameField
+            dateField
+            if isEditing {
+                CapsulePicker(selection: $status, title: "Statut") { item, _ in
+                    Text(item.label)
+                }
+            }
+
+            if let error {
+                ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
+                    self.error = nil
+                }
+            }
+
+            saveButton
+            if isEditing {
+                deleteButton
+            }
+        }
+        .confirmationDialog(
+            "Supprimer cet objectif ?",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Supprimer", role: .destructive) {
+                Task { await deleteGoal() }
+            }
+            Button("Annuler", role: .cancel) {}
+        } message: {
+            Text("Tes prévisions rattachées seront déliées, jamais supprimées.")
+        }
+    }
+
+    // MARK: - Fields
+
+    private var nameField: some View {
+        FormTextField(
+            hint: "Maison, vacances, voiture…",
+            text: $name,
+            label: "Nom de l'objectif",
+            accessibilityLabel: "Nom de l'objectif d'épargne",
+            focusBinding: $focusedField,
+            field: .description
+        )
+    }
+
+    private var dateField: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            Text("Échéance")
+                .font(PulpeTypography.labelMedium)
+                .foregroundStyle(Color.onSurfaceVariant)
+            DatePicker(
+                "Échéance",
+                selection: $targetDate,
+                in: Date()...,
+                displayedComponents: .date
+            )
+            .labelsHidden()
+            .datePickerStyle(.compact)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Buttons
+
+    private var saveButton: some View {
+        Button {
+            Task { await save() }
+        } label: {
+            Text(isEditing ? "Enregistrer" : "Créer l'objectif")
+        }
+        .disabled(!canSubmit)
+        .primaryButtonStyle(isEnabled: canSubmit)
+    }
+
+    private var deleteButton: some View {
+        Button(role: .destructive) {
+            showDeleteConfirmation = true
+        } label: {
+            Text("Supprimer l'objectif")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderless)
+        .tint(.red)
+        .disabled(isLoading)
+    }
+
+    // MARK: - Logic
+
+    private func save() async {
+        guard let amount else { return }
+        isLoading = true
+        defer { isLoading = false }
+        error = nil
+
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let dateString = SavingsGoalDateFormatter.string(from: targetDate)
+
+        do {
+            if let goal {
+                _ = try await store.update(
+                    id: goal.id,
+                    data: SavingsGoalUpdate(
+                        name: trimmedName,
+                        targetAmount: amount,
+                        targetDate: dateString,
+                        status: status
+                    )
+                )
+                toastManager.show("Objectif modifié")
+            } else {
+                _ = try await store.create(
+                    SavingsGoalCreate(
+                        name: trimmedName,
+                        targetAmount: amount,
+                        targetDate: dateString,
+                        status: .active
+                    )
+                )
+                toastManager.show("Objectif créé")
+            }
+            dismiss()
+        } catch {
+            self.error = error
+        }
+    }
+
+    private func deleteGoal() async {
+        guard let goal else { return }
+        isLoading = true
+        defer { isLoading = false }
+        error = nil
+        do {
+            try await store.delete(id: goal.id)
+            toastManager.show("Objectif supprimé")
+            dismiss()
+        } catch {
+            self.error = error
+        }
+    }
+}

--- a/ios/Pulpe/Features/SavingsGoals/SavingsGoalFormSheet.swift
+++ b/ios/Pulpe/Features/SavingsGoals/SavingsGoalFormSheet.swift
@@ -144,10 +144,11 @@ struct SavingsGoalFormSheet: View {
             showDeleteConfirmation = true
         } label: {
             Text("Supprimer l'objectif")
+                .font(PulpeTypography.buttonSecondary)
+                .foregroundStyle(Color.destructivePrimary)
                 .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.borderless)
-        .tint(.red)
+        .buttonStyle(.plain)
         .disabled(isLoading)
     }
 

--- a/ios/Pulpe/Features/SavingsGoals/SavingsGoalsEntryRow.swift
+++ b/ios/Pulpe/Features/SavingsGoals/SavingsGoalsEntryRow.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Dashboard entry point to the savings goals (PUL-12). Rendered inside the
+/// Épargne section of `CurrentMonthView`. Always reachable — even with no
+/// savings yet — so the empty state stays accessible (CA18). Neutral/primary
+/// only, never an alert color (RG-002).
+struct SavingsGoalsEntryRow: View {
+    let hasSavings: Bool
+
+    var body: some View {
+        HStack(spacing: DesignTokens.Spacing.md) {
+            Image(systemName: "target")
+                .font(PulpeTypography.actionIcon)
+                .foregroundStyle(Color.pulpePrimary)
+
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxs) {
+                Text(hasSavings ? "Voir mes objectifs" : "Fixe ton premier objectif")
+                    .font(PulpeTypography.listRowTitle)
+                    .foregroundStyle(Color.textPrimary)
+                if !hasSavings {
+                    Text("Suis tes projets d'épargne long terme")
+                        .font(PulpeTypography.listRowSubtitle)
+                        .foregroundStyle(Color.textTertiary)
+                }
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(PulpeTypography.caption)
+                .foregroundStyle(Color.textTertiary)
+        }
+        .padding(DesignTokens.Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .pulpeCard()
+    }
+}

--- a/ios/Pulpe/Features/SavingsGoals/SavingsGoalsListView.swift
+++ b/ios/Pulpe/Features/SavingsGoals/SavingsGoalsListView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+/// Navigation target for the savings goals, pushed from the dashboard Épargne
+/// section onto `CurrentMonthTab`'s stack.
+enum SavingsGoalDestination: Hashable {
+    case list
+}
+
+/// What the form sheet is editing — a new goal or an existing one.
+private enum SavingsGoalFormTarget: Identifiable {
+    case create
+    case edit(SavingsGoal)
+
+    var id: String {
+        switch self {
+        case .create: "create"
+        case .edit(let goal): goal.id
+        }
+    }
+
+    var goal: SavingsGoal? {
+        switch self {
+        case .create: nil
+        case .edit(let goal): goal
+        }
+    }
+}
+
+/// Lists the user's savings goals with create / edit / status / delete entry
+/// points (PUL-12). Progression (bars, rythme) is PUL-8 — not shown here.
+struct SavingsGoalsListView: View {
+    @Environment(SavingsGoalStore.self) private var store
+    @Environment(UserSettingsStore.self) private var userSettingsStore
+
+    @State private var formTarget: SavingsGoalFormTarget?
+
+    var body: some View {
+        Group {
+            if store.isLoading && store.goals.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if store.hasError, let error = store.error {
+                ErrorView(error: error) { await store.forceRefresh() }
+            } else if store.goals.isEmpty {
+                emptyState
+            } else {
+                goalList
+            }
+        }
+        .navigationTitle("Objectifs d'épargne")
+        .navigationBarTitleDisplayMode(.large)
+        .pulpeBackground()
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    formTarget = .create
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel("Ajouter un objectif")
+            }
+        }
+        .sheet(item: $formTarget) { target in
+            SavingsGoalFormSheet(goal: target.goal, userCurrency: userSettingsStore.currency)
+        }
+        .task { await store.loadIfNeeded() }
+        .trackScreen("SavingsGoalsList")
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: DesignTokens.Spacing.lg) {
+            Image(systemName: "target")
+                .font(PulpeTypography.emojiDisplay)
+                .foregroundStyle(Color.textTertiary)
+                .symbolEffect(.pulse, options: .nonRepeating)
+            Text("Fixe ton premier objectif")
+                .font(PulpeTypography.stepTitle)
+                .foregroundStyle(Color.textPrimary)
+            Text("Suis tes projets d'épargne long terme, sans recalculer à la main")
+                .font(PulpeTypography.bodyLarge)
+                .foregroundStyle(Color.textTertiary)
+                .multilineTextAlignment(.center)
+            Button("Créer un objectif") {
+                formTarget = .create
+            }
+            .primaryButtonStyle()
+        }
+        .padding(DesignTokens.Spacing.xxxl)
+    }
+
+    // MARK: - List
+
+    private var goalList: some View {
+        List {
+            ForEach(store.goals) { goal in
+                Button {
+                    formTarget = .edit(goal)
+                } label: {
+                    SavingsGoalRow(goal: goal, currency: userSettingsStore.currency)
+                }
+                .buttonStyle(.plain)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .refreshable { await store.forceRefresh() }
+    }
+}
+
+// MARK: - Row
+
+private struct SavingsGoalRow: View {
+    let goal: SavingsGoal
+    let currency: SupportedCurrency
+
+    var body: some View {
+        HStack(alignment: .center, spacing: DesignTokens.Spacing.md) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+                Text(goal.name)
+                    .font(PulpeTypography.listRowTitle)
+                    .foregroundStyle(Color.textPrimary)
+                HStack(spacing: DesignTokens.Spacing.sm) {
+                    SavingsGoalStatusBadge(status: goal.status)
+                    if let date = goal.targetDateValue {
+                        Text("Échéance \(date.formatted(date: .abbreviated, time: .omitted))")
+                            .font(PulpeTypography.listRowSubtitle)
+                            .foregroundStyle(Color.textTertiary)
+                    }
+                }
+            }
+            Spacer()
+            Text(goal.targetAmount.asCurrency(currency))
+                .font(PulpeTypography.amountCard)
+                .foregroundStyle(Color.textPrimary)
+        }
+        .padding(DesignTokens.Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .pulpeCard()
+        .padding(.vertical, DesignTokens.Spacing.xs)
+    }
+}
+
+// MARK: - Status badge
+
+private struct SavingsGoalStatusBadge: View {
+    let status: SavingsGoalStatus
+
+    var body: some View {
+        Text(status.label)
+            .font(PulpeTypography.metricMini)
+            .foregroundStyle(color)
+            .padding(.horizontal, DesignTokens.Spacing.sm)
+            .padding(.vertical, DesignTokens.Spacing.xxs)
+            .background(color.opacity(0.12), in: Capsule())
+    }
+
+    /// Neutral / primary only — savings is never an alert color (RG-002).
+    private var color: Color {
+        switch status {
+        case .active: Color.pulpePrimary
+        case .completed: TransactionKind.saving.color
+        case .paused: Color.textTertiary
+        }
+    }
+}

--- a/ios/Pulpe/Features/SavingsGoals/SavingsGoalsListView.swift
+++ b/ios/Pulpe/Features/SavingsGoals/SavingsGoalsListView.swift
@@ -135,6 +135,7 @@ private struct SavingsGoalRow: View {
             Spacer()
             Text(goal.targetAmount.asCurrency(currency))
                 .font(PulpeTypography.amountCard)
+                .monospacedDigit()
                 .foregroundStyle(Color.textPrimary)
         }
         .padding(DesignTokens.Spacing.lg)
@@ -155,7 +156,7 @@ private struct SavingsGoalStatusBadge: View {
             .foregroundStyle(color)
             .padding(.horizontal, DesignTokens.Spacing.sm)
             .padding(.vertical, DesignTokens.Spacing.xxs)
-            .background(color.opacity(0.12), in: Capsule())
+            .background(color.opacity(DesignTokens.Opacity.badgeBackground), in: Capsule())
     }
 
     /// Neutral / primary only — savings is never an alert color (RG-002).

--- a/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
@@ -12,6 +12,7 @@ struct EditTemplateLineSheet: View {
     @State private var amount: Decimal?
     @State private var kind: TransactionKind
     @State private var recurrence: TransactionRecurrence
+    @State private var savingsGoalId: String?
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var focusedField: AmountDescriptionField?
@@ -39,6 +40,7 @@ struct EditTemplateLineSheet: View {
         _name = State(initialValue: templateLine.name)
         _kind = State(initialValue: templateLine.kind)
         _recurrence = State(initialValue: templateLine.recurrence)
+        _savingsGoalId = State(initialValue: templateLine.savingsGoalId)
 
         let inputCurrency = templateLine.originalCurrency ?? userCurrency
         let editableAmount = Self.initialAmount(for: templateLine, userCurrency: userCurrency)
@@ -85,6 +87,9 @@ struct EditTemplateLineSheet: View {
             )
             descriptionField
             recurrenceSelector
+            if kind == .saving {
+                SavingsGoalPickerField(selection: $savingsGoalId)
+            }
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -95,6 +100,10 @@ struct EditTemplateLineSheet: View {
             saveButton
         }
         .sensoryFeedback(.success, trigger: submitSuccessTrigger)
+        .onChange(of: kind) { _, newKind in
+            // Mirror the backend kind-guard: only savings can carry a goal.
+            if newKind != .saving { savingsGoalId = nil }
+        }
         .task {
             do {
                 usageData = try await dependencies.checkTemplateUsage(templateLine.templateId)
@@ -185,13 +194,17 @@ struct EditTemplateLineSheet: View {
                 nil
             }
 
-            pendingUpdate = Self.buildUpdate(
+            var update = Self.buildUpdate(
                 name: name.trimmingCharacters(in: .whitespaces),
                 amount: amount,
                 kind: kind,
                 recurrence: recurrence,
                 conversion: conversion
             )
+            // Always emit the link (id or explicit null) so a saving line can be
+            // tagged or untagged; the kind-guard clears it for non-saving kinds.
+            update.savingsGoalId = .some(kind.savingsGoalLink(savingsGoalId))
+            pendingUpdate = update
 
             let hasBudgets = usageFetchFailed || (usageData?.propagationBudgetCount ?? 0) > 0
             if hasBudgets {
@@ -235,6 +248,7 @@ struct EditTemplateLineSheet: View {
                     kind: data.kind,
                     recurrence: data.recurrence,
                     description: data.description,
+                    savingsGoalId: data.savingsGoalId,
                     originalAmount: data.originalAmount,
                     originalCurrency: data.originalCurrency,
                     targetCurrency: data.targetCurrency,
@@ -349,4 +363,5 @@ struct EditTemplateLineDependencies: Sendable {
     .environment(ToastManager())
     .environment(UserSettingsStore())
     .environment(FeatureFlagsStore())
+    .environment(SavingsGoalStore())
 }

--- a/ios/Pulpe/Shared/Components/EditBudgetLineSheet.swift
+++ b/ios/Pulpe/Shared/Components/EditBudgetLineSheet.swift
@@ -11,6 +11,7 @@ struct EditBudgetLineSheet: View {
     @State private var name: String
     @State private var amount: Decimal?
     @State private var kind: TransactionKind
+    @State private var savingsGoalId: String?
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var focusedField: AmountDescriptionField?
@@ -33,6 +34,7 @@ struct EditBudgetLineSheet: View {
         self.onUpdate = onUpdate
         _name = State(initialValue: budgetLine.name)
         _kind = State(initialValue: budgetLine.kind)
+        _savingsGoalId = State(initialValue: budgetLine.savingsGoalId)
 
         let inputCurrency = budgetLine.originalCurrency ?? userCurrency
         let editableAmount = Self.initialAmount(for: budgetLine, userCurrency: userCurrency)
@@ -78,6 +80,9 @@ struct EditBudgetLineSheet: View {
                 exchangeRate: budgetLine.exchangeRate
             )
             descriptionField
+            if kind == .saving {
+                SavingsGoalPickerField(selection: $savingsGoalId)
+            }
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -88,6 +93,10 @@ struct EditBudgetLineSheet: View {
             saveButton
         }
         .sensoryFeedback(.success, trigger: submitSuccessTrigger)
+        .onChange(of: kind) { _, newKind in
+            // Mirror the backend kind-guard: only savings can carry a goal.
+            if newKind != .saving { savingsGoalId = nil }
+        }
     }
 
     // MARK: - Description
@@ -135,13 +144,16 @@ struct EditBudgetLineSheet: View {
                 nil
             }
 
-            let data = Self.buildUpdate(
+            var data = Self.buildUpdate(
                 id: budgetLine.id,
                 name: name.trimmingCharacters(in: .whitespaces),
                 amount: amount,
                 kind: kind,
                 conversion: conversion
             )
+            // Always emit the link (id or explicit null) so a saving line can be
+            // tagged or untagged; the kind-guard clears it for non-saving kinds.
+            data.savingsGoalId = .some(kind.savingsGoalLink(savingsGoalId))
 
             let updatedLine = try await dependencies.updateBudgetLine(budgetLine.id, data)
             submitSuccessTrigger.toggle()
@@ -175,6 +187,9 @@ struct EditBudgetLineSheet: View {
 
     /// Builds the update DTO. When the line is mono-currency (or flag-off fallback),
     /// currency metadata is omitted so the backend preserves the existing values.
+    /// Builds the update DTO. When the line is mono-currency (or flag-off fallback),
+    /// currency metadata is omitted so the backend preserves the existing values.
+    /// The savings-goal link is applied by the caller (see `updateBudgetLine`).
     static func buildUpdate(
         id: String,
         name: String,
@@ -238,4 +253,5 @@ struct EditBudgetLineDependencies: Sendable {
     .environment(ToastManager())
     .environment(UserSettingsStore())
     .environment(FeatureFlagsStore())
+    .environment(SavingsGoalStore())
 }

--- a/ios/Pulpe/Shared/Components/SavingsGoalPickerField.swift
+++ b/ios/Pulpe/Shared/Components/SavingsGoalPickerField.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Form field that tags a saving prévision to a savings goal (PUL-12).
+///
+/// Reused by the template-line editor (primary tagging surface) and the
+/// budget-line Add/Edit sheets. Callers show it only for `kind == .saving`;
+/// `selection` is the goal id (`nil` = "Aucun objectif"). Reads goals from the
+/// app-level `SavingsGoalStore` and refreshes them when it appears.
+struct SavingsGoalPickerField: View {
+    @Binding var selection: String?
+
+    @Environment(SavingsGoalStore.self) private var store
+
+    private var selectedGoal: SavingsGoal? {
+        guard let selection else { return nil }
+        return store.goals.first { $0.id == selection }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            Text("Objectif")
+                .font(PulpeTypography.labelMedium)
+                .foregroundStyle(Color.onSurfaceVariant)
+
+            Menu {
+                pickerButton(title: "Aucun objectif", isSelected: selection == nil) {
+                    selection = nil
+                }
+                if !store.goals.isEmpty {
+                    Divider()
+                    ForEach(store.goals) { goal in
+                        pickerButton(title: goal.name, isSelected: goal.id == selection) {
+                            selection = goal.id
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Text(selectedGoal?.name ?? "Aucun objectif")
+                        .foregroundStyle(selectedGoal == nil ? Color.onSurfaceVariant : Color.textPrimary)
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption)
+                        .foregroundStyle(Color.onSurfaceVariant)
+                }
+                .padding(.horizontal, DesignTokens.Spacing.lg)
+                .frame(maxWidth: .infinity, minHeight: DesignTokens.TapTarget.minimum, alignment: .leading)
+                .background(
+                    Color.surfaceContainerLow,
+                    in: RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.button)
+                )
+            }
+            .accessibilityLabel("Objectif d'épargne")
+            .accessibilityValue(selectedGoal?.name ?? "Aucun objectif")
+        }
+        .task { await store.loadIfNeeded() }
+    }
+
+    @ViewBuilder
+    private func pickerButton(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            if isSelected {
+                Label(title, systemImage: "checkmark")
+            } else {
+                Text(title)
+            }
+        }
+    }
+}

--- a/ios/PulpeTests/App/SessionDataResetterTests.swift
+++ b/ios/PulpeTests/App/SessionDataResetterTests.swift
@@ -76,12 +76,14 @@ struct SessionDataResetterTests {
         let budgetListStore = BudgetListStore()
         let dashboardStore = DashboardStore()
         let userSettingsStore = UserSettingsStore()
+        let savingsGoalStore = SavingsGoalStore()
 
         let sut = LiveSessionDataResetter(
             currentMonthStore: currentMonthStore,
             budgetListStore: budgetListStore,
             dashboardStore: dashboardStore,
-            userSettingsStore: userSettingsStore
+            userSettingsStore: userSettingsStore,
+            savingsGoalStore: savingsGoalStore
         )
 
         sut.resetStores()
@@ -94,6 +96,7 @@ struct SessionDataResetterTests {
         #expect(budgetListStore.hasLoadedOnce == false)
         #expect(dashboardStore.sparseBudgets.isEmpty)
         #expect(userSettingsStore.payDayOfMonth == nil)
+        #expect(savingsGoalStore.goals.isEmpty)
     }
 }
 

--- a/ios/PulpeTests/Domain/Models/SavingsGoalCodableTests.swift
+++ b/ios/PulpeTests/Domain/Models/SavingsGoalCodableTests.swift
@@ -136,6 +136,20 @@ struct SavingsGoalCodableTests {
         #expect(try encodedObject(tag)["savingsGoalId"] as? String == "goal-9")
     }
 
+    @Test("TemplateLineUpdateWithId tri-states the link (bulk-propagate path)")
+    func templateLineUpdateWithId_triState() throws {
+        let unset = try encodedObject(TemplateLineUpdateWithId(id: "tl-1", name: "Épargne"))
+        #expect(unset["savingsGoalId"] == nil)
+
+        var untag = TemplateLineUpdateWithId(id: "tl-1")
+        untag.savingsGoalId = .some(nil)
+        #expect(try encodedObject(untag)["savingsGoalId"] is NSNull)
+
+        var tag = TemplateLineUpdateWithId(id: "tl-1")
+        tag.savingsGoalId = .some("goal-9")
+        #expect(try encodedObject(tag)["savingsGoalId"] as? String == "goal-9")
+    }
+
     @Test("TemplateLineCreate omits link when nil, sends id when set")
     func templateLineCreate_link() throws {
         let untagged = try encodedObject(

--- a/ios/PulpeTests/Domain/Models/SavingsGoalCodableTests.swift
+++ b/ios/PulpeTests/Domain/Models/SavingsGoalCodableTests.swift
@@ -84,6 +84,16 @@ struct SavingsGoalCodableTests {
         #expect((object["targetAmount"] as? NSNumber)?.intValue == 12000)
     }
 
+    // MARK: - Kind guard
+
+    @Test("savingsGoalLink keeps the id only for saving, clears it otherwise")
+    func kindGuard_savingsGoalLink() {
+        #expect(TransactionKind.saving.savingsGoalLink("goal-1") == "goal-1")
+        #expect(TransactionKind.saving.savingsGoalLink(nil) == nil)
+        #expect(TransactionKind.expense.savingsGoalLink("goal-1") == nil)
+        #expect(TransactionKind.income.savingsGoalLink("goal-1") == nil)
+    }
+
     // MARK: - Tri-state savingsGoalId (BudgetLineUpdate)
 
     @Test("BudgetLineUpdate omits savingsGoalId when unset (no change)")

--- a/ios/PulpeTests/Domain/Models/SavingsGoalCodableTests.swift
+++ b/ios/PulpeTests/Domain/Models/SavingsGoalCodableTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+/// Locks the PUL-12 iOS ↔ API contract: `SavingsGoal` decoding, the create DTO
+/// shape, and — critically — the tri-state `savingsGoalId` PATCH encoding
+/// (omit / explicit-null / value) that drives tagging & untagging.
+struct SavingsGoalCodableTests {
+    private func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    /// Encodes `value` and returns the JSON object as a dictionary so key
+    /// presence and `null` can be asserted distinctly.
+    private func encodedObject(_ value: some Encodable) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try #require(object as? [String: Any])
+    }
+
+    // MARK: - SavingsGoal decoding
+
+    @Test("SavingsGoal decodes the API response (camelCase, ISO date, null FX)")
+    func savingsGoal_decodes() throws {
+        let json = Data("""
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "userId": "22222222-2222-2222-2222-222222222222",
+            "name": "Maison",
+            "targetAmount": 50000,
+            "targetDate": "2027-12-31",
+            "status": "ACTIVE",
+            "createdAt": "2026-06-23T10:00:00Z",
+            "updatedAt": "2026-06-23T10:00:00Z",
+            "originalTargetAmount": null,
+            "originalCurrency": null,
+            "targetCurrency": null,
+            "exchangeRate": null
+        }
+        """.utf8)
+
+        let goal = try decoder().decode(SavingsGoal.self, from: json)
+
+        #expect(goal.id == "11111111-1111-1111-1111-111111111111")
+        #expect(goal.name == "Maison")
+        #expect(goal.targetAmount == 50000)
+        #expect(goal.targetDate == "2027-12-31")
+        #expect(goal.status == .active)
+        #expect(goal.originalTargetAmount == nil)
+        #expect(goal.targetDateValue == SavingsGoalDateFormatter.parse("2027-12-31"))
+    }
+
+    @Test("SavingsGoalStatus maps every raw value")
+    func status_rawValues() {
+        #expect(SavingsGoalStatus(rawValue: "ACTIVE") == .active)
+        #expect(SavingsGoalStatus(rawValue: "COMPLETED") == .completed)
+        #expect(SavingsGoalStatus(rawValue: "PAUSED") == .paused)
+        #expect(SavingsGoalStatus.allCases.count == 3)
+    }
+
+    @Test("ISO date formatter round-trips YYYY-MM-DD")
+    func dateFormatter_roundTrips() throws {
+        let date = try #require(SavingsGoalDateFormatter.parse("2027-12-31"))
+        #expect(SavingsGoalDateFormatter.string(from: date) == "2027-12-31")
+    }
+
+    // MARK: - Create DTO
+
+    @Test("SavingsGoalCreate encodes name/targetAmount/targetDate/status")
+    func savingsGoalCreate_encodes() throws {
+        let dto = SavingsGoalCreate(
+            name: "Voiture",
+            targetAmount: 12000,
+            targetDate: "2028-01-01",
+            status: .active
+        )
+        let object = try encodedObject(dto)
+
+        #expect(object["name"] as? String == "Voiture")
+        #expect(object["targetDate"] as? String == "2028-01-01")
+        #expect(object["status"] as? String == "ACTIVE")
+        #expect((object["targetAmount"] as? NSNumber)?.intValue == 12000)
+    }
+
+    // MARK: - Tri-state savingsGoalId (BudgetLineUpdate)
+
+    @Test("BudgetLineUpdate omits savingsGoalId when unset (no change)")
+    func budgetLineUpdate_omitsLinkWhenUnset() throws {
+        let dto = BudgetLineUpdate(id: "line-1", name: "Épargne")
+        let object = try encodedObject(dto)
+        #expect(object["savingsGoalId"] == nil, "unset link must be omitted, not null")
+    }
+
+    @Test("BudgetLineUpdate sends explicit null to untag")
+    func budgetLineUpdate_sendsNullToUntag() throws {
+        var dto = BudgetLineUpdate(id: "line-1")
+        dto.savingsGoalId = .some(nil)
+        let object = try encodedObject(dto)
+        #expect(object.keys.contains("savingsGoalId"), "untag must include the key")
+        #expect(object["savingsGoalId"] is NSNull, "untag must send explicit null")
+    }
+
+    @Test("BudgetLineUpdate sends the goal id when tagging")
+    func budgetLineUpdate_sendsIdWhenTagging() throws {
+        var dto = BudgetLineUpdate(id: "line-1")
+        dto.savingsGoalId = .some("goal-7")
+        let object = try encodedObject(dto)
+        #expect(object["savingsGoalId"] as? String == "goal-7")
+    }
+
+    // MARK: - Tri-state savingsGoalId (TemplateLineUpdate) + Create
+
+    @Test("TemplateLineUpdate tri-states the savings-goal link")
+    func templateLineUpdate_triState() throws {
+        let unset = try encodedObject(TemplateLineUpdate(name: "Épargne"))
+        #expect(unset["savingsGoalId"] == nil)
+
+        var untag = TemplateLineUpdate()
+        untag.savingsGoalId = .some(nil)
+        #expect(try encodedObject(untag)["savingsGoalId"] is NSNull)
+
+        var tag = TemplateLineUpdate()
+        tag.savingsGoalId = .some("goal-9")
+        #expect(try encodedObject(tag)["savingsGoalId"] as? String == "goal-9")
+    }
+
+    @Test("TemplateLineCreate omits link when nil, sends id when set")
+    func templateLineCreate_link() throws {
+        let untagged = try encodedObject(
+            TemplateLineCreate(name: "Épargne", amount: 100, kind: .saving, recurrence: .fixed)
+        )
+        #expect(untagged["savingsGoalId"] == nil)
+
+        let tagged = try encodedObject(
+            TemplateLineCreate(
+                name: "Épargne",
+                amount: 100,
+                kind: .saving,
+                recurrence: .fixed,
+                savingsGoalId: "goal-3"
+            )
+        )
+        #expect(tagged["savingsGoalId"] as? String == "goal-3")
+    }
+}

--- a/ios/PulpeTests/Domain/Store/SavingsGoalStoreTests.swift
+++ b/ios/PulpeTests/Domain/Store/SavingsGoalStoreTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+@MainActor
+struct SavingsGoalStoreTests {
+    private func makeGoal(
+        id: String,
+        name: String = "Goal",
+        status: SavingsGoalStatus = .active
+    ) -> SavingsGoal {
+        SavingsGoal(
+            id: id,
+            userId: "user-1",
+            name: name,
+            targetAmount: 1000,
+            targetDate: "2099-01-01",
+            status: status,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    @Test("forceRefresh loads goals, ACTIVE before COMPLETED")
+    func forceRefresh_loadsAndSorts() async {
+        let service = MockSavingsGoalService()
+        service.stubbedGoals = [
+            makeGoal(id: "done", name: "Alpha", status: .completed),
+            makeGoal(id: "active", name: "Zebra", status: .active),
+        ]
+        let store = SavingsGoalStore(service: service)
+
+        await store.forceRefresh()
+
+        #expect(store.goals.count == 2)
+        #expect(store.goals.first?.status == .active, "ACTIVE goals sort before COMPLETED")
+        #expect(store.goals.last?.status == .completed)
+        #expect(store.hasLoadedOnce)
+        #expect(store.error == nil)
+    }
+
+    @Test("create appends to the cache and forwards the DTO")
+    func create_appends() async throws {
+        let service = MockSavingsGoalService()
+        let store = SavingsGoalStore(service: service)
+
+        let created = try await store.create(
+            SavingsGoalCreate(name: "Maison", targetAmount: 5000, targetDate: "2099-01-01", status: .active)
+        )
+
+        #expect(store.goals.count == 1)
+        #expect(store.goals.first?.id == created.id)
+        #expect(service.lastCreate?.name == "Maison")
+    }
+
+    @Test("update replaces the goal in the cache (status change)")
+    func update_replaces() async throws {
+        let service = MockSavingsGoalService()
+        service.stubbedGoals = [makeGoal(id: "g1", status: .active)]
+        let store = SavingsGoalStore(service: service)
+        await store.forceRefresh()
+
+        _ = try await store.update(id: "g1", data: SavingsGoalUpdate(status: .completed))
+
+        #expect(store.goals.first { $0.id == "g1" }?.status == .completed)
+        #expect(service.lastUpdate?.status == .completed)
+    }
+
+    @Test("delete removes the goal from the cache")
+    func delete_removes() async throws {
+        let service = MockSavingsGoalService()
+        service.stubbedGoals = [makeGoal(id: "g1")]
+        let store = SavingsGoalStore(service: service)
+        await store.forceRefresh()
+
+        try await store.delete(id: "g1")
+
+        #expect(store.goals.isEmpty)
+        #expect(service.lastDeletedId == "g1")
+    }
+
+    @Test("forceRefresh surfaces an API error")
+    func forceRefresh_surfacesError() async {
+        let service = MockSavingsGoalService()
+        service.error = APIError.networkError(URLError(.notConnectedToInternet))
+        let store = SavingsGoalStore(service: service)
+
+        await store.forceRefresh()
+
+        #expect(store.error != nil)
+        #expect(store.goals.isEmpty)
+    }
+
+    @Test("reset clears the cache")
+    func reset_clears() async {
+        let service = MockSavingsGoalService()
+        service.stubbedGoals = [makeGoal(id: "g1")]
+        let store = SavingsGoalStore(service: service)
+        await store.forceRefresh()
+        #expect(!store.goals.isEmpty)
+
+        store.reset()
+
+        #expect(store.goals.isEmpty)
+        #expect(store.hasLoadedOnce == false)
+        #expect(store.error == nil)
+    }
+}

--- a/ios/PulpeTests/Helpers/MockSavingsGoalService.swift
+++ b/ios/PulpeTests/Helpers/MockSavingsGoalService.swift
@@ -1,0 +1,82 @@
+import Foundation
+@testable import Pulpe
+
+/// Test double for `SavingsGoalServicing`. `@MainActor`-isolated (not an `actor`)
+/// so call counts and captured payloads are readable synchronously from the
+/// `@MainActor` tests that drive `SavingsGoalStore`.
+@MainActor
+final class MockSavingsGoalService: SavingsGoalServicing {
+    var stubbedGoals: [SavingsGoal] = []
+    /// When set, every call throws this instead of returning.
+    var error: Error?
+
+    private(set) var getAllCallCount = 0
+    private(set) var createCallCount = 0
+    private(set) var updateCallCount = 0
+    private(set) var deleteCallCount = 0
+    private(set) var lastCreate: SavingsGoalCreate?
+    private(set) var lastUpdateId: String?
+    private(set) var lastUpdate: SavingsGoalUpdate?
+    private(set) var lastDeletedId: String?
+
+    func getAll() async throws -> [SavingsGoal] {
+        getAllCallCount += 1
+        if let error { throw error }
+        return stubbedGoals
+    }
+
+    func get(id: String) async throws -> SavingsGoal {
+        if let error { throw error }
+        if let goal = stubbedGoals.first(where: { $0.id == id }) { return goal }
+        throw URLError(.badServerResponse)
+    }
+
+    func create(_ data: SavingsGoalCreate) async throws -> SavingsGoal {
+        createCallCount += 1
+        lastCreate = data
+        if let error { throw error }
+        let created = SavingsGoal(
+            id: "goal-\(createCallCount)",
+            userId: "user-1",
+            name: data.name,
+            targetAmount: data.targetAmount,
+            targetDate: data.targetDate,
+            status: data.status,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+        stubbedGoals.append(created)
+        return created
+    }
+
+    func update(id: String, data: SavingsGoalUpdate) async throws -> SavingsGoal {
+        updateCallCount += 1
+        lastUpdateId = id
+        lastUpdate = data
+        if let error { throw error }
+        guard let existing = stubbedGoals.first(where: { $0.id == id }) else {
+            throw URLError(.badServerResponse)
+        }
+        let updated = SavingsGoal(
+            id: existing.id,
+            userId: existing.userId,
+            name: data.name ?? existing.name,
+            targetAmount: data.targetAmount ?? existing.targetAmount,
+            targetDate: data.targetDate ?? existing.targetDate,
+            status: data.status ?? existing.status,
+            createdAt: existing.createdAt,
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+        if let index = stubbedGoals.firstIndex(where: { $0.id == id }) {
+            stubbedGoals[index] = updated
+        }
+        return updated
+    }
+
+    func delete(id: String) async throws {
+        deleteCallCount += 1
+        lastDeletedId = id
+        if let error { throw error }
+        stubbedGoals.removeAll { $0.id == id }
+    }
+}


### PR DESCRIPTION
## Summary

iOS surface for **Savings Goals** (epic PUL-98) — create/manage goals and tag savings _prévisions_ to them from the native app. Builds on the backend + shared foundation in #485 (same `preview` base). Progression (bars/rythme) stays out — that's PUL-8.

Closes the **iOS** scope of **PUL-12**.

## Scope

In: `ios/` only. Out (other scopes): web (CA23–26), progression (PUL-8), Phase 3 (PUL-285).

## What ships (CA17–CA22)

- **Data layer**: `SavingsGoal` model + `SavingsGoalStatus`, `SavingsGoalService` (actor, CRUD), `SavingsGoalStore` (`@Observable`, injected at app root, reset on logout). `/savings-goals` endpoints.
- **Dashboard entry (CA17/CA18)**: the Épargne section always shows a goals entry — **« Voir mes objectifs »** when there's savings, **« Fixe ton premier objectif »** when not (the summary card is hidden with no savings, so the entry can't live only on it). The card stays a monthly summary, goal-agnostic.
- **List + form + status + delete (CA19)**: `SavingsGoalsListView` (empty state, create/edit), `SavingsGoalFormSheet` (name, target amount, échéance ≥ today, status Actif/En pause/Atteint with COMPLETED reversible, delete). DELETE unlinks prévisions server-side; none are deleted.
- **Navigation (CA22)**: `CurrentMonthTab` → `SavingsGoalDestination` → list. (The v1 "détail" is the edit form; the progression detail is PUL-8.)
- **Tagging (CA20/CA21)**: reusable `SavingsGoalPickerField` in the **template-line editor** (primary surface), the **budget-line Add + Edit** sheets — shown only for `kind == saving`.
  - `BudgetLineUpdate` + `TemplateLine`(+`Create`/`Update`/`UpdateWithId`) gain `savingsGoalId` (CA21/CA20). The three PATCH DTOs use a **tri-state `String??`**: omit (no change) / explicit `null` (untag) / id (tag) — the only way to express untag through a partial PATCH.
  - Both template save paths carry the link: single PATCH **and** bulk "Appliquer aux mois suivants".
- **Kind-guard (cross-cutting)**: `TransactionKind.savingsGoalLink` clears the link for non-saving on create and update, mirroring the backend guard.
- **CA27/CA28**: account currency only (no selector); savings never amber/red.

## Tests added

- Codec contract: `SavingsGoal` decode, create DTO, and the tri-state `savingsGoalId` encoding (omit / `NSNull` / value) for `BudgetLineUpdate`, `TemplateLineUpdate` **and** `TemplateLineUpdateWithId`.
- Kind-guard (`savingsGoalLink`), `SavingsGoalStore` (load/sort/create/update/delete/reset/error) via a mock service, and `LiveSessionDataResetter` now resets the savings store.

## QA

- `xcodebuild` (PulpeLocal) build green; `swiftlint --strict` clean on every changed file.
- Full `PulpeTests` suite: **1565 pass**, 1 known **pre-existing** failure — `BudgetDetailsCoordinatorTests.showCheckToast…SwissLocale` (CHF decimal separator). It passes in isolation and still reproduces with all savings tests skipped (a `NumberFormatter`-cache test-ordering issue in code this PR doesn't touch). Not a PUL-12 regression.

## Review

Two adversarial `code-reviewer` passes (correctness/contract/integration + iOS conventions/concurrency/design). No correctness, contract, or concurrency defects. Fixed every confirmed design-system finding: destructive delete uses `Color.destructivePrimary` (was raw red), list amount gains `.monospacedDigit()`, status-badge opacity via `DesignTokens.Opacity.badgeBackground`, plus the added bulk-path encoding test.

## Follow-ups

- PUL-12 **web** (CA23–26), then **PUL-8** progression detail.
- Minor (deferred, LOW): `SavingsGoalStore` mutations aren't guarded against an in-flight `forceRefresh` (transient staleness only; matches the existing `BudgetListStore` precedent).

Issue: https://linear.app/pulpe/issue/PUL-12
