### PR TITLE
fix(ios): postpone confirmation renders as alert, not broken action sheet (PUL-22)

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetDetails/PostponeConfirmation.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/PostponeConfirmation.swift
@@ -47,14 +47,19 @@ private struct PostponeConfirmationModifier: ViewModifier {
     let onConfirm: (PostponeTarget) -> Void
 
     func body(content: Content) -> some View {
-        content.confirmationDialog(
+        // Alert, not a confirmationDialog: the action is reached from the
+        // detail-page header menu while the amount keyboard is often still up.
+        // A bottom action sheet can't anchor over the keyboard and degrades to
+        // a cramped popover near the toolbar button — an alert renders centered
+        // and robustly regardless of keyboard state, matching the sibling
+        // delete confirmation on the same page.
+        content.alert(
             confirmationTitle,
             isPresented: isPresentedBinding,
-            titleVisibility: .visible,
             presenting: target
         ) { item in
-            Button("Reporter") { onConfirm(item) }
             Button("Annuler", role: .cancel) {}
+            Button("Reporter") { onConfirm(item) }
         }
     }
 
@@ -66,7 +71,7 @@ private struct PostponeConfirmationModifier: ViewModifier {
         return "Reporter \(target.name) au mois suivant ?"
     }
 
-    /// Bridges the `PostponeTarget?` state to the `Bool` binding the dialog
+    /// Bridges the `PostponeTarget?` state to the `Bool` binding the alert
     /// needs: present while a target is set, clear the target on dismissal.
     private var isPresentedBinding: Binding<Bool> {
         Binding(


### PR DESCRIPTION
## Problem

The "Reporter au mois suivant" confirmation (PUL-22) rendered as an ugly, cramped gray popover floating near the top toolbar instead of a normal iOS confirmation.

**Root cause:** it used `.confirmationDialog` (a bottom action sheet), triggered from the detail-page header `…` menu while the amount keyboard is still up. The keyboard occupies the bottom of the screen, so UIKit can't anchor the action sheet there and degrades it to a popover anchored to the toolbar button — the broken card the user reported.

Notably, the **delete** confirmation on the same page already uses `.alert` and renders correctly; the postpone one was the outlier.

## Fix

Swap the shared `postponeConfirmation` modifier from `.confirmationDialog` to `.alert`. Alerts render centered and modally, dim the background, and are robust regardless of keyboard state. One shared modifier => fixes both call sites (`EditTransactionPage` and `BudgetLineDetailPage`). Buttons reordered so `Reporter` is the emphasized default action and `Annuler` the cancel role.

## Verification

- `xcodebuild build -scheme PulpeLocal` succeeds.
- Existing postpone coverage is coordinator-level (`BudgetDetailsCoordinatorPostponeTests`) and unaffected by the presentation swap.
- Runtime logs confirmed the postpone code path executes with the new `.alert` modifier.

Base: `preview` (default branch).