### PR TITLE
feat(settings): pointage optionnel via toggle dans les préférences (PUL-110)

### DIFF
--- a/backend-nest/src/modules/user/application/update-user-settings.use-case.spec.ts
+++ b/backend-nest/src/modules/user/application/update-user-settings.use-case.spec.ts
@@ -35,6 +35,7 @@ describe('UpdateUserSettingsUseCase', () => {
       payDayOfMonth: 28,
       currency: 'EUR' as const,
       showCurrencySelector: false,
+      checkingEnabled: true,
     };
     mockRepo.updateSettings = mock(async () => settings);
 

--- a/backend-nest/src/modules/user/domain/user.entity.ts
+++ b/backend-nest/src/modules/user/domain/user.entity.ts
@@ -19,6 +19,7 @@ export interface UserSettings {
   payDayOfMonth: number | null;
   currency: SupportedCurrency;
   showCurrencySelector: boolean;
+  checkingEnabled: boolean;
 }
 
 /**
@@ -38,6 +39,7 @@ export interface UpdateUserSettingsInput {
   payDayOfMonth?: number | null;
   currency?: SupportedCurrency;
   showCurrencySelector?: boolean;
+  checkingEnabled?: boolean;
 }
 
 /**

--- a/backend-nest/src/modules/user/infrastructure/http/user.controller.spec.ts
+++ b/backend-nest/src/modules/user/infrastructure/http/user.controller.spec.ts
@@ -29,12 +29,14 @@ function buildController() {
       payDayOfMonth: 15,
       currency: 'EUR' as const,
       showCurrencySelector: true,
+      checkingEnabled: true,
     })),
   };
   const updateSettings = {
     execute: mock(async () => ({
       payDayOfMonth: 20,
       currency: 'CHF' as const,
+      checkingEnabled: true,
       showCurrencySelector: false,
     })),
   };
@@ -112,6 +114,7 @@ describe('UserController (HTTP wiring)', () => {
         payDayOfMonth: 15,
         currency: 'EUR',
         showCurrencySelector: true,
+        checkingEnabled: true,
       });
     });
   });

--- a/backend-nest/src/modules/user/infrastructure/persistence/supabase-user.repository.spec.ts
+++ b/backend-nest/src/modules/user/infrastructure/persistence/supabase-user.repository.spec.ts
@@ -11,6 +11,7 @@ interface MockUserMetadata {
   payDayOfMonth?: number | null;
   currency?: string;
   showCurrencySelector?: boolean;
+  checkingEnabled?: boolean;
   scheduledDeletionAt?: string;
 }
 
@@ -180,7 +181,19 @@ describe('SupabaseUserRepository', () => {
         payDayOfMonth: 15,
         currency: 'EUR',
         showCurrencySelector: true,
+        checkingEnabled: true,
       });
+    });
+
+    it('returns checkingEnabled=false when metadata disables it', async () => {
+      const client = buildAuthenticatedClient({ checkingEnabled: false });
+      Object.defineProperty(authenticatedProvider, 'client', {
+        get: () => client,
+      });
+
+      const result = await repo.findSettings();
+
+      expect(result.checkingEnabled).toBe(false);
     });
 
     it('falls back to CHF when currency is invalid', async () => {
@@ -207,6 +220,7 @@ describe('SupabaseUserRepository', () => {
         payDayOfMonth: null,
         currency: 'CHF',
         showCurrencySelector: false,
+        checkingEnabled: true,
       });
     });
   });

--- a/backend-nest/src/modules/user/infrastructure/persistence/supabase-user.repository.ts
+++ b/backend-nest/src/modules/user/infrastructure/persistence/supabase-user.repository.ts
@@ -25,6 +25,7 @@ interface SupabaseUserMetadata {
   payDayOfMonth?: number | null;
   currency?: string;
   showCurrencySelector?: boolean;
+  checkingEnabled?: boolean;
   scheduledDeletionAt?: string;
 }
 
@@ -107,6 +108,9 @@ export class SupabaseUserRepository implements UserRepositoryPort {
       ...(patch.currency !== undefined && { currency: patch.currency }),
       ...(patch.showCurrencySelector !== undefined && {
         showCurrencySelector: patch.showCurrencySelector,
+      }),
+      ...(patch.checkingEnabled !== undefined && {
+        checkingEnabled: patch.checkingEnabled,
       }),
     };
 
@@ -233,6 +237,9 @@ export class SupabaseUserRepository implements UserRepositoryPort {
       payDayOfMonth,
       currency,
       showCurrencySelector: metadata?.showCurrencySelector === true,
+      // Absent metadata means the user never touched the toggle — checking
+      // (pointage) stays visible, preserving pre-PUL-110 behavior.
+      checkingEnabled: metadata?.checkingEnabled !== false,
     };
   }
 }

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -238,6 +238,8 @@
     "currencyLabel": "Devise",
     "currencySelectorLabel": "Sélecteur de devise",
     "currencySelectorDescription": "Afficher un sélecteur de devise sur les champs montant",
+    "checkingLabel": "Suivi du pointage",
+    "checkingDescription": "Pointe tes prévisions et transactions après les avoir vérifiées sur ton relevé bancaire",
     "converterTitle": "Convertisseur",
     "converterAmountLabel": "Montant",
     "converterAmountMaxError": "Le montant ne peut pas dépasser {{ max }}.",

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
@@ -19,6 +19,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   payDayOfMonth: null,
   currency: 'CHF',
   showCurrencySelector: false,
+  checkingEnabled: true,
 };
 
 function createMockUserSettingsStore(
@@ -316,6 +317,7 @@ describe('User consent and tracking behavior', () => {
         payDayOfMonth: 25,
         currency: 'EUR',
         showCurrencySelector: true,
+        checkingEnabled: true,
       });
       mockFeatureFlagsService.setEnabled(true);
 
@@ -392,6 +394,7 @@ describe('User consent and tracking behavior', () => {
         payDayOfMonth: 1,
         currency: 'EUR',
         showCurrencySelector: false,
+        checkingEnabled: true,
       });
       TestBed.tick();
 

--- a/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.spec.ts
+++ b/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.spec.ts
@@ -32,6 +32,7 @@ describe('UserSettingsStore', () => {
     payDayOfMonth: 25,
     currency: 'CHF',
     showCurrencySelector: false,
+    checkingEnabled: true,
   };
 
   beforeEach(() => {
@@ -119,6 +120,7 @@ describe('UserSettingsStore', () => {
         payDayOfMonth: 15,
         currency: 'CHF',
         showCurrencySelector: false,
+        checkingEnabled: true,
       };
       mockApi.updateSettings$ = vi
         .fn()
@@ -137,6 +139,7 @@ describe('UserSettingsStore', () => {
         payDayOfMonth: 15,
         currency: 'CHF',
         showCurrencySelector: false,
+        checkingEnabled: true,
       };
       mockApi.updateSettings$ = vi
         .fn()
@@ -170,6 +173,7 @@ describe('UserSettingsStore', () => {
         payDayOfMonth: 25,
         currency: 'EUR',
         showCurrencySelector: false,
+        checkingEnabled: true,
       };
       mockApi.getSettings$ = vi
         .fn()
@@ -199,6 +203,7 @@ describe('UserSettingsStore', () => {
         payDayOfMonth: 10,
         currency: 'CHF',
         showCurrencySelector: false,
+        checkingEnabled: true,
       };
       mockApi.getSettings$ = vi
         .fn()
@@ -330,6 +335,7 @@ describe('UserSettingsStore — loading conditions', () => {
       payDayOfMonth: 25,
       currency: 'CHF',
       showCurrencySelector: false,
+      checkingEnabled: true,
     };
 
     TestBed.configureTestingModule({

--- a/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.ts
+++ b/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.ts
@@ -52,6 +52,11 @@ export class UserSettingsStore {
     () => this.settings()?.showCurrencySelector ?? false,
   );
 
+  /** Pointage (bank reconciliation) visibility — defaults to enabled. */
+  readonly isCheckingEnabled = computed(
+    () => this.settings()?.checkingEnabled ?? true,
+  );
+
   readonly isLoading = this.#settingsResource.isInitialLoading;
 
   readonly error = this.#settingsResource.error;

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/create-dialog/form.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/create-dialog/form.spec.ts
@@ -85,6 +85,7 @@ const setupWithCurrency = ({
   const settings = {
     currency: signal<SupportedCurrency>(userCurrency),
     showCurrencySelector: signal(showCurrencyPref),
+    isCheckingEnabled: signal(true),
   };
   const converter = {
     convertWithMetadata: vi.fn().mockResolvedValue({

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/create-dialog/form.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/create-dialog/form.ts
@@ -121,15 +121,17 @@ interface CreateAllocatedTransactionModel {
         }
       </mat-form-field>
 
-      <div class="flex items-center justify-between py-2 px-1">
-        <span class="text-body-medium text-on-surface">{{
-          'transactionForm.checkedToggle' | transloco
-        }}</span>
-        <mat-slide-toggle
-          [formField]="transactionForm.isChecked"
-          [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
-        />
-      </div>
+      @if (isCheckingEnabled()) {
+        <div class="flex items-center justify-between py-2 px-1">
+          <span class="text-body-medium text-on-surface">{{
+            'transactionForm.checkedToggle' | transloco
+          }}</span>
+          <mat-slide-toggle
+            [formField]="transactionForm.isChecked"
+            [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
+          />
+        </div>
+      }
     </form>
 
     @if (conversionError()) {
@@ -143,6 +145,7 @@ interface CreateAllocatedTransactionModel {
 })
 export class CreateAllocatedTransactionForm {
   readonly #settings = inject(UserSettingsStore);
+  protected readonly isCheckingEnabled = this.#settings.isCheckingEnabled;
   readonly #converter = inject(CurrencyConverterService);
   readonly #logger = inject(Logger);
   readonly #staleRateNotifier = inject(StaleRateNotifier);

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/details-dialog/bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/details-dialog/bottom-sheet.spec.ts
@@ -102,7 +102,11 @@ describe('AllocatedTransactionsBottomSheet', () => {
         { provide: MatBottomSheetRef, useValue: mockBottomSheetRef },
         {
           provide: UserSettingsStore,
-          useValue: { currency: signal('CHF'), payDayOfMonth: signal(1) },
+          useValue: {
+            currency: signal('CHF'),
+            payDayOfMonth: signal(1),
+            isCheckingEnabled: signal(true),
+          },
         },
         {
           provide: FeatureFlagsService,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/details-dialog/bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/allocated-transactions/details-dialog/bottom-sheet.ts
@@ -149,16 +149,18 @@ import type {
                 class="flex flex-col gap-1 py-2 px-2 bg-surface-container-low rounded-lg"
               >
                 <div class="flex items-center gap-2">
-                  <mat-slide-toggle
-                    [checked]="!!tx.checkedAt"
-                    (change)="onToggleCheck(tx.id)"
-                    (click)="$event.stopPropagation()"
-                    [attr.data-testid]="'toggle-tx-check-' + tx.id"
-                    [attr.aria-label]="
-                      'budget.toggleCheckAriaLabel'
-                        | transloco: { name: tx.name }
-                    "
-                  />
+                  @if (isCheckingEnabled()) {
+                    <mat-slide-toggle
+                      [checked]="!!tx.checkedAt"
+                      (change)="onToggleCheck(tx.id)"
+                      (click)="$event.stopPropagation()"
+                      [attr.data-testid]="'toggle-tx-check-' + tx.id"
+                      [attr.aria-label]="
+                        'budget.toggleCheckAriaLabel'
+                          | transloco: { name: tx.name }
+                      "
+                    />
+                  }
                   <span
                     class="flex-1 min-w-0 text-body-medium font-medium truncate ph-no-capture"
                     [class.line-through]="tx.checkedAt"
@@ -274,6 +276,7 @@ import type {
 })
 export class AllocatedTransactionsBottomSheet {
   readonly #userSettings = inject(UserSettingsStore);
+  protected readonly isCheckingEnabled = this.#userSettings.isCheckingEnabled;
   readonly #featureFlags = inject(FeatureFlagsService);
   protected readonly store = inject(BudgetDetailsStore);
   protected readonly currency = this.#userSettings.currency;

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-grid/budget-detail-panel.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-grid/budget-detail-panel.ts
@@ -282,19 +282,21 @@ const DETAIL_SEGMENT_COUNT = 12;
                     />
                   </div>
                   <div class="flex items-center gap-1">
-                    <mat-slide-toggle
-                      [checked]="!!tx.checkedAt"
-                      (change)="onToggleCheck(tx.id)"
-                      (click)="$event.stopPropagation()"
-                      [attr.data-testid]="'toggle-tx-check-' + tx.id"
-                      [attr.aria-label]="
-                        tx.checkedAt
-                          ? ('budgetLine.uncheckLabel'
-                            | transloco: { name: tx.name })
-                          : ('budgetLine.checkLabel'
-                            | transloco: { name: tx.name })
-                      "
-                    />
+                    @if (isCheckingEnabled()) {
+                      <mat-slide-toggle
+                        [checked]="!!tx.checkedAt"
+                        (change)="onToggleCheck(tx.id)"
+                        (click)="$event.stopPropagation()"
+                        [attr.data-testid]="'toggle-tx-check-' + tx.id"
+                        [attr.aria-label]="
+                          tx.checkedAt
+                            ? ('budgetLine.uncheckLabel'
+                              | transloco: { name: tx.name })
+                            : ('budgetLine.checkLabel'
+                              | transloco: { name: tx.name })
+                        "
+                      />
+                    }
                     <button
                       matIconButton
                       (click)="onEditTransaction(tx)"
@@ -377,6 +379,7 @@ export class BudgetDetailPanel {
   readonly #userSettings = inject(UserSettingsStore);
   readonly #featureFlags = inject(FeatureFlagsService);
   protected readonly currency = this.#userSettings.currency;
+  protected readonly isCheckingEnabled = this.#userSettings.isCheckingEnabled;
   // Date locale (fr-CH / fr-FR) for month names — NOT numberLocale (de-CH),
   // which would render the spread months in German ("Juni" instead of "juin").
   protected readonly locale = computed(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-grid/budget-grid-card.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-grid/budget-grid-card.ts
@@ -2,10 +2,12 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  inject,
   input,
   output,
 } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { UserSettingsStore } from '@core/user-settings';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
@@ -203,19 +205,21 @@ import { BudgetActionMenu } from '../budget-action-menu';
           {{ item().data.recurrence | recurrenceLabel }}
         </mat-chip>
 
-        <mat-slide-toggle
-          [checked]="!!item().data.checkedAt"
-          (change)="toggleCheck.emit(item().data.id)"
-          (click)="$event.stopPropagation()"
-          [attr.data-testid]="'toggle-check-' + item().data.id"
-          [attr.aria-label]="
-            item().data.checkedAt
-              ? ('budgetLine.uncheckLabel'
-                | transloco: { name: item().data.name })
-              : ('budgetLine.checkLabel'
-                | transloco: { name: item().data.name })
-          "
-        />
+        @if (isCheckingEnabled()) {
+          <mat-slide-toggle
+            [checked]="!!item().data.checkedAt"
+            (change)="toggleCheck.emit(item().data.id)"
+            (click)="$event.stopPropagation()"
+            [attr.data-testid]="'toggle-check-' + item().data.id"
+            [attr.aria-label]="
+              item().data.checkedAt
+                ? ('budgetLine.uncheckLabel'
+                  | transloco: { name: item().data.name })
+                : ('budgetLine.checkLabel'
+                  | transloco: { name: item().data.name })
+            "
+          />
+        }
       </div>
     </div>
   `,
@@ -227,6 +231,9 @@ import { BudgetActionMenu } from '../budget-action-menu';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BudgetGridCard {
+  protected readonly isCheckingEnabled =
+    inject(UserSettingsStore).isCheckingEnabled;
+
   readonly item = input.required<BudgetLineTableItem>();
   readonly currency = input<SupportedCurrency>('CHF');
   readonly isSelected = input<boolean>(false);

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-grid/budget-grid.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-grid/budget-grid.ts
@@ -16,6 +16,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AppCurrencyPipe, FormatConversionPipe } from '@core/currency';
 import { getDateDisplayFormats } from '@core/date/date-display-formats';
+import { UserSettingsStore } from '@core/user-settings';
 import { FeatureFlagsService } from '@core/feature-flags';
 import { FinancialKindDirective } from '@ui/financial-kind';
 import { FinancialKindIndicator } from '@ui/financial-kind-indicator';
@@ -277,17 +278,19 @@ export function groupByKind<T extends { data: { kind: string } }>(
             <span class="text-label-small text-on-surface-variant">
               {{ item.data.kind | transactionLabel }}
             </span>
-            <mat-slide-toggle
-              [checked]="!!item.data.checkedAt"
-              (change)="toggleTransactionCheck.emit(item.data.id)"
-              (click)="$event.stopPropagation()"
-              [attr.data-testid]="'toggle-check-tx-' + item.data.id"
-              [attr.aria-label]="
-                item.data.checkedAt
-                  ? ('budgetLine.removeCheck' | transloco)
-                  : ('budgetLine.addCheck' | transloco)
-              "
-            />
+            @if (isCheckingEnabled()) {
+              <mat-slide-toggle
+                [checked]="!!item.data.checkedAt"
+                (change)="toggleTransactionCheck.emit(item.data.id)"
+                (click)="$event.stopPropagation()"
+                [attr.data-testid]="'toggle-check-tx-' + item.data.id"
+                [attr.aria-label]="
+                  item.data.checkedAt
+                    ? ('budgetLine.removeCheck' | transloco)
+                    : ('budgetLine.addCheck' | transloco)
+                "
+              />
+            }
           </div>
         </mat-card-content>
       </mat-card>
@@ -356,17 +359,19 @@ export function groupByKind<T extends { data: { kind: string } }>(
               </span>
             }
           </div>
-          <mat-slide-toggle
-            [checked]="!!item.data.checkedAt"
-            (change)="toggleTransactionCheck.emit(item.data.id)"
-            (click)="$event.stopPropagation()"
-            [attr.data-testid]="'toggle-check-tx-' + item.data.id"
-            [attr.aria-label]="
-              item.data.checkedAt
-                ? ('budgetLine.removeCheck' | transloco)
-                : ('budgetLine.addCheck' | transloco)
-            "
-          />
+          @if (isCheckingEnabled()) {
+            <mat-slide-toggle
+              [checked]="!!item.data.checkedAt"
+              (change)="toggleTransactionCheck.emit(item.data.id)"
+              (click)="$event.stopPropagation()"
+              [attr.data-testid]="'toggle-check-tx-' + item.data.id"
+              [attr.aria-label]="
+                item.data.checkedAt
+                  ? ('budgetLine.removeCheck' | transloco)
+                  : ('budgetLine.addCheck' | transloco)
+              "
+            />
+          }
         </div>
       </div>
     </ng-template>
@@ -380,6 +385,8 @@ export function groupByKind<T extends { data: { kind: string } }>(
 })
 export class BudgetGrid {
   readonly #dialog = inject(MatDialog);
+  protected readonly isCheckingEnabled =
+    inject(UserSettingsStore).isCheckingEnabled;
   readonly #viewContainerRef = inject(ViewContainerRef);
   readonly #featureFlags = inject(FeatureFlagsService);
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.spec.ts
@@ -136,6 +136,7 @@ function setupComponent(
   mockStore: MockStore,
   mockDialogService: MockDialogService,
   mockSnackBar: { open: ReturnType<typeof vi.fn> },
+  options: { isCheckingEnabled?: boolean } = {},
 ): ComponentFixture<BudgetItemsContainer> {
   TestBed.configureTestingModule({
     imports: [BudgetItemsContainer, NoopAnimationsModule],
@@ -151,6 +152,7 @@ function setupComponent(
         useValue: {
           currency: signal('CHF'),
           payDayOfMonth: signal(1),
+          isCheckingEnabled: signal(options.isCheckingEnabled ?? true),
         },
       },
       { provide: Logger, useValue: { warn: vi.fn(), error: vi.fn() } },
@@ -159,6 +161,55 @@ function setupComponent(
 
   return TestBed.createComponent(BudgetItemsContainer);
 }
+
+describe('BudgetItemsContainer — pointage visibility (PUL-110)', () => {
+  let mockStore: MockStore;
+
+  beforeEach(() => {
+    mockStore = createMockStore();
+    mockStore.checkedItemsCount.set(2);
+    mockStore.totalItemsCount.set(3);
+    // Render the search empty state instead of the table: BudgetTable's
+    // required inputs trigger NG0950 under TestBed host rendering (see
+    // template-list-item.spec.ts). Filter chips + summary render regardless.
+    mockStore.searchText.set('xyz');
+  });
+
+  it('shows the checked filter and checking summary when pointage is enabled', () => {
+    const fixture = setupComponent(mockStore, createMockDialogService(), {
+      open: vi.fn(),
+    });
+
+    fixture.detectChanges();
+
+    const nativeEl: HTMLElement = fixture.nativeElement;
+    expect(
+      nativeEl.querySelector('pulpe-budget-table-checked-filter'),
+    ).not.toBeNull();
+    expect(
+      nativeEl.querySelector('[data-testid="budget-items-checking-summary"]'),
+    ).not.toBeNull();
+  });
+
+  it('hides the checked filter and checking summary when pointage is disabled', () => {
+    const fixture = setupComponent(
+      mockStore,
+      createMockDialogService(),
+      { open: vi.fn() },
+      { isCheckingEnabled: false },
+    );
+
+    fixture.detectChanges();
+
+    const nativeEl: HTMLElement = fixture.nativeElement;
+    expect(
+      nativeEl.querySelector('pulpe-budget-table-checked-filter'),
+    ).toBeNull();
+    expect(
+      nativeEl.querySelector('[data-testid="budget-items-checking-summary"]'),
+    ).toBeNull();
+  });
+});
 
 describe('BudgetItemsContainer — contextual empty states', () => {
   let mockStore: MockStore;
@@ -350,6 +401,7 @@ describe('BudgetItemsContainer — PATCH transaction body contract', () => {
           useValue: {
             currency: signal('CHF'),
             payDayOfMonth: signal(1),
+            isCheckingEnabled: signal(true),
           },
         },
         { provide: Logger, useValue: createMockLogger() },

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
@@ -99,13 +99,17 @@ import {
       />
 
       <!-- Filter -->
-      <pulpe-budget-table-checked-filter
-        [isShowingOnlyUnchecked]="store.isShowingOnlyUnchecked()"
-        (isShowingOnlyUncheckedChange)="store.setIsShowingOnlyUnchecked($event)"
-      />
+      @if (isCheckingEnabled()) {
+        <pulpe-budget-table-checked-filter
+          [isShowingOnlyUnchecked]="store.isShowingOnlyUnchecked()"
+          (isShowingOnlyUncheckedChange)="
+            store.setIsShowingOnlyUnchecked($event)
+          "
+        />
+      }
 
       <!-- Checking summary — progressive disclosure -->
-      @if (store.checkedItemsCount() > 0) {
+      @if (isCheckingEnabled() && store.checkedItemsCount() > 0) {
         <p
           class="text-body-medium text-on-surface-variant flex items-center gap-1.5 -mt-1"
           data-testid="budget-items-checking-summary"
@@ -256,6 +260,7 @@ export class BudgetItemsContainer {
   readonly #userSettings = inject(UserSettingsStore);
 
   protected readonly currency = this.#userSettings.currency;
+  protected readonly isCheckingEnabled = this.#userSettings.isCheckingEnabled;
   protected readonly locale = computed(
     () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-table/cells/actions-cell.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-table/cells/actions-cell.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  inject,
   input,
   output,
 } from '@angular/core';
@@ -12,6 +13,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { UserSettingsStore } from '@core/user-settings';
 import type { Transaction } from 'pulpe-shared';
 import type { BudgetLine } from 'pulpe-shared';
 import type {
@@ -32,20 +34,22 @@ import type {
   ],
   template: `
     <div class="flex gap-1 justify-end items-center">
-      @if (line().metadata.itemType === 'budget_line') {
-        <mat-slide-toggle
-          [checked]="!!line().data.checkedAt"
-          (change)="toggleCheck.emit(line().data.id)"
-          (click)="$event.stopPropagation()"
-          [attr.data-testid]="'toggle-check-' + line().data.id"
-        />
-      } @else if (line().metadata.itemType === 'transaction') {
-        <mat-slide-toggle
-          [checked]="!!line().data.checkedAt"
-          (change)="toggleTransactionCheck.emit(line().data.id)"
-          (click)="$event.stopPropagation()"
-          [attr.data-testid]="'toggle-check-tx-' + line().data.id"
-        />
+      @if (isCheckingEnabled()) {
+        @if (line().metadata.itemType === 'budget_line') {
+          <mat-slide-toggle
+            [checked]="!!line().data.checkedAt"
+            (change)="toggleCheck.emit(line().data.id)"
+            (click)="$event.stopPropagation()"
+            [attr.data-testid]="'toggle-check-' + line().data.id"
+          />
+        } @else if (line().metadata.itemType === 'transaction') {
+          <mat-slide-toggle
+            [checked]="!!line().data.checkedAt"
+            (change)="toggleTransactionCheck.emit(line().data.id)"
+            (click)="$event.stopPropagation()"
+            [attr.data-testid]="'toggle-check-tx-' + line().data.id"
+          />
+        }
       }
       <button
         matIconButton
@@ -188,6 +192,9 @@ import type {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ActionsCell {
+  protected readonly isCheckingEnabled =
+    inject(UserSettingsStore).isCheckingEnabled;
+
   readonly line = input.required<BudgetLineTableItem | TransactionTableItem>();
 
   readonly edit = output<BudgetLineTableItem>();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-search.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-search.spec.ts
@@ -154,6 +154,7 @@ describe('BudgetDetailsStore - Search Filtering', () => {
           useValue: {
             currency: signal('CHF'),
             payDayOfMonth: signal(1),
+            isCheckingEnabled: signal(true),
           },
         },
         {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -91,6 +91,14 @@ export class BudgetDetailsStore {
   );
   readonly isShowingOnlyUnchecked = this.#isShowingOnlyUnchecked.asReadonly();
 
+  // PUL-110 — when the user disabled pointage in settings, the "À pointer"
+  // filter chip is hidden, so the persisted filter must not silently hide
+  // checked items: the effective filter is forced off.
+  readonly #isUncheckedFilterActive = computed(
+    () =>
+      this.#isShowingOnlyUnchecked() && this.#userSettings.isCheckingEnabled(),
+  );
+
   readonly #searchText = signal('');
   readonly searchText = this.#searchText.asReadonly();
 
@@ -386,7 +394,7 @@ export class BudgetDetailsStore {
 
   readonly filteredBudgetLines = computed<BudgetLine[]>(() => {
     let lines = this.displayBudgetLines();
-    if (this.#isShowingOnlyUnchecked()) {
+    if (this.#isUncheckedFilterActive()) {
       lines = lines.filter((line) => line.checkedAt === null);
     }
     const search = normalizeText(this.#searchText());
@@ -428,7 +436,7 @@ export class BudgetDetailsStore {
       }
       // Free transaction
       const passesCheckedFilter =
-        !this.#isShowingOnlyUnchecked() || tx.checkedAt === null;
+        !this.#isUncheckedFilterActive() || tx.checkedAt === null;
       if (!passesCheckedFilter) return false;
       if (!search) return true;
       return (

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
@@ -20,6 +20,7 @@ interface FlagsMock {
 interface SettingsMock {
   currency: ReturnType<typeof signal<SupportedCurrency>>;
   showCurrencySelector: ReturnType<typeof signal<boolean>>;
+  isCheckingEnabled: ReturnType<typeof signal<boolean>>;
 }
 interface ConverterMock {
   convertWithMetadata: ReturnType<typeof vi.fn>;
@@ -33,10 +34,12 @@ function configureBottomSheet({
   userCurrency = 'CHF' as SupportedCurrency,
   flagEnabled = false,
   showCurrencyPref = true,
+  isCheckingEnabled = true,
 }: {
   userCurrency?: SupportedCurrency;
   flagEnabled?: boolean;
   showCurrencyPref?: boolean;
+  isCheckingEnabled?: boolean;
 } = {}) {
   const bottomSheetRef: BottomSheetRefMock = {
     dismiss: vi.fn(),
@@ -48,6 +51,7 @@ function configureBottomSheet({
   const settings: SettingsMock = {
     currency: signal<SupportedCurrency>(userCurrency),
     showCurrencySelector: signal(showCurrencyPref),
+    isCheckingEnabled: signal(isCheckingEnabled),
   };
   const converter: ConverterMock = {
     convertWithMetadata: vi.fn().mockImplementation(async (amount: number) => ({
@@ -203,6 +207,43 @@ describe('AddTransactionBottomSheet', () => {
       expect(bottomSheetRef.dismiss).toHaveBeenCalledWith(
         expect.objectContaining({ checkedAt: null }),
       );
+    });
+
+    it('should show the checked toggle when pointage is enabled (PUL-110)', () => {
+      const { fixture } = configureBottomSheet({ isCheckingEnabled: true });
+
+      fixture.detectChanges();
+
+      const toggle = fixture.nativeElement.querySelector('mat-slide-toggle');
+      expect(toggle).not.toBeNull();
+    });
+
+    it('should hide the checked toggle when pointage is disabled (PUL-110)', () => {
+      const { fixture } = configureBottomSheet({ isCheckingEnabled: false });
+
+      fixture.detectChanges();
+
+      const toggle = fixture.nativeElement.querySelector('mat-slide-toggle');
+      expect(toggle).toBeNull();
+    });
+
+    it('should keep auto-checking new transactions when pointage is disabled (PUL-110)', async () => {
+      const { component, bottomSheetRef } = configureBottomSheet({
+        isCheckingEnabled: false,
+      });
+      component['model'].update((m) => ({
+        ...m,
+        name: 'Test',
+        money: { ...m.money, amount: 10 },
+        kind: 'expense',
+      }));
+
+      await component['onSubmit']();
+
+      const callArg: TransactionFormData =
+        bottomSheetRef.dismiss.mock.calls[0][0];
+      expect(callArg.checkedAt).toBeDefined();
+      expect(typeof callArg.checkedAt).toBe('string');
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -210,15 +210,17 @@ interface AddTransactionModel {
           <span>{{ 'currentMonth.addTransactionToday' | transloco }}</span>
         </div>
 
-        <div class="flex items-center justify-between py-2 px-1">
-          <span class="text-body-medium text-on-surface">{{
-            'transactionForm.checkedToggle' | transloco
-          }}</span>
-          <mat-slide-toggle
-            [formField]="transactionForm.isChecked"
-            [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
-          />
-        </div>
+        @if (isCheckingEnabled()) {
+          <div class="flex items-center justify-between py-2 px-1">
+            <span class="text-body-medium text-on-surface">{{
+              'transactionForm.checkedToggle' | transloco
+            }}</span>
+            <mat-slide-toggle
+              [formField]="transactionForm.isChecked"
+              [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
+            />
+          </div>
+        }
       </form>
 
       @if (conversionError()) {
@@ -270,6 +272,7 @@ export class AddTransactionBottomSheet {
   }
 
   protected readonly currency = this.#userSettings.currency;
+  protected readonly isCheckingEnabled = this.#userSettings.isCheckingEnabled;
   protected readonly predefinedAmounts = [10, 15, 20, 30] as const;
   protected readonly conversionError = signal(false);
   protected readonly isSubmitting = signal(false);

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -122,7 +122,8 @@ import { CURRENCY_CONFIG } from '@core/currency';
 
           <!-- Paired lists: Recent Transactions + Unchecked Forecasts -->
           <div
-            class="grid grid-cols-1 lg:grid-cols-2 gap-8"
+            class="grid grid-cols-1 gap-8"
+            [class.lg:grid-cols-2]="isCheckingEnabled()"
             data-tour="dashboard-lists"
           >
             <pulpe-dashboard-recent-transactions
@@ -132,15 +133,17 @@ import { CURRENCY_CONFIG } from '@core/currency';
               data-testid="dashboard-block-recent-transactions"
             />
 
-            <pulpe-dashboard-unchecked-forecasts
-              class="order-1 lg:order-2"
-              [forecasts]="store.uncheckedForecasts()"
-              [consumptions]="store.consumptions()"
-              [currency]="currency()"
-              (toggleCheck)="checkBudgetLine($event)"
-              (viewBudget)="navigateToBudgetDetails()"
-              data-testid="dashboard-block-forecasts"
-            />
+            @if (isCheckingEnabled()) {
+              <pulpe-dashboard-unchecked-forecasts
+                class="order-1 lg:order-2"
+                [forecasts]="store.uncheckedForecasts()"
+                [consumptions]="store.consumptions()"
+                [currency]="currency()"
+                (toggleCheck)="checkBudgetLine($event)"
+                (viewBudget)="navigateToBudgetDetails()"
+                data-testid="dashboard-block-forecasts"
+              />
+            }
           </div>
 
           <!-- Future Projection Chart -->
@@ -323,7 +326,9 @@ import { CURRENCY_CONFIG } from '@core/currency';
 })
 export default class Dashboard {
   protected readonly store = inject(DashboardStore);
-  protected readonly currency = inject(UserSettingsStore).currency;
+  readonly #userSettings = inject(UserSettingsStore);
+  protected readonly currency = this.#userSettings.currency;
+  protected readonly isCheckingEnabled = this.#userSettings.isCheckingEnabled;
   protected readonly currencyLocale = computed(
     () => CURRENCY_CONFIG[this.currency()].numberLocale,
   );

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.spec.ts
@@ -28,6 +28,7 @@ describe('SettingsPage', () => {
     payDayOfMonth: ReturnType<typeof signal<number | null>>;
     currency: ReturnType<typeof signal<string>>;
     showCurrencySelector: ReturnType<typeof signal<boolean>>;
+    isCheckingEnabled: ReturnType<typeof signal<boolean>>;
     updateSettings: ReturnType<typeof vi.fn>;
     deleteAccount: ReturnType<typeof vi.fn>;
   };
@@ -61,6 +62,7 @@ describe('SettingsPage', () => {
       payDayOfMonth: signal<number | null>(null),
       currency: signal('CHF'),
       showCurrencySelector: signal(false),
+      isCheckingEnabled: signal(true),
       updateSettings: vi.fn().mockResolvedValue({}),
       deleteAccount: vi.fn().mockResolvedValue(undefined),
     };
@@ -271,6 +273,37 @@ describe('SettingsPage', () => {
         'OK',
         expect.any(Object),
       );
+    });
+  });
+
+  describe('checking (pointage) toggle', () => {
+    it('should render the checking toggle', () => {
+      const toggle = fixture.nativeElement.querySelector(
+        '[data-testid="checking-enabled-toggle"]',
+      );
+
+      expect(toggle).not.toBeNull();
+    });
+
+    it('should save checkingEnabled=false when the toggle is turned off', async () => {
+      fixture.componentInstance.onCheckingEnabledChange(false);
+
+      await fixture.componentInstance.saveSettings();
+      await fixture.whenStable();
+
+      expect(mockUserSettingsStore.updateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ checkingEnabled: false }),
+      );
+    });
+
+    it('should reset the toggle to the stored value on cancel', () => {
+      fixture.componentInstance.onCheckingEnabledChange(false);
+      expect(fixture.componentInstance.hasChanges()).toBe(true);
+
+      fixture.componentInstance.resetChanges();
+
+      expect(fixture.componentInstance.selectedCheckingEnabled()).toBe(true);
+      expect(fixture.componentInstance.hasChanges()).toBe(false);
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
@@ -168,6 +168,23 @@ import { VerifyRecoveryKeyDialog } from './components/verify-recovery-key-dialog
               }
             }
 
+            <!-- Checking (pointage) Toggle -->
+            <div class="flex items-center justify-between gap-4 py-2">
+              <div class="space-y-0.5">
+                <p class="text-body-medium">
+                  {{ 'settings.checkingLabel' | transloco }}
+                </p>
+                <p class="text-body-small text-on-surface-variant">
+                  {{ 'settings.checkingDescription' | transloco }}
+                </p>
+              </div>
+              <mat-slide-toggle
+                [checked]="selectedCheckingEnabled()"
+                (change)="onCheckingEnabledChange($event.checked)"
+                data-testid="checking-enabled-toggle"
+              />
+            </div>
+
             <mat-form-field
               appearance="outline"
               subscriptSizing="dynamic"
@@ -419,6 +436,11 @@ export default class SettingsPage {
     this.#userSettingsStore.showCurrencySelector(),
   );
 
+  // Checking (pointage) toggle
+  readonly selectedCheckingEnabled = linkedSignal(() =>
+    this.#userSettingsStore.isCheckingEnabled(),
+  );
+
   readonly initialPayDay = computed(() =>
     this.#userSettingsStore.payDayOfMonth(),
   );
@@ -426,12 +448,17 @@ export default class SettingsPage {
   readonly initialShowCurrencySelector = computed(() =>
     this.#userSettingsStore.showCurrencySelector(),
   );
+  readonly initialCheckingEnabled = computed(() =>
+    this.#userSettingsStore.isCheckingEnabled(),
+  );
 
   readonly hasChanges = computed(() => {
     return (
       this.initialPayDay() !== this.selectedPayDay() ||
       this.initialCurrency() !== this.selectedCurrency() ||
-      this.initialShowCurrencySelector() !== this.selectedShowCurrencySelector()
+      this.initialShowCurrencySelector() !==
+        this.selectedShowCurrencySelector() ||
+      this.initialCheckingEnabled() !== this.selectedCheckingEnabled()
     );
   });
 
@@ -445,6 +472,10 @@ export default class SettingsPage {
 
   onShowCurrencySelectorChange(value: boolean): void {
     this.selectedShowCurrencySelector.set(value);
+  }
+
+  onCheckingEnabledChange(value: boolean): void {
+    this.selectedCheckingEnabled.set(value);
   }
 
   onCurrencyChange(value: SupportedCurrency): void {
@@ -466,6 +497,7 @@ export default class SettingsPage {
         payDayOfMonth: this.selectedPayDay(),
         currency: newCurrency,
         showCurrencySelector: newSelector,
+        checkingEnabled: this.selectedCheckingEnabled(),
       });
 
       this.#trackCurrencyAnalytics({
@@ -504,6 +536,7 @@ export default class SettingsPage {
     this.selectedPayDay.set(this.initialPayDay());
     this.selectedCurrency.set(this.initialCurrency());
     this.selectedShowCurrencySelector.set(this.initialShowCurrencySelector());
+    this.selectedCheckingEnabled.set(this.initialCheckingEnabled());
   }
 
   #trackCurrencyAnalytics(args: {

--- a/ios/Pulpe/Domain/Models/UserSettings.swift
+++ b/ios/Pulpe/Domain/Models/UserSettings.swift
@@ -5,6 +5,7 @@ struct UserSettings: Codable, Sendable {
     let payDayOfMonth: Int?
     let currency: SupportedCurrency?
     let showCurrencySelector: Bool?
+    let checkingEnabled: Bool?
 }
 
 /// Request body for PUT /users/settings
@@ -12,10 +13,17 @@ struct UpdateUserSettings: Codable, Sendable {
     let payDayOfMonth: Int?
     let currency: SupportedCurrency?
     let showCurrencySelector: Bool?
+    let checkingEnabled: Bool?
 
-    init(payDayOfMonth: Int? = nil, currency: SupportedCurrency? = nil, showCurrencySelector: Bool? = nil) {
+    init(
+        payDayOfMonth: Int? = nil,
+        currency: SupportedCurrency? = nil,
+        showCurrencySelector: Bool? = nil,
+        checkingEnabled: Bool? = nil
+    ) {
         self.payDayOfMonth = payDayOfMonth
         self.currency = currency
         self.showCurrencySelector = showCurrencySelector
+        self.checkingEnabled = checkingEnabled
     }
 }

--- a/ios/Pulpe/Domain/Store/UserSettingsStore.swift
+++ b/ios/Pulpe/Domain/Store/UserSettingsStore.swift
@@ -7,6 +7,8 @@ final class UserSettingsStore: StoreProtocol {
     private(set) var payDayOfMonth: Int?
     private(set) var currency: SupportedCurrency = .chf
     private(set) var showCurrencySelector = false
+    /// Pointage (bank reconciliation) visibility — defaults to enabled.
+    private(set) var checkingEnabled = true
     private(set) var isLoading = false
     private(set) var error: APIError?
 
@@ -76,6 +78,7 @@ final class UserSettingsStore: StoreProtocol {
                 payDayOfMonth = settings.payDayOfMonth
                 currency = settings.currency ?? .chf
                 showCurrencySelector = settings.showCurrencySelector ?? false
+                checkingEnabled = settings.checkingEnabled ?? true
                 lastLoadTime = Date()
             } catch is CancellationError {
                 // Task was cancelled, don't update error state
@@ -103,6 +106,7 @@ final class UserSettingsStore: StoreProtocol {
         payDayOfMonth = nil
         currency = .chf
         showCurrencySelector = false
+        checkingEnabled = true
         lastLoadTime = nil
         error = nil
     }
@@ -150,6 +154,29 @@ final class UserSettingsStore: StoreProtocol {
             self.error = apiError
         } catch {
             showCurrencySelector = previousValue
+            self.error = .networkError(error)
+        }
+    }
+
+    func updateCheckingEnabled(_ newValue: Bool) async {
+        let previousValue = checkingEnabled
+        error = nil
+
+        // Optimistic update
+        checkingEnabled = newValue
+
+        do {
+            let updated = try await service.updateSettings(
+                UpdateUserSettings(checkingEnabled: newValue)
+            )
+            // Backend may omit the field on partial responses; keep the value we just persisted.
+            checkingEnabled = updated.checkingEnabled ?? newValue
+            lastLoadTime = Date()
+        } catch let apiError as APIError {
+            checkingEnabled = previousValue
+            self.error = apiError
+        } catch {
+            checkingEnabled = previousValue
             self.error = .networkError(error)
         }
     }

--- a/ios/Pulpe/Features/Account/PreferencesView.swift
+++ b/ios/Pulpe/Features/Account/PreferencesView.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 struct PreferencesView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(UserSettingsStore.self) private var userSettingsStore
     @State private var showPayDayPicker = false
+    @State private var saveCheckingToggleTask: Task<Void, Never>?
+    @State private var checkingSuccessTrigger = false
     @FocusState private var currencyConverterFocus: CurrencySettingView.ConverterField?
 
     var body: some View {
@@ -21,14 +25,65 @@ struct PreferencesView: View {
                     .font(PulpeTypography.labelLarge)
             }
             .listRowBackground(Color.surfaceContainerHigh)
+
+            checkingSection
         }
         .scrollContentBackground(.hidden)
         .pulpeBackground()
         .listStyle(.insetGrouped)
         .navigationTitle("Préférences")
         .keyboardFieldNavigation(focus: $currencyConverterFocus, order: [.input])
+        .sensoryFeedback(.success, trigger: checkingSuccessTrigger)
         .sheet(isPresented: $showPayDayPicker) {
             PayDayPickerSheet()
+        }
+    }
+
+    // MARK: - Pointage Toggle (PUL-110)
+
+    private var checkingSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { userSettingsStore.checkingEnabled },
+                set: { newValue in
+                    saveCheckingToggleTask?.cancel()
+                    saveCheckingToggleTask = Task(name: "Preferences.saveCheckingToggle") {
+                        await persistCheckingToggle(newValue)
+                    }
+                }
+            )) {
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxs) {
+                    Text("Suivi du pointage")
+                        .font(PulpeTypography.listRowTitle)
+                    Text(
+                        "Pointe tes prévisions et transactions après les avoir "
+                            + "vérifiées sur ton relevé bancaire."
+                    )
+                    .font(PulpeTypography.caption)
+                    .foregroundStyle(Color.onSurfaceVariant)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .tint(Color.pulpePrimary)
+            .accessibilityLabel("Suivi du pointage")
+            .accessibilityHint(
+                "Désactive pour masquer les sections À pointer du tableau de bord et du budget."
+            )
+        } header: {
+            Text("POINTAGE")
+                .font(PulpeTypography.labelLarge)
+        }
+        .listRowBackground(Color.surfaceContainerHigh)
+    }
+
+    private func persistCheckingToggle(_ newValue: Bool) async {
+        await userSettingsStore.updateCheckingEnabled(newValue)
+        guard !Task.isCancelled else { return }
+        if userSettingsStore.error == nil {
+            checkingSuccessTrigger.toggle()
+            appState.toastManager.show("Préférence enregistrée", type: .success)
+        } else {
+            appState.toastManager.show("Erreur lors de la sauvegarde", type: .error)
         }
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionPage.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionPage.swift
@@ -120,7 +120,9 @@ struct AddAllocatedTransactionPage: View {
 
             TransactionDateSelector(date: $transactionDate, currency: userSettingsStore.currency)
 
-            CheckedToggle(isOn: $isChecked, tintColor: line.kind.color)
+            if userSettingsStore.checkingEnabled {
+                CheckedToggle(isOn: $isChecked, tintColor: line.kind.color)
+            }
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -124,7 +124,7 @@ struct AddBudgetLineSheet: View {
                     currency: inputCurrency,
                     accentColor: kind.color
                 )
-            } else {
+            } else if userSettingsStore.checkingEnabled {
                 CheckedToggle(isOn: $isChecked, tintColor: kind.color)
             }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
@@ -19,6 +19,8 @@ struct BudgetDetailsFreeTransactionsList: View {
     let currency: SupportedCurrency
     let onTap: (Transaction) -> Void
     let onTogglePointed: (Transaction) -> Void
+    /// PUL-110 — hides the leading PointCircle when pointage is disabled.
+    var showsCheckToggle = true
 
     @State private var isExpanded = false
     private let collapsedItemCount = 3
@@ -59,6 +61,7 @@ struct BudgetDetailsFreeTransactionsList: View {
                     transaction: item.transaction,
                     isSyncing: item.isSyncing,
                     currency: currency,
+                    showsCheckToggle: showsCheckToggle,
                     onTap: { onTap(item.transaction) },
                     onTogglePointed: { onTogglePointed(item.transaction) }
                 )
@@ -100,6 +103,7 @@ private struct BudgetDetailsFreeTransactionRow: View {
     let transaction: Transaction
     let isSyncing: Bool
     let currency: SupportedCurrency
+    var showsCheckToggle = true
     let onTap: () -> Void
     let onTogglePointed: () -> Void
 
@@ -157,12 +161,14 @@ private struct BudgetDetailsFreeTransactionRow: View {
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: DesignTokens.Spacing.xxs) {
-                PointCircle(
-                    isPointed: isPointed,
-                    color: dotColor,
-                    isSyncing: isSyncing,
-                    onToggle: handleTogglePointed
-                )
+                if showsCheckToggle {
+                    PointCircle(
+                        isPointed: isPointed,
+                        color: dotColor,
+                        isSyncing: isSyncing,
+                        onToggle: handleTogglePointed
+                    )
+                }
 
                 centerColumn
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -112,6 +112,14 @@ struct BudgetDetailsView: View {
                 dashboardStore: dashboardStore,
                 currentMonthStore: currentMonthStore
             )
+            // PUL-110 — the état filter chip is hidden when pointage is
+            // disabled, so a persisted "À pointer"/"Pointé" filter would
+            // silently hide items with no way to escape it. Normalize to
+            // "Tout voir".
+            if !userSettingsStore.checkingEnabled,
+               coordinator.filtersStore.checkedFilter != .all {
+                await coordinator.dispatch(.setCheckedFilter(.all))
+            }
             if !screenState.hasAllBudgets {
                 await coordinator.dispatch(.loadDetails(force: false))
             } else {
@@ -183,7 +191,8 @@ struct BudgetDetailsView: View {
                     kind: typeFilterBinding,
                     checked: checkedFilterBinding,
                     counts: screenState.kindCounts,
-                    checkedCounts: screenState.checkedCounts
+                    checkedCounts: screenState.checkedCounts,
+                    showsCheckedFilter: userSettingsStore.checkingEnabled
                 )
                 .popoverTip(ProductTips.checking)
 
@@ -218,7 +227,8 @@ struct BudgetDetailsView: View {
                                 )
                             }
                         },
-                        tip: section.kind == screenState.firstSectionKind ? ProductTips.gestures : nil
+                        tip: section.kind == screenState.firstSectionKind ? ProductTips.gestures : nil,
+                        showsCheckToggle: userSettingsStore.checkingEnabled
                     )
                 }
 
@@ -233,7 +243,8 @@ struct BudgetDetailsView: View {
                             Task {
                                 await coordinator.dispatch(.toggleTransaction(transaction))
                             }
-                        }
+                        },
+                        showsCheckToggle: userSettingsStore.checkingEnabled
                     )
                 }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage.swift
@@ -314,15 +314,17 @@ private extension BudgetLineDetailPage {
         }
         .tint(Color.destructivePrimary)
 
-        Button {
-            Task { await coordinator.dispatch(.toggleTransaction(transaction)) }
-        } label: {
-            Label(
-                transaction.isChecked ? "Dépointer" : "Pointer",
-                systemImage: transaction.isChecked ? "arrow.uturn.backward" : "checkmark.circle"
-            )
+        if userSettingsStore.checkingEnabled {
+            Button {
+                Task { await coordinator.dispatch(.toggleTransaction(transaction)) }
+            } label: {
+                Label(
+                    transaction.isChecked ? "Dépointer" : "Pointer",
+                    systemImage: transaction.isChecked ? "arrow.uturn.backward" : "checkmark.circle"
+                )
+            }
+            .tint(transaction.isChecked ? Color.financialOverBudget : .pulpePrimary)
         }
-        .tint(transaction.isChecked ? Color.financialOverBudget : .pulpePrimary)
 
         Button {
             router.push(.editTx(transactionId: transaction.id))

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineMixedRow.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineMixedRow.swift
@@ -25,6 +25,10 @@ struct BudgetLineMixedRow: View {
     /// the user-settings environment so the row does not observe the whole
     /// store and re-render on unrelated changes (broad observation fan-out).
     let currency: SupportedCurrency
+    /// PUL-110 — hides the leading PointCircle when pointage is disabled.
+    /// Primitive `var` (not an environment read) for the same fan-out reason
+    /// as `currency` above.
+    var showsCheckToggle = true
     let onTap: () -> Void
     let onTogglePointed: () -> Void
 
@@ -124,12 +128,14 @@ struct BudgetLineMixedRow: View {
     var body: some View {
         Button(action: handleTap) {
             HStack(spacing: DesignTokens.Spacing.xxs) {
-                PointCircle(
-                    isPointed: isPointed,
-                    color: dotColor,
-                    isSyncing: isSyncing,
-                    onToggle: handleTogglePointed
-                )
+                if showsCheckToggle {
+                    PointCircle(
+                        isPointed: isPointed,
+                        color: dotColor,
+                        isSyncing: isSyncing,
+                        onToggle: handleTogglePointed
+                    )
+                }
 
                 centerColumn
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetMixedSection.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetMixedSection.swift
@@ -15,6 +15,8 @@ struct BudgetMixedSection: View {
     let onTap: (BudgetLine) -> Void
     let onTogglePointed: (BudgetLine) -> Void
     var tip: (any Tip)?
+    /// PUL-110 — hides the leading PointCircle when pointage is disabled.
+    var showsCheckToggle = true
 
     init(
         kind: TransactionKind,
@@ -22,7 +24,8 @@ struct BudgetMixedSection: View {
         currency: SupportedCurrency,
         onTap: @escaping (BudgetLine) -> Void,
         onTogglePointed: @escaping (BudgetLine) -> Void,
-        tip: (any Tip)? = nil
+        tip: (any Tip)? = nil,
+        showsCheckToggle: Bool = true
     ) {
         self.kind = kind
         self.items = items
@@ -30,6 +33,7 @@ struct BudgetMixedSection: View {
         self.onTap = onTap
         self.onTogglePointed = onTogglePointed
         self.tip = tip
+        self.showsCheckToggle = showsCheckToggle
     }
 
     private var headerTitle: String {
@@ -70,6 +74,7 @@ struct BudgetMixedSection: View {
                     consumption: item.consumption,
                     isSyncing: item.isSyncing,
                     currency: currency,
+                    showsCheckToggle: showsCheckToggle,
                     onTap: { onTap(item.line) },
                     onTogglePointed: { onTogglePointed(item.line) }
                 )

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetTypeFilter.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetTypeFilter.swift
@@ -125,12 +125,17 @@ struct BudgetTypeFilter: View {
     @Binding var checked: CheckedFilterOption
     let counts: BudgetLineKindCounts
     let checkedCounts: CheckedFilterCounts
+    /// PUL-110 — the état axis (À pointer / Pointé / Tout voir) disappears
+    /// when the user disabled pointage in the preferences.
+    var showsCheckedFilter = true
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: DesignTokens.ChipMetrics.Standard.interChipGap) {
-                checkedMenuButton()
-                    .padding(.trailing, DesignTokens.Spacing.xs)
+                if showsCheckedFilter {
+                    checkedMenuButton()
+                        .padding(.trailing, DesignTokens.Spacing.xs)
+                }
 
                 ForEach(BudgetLineKindFilter.allCases) { option in
                     typePill(option)

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -86,7 +86,9 @@ struct AddTransactionSheet: View {
             .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
             descriptionField
             dateSelector
-            CheckedToggle(isOn: $isChecked, tintColor: kind.color)
+            if userSettingsStore.checkingEnabled {
+                CheckedToggle(isOn: $isChecked, tintColor: kind.color)
+            }
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -262,9 +262,11 @@ struct CurrentMonthView: View {
 
     // MARK: - Unchecked Forecasts Section
 
+    // PUL-110 — the whole section (list + empty state) disappears when the
+    // user disabled pointage in the preferences.
     @ViewBuilder
     private var uncheckedForecastsSection: some View {
-        if !store.uncheckedItems.isEmpty {
+        if userSettingsStore.checkingEnabled, !store.uncheckedItems.isEmpty {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                 HStack(spacing: DesignTokens.Spacing.sm) {
                     Text("À pointer")
@@ -301,7 +303,8 @@ struct CurrentMonthView: View {
                 )
                 .popoverTip(ProductTips.checking)
             }
-        } else if !store.budgetLines.isEmpty || !store.transactions.isEmpty {
+        } else if userSettingsStore.checkingEnabled,
+                  !store.budgetLines.isEmpty || !store.transactions.isEmpty {
             UncheckedForecastsEmptyState()
         }
     }

--- a/ios/PulpeTests/Domain/Services/WidgetDataSyncServiceTests.swift
+++ b/ios/PulpeTests/Domain/Services/WidgetDataSyncServiceTests.swift
@@ -10,7 +10,8 @@ struct WidgetDataSyncServiceTests {
             stubbedGetSettings: UserSettings(
                 payDayOfMonth: 15,
                 currency: .eur,
-                showCurrencySelector: false
+                showCurrencySelector: false,
+                checkingEnabled: true
             )
         )
         let sut = WidgetDataSyncService(userSettingsService: mockService)

--- a/ios/PulpeTests/Domain/Store/UserSettingsStoreTests.swift
+++ b/ios/PulpeTests/Domain/Store/UserSettingsStoreTests.swift
@@ -11,7 +11,8 @@ struct UserSettingsStoreTests {
             stubbedUpdateSettings: UserSettings(
                 payDayOfMonth: nil,
                 currency: .chf,
-                showCurrencySelector: true
+                showCurrencySelector: true,
+                checkingEnabled: true
             )
         )
         let store = UserSettingsStore(service: mockService)
@@ -41,6 +42,44 @@ struct UserSettingsStoreTests {
         #expect(store.error != nil)
     }
 
+    @Test func updateCheckingEnabled_onSuccess_updatesValueAndSendsPayload() async {
+        // Arrange
+        let mockService = MockUserSettingsService(
+            stubbedUpdateSettings: UserSettings(
+                payDayOfMonth: nil,
+                currency: .chf,
+                showCurrencySelector: false,
+                checkingEnabled: false
+            )
+        )
+        let store = UserSettingsStore(service: mockService)
+        #expect(store.checkingEnabled == true)
+
+        // Act
+        await store.updateCheckingEnabled(false)
+
+        // Assert
+        #expect(store.checkingEnabled == false)
+        #expect(store.error == nil)
+        #expect(await mockService.updateSettingsCallCount == 1)
+        let payload = await mockService.lastUpdatePayload
+        #expect(payload?.checkingEnabled == false)
+    }
+
+    @Test func updateCheckingEnabled_onFailure_revertsOptimisticUpdate() async {
+        // Arrange — store starts enabled, backend will reject
+        let mockService = MockUserSettingsService()
+        await mockService.setUpdateError(APIError.networkError(URLError(.notConnectedToInternet)))
+        let store = UserSettingsStore(service: mockService)
+
+        // Act
+        await store.updateCheckingEnabled(false)
+
+        // Assert — optimistic flip reverted to the initial `true`
+        #expect(store.checkingEnabled == true)
+        #expect(store.error != nil)
+    }
+
     @Test func showCurrencySelectorEffective_gatedByFeatureFlag_returnsFalseWhenFlagOff() async throws {
         // Arrange — fresh UserDefaults suite to control the feature flag without touching prod defaults
         let suiteName = "pulpe.tests.\(UUID().uuidString)"
@@ -54,7 +93,8 @@ struct UserSettingsStoreTests {
             stubbedUpdateSettings: UserSettings(
                 payDayOfMonth: nil,
                 currency: .chf,
-                showCurrencySelector: true
+                showCurrencySelector: true,
+                checkingEnabled: true
             )
         )
         let store = UserSettingsStore(service: mockService, featureFlags: featureFlags)

--- a/ios/PulpeTests/Helpers/MockUserSettingsService.swift
+++ b/ios/PulpeTests/Helpers/MockUserSettingsService.swift
@@ -15,12 +15,14 @@ actor MockUserSettingsService: UserSettingsServicing {
         stubbedGetSettings: UserSettings = UserSettings(
             payDayOfMonth: nil,
             currency: .chf,
-            showCurrencySelector: false
+            showCurrencySelector: false,
+            checkingEnabled: true
         ),
         stubbedUpdateSettings: UserSettings = UserSettings(
             payDayOfMonth: nil,
             currency: .chf,
-            showCurrencySelector: false
+            showCurrencySelector: false,
+            checkingEnabled: true
         )
     ) {
         self.stubbedGetSettings = stubbedGetSettings

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -1216,6 +1216,7 @@ export const updateUserSettingsSchema = z.strictObject({
     .optional(),
   currency: supportedCurrencySchema.optional(),
   showCurrencySelector: z.boolean().optional(),
+  checkingEnabled: z.boolean().optional(),
 });
 export type UpdateUserSettings = z.infer<typeof updateUserSettingsSchema>;
 
@@ -1223,6 +1224,7 @@ export const userSettingsSchema = z.object({
   payDayOfMonth: payDayOfMonthSchema,
   currency: supportedCurrencySchema.default('CHF'),
   showCurrencySelector: z.boolean().default(false),
+  checkingEnabled: z.boolean().default(true),
 });
 export type UserSettings = z.infer<typeof userSettingsSchema>;
 


### PR DESCRIPTION
Nouveau réglage `checkingEnabled` (user_metadata, défaut true — aucun changement pour les utilisateurs existants), toggle « Suivi du pointage » web + iOS. Désactivé : sections « À pointer » (dashboard), filtre Pointé/Tout et résumé du détail budget, toggles/swipes/cercles de pointage sur toutes les surfaces des deux plateformes ; le filtre persisté est normalisé pour ne jamais masquer silencieusement des lignes. Vérifié : quality 10/10, 2115 tests web, 907 backend, build iOS + tests ciblés 7/7.