### PR TITLE
fix(spread): await onSpread callback in lisser-existing sheet (PUL-17)

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Routing.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Routing.swift
@@ -59,19 +59,20 @@ extension BudgetDetailsView {
                 currency: userSettingsStore.currency
             )
         case .spreadExisting(let source):
+            // The closure is awaited by the sheet (behind its blocking overlay),
+            // so dispatch directly — NO wrapping `Task`, which would return
+            // instantly and defeat the in-progress feedback.
             SpreadExistingSheet(source: source, currency: userSettingsStore.currency) { periods in
                 let ctx = toastContext
-                Task {
-                    switch source.sourceType {
-                    case .budgetLine:
-                        await coordinator.dispatch(
-                            .spreadBudgetLineFromExisting(lineId: source.id, periods: periods, ctx)
-                        )
-                    case .transaction:
-                        await coordinator.dispatch(
-                            .spreadTransactionFromExisting(txId: source.id, periods: periods, ctx)
-                        )
-                    }
+                switch source.sourceType {
+                case .budgetLine:
+                    await coordinator.dispatch(
+                        .spreadBudgetLineFromExisting(lineId: source.id, periods: periods, ctx)
+                    )
+                case .transaction:
+                    await coordinator.dispatch(
+                        .spreadTransactionFromExisting(txId: source.id, periods: periods, ctx)
+                    )
                 }
             }
         }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -261,6 +261,12 @@ struct SpreadExistingSheet: View {
                 // instant close (parity with the additive `AddBudgetLineSheet`).
                 guard !isSubmitting else { return }
                 isSubmitting = true
+                // Reset on every exit path so the sheet can never lock with the
+                // overlay up + cancel/swipe disabled — same escape hatch as every
+                // other submit handler (e.g. `AddBudgetLineSheet`). In the normal
+                // path `dismiss()` tears the view down anyway; this only matters if
+                // `dismiss()` no-ops or `onSpread` ever becomes throwing.
+                defer { isSubmitting = false }
                 await onSpread(calculator.periods())
                 dismiss()
             }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -5,12 +5,14 @@ import SwiftUI
 /// The source total is LOCKED (read-only): the user picks the end month + the
 /// months to skip, and `T` is redistributed into `T/N` via the calculator's
 /// `SpreadSplit` (M0 included, drops to ~T/N). Mirrors the web
