### PR TITLE
refactor(webapp): dette auth Tier-3 restante (PUL-138)

### DIFF
--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -157,7 +157,8 @@
       "sessionExpired": "Ta session a expiré — reconnecte-toi",
       "refreshFailed": "Reconnexion impossible — réessaie",
       "accountBlocked": "Ton compte est en cours de suppression.",
-      "clientKeyMissing": "Ta clé de coffre est manquante — saisis-la pour continuer"
+      "clientKeyMissing": "Ta clé de coffre est manquante — saisis-la pour continuer",
+      "userNotConnected": "Utilisateur non connecté"
     }
   },
   "welcome": {

--- a/frontend/projects/webapp/src/app/core/auth/auth-constants.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-constants.ts
@@ -25,6 +25,7 @@ export const AUTH_ERROR_KEYS = {
   REFRESH_FAILED: 'auth.errors.refreshFailed',
   ACCOUNT_BLOCKED: 'auth.errors.accountBlocked',
   CLIENT_KEY_MISSING: 'auth.errors.clientKeyMissing',
+  USER_NOT_CONNECTED: 'auth.errors.userNotConnected',
 } as const;
 
 export function formatDeletionDate(

--- a/frontend/projects/webapp/src/app/core/auth/auth-interceptor.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-interceptor.spec.ts
@@ -176,6 +176,39 @@ describe('authInterceptor', () => {
       await Promise.all([promise1, promise2]);
     });
 
+    it('should sign out and redirect all pending requests when shared refresh resolves false', async () => {
+      let resolveSharedRefresh!: (value: boolean) => void;
+      const sharedRefresh = new Promise<boolean>((resolve) => {
+        resolveSharedRefresh = resolve;
+      });
+      mockAuthSession.refreshSession.mockImplementation(() => sharedRefresh);
+
+      const promise1 = firstValueFrom(
+        http.get(`${BACKEND_URL}/endpoint1`),
+      ).catch((err) => err);
+      const promise2 = firstValueFrom(
+        http.get(`${BACKEND_URL}/endpoint2`),
+      ).catch((err) => err);
+
+      await flushMicrotasks();
+
+      httpTesting
+        .expectOne(`${BACKEND_URL}/endpoint1`)
+        .flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+      httpTesting
+        .expectOne(`${BACKEND_URL}/endpoint2`)
+        .flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+
+      resolveSharedRefresh(false);
+
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+
+      expect(result1).toBeInstanceOf(Error);
+      expect(result2).toBeInstanceOf(Error);
+      expect(mockAuthSession.signOut).toHaveBeenCalled();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/', 'login']);
+    });
+
     it('should redirect to login when refresh returns false', async () => {
       const promise1 = firstValueFrom(
         http.get(`${BACKEND_URL}/endpoint1`),

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -47,6 +47,7 @@ describe('AuthSessionService', () => {
     user: () => User | null;
   };
   let mockConfig: Partial<ApplicationConfiguration>;
+  let supabaseUrlSignal: ReturnType<typeof signal<string>>;
   let mockLogger: {
     info: Mock;
     warn: Mock;
@@ -97,8 +98,9 @@ describe('AuthSessionService', () => {
       user: mockUserSignal.asReadonly(),
     };
 
+    supabaseUrlSignal = signal('https://test.supabase.co');
     mockConfig = {
-      supabaseUrl: signal('https://test.supabase.co'),
+      supabaseUrl: supabaseUrlSignal,
       supabaseAnonKey: signal('test-key'),
     };
 
@@ -526,6 +528,27 @@ describe('AuthSessionService', () => {
       expect(mockErrorLocalizer.localizeAuthError).toHaveBeenCalledWith(error);
     });
 
+    it('should return failure when Supabase returns no session without error', async () => {
+      mockSupabaseClient.auth.setSession.mockResolvedValue({
+        data: { session: null, user: null },
+        error: null,
+      });
+
+      const result = await service.setSession({
+        access_token: validJwt,
+        refresh_token: 'test-refresh',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(mockAuthStore.set).toHaveBeenCalledWith({
+        phase: 'unauthenticated',
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'setSession returned no session without error',
+      );
+    });
+
     it('should handle unexpected error in setSession', async () => {
       mockSupabaseClient.auth.setSession.mockRejectedValue(
         new Error('Unexpected error'),
@@ -637,6 +660,71 @@ describe('AuthSessionService', () => {
 
     expect(mockSupabaseClient.auth.getSession).toHaveBeenCalledTimes(1);
     expect(mockSupabaseClient.auth.onAuthStateChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry initialization after a failed attempt', async () => {
+    supabaseUrlSignal.set('');
+
+    await expect(service.initializeAuthState()).rejects.toThrow(
+      'Configuration Supabase manquante après initialisation',
+    );
+
+    supabaseUrlSignal.set('https://test.supabase.co');
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+    mockSupabaseClient.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+
+    await service.initializeAuthState();
+
+    expect(mockSupabaseClient.auth.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  describe('signOut deduplication', () => {
+    beforeEach(async () => {
+      mockSupabaseClient.auth.getSession.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+      mockSupabaseClient.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      });
+      await service.initializeAuthState();
+      mockCleanup.performCleanup.mockClear();
+    });
+
+    it('should deduplicate concurrent signOut calls', async () => {
+      let resolveSignOut!: (value: { error: null }) => void;
+      mockSupabaseClient.auth.signOut.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSignOut = resolve;
+          }),
+      );
+
+      const pendingSignOuts = Promise.all([
+        service.signOut(),
+        service.signOut(),
+        service.signOut(),
+      ]);
+      resolveSignOut({ error: null });
+      await pendingSignOuts;
+
+      expect(mockSupabaseClient.auth.signOut).toHaveBeenCalledTimes(1);
+      expect(mockCleanup.performCleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow a new signOut after the previous one completed', async () => {
+      mockSupabaseClient.auth.signOut.mockResolvedValue({ error: null });
+
+      await service.signOut();
+      await service.signOut();
+
+      expect(mockSupabaseClient.auth.signOut).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('verifyPassword', () => {

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -37,6 +37,7 @@ export class AuthSessionService {
   #authSubscription: (() => void) | null = null;
   #initPromise: Promise<void> | null = null;
   #refreshPromise: Promise<boolean> | null = null;
+  #signOutPromise: Promise<void> | null = null;
 
   getClient(): SupabaseClient {
     if (!this.#supabaseClient) {
@@ -50,7 +51,10 @@ export class AuthSessionService {
       this.#logger.debug('Auth already initialized, skipping');
       return Promise.resolve();
     }
-    return (this.#initPromise ??= this.#initializeSupabaseSessionTracking());
+    return (this.#initPromise ??=
+      this.#initializeSupabaseSessionTracking().finally(() => {
+        this.#initPromise = null;
+      }));
   }
 
   async setSession(session: {
@@ -88,6 +92,15 @@ export class AuthSessionService {
         };
       }
 
+      if (!data.session) {
+        this.#logger.warn('setSession returned no session without error');
+        this.#updateAuthStateFromSession(null);
+        return {
+          success: false,
+          error: this.#transloco.translate(AUTH_ERROR_KEYS.SESSION_EXPIRED),
+        };
+      }
+
       this.#updateAuthStateFromSession(data.session);
       return { success: true };
     } catch (error) {
@@ -107,7 +120,10 @@ export class AuthSessionService {
     try {
       const email = this.#authStore.user()?.email;
       if (!email) {
-        return { success: false, error: 'Utilisateur non connecté' };
+        return {
+          success: false,
+          error: this.#transloco.translate(AUTH_ERROR_KEYS.USER_NOT_CONNECTED),
+        };
       }
 
       const { error } = await this.getClient().auth.signInWithPassword({
@@ -168,7 +184,13 @@ export class AuthSessionService {
     }
   }
 
-  async signOut(): Promise<void> {
+  signOut(): Promise<void> {
+    return (this.#signOutPromise ??= this.#performSignOut().finally(() => {
+      this.#signOutPromise = null;
+    }));
+  }
+
+  async #performSignOut(): Promise<void> {
     try {
       if (isE2EMode()) {
         this.#logger.debug('🎭 Mode test E2E: Simulation du logout');

--- a/frontend/projects/webapp/src/app/core/auth/public-guard.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/public-guard.spec.ts
@@ -1,0 +1,111 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  type ActivatedRouteSnapshot,
+  Router,
+  type RouterStateSnapshot,
+  type UrlTree,
+} from '@angular/router';
+import { firstValueFrom, type Observable } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ROUTES } from '@core/routing/routes-constants';
+import { publicGuard } from './public-guard';
+import { type AuthState, AuthStore } from './auth-store';
+
+describe('publicGuard', () => {
+  let stateSignal: ReturnType<typeof signal<AuthState>>;
+  let mockRouter: {
+    createUrlTree: ReturnType<typeof vi.fn>;
+  };
+
+  const mockUrlTree = {} as UrlTree;
+  const mockRoute = {} as ActivatedRouteSnapshot;
+  const mockState = {} as RouterStateSnapshot;
+
+  const runGuard = (): Observable<boolean | UrlTree> =>
+    TestBed.runInInjectionContext(
+      () => publicGuard(mockRoute, mockState) as Observable<boolean | UrlTree>,
+    );
+
+  beforeEach(() => {
+    stateSignal = signal<AuthState>({
+      user: null,
+      session: null,
+      isLoading: true,
+      isAuthenticated: false,
+    });
+
+    mockRouter = {
+      createUrlTree: vi.fn().mockReturnValue(mockUrlTree),
+    };
+
+    const mockAuthStore = {
+      authState: stateSignal.asReadonly(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: AuthStore, useValue: mockAuthStore },
+        { provide: Router, useValue: mockRouter },
+      ],
+    });
+  });
+
+  it('should allow navigation when unauthenticated and resolved', async () => {
+    stateSignal.set({
+      user: null,
+      session: null,
+      isLoading: false,
+      isAuthenticated: false,
+    });
+
+    const result = await firstValueFrom(runGuard());
+
+    expect(result).toBe(true);
+    expect(mockRouter.createUrlTree).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to dashboard when authenticated and resolved', async () => {
+    stateSignal.set({
+      user: {} as AuthState['user'],
+      session: {} as AuthState['session'],
+      isLoading: false,
+      isAuthenticated: true,
+    });
+
+    const result = await firstValueFrom(runGuard());
+
+    expect(result).toBe(mockUrlTree);
+    expect(mockRouter.createUrlTree).toHaveBeenCalledWith([
+      '/',
+      ROUTES.DASHBOARD,
+    ]);
+  });
+
+  it('should wait for auth state to resolve before allowing navigation', async () => {
+    const resultPromise = firstValueFrom(runGuard());
+
+    stateSignal.set({
+      user: null,
+      session: null,
+      isLoading: false,
+      isAuthenticated: false,
+    });
+
+    await expect(resultPromise).resolves.toBe(true);
+  });
+
+  it('should wait for auth state to resolve before redirecting to dashboard', async () => {
+    const resultPromise = firstValueFrom(runGuard());
+
+    stateSignal.set({
+      user: {} as AuthState['user'],
+      session: {} as AuthState['session'],
+      isLoading: false,
+      isAuthenticated: true,
+    });
+
+    await expect(resultPromise).resolves.toBe(mockUrlTree);
+  });
+});


### PR DESCRIPTION
Résidu Tier-3 reconstruit depuis les review threads de la PR #413 : reset de `#initPromise` après échec d'init, échec explicite quand `setSession` rend une session nulle sans erreur, dédup des signOut concurrents après refresh raté, spec interceptor multi-401, i18n du message « Utilisateur non connecté », spec du public-guard. 6 fichiers, +261/−5, 9 nouveaux tests. Vérifié : quality 10/10, 2116 tests. Restent 2 items nécessitant une décision produit (double write AuthStore au login ; itemisation « dette structurelle macro » bloquée par Linear).