### PR TITLE
fix(web): aligner 2 agrégats hors-politique sur 0 décimale (PUL-276)

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/template-list-item.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/template-list-item.ts
@@ -118,7 +118,7 @@ import { type TemplateViewModel } from './template-view-model';
                 class="ph-no-capture text-body-medium! font-medium!"
               >
                 {{
-                  templateViewModel().income | appCurrency: currency() : '1.2-2'
+                  templateViewModel().income | appCurrency: currency() : '1.0-0'
                 }}
               </span>
             </mat-list-item>
@@ -139,7 +139,7 @@ import { type TemplateViewModel } from './template-view-model';
               >
                 {{
                   templateViewModel().expenses
-                    | appCurrency: currency() : '1.2-2'
+                    | appCurrency: currency() : '1.0-0'
                 }}
               </span>
             </mat-list-item>
@@ -160,7 +160,7 @@ import { type TemplateViewModel } from './template-view-model';
               >
                 {{
                   templateViewModel().netBalance
-                    | appCurrency: currency() : '1.2-2'
+                    | appCurrency: currency() : '1.0-0'
                 }}
               </span>
             </mat-list-item>

--- a/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-next-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/dashboard-next-month.ts
@@ -52,7 +52,7 @@ import { AppCurrencyPipe } from '@core/currency';
                   : 'text-financial-negative'
               "
             >
-              {{ estimatedRollover() | appCurrency: currency() : '1.2-2' }}
+              {{ estimatedRollover() | appCurrency: currency() : '1.0-0' }}
             </span>
           </p>
         } @else {


### PR DESCRIPTION
Audit complet web+iOS contre la politique duale documentée (rule webapp-currency-formatting) : 2 seuls écarts réels, corrigés — rollover estimé du dashboard next-month et totaux des templates dans create-budget ('1.2-2' → '1.0-0'). iOS : zéro violation. Vérifié : quality 10/10, 2107 tests.