### PR TITLE
fix(web): use local date in Excel export filename (PUL-150)

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.spec.ts
@@ -9,7 +9,7 @@ import { of } from 'rxjs';
 import { type BudgetExportResponse } from 'pulpe-shared';
 
 import { ExcelExportService } from '@core/budget/excel-export.service';
-import { downloadAsExcelFile } from '@core/file-download';
+import { downloadAsExcelFile, downloadAsJsonFile } from '@core/file-download';
 import { Logger } from '@core/logging/logger';
 import { LoadingIndicator } from '@core/loading/loading-indicator';
 import { ProductTourService } from '@core/product-tour/product-tour.service';
@@ -101,6 +101,27 @@ describe('BudgetListPage', () => {
 
       // Assert
       expect(downloadAsExcelFile).toHaveBeenCalledWith(
+        expect.anything(),
+        'pulpe-export-2026-01-01',
+      );
+    });
+  });
+
+  describe('onExportBudgets', () => {
+    it('should name the file with the local date, not the UTC date', async () => {
+      // Arrange: Zurich local 00:30 on Jan 1st is still Dec 31st in UTC
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date(2026, 0, 1, 0, 30));
+
+      // Canary: fail loudly if the TZ override above didn't take effect,
+      // instead of silently passing against a UTC-equivalent worker.
+      expect(new Date().getTimezoneOffset()).toBe(-60);
+
+      // Act
+      await component.onExportBudgets();
+
+      // Assert
+      expect(downloadAsJsonFile).toHaveBeenCalledWith(
         expect.anything(),
         'pulpe-export-2026-01-01',
       );

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.spec.ts
@@ -1,0 +1,109 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { type ComponentFixture, TestBed } from '@angular/core/testing';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { provideRouter } from '@angular/router';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { type BudgetExportResponse } from 'pulpe-shared';
+
+import { ExcelExportService } from '@core/budget/excel-export.service';
+import { downloadAsExcelFile } from '@core/file-download';
+import { Logger } from '@core/logging/logger';
+import { LoadingIndicator } from '@core/loading/loading-indicator';
+import { ProductTourService } from '@core/product-tour/product-tour.service';
+import { TitleDisplay } from '@core/routing';
+import { UserSettingsStore } from '@core/user-settings';
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+
+import BudgetListPage from './budget-list-page';
+import { BudgetListStore } from './budget-list-store';
+
+vi.mock('@core/file-download', () => ({
+  downloadAsExcelFile: vi.fn(),
+  downloadAsJsonFile: vi.fn(),
+}));
+
+describe('BudgetListPage', () => {
+  let fixture: ComponentFixture<BudgetListPage>;
+  let component: BudgetListPage;
+  let mockStore: {
+    budgets: { status: ReturnType<typeof signal<string>> };
+    refreshData: ReturnType<typeof vi.fn>;
+    exportAllBudgets: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    vi.stubEnv('TZ', 'Europe/Zurich');
+
+    mockStore = {
+      budgets: { status: signal('resolved') },
+      refreshData: vi.fn(),
+      exportAllBudgets: vi.fn().mockResolvedValue({
+        success: true,
+        data: { exportDate: '2026-01-01', totalBudgets: 0, budgets: [] },
+      } satisfies BudgetExportResponse),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [BudgetListPage],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        ...provideTranslocoForTest(),
+        { provide: BudgetListStore, useValue: mockStore },
+        { provide: TitleDisplay, useValue: { currentTitle: signal('') } },
+        {
+          provide: ProductTourService,
+          useValue: {
+            hasSeenPageTour: vi.fn().mockReturnValue(true),
+            startPageTour: vi.fn(),
+          },
+        },
+        { provide: MatDialog, useValue: { open: vi.fn() } },
+        {
+          provide: BreakpointObserver,
+          useValue: { observe: () => of({ matches: false }) },
+        },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: Logger, useValue: { error: vi.fn() } },
+        { provide: LoadingIndicator, useValue: { setLoading: vi.fn() } },
+        {
+          provide: ExcelExportService,
+          useValue: { buildWorkbook: vi.fn().mockReturnValue({}) },
+        },
+        { provide: UserSettingsStore, useValue: { currency: signal('CHF') } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BudgetListPage);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  describe('onExportBudgetsAsExcel', () => {
+    it('should name the file with the local date, not the UTC date', async () => {
+      // Arrange: Zurich local 00:30 on Jan 1st is still Dec 31st in UTC
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date(2026, 0, 1, 0, 30));
+
+      // Canary: fail loudly if the TZ override above didn't take effect,
+      // instead of silently passing against a UTC-equivalent worker.
+      expect(new Date().getTimezoneOffset()).toBe(-60);
+
+      // Act
+      await component.onExportBudgetsAsExcel();
+
+      // Assert
+      expect(downloadAsExcelFile).toHaveBeenCalledWith(
+        expect.anything(),
+        'pulpe-export-2026-01-01',
+      );
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
@@ -18,6 +18,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Router } from '@angular/router';
 import { ExcelExportService } from '@core/budget/excel-export.service';
+import { formatLocalDate } from '@core/date/format-local-date';
 import { downloadAsExcelFile, downloadAsJsonFile } from '@core/file-download';
 import { ROUTES, TitleDisplay } from '@core/routing';
 import {
@@ -299,7 +300,7 @@ export default class BudgetListPage {
   }
 
   async onExportBudgetsAsExcel(): Promise<void> {
-    const today = new Date().toISOString().split('T')[0];
+    const today = formatLocalDate(new Date()).split('T')[0];
     return this.#executeExport({
       isLoadingSignal: this.isExportingExcel,
       download: (data) => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
@@ -290,7 +290,7 @@ export default class BudgetListPage {
   }
 
   async onExportBudgets(): Promise<void> {
-    const today = new Date().toISOString().split('T')[0];
+    const today = formatLocalDate(new Date()).split('T')[0];
     return this.#executeExport({
       isLoadingSignal: this.isExporting,
       download: (data) => downloadAsJsonFile(data, `pulpe-export-${today}`),


### PR DESCRIPTION
## Summary
- Excel export filename used `new Date().toISOString().split('T')[0]` (UTC calendar date) instead of the user's local date — off-by-one near midnight in Europe/Zurich.
- Swapped to the existing `formatLocalDate` helper (`@core/date/format-local-date`, already used in `budget-details-store`) for both export call sites: `onExportBudgetsAsExcel` and `onExportBudgets` (JSON).
- The JSON export fix was originally deferred as out-of-scope per PUL-150's own "Hors périmètre" note, but was folded into this PR since it's the identical bug at the same call site, one line away.

## Test plan
- [x] Regression tests (`budget-list-page.spec.ts`) for both export methods: mocked system time to Zurich-local `2026-01-01 00:30` (UTC `2025-12-31 23:30`); assert filename is `pulpe-export-2026-01-01`, not `...2025-12-31`. Each test includes a canary assertion (`getTimezoneOffset() === -60`) so a silently-no-op TZ stub fails loudly instead of green-washing the assertion.
- [x] Verified red→green manually for both: reverted each fix locally, confirmed the corresponding test fails with the UTC-shifted filename, then restored the fix.
- [x] `pnpm run lint`, `pnpm run typecheck:spec`, `pnpm run build` all clean.
- [x] Full `budget-list` + `core/date` suite green (119 tests), no regressions.

Closes PUL-150.