-/// `SpreadExistingDialog`. On submit it emits the chosen `periods` and dismisses;
-/// the caller routes them to the coordinator (which deletes the source + fans out).
+/// `SpreadExistingDialog`. On submit it awaits the caller's spread work behind a
+/// blocking loading overlay and dismisses only once it completes (parity with the
+/// additive `AddBudgetLineSheet` flow); the caller routes the chosen `periods` to
+/// the coordinator (which deletes the source + fans out).
 struct SpreadExistingSheet: View {
     let source: SpreadExistingSource
     let currency: SupportedCurrency
-    let onSpread: ([SpreadFromExistingPeriod]) -> Void
+    let onSpread: ([SpreadFromExistingPeriod]) async -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var calculator: SpreadExistingCalculator
@@ -20,7 +22,7 @@ struct SpreadExistingSheet: View {
     init(
         source: SpreadExistingSource,
         currency: SupportedCurrency,
-        onSpread: @escaping ([SpreadFromExistingPeriod]) -> Void
+        onSpread: @escaping ([SpreadFromExistingPeriod]) async -> Void
     ) {
         self.source = source
         self.currency = currency
@@ -62,6 +64,10 @@ struct SpreadExistingSheet: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { SheetCloseButton() }
             }
+            // Blocking overlay while the spread runs server-side (delete source +
+            // fan out N tranches) — parity with the additive flow. The message
+            // matters: a bare spinner on a multi-month fan-out reads as frozen.
+            .loadingOverlay(isSubmitting, message: "Lissage en cours…")
             .sheet(isPresented: $isPickingEnd) {
                 SpreadMonthPickerSheet(
                     title: "Dernier mois",
@@ -238,13 +244,17 @@ struct SpreadExistingSheet: View {
 
     private var submitButton: some View {
         Button {
-            // The sheet dismisses synchronously, but the dismiss animation isn't
-            // instant — a fast double-tap would otherwise spawn two dispatches on
-            // the same source (the 2nd hits a 404 after the 1st deletes it).
-            guard !isSubmitting else { return }
-            isSubmitting = true
-            onSpread(calculator.periods())
-            dismiss()
+            Task {
+                // `isSubmitting` guards against a double-tap (the button is also
+                // disabled while it's true) AND drives the blocking overlay. We
+                // await the caller's spread work and dismiss only once it
+                // completes, so the user gets in-progress feedback instead of an
+                // instant close (parity with the additive `AddBudgetLineSheet`).
+                guard !isSubmitting else { return }
+                isSubmitting = true
+                await onSpread(calculator.periods())
+                dismiss()
+            }
         } label: {
             Text(spreadTitle)
         }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -62,7 +62,12 @@ struct SpreadExistingSheet: View {
             .navigationTitle(spreadTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) { SheetCloseButton() }
+                // Disabled during submit: the loading overlay covers SwiftUI
+                // content but not the UIKit nav bar, so without this the user
+                // could dismiss mid-spread while the fan-out keeps running.
+                ToolbarItem(placement: .cancellationAction) {
+                    SheetCloseButton().disabled(isSubmitting)
+                }
             }
             // Blocking overlay while the spread runs server-side (delete source +
             // fan out N tranches) — parity with the additive flow. The message

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadExistingSheet.swift
@@ -83,6 +83,10 @@ struct SpreadExistingSheet: View {
             }
         }
         .standardSheetPresentation(detents: [.medium, .large])
+        // Block swipe-to-dismiss while the spread runs — same guard as the
+        // disabled cancel button, closing the other path that could dismiss the
+        // sheet mid-fan-out (parity with ConfirmPasswordSheet).
+        .interactiveDismissDisabled(isSubmitting)
     }
 
     // MARK: - Locked total

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -239,13 +239,13 @@
       "source": "pbakaus/impeccable",
       "sourceType": "github",
       "skillPath": ".agents/skills/impeccable/SKILL.md",
-      "computedHash": "c3fc1193e4777c1fde1e8455a6ce23bbc0ae506dabb026b639cf594fdfa6c733"
+      "computedHash": "d28c91b173fd8563f34dd5d9590d194e820a96ca6ae401453e39c72e9f908463"
     },
     "ios-marketing-capture": {
       "source": "ParthJadhav/ios-marketing-capture",
       "sourceType": "github",
       "skillPath": "SKILL.md",
-      "computedHash": "5d59383d4c9cf675e2c4b5fc6ed0130a2c0f23a7f3334d4cc68b7e79998ce7f3"
+      "computedHash": "de97c90ce514c5f730915e042aea0c0990e203dacc5a980e605458f0b48daeb6"
     },
     "likec4-dsl": {
       "source": "likec4.dev",
@@ -268,7 +268,7 @@
       "source": "currents-dev/playwright-best-practices-skill",
       "sourceType": "github",
       "skillPath": "SKILL.md",
-      "computedHash": "320eaf861e3a0a923bfaad0726cb311a3fe30093378f8d26c89b9c5ae5c42b35"
+      "computedHash": "63ce3ddf87fb796c7855f4d6b34f892b3f83b288cf11c1ea1e4503a0c1b6cc6b"
     },
     "posthog-instrumentation": {
       "source": "posthog/posthog-for-claude",
@@ -334,7 +334,7 @@
       "source": "nextlevelbuilder/ui-ux-pro-max-skill",
       "sourceType": "github",
       "skillPath": ".claude/skills/ui-ux-pro-max/SKILL.md",
-      "computedHash": "0a413bf988d06481f69bb81df2070741c3ba12dd9f1be2706d57f259c905992d"
+      "computedHash": "c0e71f1ea9d80c74f710960c2b4d9ab0f8a6d14c331f8d361df2c28d1879846e"
     },
     "update-swiftui-apis": {
       "source": "avdlee/swiftui-agent-skill",


### PR DESCRIPTION
## Contexte

Feedback sur le lissage d'une dépense existante (PUL-17).

## Changement

- `onSpread` du `SpreadExistingSheet` passe en `async` : le bouton submit attend la fin de l'opération avant de fermer la sheet.
- Wiring correspondant dans `BudgetDetailsView+Routing`.

## Test

iOS build + suites BudgetDetails existantes.