### PR TITLE
chore(worktree): auto-sync .env once per Claude worktree

### DIFF
--- a/.claude/hooks/sync-env-on-worktree-start.sh
+++ b/.claude/hooks/sync-env-on-worktree-start.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# SessionStart hook (matcher: startup). Syncs .env files into a fresh git
+# worktree exactly ONCE — the first session that opens in it. Cloud/agent
+# worktrees are pre-created by the harness before the session starts, so
+# SessionStart is the only lifecycle event that provably runs inside the
+# session after the worktree exists (WorktreeCreate does not fire for this
+# path, and no EnterWorktree tool call happens). An idempotency marker in the
+# worktree's private git dir makes every later session a ~1ms no-op — no
+# repeated sync, no model tokens (a command hook is a shell process, not an
+# LLM call).
+#
+# Never blocks session start: any failure here is non-fatal.
+
+set -uo pipefail
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD="${CWD:-$PWD}"
+
+REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+if [[ ! -f "$REPO_ROOT/.git" ]]; then
+  # .git is a directory here → main checkout, not a worktree. Nothing to do.
+  exit 0
+fi
+
+# Per-worktree, never-committed marker (lives in this worktree's private git
+# dir). Present → already synced once → instant no-op.
+MARKER=$(git -C "$CWD" rev-parse --git-path pulpe-env-synced 2>/dev/null) || exit 0
+[[ -f "$MARKER" ]] && exit 0
+
+if [[ ! -x "$REPO_ROOT/sync-env.sh" ]]; then
+  exit 0
+fi
+
+if [[ -z "${CONDUCTOR_ROOT_PATH:-}" && -z "${PULPE_MAIN_WORKSPACE:-}" ]]; then
+  # sync-env.sh needs one of these to know the source workspace; skip quietly
+  # (do NOT write the marker — a later session with the var set still syncs).
+  exit 0
+fi
+
+OUTPUT=$("$REPO_ROOT/sync-env.sh" 2>&1)
+STATUS=$?
+
+if [[ $STATUS -eq 0 ]]; then
+  touch "$MARKER"
+else
+  # A configured source (CONDUCTOR_ROOT_PATH/PULPE_MAIN_WORKSPACE) failed to
+  # sync — surface it instead of swallowing it, and leave the marker unset so
+  # the next session retries.
+  jq -n --arg msg "sync-env.sh a échoué au démarrage de la session :
+$OUTPUT" '{systemMessage: $msg}'
+fi
+
+exit 0

--- a/.claude/hooks/sync-env-on-worktree-start.sh
+++ b/.claude/hooks/sync-env-on-worktree-start.sh
@@ -12,7 +12,9 @@
 #
 # Never blocks session start: any failure here is non-fatal.
 
-set -uo pipefail
+# No `-e`: failures here must never block session start; each is handled
+# explicitly. No `pipefail` either — nothing consumes a pipeline's status.
+set -u
 
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
@@ -40,8 +42,11 @@ if [[ -z "${CONDUCTOR_ROOT_PATH:-}" && -z "${PULPE_MAIN_WORKSPACE:-}" ]]; then
   exit 0
 fi
 
+# sync-env.sh colorizes with ANSI escapes; strip them so they don't show up
+# raw in the systemMessage shown to Claude Code.
 OUTPUT=$("$REPO_ROOT/sync-env.sh" 2>&1)
 STATUS=$?
+OUTPUT=$(printf '%s' "$OUTPUT" | sed $'s/\033\\[[0-9;]*m//g')
 
 if [[ $STATUS -eq 0 ]]; then
   touch "$MARKER"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,5 +16,19 @@
   "enableAllProjectMcpServers": true,
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/sync-env-on-worktree-start.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
   }
 }

--- a/sync-env.sh
+++ b/sync-env.sh
@@ -32,6 +32,12 @@ if [[ -z "$SOURCE_WORKSPACE" ]]; then
     exit 1
 fi
 
+if [[ ! -d "$SOURCE_WORKSPACE" ]]; then
+    echo -e "${RED}Erreur: le workspace source n'existe pas: $SOURCE_WORKSPACE${NC}"
+    echo "CONDUCTOR_ROOT_PATH ou PULPE_MAIN_WORKSPACE pointe vers un chemin invalide (workspace déplacé/supprimé ?)."
+    exit 1
+fi
+
 # Répertoire du worktree courant
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
## Problème

Une nouvelle session Claude dans un worktree git frais démarre avec des `.env` absents ou périmés (ex. Vite qui sert un vieux bundle `pulpe-shared` → `does not provide an export named ...`). Le script `sync-env.sh` existe déjà mais il faut le lancer à la main à chaque worktree, et c'est facile à oublier.

## Solution

Un seul hook **`SessionStart`** (matcher `startup`) qui lance `.claude/hooks/sync-env-on-worktree-start.sh`. Il ne sync que si :
- la session s'est ouverte **dans un worktree git** (détecté via le marqueur standard `.git` = fichier, pas dossier), et
- une source est configurée (`CONDUCTOR_ROOT_PATH` ou `PULPE_MAIN_WORKSPACE`).

Sinon, no-op silencieux.

### Pourquoi `SessionStart` et pas `WorktreeCreate`

Les worktrees Claude sont créés **in-session** (tool EnterWorktree / isolation agent) avec la création git native, qui **ne déclenche pas** `WorktreeCreate`. Cet event ne fire que pour la création via `claude --worktree` en CLI — et quand il fire, il **remplace** la création du worktree au lieu de notifier après. `SessionStart` est le seul événement qui tourne dans la session une fois le worktree créé.

### Idempotent

Un marqueur par-worktree dans le git-dir privé du worktree (`git rev-parse --git-path`) rend toute session après la première un no-op instantané : pas de re-sync, et un hook `command` est un process shell (jamais un appel modèle) → zéro token.

### Durcissement de `sync-env.sh`

`CONDUCTOR_ROOT_PATH`/`PULPE_MAIN_WORKSPACE` pointant vers un dossier inexistant reportait chaque fichier en `Non trouvé` mais sortait quand même en 0 avec `Synchronisation terminée` — faux succès silencieux. C'est maintenant une erreur distincte en exit 1, et le hook remonte les échecs via `systemMessage` au lieu de les avaler.

## Portée

Scoped à ce repo uniquement (`.claude/settings.json` projet, pas `~/.claude`) — n'affecte aucun worktree d'un autre projet.

## Test

- `sync-env.sh` : 3 scénarios vérifiés (var absente → exit 1 ; chemin inexistant → exit 1 loud ; source réelle → copie 3/4 fichiers, byte-identiques au repo principal).
- Garde d'idempotence : vérifié que le 1er passage sync + écrit le marqueur, les suivants no-op sans relancer le sync, et qu'un échec ne pose pas le marqueur (retry préservé).