### PR TITLE
fix(web): show postpone action disabled+tooltip for recurring lines (PUL-22)

### DIFF
--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -350,6 +350,7 @@
     "postponeConfirm": "Reporter",
     "postponeDisabledTooltip": "Crée d'abord le budget de {{ month }}",
     "postponeUnavailableChecked": "Un élément pointé ne peut pas être reporté",
+    "postponeUnavailableRecurrent": "Une dépense récurrente revient chaque mois automatiquement, elle ne peut pas être reportée individuellement.",
     "postponed": "Reporté en {{ month }}",
     "postponeError": "Erreur lors du report au mois suivant",
     "forecastUpdateError": "Erreur lors de la modification de la prévision",

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-action-menu.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-action-menu.ts
@@ -152,6 +152,22 @@ function getBalanceFormatter(
             <span>{{ 'budget.postpone' | transloco }}</span>
           </button>
         </span>
+      } @else if (showPostponeUnavailableRecurrent()) {
+        <!-- Tooltip wrapper: matTooltip is suppressed on disabled buttons -->
+        <span
+          class="block w-full"
+          [matTooltip]="'budget.postponeUnavailableRecurrent' | transloco"
+          matTooltipPosition="above"
+        >
+          <button
+            mat-menu-item
+            disabled
+            [attr.data-testid]="'postpone-disabled-' + item().data.id"
+          >
+            <mat-icon matMenuItemIcon>event_upcoming</mat-icon>
+            <span>{{ 'budget.postpone' | transloco }}</span>
+          </button>
+        </span>
       }
       <button
         mat-menu-item
@@ -193,6 +209,19 @@ export class BudgetActionMenu {
   protected readonly showSpreadUnavailable = computed(() => {
     const { data, metadata } = this.item();
     if (metadata.canSpread) return false;
+    return data.recurrence === 'fixed' && data.kind !== 'income';
+  });
+
+  // A recurrent (`fixed`) line is regenerated every month by its template, so
+  // postponing a single occurrence doesn't apply — but hiding the action
+  // outright leaves the user wondering where it went (same rationale as
+  // showSpreadUnavailable above). Income stays hidden too: the tooltip copy
+  // is expense-specific and recurring income has no "report" mental model.
+  // Other hidden cases (already has a transaction, spread occurrence) stay
+  // hidden — not a teachable absence.
+  protected readonly showPostponeUnavailableRecurrent = computed(() => {
+    const { data, metadata } = this.item();
+    if (metadata.showPostpone) return false;
     return data.recurrence === 'fixed' && data.kind !== 'income';
   });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-table/cells/actions-cell.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-table/cells/actions-cell.ts
@@ -156,6 +156,22 @@ import type {
               <span>{{ 'budget.postpone' | transloco }}</span>
             </button>
           </span>
+        } @else if (showPostponeUnavailableRecurrent()) {
+          <!-- Tooltip wrapper: matTooltip is suppressed on disabled buttons -->
+          <span
+            class="block w-full"
+            [matTooltip]="'budget.postponeUnavailableRecurrent' | transloco"
+            matTooltipPosition="above"
+          >
+            <button
+              mat-menu-item
+              disabled
+              [attr.data-testid]="'postpone-disabled-' + line().data.id"
+            >
+              <mat-icon matMenuItemIcon>event_upcoming</mat-icon>
+              <span>{{ 'budget.postpone' | transloco }}</span>
+            </button>
+          </span>
         }
         <button
           mat-menu-item
@@ -200,6 +216,25 @@ export class ActionsCell {
   readonly showSpreadUnavailable = computed(() => {
     const item = this.line();
     if (item.metadata.itemType !== 'budget_line' || item.metadata.canSpread) {
+      return false;
+    }
+    const data = item.data as BudgetLine;
+    return data.recurrence === 'fixed' && data.kind !== 'income';
+  });
+
+  // A recurrent (`fixed`) line is regenerated every month by its template, so
+  // postponing a single occurrence doesn't apply — but hiding the action
+  // outright leaves the user wondering where it went (same rationale as
+  // showSpreadUnavailable above). Income stays hidden too: the tooltip copy
+  // is expense-specific and recurring income has no "report" mental model.
+  // Transactions and other hidden budget-line cases (already has a
+  // transaction, spread occurrence) stay hidden.
+  readonly showPostponeUnavailableRecurrent = computed(() => {
+    const item = this.line();
+    if (
+      item.metadata.itemType !== 'budget_line' ||
+      item.metadata.showPostpone
+    ) {
       return false;
     }
     const data = item.data as BudgetLine;


### PR DESCRIPTION
## Summary
- "Reporter au mois suivant" (postpone) now mirrors "Lisser sur plusieurs mois" (spread): recurring (`fixed`) expense/saving lines show the action **disabled + tooltip** instead of silently vanishing.
- Fixes confusion where a recurring line (e.g. a subscription like Revolut) simply had no "Reporter" entry in its menu, with no explanation.
- Income and other already-hidden cases (line already has a transaction, spread occurrence) remain hidden — unchanged.

## Test plan
- [x] `ng build` (template typecheck) clean
- [x] `ng lint` clean
- [x] `prettier --check` clean
- [x] Full frontend unit suite: 2107/2107 passing
- [x] Adversarial review (logic + clean-code) — 1 MEDIUM finding (missing income exclusion) fixed and reverified