### PR TITLE
feat(spread): reste à provisionner + à prévoir par mois (PUL-290)

### DIFF
--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -578,7 +578,10 @@
       "trackerPosition": "{{ ordinal }} mois sur {{ count }}",
       "trackerNotStarted": "Commence le mois prochain",
       "trackerCumulated": "{{ cumulated }} sur {{ total }}",
-      "trackerPerMonth": "{{ perMonth }} par mois"
+      "trackerRemaining": "Reste {{ remaining }} à provisionner",
+      "trackerPerRemainingMonth": "Prévois ~{{ perMonth }} par mois pour tenir l'objectif",
+      "trackerFinalGap": "Tous les mois sont clôturés · il reste {{ remaining }} non provisionné",
+      "trackerGoalReached": "Objectif atteint"
     }
   },
   "transaction": {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/spread-occurrences/spread-occurrence.view-model.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/spread-occurrences/spread-occurrence.view-model.spec.ts
@@ -330,3 +330,95 @@ describe('buildSpreadTracker (PUL-17 — réalisé)', () => {
     expect(buildSpreadTracker(vms)!.perMonthAmount).toBeCloseTo(33.34, 2);
   });
 });
+
+describe('buildSpreadTracker (PUL-290 — reste à provisionner)', () => {
+  const viewed: BudgetPeriod = { month: 6, year: 2026 };
+
+  it('should grow the per-remaining-month to cover an under-provisioned past month (300 / 3, mois 2 réalisé 50 → 150)', () => {
+    const occurrences = [
+      occurrence({ month: 5, year: 2026, amount: 100 }),
+      occurrence({
+        month: 6,
+        year: 2026,
+        amount: 100,
+        consumed: 50,
+        transactionCount: 2,
+      }),
+      occurrence({ month: 7, year: 2026, amount: 100 }),
+    ];
+    // live = July → May & June closed (réalisé 100 + 50 = 150), July still open.
+    const vms = buildSpreadOccurrenceViewModels(occurrences, viewed, {
+      month: 7,
+      year: 2026,
+    });
+
+    const tracker = buildSpreadTracker(vms)!;
+
+    expect(tracker.remainingToProvision).toBe(150);
+    expect(tracker.perRemainingMonth).toBe(150);
+  });
+
+  it('should report objectif atteint (remaining 0, no per-month) once provisionné ≥ objectif', () => {
+    const occurrences = [
+      occurrence({ month: 5, year: 2026, amount: 100 }),
+      occurrence({ month: 6, year: 2026, amount: 100 }),
+    ];
+    // live = December → both closed, réalisé = prévu = 200 = total.
+    const vms = buildSpreadOccurrenceViewModels(occurrences, viewed, {
+      month: 12,
+      year: 2026,
+    });
+
+    const tracker = buildSpreadTracker(vms)!;
+
+    expect(tracker.remainingToProvision).toBe(0);
+    expect(tracker.perRemainingMonth).toBeNull();
+  });
+
+  it('should leave a final gap with no per-month when every month is closed but under-provisioned', () => {
+    const occurrences = [
+      occurrence({
+        month: 5,
+        year: 2026,
+        amount: 100,
+        consumed: 60,
+        transactionCount: 1,
+      }),
+      occurrence({ month: 6, year: 2026, amount: 100 }),
+    ];
+    // live = December → both closed; réalisé = 60 (consumed) + 100 (prévu) = 160.
+    const vms = buildSpreadOccurrenceViewModels(occurrences, viewed, {
+      month: 12,
+      year: 2026,
+    });
+
+    const tracker = buildSpreadTracker(vms)!;
+
+    expect(tracker.remainingToProvision).toBe(40);
+    expect(tracker.perRemainingMonth).toBeNull();
+  });
+
+  it('should exclude a pointée-but-open current month from the divisor (no double-count)', () => {
+    const occurrences = [
+      occurrence({
+        month: 6,
+        year: 2026,
+        amount: 100,
+        checkedAt: '2026-06-02T00:00:00+02:00',
+      }),
+      occurrence({ month: 7, year: 2026, amount: 100 }),
+    ];
+    // live = June → June is current (not closed) but pointée → counts in réalisé
+    // AND must NOT also be a divisor slot. Only July is open → 100 / 1 = 100.
+    const vms = buildSpreadOccurrenceViewModels(occurrences, viewed, {
+      month: 6,
+      year: 2026,
+    });
+
+    const tracker = buildSpreadTracker(vms)!;
+
+    expect(tracker.cumulatedAmount).toBe(100);
+    expect(tracker.remainingToProvision).toBe(100);
+    expect(tracker.perRemainingMonth).toBe(100);
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/spread-occurrences/spread-occurrence.view-model.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/spread-occurrences/spread-occurrence.view-model.ts
@@ -80,6 +80,22 @@ export function spreadOccurrenceRealizedAmount(
  * - `perMonthAmount`  = representative tranche (viewed month's amount, else the
  *                       last/base split value).
  * - `progressPercent` = realized / total, clamped to [0, 100].
+ *
+ * PUL-290 — the explicit catch-up, so the user never subtracts and divides by
+ * hand:
+ *
+ * - `remainingToProvision` = `max(0, totalAmount − cumulatedAmount)`. The
+ *                       objectif is the Σ of the current tranches' prévu
+ *                       (`totalAmount`); the provisionné is the réalisé
+ *                       (`cumulatedAmount`). No stored target — editing a tranche
+ *                       moves the objectif. Clamped so over-provisioning never
+ *                       shows a negative catch-up.
+ * - `perRemainingMonth` = `remainingToProvision` ÷ the count of OPEN months
+ *                       (occurrences neither closed NOR pointée — the exact
+ *                       complement of the réalisé filter, so a pointée month
+ *                       counted in `cumulatedAmount` is never also a divisor
+ *                       slot). `null` when nothing remains to provision OR no
+ *                       open month is left (no division by zero).
  */
 export function buildSpreadTracker(
   viewModels: readonly SpreadOccurrenceViewModel[],
@@ -111,6 +127,15 @@ export function buildSpreadTracker(
       ? Math.min(100, Math.max(0, (cumulatedAmount / totalAmount) * 100))
       : 0;
 
+  const remainingToProvision = Math.max(0, totalAmount - cumulatedAmount);
+  const openMonths = viewModels.filter(
+    (vm) => !(vm.isClosed || vm.isChecked),
+  ).length;
+  const perRemainingMonth =
+    remainingToProvision > 0 && openMonths > 0
+      ? remainingToProvision / openMonths
+      : null;
+
   return {
     count,
     currentIndex,
@@ -118,5 +143,7 @@ export function buildSpreadTracker(
     totalAmount,
     perMonthAmount: representative,
     progressPercent,
+    remainingToProvision,
+    perRemainingMonth,
   };
 }

--- a/frontend/projects/webapp/src/app/ui/spread-occurrences-list/spread-occurrences-list.spec.ts
+++ b/frontend/projects/webapp/src/app/ui/spread-occurrences-list/spread-occurrences-list.spec.ts
@@ -97,6 +97,8 @@ describe('SpreadOccurrencesList', () => {
     totalAmount: 100,
     perMonthAmount: 33.33,
     progressPercent: 66.67,
+    remainingToProvision: 33.33,
+    perRemainingMonth: 33.33,
     ...overrides,
   });
 
@@ -150,17 +152,64 @@ describe('SpreadOccurrencesList', () => {
     expect(text).not.toContain('100,00');
   });
 
-  it('should format the per-month tracker amount as ligne (2 decimals)', () => {
+  it('should render the PUL-290 catch-up (reste + à prévoir/mois) as aggregation (0 decimals)', () => {
     const occurrences = [viewModel(occurrence({ month: 6, year: 2026 }))];
 
     const host = render({
       occurrences,
-      tracker: tracker({ perMonthAmount: 33.33 }),
+      tracker: tracker({ remainingToProvision: 150, perRemainingMonth: 150 }),
     });
 
-    const text =
-      host.querySelector('[data-testid="spread-tracker"]')?.textContent ?? '';
-    expect(text).toContain('33,33');
+    const remaining = host.querySelector(
+      '[data-testid="spread-provision-remaining"]',
+    );
+    const perMonth = host.querySelector(
+      '[data-testid="spread-provision-per-month"]',
+    );
+    // Aggregation (0-dec, CA8): "Reste 150 € à provisionner" / "~150 € par mois".
+    expect(remaining?.textContent).toContain('150');
+    expect(remaining?.textContent).not.toContain('150,00');
+    expect(perMonth?.textContent).toContain('150');
+    expect(perMonth?.textContent).not.toContain('150,00');
+  });
+
+  it('should show "objectif atteint" and hide the catch-up lines when nothing is left to provision', () => {
+    const occurrences = [viewModel(occurrence({ month: 6, year: 2026 }))];
+
+    const host = render({
+      occurrences,
+      tracker: tracker({ remainingToProvision: 0, perRemainingMonth: null }),
+    });
+
+    expect(
+      host.querySelector('[data-testid="spread-provision-reached"]'),
+    ).not.toBeNull();
+    expect(
+      host.querySelector('[data-testid="spread-provision-remaining"]'),
+    ).toBeNull();
+    expect(
+      host.querySelector('[data-testid="spread-provision-per-month"]'),
+    ).toBeNull();
+  });
+
+  it('should show only the final gap (no per-month) when every month is closed but the objectif is unmet', () => {
+    const occurrences = [viewModel(occurrence({ month: 6, year: 2026 }))];
+
+    const host = render({
+      occurrences,
+      tracker: tracker({ remainingToProvision: 80, perRemainingMonth: null }),
+    });
+
+    const finalGap = host.querySelector(
+      '[data-testid="spread-provision-final-gap"]',
+    );
+    expect(finalGap?.textContent).toContain('80');
+    expect(
+      host.querySelector('[data-testid="spread-provision-per-month"]'),
+    ).toBeNull();
+    expect(
+      host.querySelector('[data-testid="spread-provision-reached"]'),
+    ).toBeNull();
   });
 
   it('should format each occurrence amount as ligne (2 decimals)', () => {

--- a/frontend/projects/webapp/src/app/ui/spread-occurrences-list/spread-occurrences-list.ts
+++ b/frontend/projects/webapp/src/app/ui/spread-occurrences-list/spread-occurrences-list.ts
@@ -17,7 +17,7 @@ import type {
  * PUL-17 — pure presentational cross-month view of a spread group.
  *
  * Renders the progress tracker (ordinal position · cumulé · `bg-primary` bar ·
- * per-month) followed by the month-by-month occurrence list (past dimmed,
+ * PUL-290 catch-up) followed by the month-by-month occurrence list (past dimmed,
  * viewed-month badged, future normal, checked struck-through).
  *
  * Pure `ui/`: inputs only, NO `@core/` import, NO store. Amounts use
@@ -26,10 +26,11 @@ import type {
  * hand-rolled because this view needs three variants the fixed-2-decimal
  * `getCurrencyFormatter` can't produce: 0-dec aggregation, 2-dec ligne, and the
  * composite "consommé / prévu" sharing a single symbol (see
- * `webapp-currency-formatting.md`). Dual decimal policy: tracker cumulé/total =
- * aggregation (0 decimals), per-month + each occurrence amount = ligne (2
- * decimals). `ph-no-capture` wraps every amount span, never the month name or
- * the position label.
+ * `webapp-currency-formatting.md`). Dual decimal policy: tracker cumulé/total +
+ * the PUL-290 catch-up (reste à provisionner, à prévoir par mois) = aggregation
+ * (0 decimals, per CA8); each occurrence amount = ligne (2 decimals).
+ * `ph-no-capture` wraps every amount span, never the month name or the position
+ * label.
  *
  * `isCurrentPeriod` distinguishes "this budget IS the live current month"
  * ("Ce mois") from "this is just the month you are looking at" ("Ici").
@@ -79,12 +80,49 @@ import type {
             [style.width.%]="t.progressPercent"
           ></div>
         </div>
-        <span class="ph-no-capture text-body-small text-on-surface-variant">
-          {{
-            'budgetLine.spread.trackerPerMonth'
-              | transloco: { perMonth: formatLine(t.perMonthAmount) }
-          }}
-        </span>
+        <!-- PUL-290 — explicit catch-up: replaces the static "T/N par mois"
+             (which forced the user to do the math) with the forward-looking
+             amount to provision to hit the objectif. Three serene states. -->
+        @if (t.remainingToProvision === 0) {
+          <span
+            class="text-body-small font-medium text-primary"
+            data-testid="spread-provision-reached"
+          >
+            {{ 'budgetLine.spread.trackerGoalReached' | transloco }}
+          </span>
+        } @else if (t.perRemainingMonth === null) {
+          <span
+            class="ph-no-capture text-body-small text-on-surface-variant"
+            data-testid="spread-provision-final-gap"
+          >
+            {{
+              'budgetLine.spread.trackerFinalGap'
+                | transloco
+                  : { remaining: formatAggregation(t.remainingToProvision) }
+            }}
+          </span>
+        } @else {
+          <span
+            class="ph-no-capture text-body-small text-on-surface-variant"
+            data-testid="spread-provision-remaining"
+          >
+            {{
+              'budgetLine.spread.trackerRemaining'
+                | transloco
+                  : { remaining: formatAggregation(t.remainingToProvision) }
+            }}
+          </span>
+          <span
+            class="ph-no-capture text-body-small font-medium text-on-surface"
+            data-testid="spread-provision-per-month"
+          >
+            {{
+              'budgetLine.spread.trackerPerRemainingMonth'
+                | transloco
+                  : { perMonth: formatAggregation(t.perRemainingMonth) }
+            }}
+          </span>
+        }
       </div>
     }
 

--- a/frontend/projects/webapp/src/app/ui/spread-occurrences-list/spread-occurrences-list.types.ts
+++ b/frontend/projects/webapp/src/app/ui/spread-occurrences-list/spread-occurrences-list.types.ts
@@ -45,9 +45,20 @@ export interface SpreadOccurrenceViewModel {
  *                       not calendar position — NOT `index × perMonth`.
  * - `totalAmount`     = Σ of ALL occurrence amounts (Σ = the source total T).
  * - `perMonthAmount`  = representative tranche (viewed month's amount, else the
- *                       last/base split value), for the "{{ perMonth }} par
- *                       mois" line.
+ *                       last/base split value). No longer rendered: PUL-290
+ *                       replaced the static "par mois" line with the
+ *                       forward-looking `perRemainingMonth`. Retained as the
+ *                       derived base split value (still locked by its spec).
  * - `progressPercent` = cumulated / total, clamped to [0, 100].
+ *
+ * PUL-290 — explicit catch-up so the user never does the mental math:
+ * - `remainingToProvision` = objectif − provisionné, clamped to ≥ 0
+ *                       (`max(0, totalAmount − cumulatedAmount)`). 0 ⇒ objectif
+ *                       atteint.
+ * - `perRemainingMonth` = `remainingToProvision` ÷ the number of months still
+ *                       open (occurrences NOT closed and NOT pointée), or `null`
+ *                       when nothing is left to provision OR no open month
+ *                       remains (no division by zero, no negative catch-up).
  */
 export interface SpreadTracker {
   readonly count: number;
@@ -56,4 +67,6 @@ export interface SpreadTracker {
   readonly totalAmount: number;
   readonly perMonthAmount: number;
   readonly progressPercent: number;
+  readonly remainingToProvision: number;
+  readonly perRemainingMonth: number | null;
 }

--- a/ios/Pulpe/Domain/Formulas/SpreadProgress.swift
+++ b/ios/Pulpe/Domain/Formulas/SpreadProgress.swift
@@ -26,6 +26,13 @@ struct SpreadOccurrenceItem: Identifiable, Sendable {
 /// `cumulatedAmount` sums REALIZED occurrences only (closed OR pointé) of their
 /// realized amount (consommé if sub-transactions, else prévu) — never
 /// `index × perMonth`.
+///
+/// PUL-290 — the explicit catch-up (mirrors web): `remainingToProvision` =
+/// `max(0, totalAmount − cumulatedAmount)` (objectif − provisionné, 0 ⇒ objectif
+/// atteint); `perRemainingMonth` = that remainder ÷ the number of OPEN months
+/// (occurrences neither closed NOR pointée — exact complement of the réalisé
+/// filter), `nil` when nothing is left to provision OR no open month remains
+/// (no division by zero, no negative catch-up).
 struct SpreadTracker: Equatable, Sendable {
     let count: Int
     let currentIndex: Int
@@ -33,6 +40,8 @@ struct SpreadTracker: Equatable, Sendable {
     let totalAmount: Decimal
     let perMonthAmount: Decimal
     let progressPercent: Double
+    let remainingToProvision: Decimal
+    let perRemainingMonth: Decimal?
 }
 
 /// Pure derivation of the spread occurrence items + progress tracker. Port of
@@ -92,13 +101,21 @@ enum SpreadProgress {
             progressPercent = 0
         }
 
+        let remainingToProvision = Swift.max(Decimal.zero, totalAmount - cumulatedAmount)
+        let openMonths = items.filter { !($0.isClosed || $0.isChecked) }.count
+        let perRemainingMonth: Decimal? = (remainingToProvision > 0 && openMonths > 0)
+            ? remainingToProvision / Decimal(openMonths)
+            : nil
+
         return SpreadTracker(
             count: items.count,
             currentIndex: currentIndex,
             cumulatedAmount: cumulatedAmount,
             totalAmount: totalAmount,
             perMonthAmount: perMonthAmount,
-            progressPercent: progressPercent
+            progressPercent: progressPercent,
+            remainingToProvision: remainingToProvision,
+            perRemainingMonth: perRemainingMonth
         )
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadTrackerHeader.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Spread/SpreadTrackerHeader.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 /// PUL-17 — progress tracker header for the "Dépense lissée" sheet: a position
 /// line, the realized cumulé/total, a `pulpePrimary` bar filled to
-/// `progressPercent`, and the per-month tranche.
+/// `progressPercent`, and (PUL-290) the explicit catch-up that replaces the
+/// static "T/N par mois" line the user used to compute by hand.
 ///
 /// All amounts use `asCurrency` (2 decimals) per
 /// `feedback_two_decimals_ios_budget_detail` — the budget-detail surface forbids
@@ -30,15 +31,42 @@ struct SpreadTrackerHeader: View {
 
             progressBar
 
-            Text("\(tracker.perMonthAmount.asCurrency(currency)) par mois")
+            provisionLine
+        }
+        .padding(.vertical, DesignTokens.Spacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    /// PUL-290 — three serene states: objectif atteint (nothing left), the
+    /// rattrapage (reste + à prévoir par mois), or the final gap (every month
+    /// closed yet under-provisioned — no actionable month, no division by zero).
+    @ViewBuilder
+    private var provisionLine: some View {
+        if tracker.remainingToProvision <= 0 {
+            Text("Objectif atteint")
+                .font(PulpeTypography.metricMini)
+                .foregroundStyle(Color.pulpePrimary)
+        } else if let perRemaining = tracker.perRemainingMonth {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxs) {
+                Text(remainingLabel)
+                    .font(PulpeTypography.metricMini)
+                    .foregroundStyle(Color.textTertiary)
+                    .monospacedDigit()
+                    .sensitiveAmount()
+                Text(perRemainingMonthLabel(perRemaining))
+                    .font(PulpeTypography.metricMini)
+                    .foregroundStyle(Color.textSecondary)
+                    .monospacedDigit()
+                    .sensitiveAmount()
+            }
+        } else {
+            Text(finalGapLabel)
                 .font(PulpeTypography.metricMini)
                 .foregroundStyle(Color.textTertiary)
                 .monospacedDigit()
                 .sensitiveAmount()
         }
-        .padding(.vertical, DesignTokens.Spacing.xs)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel)
     }
 
     private var progressBar: some View {
@@ -67,8 +95,31 @@ struct SpreadTrackerHeader: View {
         "\(tracker.cumulatedAmount.asCurrency(currency)) sur \(tracker.totalAmount.asCurrency(currency))"
     }
 
+    private var remainingLabel: String {
+        "Reste \(tracker.remainingToProvision.asCurrency(currency)) à provisionner"
+    }
+
+    private func perRemainingMonthLabel(_ amount: Decimal) -> String {
+        "Prévois ~\(amount.asCurrency(currency)) par mois pour tenir l'objectif"
+    }
+
+    private var finalGapLabel: String {
+        "Tous les mois sont clôturés · il reste "
+            + "\(tracker.remainingToProvision.asCurrency(currency)) non provisionné"
+    }
+
+    private var provisionLabel: String {
+        if tracker.remainingToProvision <= 0 {
+            return "Objectif atteint"
+        }
+        if let perRemaining = tracker.perRemainingMonth {
+            return "\(remainingLabel), \(perRemainingMonthLabel(perRemaining))"
+        }
+        return finalGapLabel
+    }
+
     private var accessibilityLabel: String {
-        "\(positionLabel), \(cumulatedLabel), \(tracker.perMonthAmount.asCurrency(currency)) par mois"
+        "\(positionLabel), \(cumulatedLabel), \(provisionLabel)"
     }
 }
 
@@ -80,7 +131,9 @@ struct SpreadTrackerHeader: View {
             cumulatedAmount: 200,
             totalAmount: 600,
             perMonthAmount: 100,
-            progressPercent: 33.3
+            progressPercent: 33.3,
+            remainingToProvision: 400,
+            perRemainingMonth: 100
         ),
         currency: .chf
     )

--- a/ios/PulpeTests/Domain/Formulas/SpreadProgressTests.swift
+++ b/ios/PulpeTests/Domain/Formulas/SpreadProgressTests.swift
@@ -127,4 +127,50 @@ struct SpreadProgressTests {
         let noCurrent = [occ(month: 5, amount: 100), occ(month: 6, amount: 100), occ(month: 7, amount: 333)]
         #expect(tracker(noCurrent, ref: 2, live: 2)?.perMonthAmount == 333)
     }
+
+    // MARK: - PUL-290 reste à provisionner (parity with the web view-model spec)
+
+    @Test func buildTracker_perRemainingMonth_growsToCoverAnUnderProvisionedMonth() {
+        // 300 / 3, mois 2 réalisé 50 → reste 150, le mois restant doit prévoir 150.
+        let occurrences = [
+            occ(month: 5, amount: 100),
+            occ(month: 6, amount: 100, consumed: 50, transactionCount: 2),
+            occ(month: 7, amount: 100),
+        ]
+        // live = July → May & June closed (réalisé 100 + 50 = 150), July open.
+        let result = tracker(occurrences, ref: 6, live: 7)
+        #expect(result?.remainingToProvision == 150)
+        #expect(result?.perRemainingMonth == 150)
+    }
+
+    @Test func buildTracker_objectifAtteint_remainingZero_perRemainingNil() {
+        let occurrences = [occ(month: 5, amount: 100), occ(month: 6, amount: 100)]
+        // live = December → both closed, réalisé = prévu = 200 = total.
+        let result = tracker(occurrences, ref: 6, live: 12)
+        #expect(result?.remainingToProvision == 0)
+        #expect(result?.perRemainingMonth == nil)
+    }
+
+    @Test func buildTracker_finalGap_allClosedButUnderProvisioned_perRemainingNil() {
+        let occurrences = [
+            occ(month: 5, amount: 100, consumed: 60, transactionCount: 1),
+            occ(month: 6, amount: 100),
+        ]
+        // live = December → both closed; réalisé = 60 (consumed) + 100 (prévu) = 160.
+        let result = tracker(occurrences, ref: 6, live: 12)
+        #expect(result?.remainingToProvision == 40)
+        #expect(result?.perRemainingMonth == nil)
+    }
+
+    @Test func buildTracker_pointeeOpenMonth_isExcludedFromDivisor() {
+        let occurrences = [
+            occ(month: 6, amount: 100, checkedAt: Date()), // current + pointé → réalisé, NOT a divisor slot
+            occ(month: 7, amount: 100),                    // open → the only divisor slot
+        ]
+        // live = June → June current (not closed) but pointée; only July is open → 100 / 1.
+        let result = tracker(occurrences, ref: 6, live: 6)
+        #expect(result?.cumulatedAmount == 100)
+        #expect(result?.remainingToProvision == 100)
+        #expect(result?.perRemainingMonth == 100)
+    }
 }


### PR DESCRIPTION
## Summary

Une dépense lissée chiffre désormais le rattrapage dans le panneau de détail — l'utilisateur ne fait plus la soustraction/division de tête.

- **Tracker dérivé** (`SpreadTracker` web + iOS, `buildSpreadTracker`/`SpreadProgress.buildTracker`) :
  - `remainingToProvision = max(0, objectif − provisionné)` (objectif = Σ prévus des tranches ; provisionné = Σ réalisés clôturés/pointés). Clamp ≥ 0 → jamais de rattrapage négatif.
  - `perRemainingMonth = reste ÷ mois ouverts`, ou `null`. Mois ouvert = complément **exact** du filtre réalisé (`!(isClosed || isChecked)`) → un mois pointé compte dans le provisionné ET sort du diviseur (pas de double comptage, pas de division par zéro).
- **3 états sereins** (remplace la ligne statique « T/N par mois », jugée non-aidante par le ticket) : rattrapage (`Reste X` + `Prévois ~Y par mois`), objectif atteint, écart final (tous les mois clôturés).
- **Parité web (agrégation `1.0-0`, CA8) ↔ iOS (2 décimales, règle Budget Detail)**, microcopie DA Pulpe (sérénité, aucune alarme). 100 % dérivé, aucun backend/endpoint.
- Verrouillé par tests des deux côtés, dont le cas signature **300 / 3 mois, mois 2 réalisé 50 → mois restant 150**.

## Validation

- Web : `2090 passed` + `ng build` OK (templates type-checkés, CSP OK).
- iOS : `15 tests passed` (`SpreadProgressTests`) + app build OK.

## Type

feat