### PR TITLE
feat(frontend): adapt quick transaction dialog for larger screens

### DIFF
--- a/aidd_docs/tasks/2026_07/2026_07_16_quick_transaction_adaptive_dialog/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_16_quick_transaction_adaptive_dialog/phase-1.md
@@ -1,0 +1,178 @@
+---
+status: done
+---
+
+# Instruction: Livrer et vérifier la surface adaptative d’ajout rapide
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+frontend/
+├── e2e/tests/features/
+│   └── ✏️ current-month-transactions.spec.ts
+└── projects/webapp/src/
+    ├── app/
+    │   ├── feature/current-month/
+    │   │   ├── ✏️ current-month.routes.ts
+    │   │   ├── ✏️ current-month.spec.ts
+    │   │   ├── ✏️ current-month.ts
+    │   │   ├── components/
+    │   │   │   ├── ✏️ add-transaction-bottom-sheet.spec.ts
+    │   │   │   ├── ✏️ add-transaction-bottom-sheet.ts
+    │   │   │   ├── ✅ add-transaction-dialog.ts
+    │   │   │   ├── ✅ add-transaction-form.spec.ts
+    │   │   │   └── ✅ add-transaction-form.ts
+    │   │   └── services/
+    │   │       ├── ✅ add-transaction-dialog.service.spec.ts
+    │   │       └── ✅ add-transaction-dialog.service.ts
+    │   └── styles/
+    │       └── ✏️ _dialogs.scss
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["L’utilisateur active l’ajout rapide"] --> B{"Viewport Handset ?"}
+  B -->|Oui| C["Ouvrir le bottom sheet mobile"]
+  B -->|Non| D["Ouvrir le dialog tablette ou desktop"]
+  C --> E["Afficher le formulaire partagé"]
+  D --> E
+  E --> F{"Annuler ou valider ?"}
+  F -->|Annuler| G["Fermer sans mutation"]
+  F -->|Valider| H["Retourner la transaction normalisée"]
+  H --> I["Ajouter la transaction au mois courant"]
+```
+
+## Wireframe
+
+### Tablette
+
+```txt
+┌──────────────────────────────────────────────────────────────┐
+│ (1) En-tête : titre · contexte                     [fermer]  │
+├──────────────────────────────┬───────────────────────────────┤
+│ (2) Saisie principale        │ (3) Détails de transaction    │
+│ [champ montant]              │ [champ description]           │
+│ [grille de montants rapides] │ [sélecteur de type]           │
+│                              │ [champ notes]                  │
+├──────────────────────────────┴───────────────────────────────┤
+│ (4) Métadonnées : [date]                    [statut + toggle] │
+├──────────────────────────────────────────────────────────────┤
+│ (5) Actions                                 [retour] [valider]│
+└──────────────────────────────────────────────────────────────┘
+```
+
+1. En-tête : identifie la tâche et fournit une sortie explicite.
+2. Saisie principale : regroupe le montant et ses raccourcis.
+3. Détails : regroupe les champs descriptifs dans l’ordre de lecture.
+4. Métadonnées : rassemble les informations secondaires sans allonger une colonne.
+5. Actions : garde les décisions finales visibles hors de la zone scrollable.
+
+### Desktop
+
+```txt
+┌──────────────────────────────────────────────────────────────────────┐
+│ (1) En-tête : titre · contexte                             [fermer]  │
+├─────────────────────────────────┬────────────────────────────────────┤
+│ (2) Saisie principale           │ (3) Détails de transaction         │
+│ [champ montant]                 │ [champ description]                │
+│ [grille de montants rapides]    │ [sélecteur de type]                │
+│                                 │ [champ notes]                       │
+├─────────────────────────────────┴────────────────────────────────────┤
+│ (4) Métadonnées : [date]                            [statut + toggle] │
+├──────────────────────────────────────────────────────────────────────┤
+│ (5) Actions                                         [retour] [valider]│
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+1. En-tête : conserve une hiérarchie courte adaptée à une tâche rapide.
+2. Saisie principale : donne la priorité au montant sans étirer le formulaire.
+3. Détails : utilise la largeur disponible sans ajouter de contenu.
+4. Métadonnées : forme une rangée secondaire commune aux deux colonnes.
+5. Actions : reste ancrée au bas du dialog et alignée sur la fin.
+
+## Tasks to do
+
+### `1)` Verrouiller le défaut responsive
+
+> Reproduire le mauvais conteneur avant de modifier l’implémentation.
+
+1. Ajouter dans `current-month-transactions.spec.ts` un scénario tablette `768 × 1024` qui échoue tant que le FAB ouvre un bottom sheet.
+2. Couvrir aussi un desktop `1440 × 900` et un handset `390 × 844` : dialog pour les deux grands viewports, bottom sheet pour le handset.
+3. Vérifier que le bouton de validation est visible dans le viewport dès l’ouverture sur tablette et desktop.
+
+### `2)` Séparer le formulaire de ses conteneurs adaptatifs
+
+> Réutiliser le pattern dialog + bottom sheet + formulaire partagé déjà présent dans la feature budget.
+
+1. Déplacer modèle, Signal Form, validations, conversion, état de soumission et construction de `TransactionFormData` dans `AddTransactionForm`.
+2. Exposer uniquement `created`, `canSubmit`, `isSubmitting`, `submit()` et `focusAmount()` aux wrappers.
+3. Réduire `AddTransactionBottomSheet` au chrome mobile : poignée, en-tête, formulaire partagé et actions.
+4. Créer `AddTransactionDialog` avec les primitives `mat-dialog-title`, `mat-dialog-content` et `mat-dialog-actions` afin que seules les données du formulaire scrollent.
+5. Créer `AddTransactionDialogService`, scoped dans `current-month.routes.ts`, qui choisit `MatBottomSheet` pour `Breakpoints.Handset` et `MatDialog` sinon, puis retourne un résultat unique au dashboard.
+6. Remplacer l’ouverture directe dans `current-month.ts` par le service sans déplacer la mutation vers ce service.
+
+#### Surface adaptative
+
+| Before | After |
+| --- | --- |
+| `current-month.ts` ouvre `AddTransactionBottomSheet` à toute largeur | `AddTransactionDialogService` ouvre le bottom sheet sur handset et le dialog sur tablette/desktop |
+| Formulaire, fermeture et chrome mobile vivent dans `add-transaction-bottom-sheet.ts` | `AddTransactionForm` porte le métier ; chaque wrapper ne porte que sa présentation et son type de ref |
+| Poignée de glissement visible sur desktop | Poignée réservée au bottom sheet ; le dialog utilise un en-tête Material et une fermeture explicite |
+
+### `3)` Composer le dialog pour tablette et desktop
+
+> Réduire la hauteur, clarifier la hiérarchie et préserver l’ordre clavier.
+
+1. Donner au dialog une largeur cible de `720px`, limitée par le viewport, avec un `panelClass` et un override Material scoped dans `_dialogs.scss`.
+2. Passer le contenu à deux groupes en colonnes à partir du breakpoint tablette : montant + raccourcis à gauche, description + type + notes à droite.
+3. Garder la date et le toggle dans une rangée pleine largeur sous les deux groupes ; conserver un flux monocolonne dans le bottom sheet.
+4. Maintenir l’ordre DOM montant → raccourcis → description → type → notes → date → statut pour que le parcours clavier suive la lecture.
+5. Conserver l’autofocus du montant après ouverture, la fermeture par Échap/backdrop et la restauration du focus vers le FAB.
+6. Utiliser le bouton de chargement existant pour une action primaire remplie, désactivée pendant la conversion, avec retour d’attente accessible.
+7. Appliquer les chiffres tabulaires au montant et aux raccourcis, puis supprimer l’échelle de press lorsque `prefers-reduced-motion` est actif.
+
+#### Hiérarchie et densité
+
+| Before | After |
+| --- | --- |
+| Une colonne étroite et longue sur tous les viewports | Deux colonnes sémantiques dès la tablette, une colonne conservée sur handset |
+| Actions après tout le contenu de la feuille | `mat-dialog-actions` fixe les actions hors du contenu scrollable sur tablette/desktop |
+| Action principale `outlined` sans indicateur d’attente | Action `filled` unique via `pulpe-loading-button`, avec spinner et blocage du double envoi |
+| Montants rapides en `flex-wrap` avec une hauteur de `40px` | Grille de quatre cibles de `44px` minimum, chiffres tabulaires sur tous les montants et largeur régulière |
+
+#### Interaction et finition
+
+| Before | After |
+| --- | --- |
+| Raccourcis sans retour tactile dédié | `scale(0.96)` au press avec transition limitée à `transform` sur `150ms`, neutralisée en reduced motion |
+| Titre et sous-titre utilisent le wrapping par défaut | Titre équilibré et texte court en wrapping lisible, sans changer Manrope/DM Sans |
+| Ouverture desktop calquée sur le mouvement d’une feuille mobile | Transition native du dialog Material ; aucune animation décorative ou dépendance ajoutée |
+| Fermeture et champs testés surtout par leur logique métier | Cibles ≥40px desktop / 44px tactile, focus visible, libellés conservés et ordre clavier vérifié |
+
+### `4)` Répartir les tests et prouver le parcours
+
+> Garder une preuve ciblée du bug et du happy path, sans dupliquer toute la matrice existante.
+
+1. Déplacer les tests de modèle, validation, conversion et montants rapides vers `add-transaction-form.spec.ts`.
+2. Limiter `add-transaction-bottom-sheet.spec.ts` au branchement du wrapper : focus, annulation, soumission et propagation du résultat.
+3. Tester dans `add-transaction-dialog.service.spec.ts` les deux branches de breakpoint, leurs configurations et le même type de résultat.
+4. Adapter `current-month.spec.ts` pour vérifier que le dashboard délègue l’ouverture et conserve la mutation après un résultat défini.
+5. Exécuter les tests Vitest ciblés, le scénario Playwright de transactions du mois courant, puis `pnpm quality`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | À `768 × 1024` et `1440 × 900`, le FAB ouvre un dialog centré et non un bottom sheet ; l’action principale est visible sans scroll du document. |
+| 1 | À `390 × 844`, le même FAB ouvre toujours le bottom sheet mobile. |
+| 2 | Les deux conteneurs rendent le même formulaire, produisent le même `TransactionFormData` et une annulation ne déclenche aucune mutation. |
+| 2 | Validation, devise, conversion, notes optionnelles et état pointé conservent leur comportement actuel. |
+| 3 | Sur tablette et desktop, montant/raccourcis et détails occupent deux colonnes, tandis que date/statut et actions utilisent toute la largeur. |
+| 3 | Le parcours clavier suit l’ordre visuel, le montant reçoit le focus initial, Échap ferme la surface et le focus revient au FAB. |
+| 3 | Les montants utilisent des chiffres tabulaires, les raccourcis ont une cible tactile d’au moins `44px`, le reduced motion est respecté et le submit affiche un état d’attente sans double envoi. |
+| 4 | Le parcours E2E ajoute une transaction libre depuis le dialog desktop et la transaction apparaît dans les dernières transactions avec les totaux recalculés. |
+| 4 | Les tests ciblés et la qualité frontend passent sans régression du bottom sheet mobile. |

--- a/aidd_docs/tasks/2026_07/2026_07_16_quick_transaction_adaptive_dialog/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_16_quick_transaction_adaptive_dialog/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Sur tablette et desktop, l’ajout rapide d’une transaction s’ouvre dans un dialog centré, compact et accessible, tandis que le mobile conserve son bottom sheet et le même résultat métier."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Adapter l’ajout rapide de transaction aux grands écrans

--- a/aidd_docs/tasks/2026_07/2026_07_16_quick_transaction_adaptive_dialog/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_16_quick_transaction_adaptive_dialog/plan.md
@@ -1,0 +1,34 @@
+---
+objective: "Sur tablette et desktop, l’ajout rapide d’une transaction s’ouvre dans un dialog centré, compact et accessible, tandis que le mobile conserve son bottom sheet et le même résultat métier."
+status: in-progress
+---
+
+# Plan: Adapter l’ajout rapide de transaction aux grands écrans
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| **Goal** | Remplacer la feuille mobile étroite sur tablette et desktop par un dialog adaptatif qui exploite l’espace sans rallonger le parcours. |
+| **Source** | Demande utilisateur et capture `/var/folders/th/8y0_0gcn4jz28x2y9gn3h2x80000gp/T/TemporaryItems/NSIRD_screencaptureui_ojYKKA/Screenshot 2026-07-16 at 16.06.25.png` |
+
+## Phases
+
+| # | Phase | File |
+| --- | --- | --- |
+| 1 | Livrer et vérifier la surface adaptative d’ajout rapide | [`phase-1.md`](./phase-1.md) |
+
+## Resources
+
+| Source | Verified |
+| --- | --- |
+| https://material.angular.dev/components | Le bottom sheet est une surface principalement mobile, tandis que le dialog est la primitive modale configurable adaptée aux grands écrans. |
+| https://material.angular.dev/components/dialog/styling | Les dimensions et la forme du conteneur peuvent être ajustées avec un override Material scoped, sans `::ng-deep`. |
+| https://material.angular.dev/cdk/layout/api | `BreakpointObserver` permet de tester le breakpoint courant et de garder la bifurcation dialog/bottom sheet alignée sur le layout. |
+
+## Decisions
+
+| Decision | Why |
+| --- | --- |
+| Partager un seul composant de formulaire entre un wrapper bottom sheet mobile et un wrapper dialog tablette/desktop | La présentation devient réellement adaptative sans dupliquer les validations, la conversion de devise ni le payload de transaction. |
+| Utiliser `Breakpoints.Handset` comme frontière de présentation | Le shell principal utilise déjà cette définition CDK ; reprendre la même frontière évite une zone où navigation et modale classeraient différemment le même viewport. |

--- a/frontend/e2e/tests/features/current-month-transactions.spec.ts
+++ b/frontend/e2e/tests/features/current-month-transactions.spec.ts
@@ -40,6 +40,59 @@ test.describe('Current Month Transactions', () => {
     kind: 'expense',
   });
 
+  test('should adapt the quick transaction surface to the viewport', async ({
+    authenticatedPage,
+    currentMonthPage,
+  }) => {
+    await authenticatedPage.route('**/api/v1/budgets/*/details', (route) => {
+      const response = createBudgetDetailsMock(budgetId, {
+        budget: { rollover: 0, month: currentMonth, year: currentYear },
+        budgetLines: [salaireLine, coursesLine],
+        transactions: [],
+      });
+
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      });
+    });
+
+    await authenticatedPage.setViewportSize({ width: 768, height: 1024 });
+    await currentMonthPage.goto();
+
+    for (const viewport of [
+      { width: 768, height: 1024, expectedSurface: 'dialog' },
+      { width: 1440, height: 900, expectedSurface: 'dialog' },
+      { width: 390, height: 844, expectedSurface: 'bottom-sheet' },
+    ] as const) {
+      await authenticatedPage.setViewportSize(viewport);
+      await authenticatedPage.getByTestId('add-transaction-fab').click();
+
+      const surface = authenticatedPage.locator(
+        viewport.expectedSurface === 'dialog'
+          ? 'pulpe-add-transaction-dialog'
+          : 'pulpe-add-transaction-bottom-sheet',
+      );
+      await expect(surface).toBeVisible();
+
+      const formColumns = await surface
+        .locator('.add-transaction-form-grid')
+        .evaluate((element) =>
+          getComputedStyle(element).gridTemplateColumns.split(' '),
+        );
+      expect(formColumns).toHaveLength(
+        viewport.expectedSurface === 'dialog' ? 2 : 1,
+      );
+
+      const submit = surface.getByTestId('transaction-submit-button');
+      await expect(submit).toBeInViewport();
+
+      await surface.getByTestId('transaction-cancel-button').click();
+      await expect(surface).toBeHidden();
+    }
+  });
+
   test('should add a transaction via FAB and display it in recent transactions', async ({
     authenticatedPage,
     currentMonthPage,

--- a/frontend/e2e/tests/features/current-month-transactions.spec.ts
+++ b/frontend/e2e/tests/features/current-month-transactions.spec.ts
@@ -62,6 +62,7 @@ test.describe('Current Month Transactions', () => {
     await currentMonthPage.goto();
 
     for (const viewport of [
+      { width: 600, height: 900, expectedSurface: 'dialog' },
       { width: 768, height: 1024, expectedSurface: 'dialog' },
       { width: 1440, height: 900, expectedSurface: 'dialog' },
       { width: 390, height: 844, expectedSurface: 'bottom-sheet' },

--- a/frontend/e2e/tests/features/current-month-transactions.spec.ts
+++ b/frontend/e2e/tests/features/current-month-transactions.spec.ts
@@ -164,14 +164,14 @@ test.describe('Current Month Transactions', () => {
 
     await currentMonthPage.goto();
 
-    // Open bottom sheet via FAB
+    // Open the adaptive transaction surface via FAB
     await authenticatedPage.getByTestId('add-transaction-fab').click();
 
     // Fill the transaction form
     const form = authenticatedPage.getByTestId('transaction-form');
     await expect(form).toBeVisible();
 
-    // Wait for auto-focus setTimeout(200ms) to settle before filling (CI timing)
+    // Wait for the surface opening animation and initial focus to settle
     const amountInput = authenticatedPage.locator(
       '[data-testid="transaction-form"] [data-testid="amount-input-value"]',
     );
@@ -188,7 +188,7 @@ test.describe('Current Month Transactions', () => {
     // Submit
     await authenticatedPage.getByTestId('transaction-submit-button').click();
 
-    // Bottom sheet should close
+    // The transaction surface should close
     await expect(form).toBeHidden();
 
     // Transaction should appear in the recent transactions block

--- a/frontend/e2e/tests/features/current-month-transactions.spec.ts
+++ b/frontend/e2e/tests/features/current-month-transactions.spec.ts
@@ -77,6 +77,29 @@ test.describe('Current Month Transactions', () => {
       );
       await expect(surface).toBeVisible();
 
+      if (viewport.expectedSurface === 'dialog') {
+        await expect(surface.locator('h2[mat-dialog-title]')).toBeVisible();
+        const closeButton = surface.locator('button[maticonbutton]').first();
+        const dialogSurface = authenticatedPage.locator(
+          '.mat-mdc-dialog-surface',
+        );
+        await expect(closeButton).toHaveCSS('position', 'absolute');
+
+        const [surfaceBox, closeButtonBox] = await Promise.all([
+          dialogSurface.boundingBox(),
+          closeButton.boundingBox(),
+        ]);
+        if (!surfaceBox || !closeButtonBox) {
+          throw new Error('Dialog surface geometry is unavailable');
+        }
+        expect(closeButtonBox.x + closeButtonBox.width / 2).toBeGreaterThan(
+          surfaceBox.x + surfaceBox.width / 2,
+        );
+      }
+
+      const quickAmount = surface.locator('button[matbutton="tonal"]').first();
+      await expect(quickAmount).toHaveCSS('white-space', 'nowrap');
+
       const formColumns = await surface
         .locator('.add-transaction-form-grid')
         .evaluate((element) =>

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -792,6 +792,7 @@
     "addTransactionAmountRequired": "Le montant est requis",
     "addTransactionQuickAmounts": "Montants rapides",
     "addTransactionDescription": "Description",
+    "addTransactionDescriptionPlaceholder": "Ex: Courses chez Migros",
     "addTransactionDescriptionRequired": "La description est requise",
     "addTransactionDescriptionMin": "La description doit contenir au moins 2 caractères",
     "addTransactionType": "Type de transaction",

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
@@ -76,7 +76,9 @@ describe('AddTransactionBottomSheet', () => {
       .mockResolvedValue();
     const { fixture } = await configureBottomSheet();
 
-    fixture.nativeElement.querySelector('pulpe-loading-button button').click();
+    fixture.nativeElement
+      .querySelector('pulpe-loading-button[testId="transaction-submit-button"]')
+      .click();
 
     expect(submitSpy).toHaveBeenCalledOnce();
   });

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
@@ -1,55 +1,32 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, signal } from '@angular/core';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { TestBed } from '@angular/core/testing';
 import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
-import { EMPTY } from 'rxjs';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { Subject } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SupportedCurrency } from 'pulpe-shared';
+
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { CurrencyConverterService } from '@core/currency';
 import { FeatureFlagsService } from '@core/feature-flags';
 import { UserSettingsStore } from '@core/user-settings';
-import type { SupportedCurrency } from 'pulpe-shared';
+import { AddTransactionBottomSheet } from './add-transaction-bottom-sheet';
 import {
-  AddTransactionBottomSheet,
+  AddTransactionForm,
   type TransactionFormData,
-} from './add-transaction-bottom-sheet';
+} from './add-transaction-form';
 
-interface FlagsMock {
-  isMultiCurrencyEnabled: ReturnType<typeof signal>;
-}
-interface SettingsMock {
-  currency: ReturnType<typeof signal<SupportedCurrency>>;
-  showCurrencySelector: ReturnType<typeof signal<boolean>>;
-}
-interface ConverterMock {
-  convertWithMetadata: ReturnType<typeof vi.fn>;
-}
-interface BottomSheetRefMock {
-  dismiss: ReturnType<typeof vi.fn>;
-  afterOpened: ReturnType<typeof vi.fn>;
-}
-
-function configureBottomSheet({
-  userCurrency = 'CHF' as SupportedCurrency,
-  flagEnabled = false,
-  showCurrencyPref = true,
-}: {
-  userCurrency?: SupportedCurrency;
-  flagEnabled?: boolean;
-  showCurrencyPref?: boolean;
-} = {}) {
-  const bottomSheetRef: BottomSheetRefMock = {
+async function configureBottomSheet() {
+  const afterOpened = new Subject<void>();
+  const bottomSheetRef = {
     dismiss: vi.fn(),
-    afterOpened: vi.fn().mockReturnValue(EMPTY),
+    afterOpened: vi.fn().mockReturnValue(afterOpened),
   };
-  const flags: FlagsMock = {
-    isMultiCurrencyEnabled: signal(flagEnabled),
+  const settings = {
+    currency: signal<SupportedCurrency>('CHF'),
+    showCurrencySelector: signal(true),
   };
-  const settings: SettingsMock = {
-    currency: signal<SupportedCurrency>(userCurrency),
-    showCurrencySelector: signal(showCurrencyPref),
-  };
-  const converter: ConverterMock = {
+  const converter = {
     convertWithMetadata: vi.fn().mockImplementation(async (amount: number) => ({
       convertedAmount: amount,
       metadata: null,
@@ -63,310 +40,72 @@ function configureBottomSheet({
       provideAnimationsAsync(),
       ...provideTranslocoForTest(),
       { provide: MatBottomSheetRef, useValue: bottomSheetRef },
-      { provide: FeatureFlagsService, useValue: flags },
+      {
+        provide: FeatureFlagsService,
+        useValue: { isMultiCurrencyEnabled: signal(false) },
+      },
       { provide: UserSettingsStore, useValue: settings },
       { provide: CurrencyConverterService, useValue: converter },
     ],
   });
 
   const fixture = TestBed.createComponent(AddTransactionBottomSheet);
-  const component = fixture.componentInstance;
-  return { fixture, component, bottomSheetRef, converter, settings, flags };
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+  TestBed.tick();
+
+  return {
+    fixture,
+    component: fixture.componentInstance,
+    bottomSheetRef,
+    afterOpened,
+  };
 }
 
 describe('AddTransactionBottomSheet', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
-  describe('predefined amounts', () => {
-    it('renders all 4 predefined amount buttons', () => {
-      const { fixture } = configureBottomSheet();
-      fixture.detectChanges();
+  it('focuses the amount after opening', async () => {
+    const focusSpy = vi.spyOn(AddTransactionForm.prototype, 'focusAmount');
+    const { afterOpened } = await configureBottomSheet();
 
-      const buttons = fixture.nativeElement.querySelectorAll(
-        'button[matButton="tonal"]',
-      );
-      expect(buttons.length).toBe(4);
-    });
+    afterOpened.next();
 
-    it('exposes predefinedAmounts as a static array (not a signal)', () => {
-      const { component } = configureBottomSheet();
-      // After the fix, predefinedAmounts is `readonly [10,15,20,30] as const`
-      // — a plain array, not a signal. Calling it as a function would throw.
-      const amounts = component['predefinedAmounts'];
-      expect(Array.isArray(amounts)).toBe(true);
-      expect(amounts).toEqual([10, 15, 20, 30]);
-    });
+    expect(focusSpy).toHaveBeenCalledOnce();
   });
 
-  describe('submit', () => {
-    it('should dismiss with transaction data when form is valid', async () => {
-      const { component, bottomSheetRef } = configureBottomSheet();
-      component['model'].update((m) => ({
-        ...m,
-        name: 'Courses Migros',
-        money: { ...m.money, amount: 45.5 },
-        kind: 'expense',
-      }));
+  it('dismisses without data on cancel', async () => {
+    const { component, bottomSheetRef } = await configureBottomSheet();
 
-      await component['onSubmit']();
+    component['close']();
 
-      expect(bottomSheetRef.dismiss).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'Courses Migros',
-          amount: 45.5,
-          kind: 'expense',
-          category: null,
-        }),
-      );
-    });
-
-    it('should not dismiss when form is invalid', async () => {
-      const { component, bottomSheetRef } = configureBottomSheet();
-      component['model'].update((m) => ({
-        ...m,
-        name: '',
-        money: { ...m.money, amount: null },
-      }));
-
-      await component['onSubmit']();
-
-      expect(bottomSheetRef.dismiss).not.toHaveBeenCalled();
-    });
-
-    it('should convert empty category to null', async () => {
-      const { component, bottomSheetRef } = configureBottomSheet();
-      component['model'].update((m) => ({
-        ...m,
-        name: 'Test',
-        money: { ...m.money, amount: 10 },
-        kind: 'expense',
-        category: '',
-      }));
-
-      await component['onSubmit']();
-
-      expect(bottomSheetRef.dismiss).toHaveBeenCalledWith(
-        expect.objectContaining({ category: null }),
-      );
-    });
-
-    it('should not dismiss when the conversion call throws', async () => {
-      const { component, bottomSheetRef, converter } = configureBottomSheet();
-      converter.convertWithMetadata.mockRejectedValueOnce(
-        new Error('rate unavailable'),
-      );
-      component['model'].update((m) => ({
-        ...m,
-        name: 'Test',
-        money: { amount: 100, inputCurrency: 'CHF' },
-      }));
-
-      await component['onSubmit']();
-
-      expect(bottomSheetRef.dismiss).not.toHaveBeenCalled();
-      expect(component['conversionError']()).toBe(true);
-    });
+    expect(bottomSheetRef.dismiss).toHaveBeenCalledWith();
   });
 
-  describe('checked toggle', () => {
-    it('should set checkedAt to ISO string when isChecked is true (default)', async () => {
-      const { component, bottomSheetRef } = configureBottomSheet();
-      component['model'].update((m) => ({
-        ...m,
-        name: 'Test',
-        money: { ...m.money, amount: 10 },
-        kind: 'expense',
-        isChecked: true,
-      }));
+  it('delegates submission to the shared form', async () => {
+    const submitSpy = vi
+      .spyOn(AddTransactionForm.prototype, 'submit')
+      .mockResolvedValue();
+    const { component } = await configureBottomSheet();
 
-      await component['onSubmit']();
+    component['submit']();
 
-      const callArg: TransactionFormData =
-        bottomSheetRef.dismiss.mock.calls[0][0];
-      expect(callArg.checkedAt).toBeDefined();
-      expect(typeof callArg.checkedAt).toBe('string');
-      expect(() => new Date(callArg.checkedAt!)).not.toThrow();
-    });
-
-    it('should set checkedAt to null when isChecked is false', async () => {
-      const { component, bottomSheetRef } = configureBottomSheet();
-      component['model'].update((m) => ({
-        ...m,
-        name: 'Test',
-        money: { ...m.money, amount: 10 },
-        kind: 'expense',
-        isChecked: false,
-      }));
-
-      await component['onSubmit']();
-
-      expect(bottomSheetRef.dismiss).toHaveBeenCalledWith(
-        expect.objectContaining({ checkedAt: null }),
-      );
-    });
+    expect(submitSpy).toHaveBeenCalledOnce();
   });
 
-  describe('close', () => {
-    it('should dismiss without data', () => {
-      const { component, bottomSheetRef } = configureBottomSheet();
+  it('dismisses with the shared form result', async () => {
+    const { component, bottomSheetRef } = await configureBottomSheet();
+    const transaction: TransactionFormData = {
+      name: 'Courses',
+      amount: 25,
+      kind: 'expense',
+      category: null,
+      checkedAt: null,
+    };
 
-      component['close']();
+    component['onCreated'](transaction);
 
-      expect(bottomSheetRef.dismiss).toHaveBeenCalledWith();
-    });
-  });
-
-  describe('form validation', () => {
-    it('should require name', () => {
-      const { component } = configureBottomSheet();
-      component['model'].update((m) => ({ ...m, name: '' }));
-
-      expect(
-        component['transactionForm']
-          .name()
-          .errors()
-          .some((e) => e.kind === 'required'),
-      ).toBe(true);
-    });
-
-    it('should enforce max length on name', () => {
-      const { component } = configureBottomSheet();
-      component['model'].update((m) => ({ ...m, name: 'a'.repeat(101) }));
-
-      expect(
-        component['transactionForm']
-          .name()
-          .errors()
-          .some((e) => e.kind === 'maxLength'),
-      ).toBe(true);
-    });
-
-    it('should require amount', () => {
-      const { component } = configureBottomSheet();
-      component['model'].update((m) => ({
-        ...m,
-        money: { ...m.money, amount: null },
-      }));
-
-      expect(
-        component['transactionForm'].money
-          .amount()
-          .errors()
-          .some((e) => e.kind === 'required'),
-      ).toBe(true);
-    });
-
-    it('should reject amount below 0.01', () => {
-      const { component } = configureBottomSheet();
-      component['model'].update((m) => ({
-        ...m,
-        money: { ...m.money, amount: 0 },
-      }));
-
-      expect(
-        component['transactionForm'].money
-          .amount()
-          .errors()
-          .some((e) => e.kind === 'min'),
-      ).toBe(true);
-    });
-
-    it('should reject negative amount', () => {
-      const { component } = configureBottomSheet();
-      component['model'].update((m) => ({
-        ...m,
-        money: { ...m.money, amount: -50 },
-      }));
-
-      expect(
-        component['transactionForm'].money
-          .amount()
-          .errors()
-          .some((e) => e.kind === 'min'),
-      ).toBe(true);
-    });
-  });
-
-  describe('predefined amounts', () => {
-    it('should update model amount when selecting predefined amount', () => {
-      const { component } = configureBottomSheet();
-
-      component['selectPredefinedAmount'](20);
-
-      expect(component['transactionForm'].money.amount().value()).toBe(20);
-      expect(component['transactionForm'].money.amount().touched()).toBe(true);
-    });
-  });
-
-  describe('currency create rules', () => {
-    it('should initialize money slice with user currency', () => {
-      const { component } = configureBottomSheet({ userCurrency: 'EUR' });
-
-      expect(component['model']().money.inputCurrency).toBe('EUR');
-      expect(component['model']().money.amount).toBeNull();
-    });
-
-    it('should call convertWithMetadata with (amount, inputCurrency, userCurrency) and include metadata in payload when currencies differ', async () => {
-      const { component, bottomSheetRef, converter } = configureBottomSheet({
-        userCurrency: 'CHF',
-        flagEnabled: true,
-      });
-      converter.convertWithMetadata.mockResolvedValueOnce({
-        convertedAmount: 108.97,
-        metadata: {
-          originalAmount: 100,
-          originalCurrency: 'EUR',
-          targetCurrency: 'CHF',
-          exchangeRate: 1.0897,
-        },
-      });
-
-      component['model'].update((m) => ({
-        ...m,
-        name: 'Test',
-        money: { amount: 100, inputCurrency: 'EUR' },
-      }));
-
-      await component['onSubmit']();
-
-      expect(converter.convertWithMetadata).toHaveBeenCalledWith(
-        100,
-        'EUR',
-        'CHF',
-      );
-      expect(bottomSheetRef.dismiss).toHaveBeenCalledTimes(1);
-      const dto: TransactionFormData = bottomSheetRef.dismiss.mock.calls[0][0];
-      expect(dto.amount).toBe(108.97);
-      expect(dto.originalAmount).toBe(100);
-      expect(dto.originalCurrency).toBe('EUR');
-      expect(dto.targetCurrency).toBe('CHF');
-      expect(dto.exchangeRate).toBe(1.0897);
-    });
-
-    it('should dismiss without conversion metadata fields when input currency matches display currency', async () => {
-      const { component, bottomSheetRef, converter } = configureBottomSheet({
-        userCurrency: 'CHF',
-        flagEnabled: true,
-      });
-      converter.convertWithMetadata.mockResolvedValueOnce({
-        convertedAmount: 50,
-        metadata: null,
-      });
-
-      component['model'].update((m) => ({
-        ...m,
-        name: 'Test',
-        money: { amount: 50, inputCurrency: 'CHF' },
-      }));
-
-      await component['onSubmit']();
-
-      const callArg: TransactionFormData =
-        bottomSheetRef.dismiss.mock.calls[0][0];
-      expect(callArg.originalAmount).toBeUndefined();
-      expect(callArg.originalCurrency).toBeUndefined();
-      expect(callArg.targetCurrency).toBeUndefined();
-      expect(callArg.exchangeRate).toBeUndefined();
-    });
+    expect(bottomSheetRef.dismiss).toHaveBeenCalledWith(transaction);
   });
 });

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
@@ -62,7 +62,7 @@ async function configureBottomSheet() {
 describe('AddTransactionBottomSheet', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
-  it('dismisses without data on cancel', async () => {
+  it('should dismiss without data on cancel', async () => {
     const { component, bottomSheetRef } = await configureBottomSheet();
 
     component['close']();
@@ -70,7 +70,7 @@ describe('AddTransactionBottomSheet', () => {
     expect(bottomSheetRef.dismiss).toHaveBeenCalledWith();
   });
 
-  it('delegates submission to the shared form', async () => {
+  it('should delegate submission to the shared form', async () => {
     const submitSpy = vi
       .spyOn(AddTransactionForm.prototype, 'submit')
       .mockResolvedValue();
@@ -81,7 +81,7 @@ describe('AddTransactionBottomSheet', () => {
     expect(submitSpy).toHaveBeenCalledOnce();
   });
 
-  it('dismisses with the shared form result', async () => {
+  it('should dismiss with the shared form result', async () => {
     const { component, bottomSheetRef } = await configureBottomSheet();
     const transaction: TransactionFormData = {
       name: 'Courses',

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.spec.ts
@@ -2,7 +2,6 @@ import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { Subject } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SupportedCurrency } from 'pulpe-shared';
 
@@ -17,10 +16,8 @@ import {
 } from './add-transaction-form';
 
 async function configureBottomSheet() {
-  const afterOpened = new Subject<void>();
   const bottomSheetRef = {
     dismiss: vi.fn(),
-    afterOpened: vi.fn().mockReturnValue(afterOpened),
   };
   const settings = {
     currency: signal<SupportedCurrency>('CHF'),
@@ -59,21 +56,11 @@ async function configureBottomSheet() {
     fixture,
     component: fixture.componentInstance,
     bottomSheetRef,
-    afterOpened,
   };
 }
 
 describe('AddTransactionBottomSheet', () => {
   beforeEach(() => TestBed.resetTestingModule());
-
-  it('focuses the amount after opening', async () => {
-    const focusSpy = vi.spyOn(AddTransactionForm.prototype, 'focusAmount');
-    const { afterOpened } = await configureBottomSheet();
-
-    afterOpened.next();
-
-    expect(focusSpy).toHaveBeenCalledOnce();
-  });
 
   it('dismisses without data on cancel', async () => {
     const { component, bottomSheetRef } = await configureBottomSheet();
@@ -87,9 +74,9 @@ describe('AddTransactionBottomSheet', () => {
     const submitSpy = vi
       .spyOn(AddTransactionForm.prototype, 'submit')
       .mockResolvedValue();
-    const { component } = await configureBottomSheet();
+    const { fixture } = await configureBottomSheet();
 
-    component['submit']();
+    fixture.nativeElement.querySelector('pulpe-loading-button button').click();
 
     expect(submitSpy).toHaveBeenCalledOnce();
   });
@@ -101,7 +88,8 @@ describe('AddTransactionBottomSheet', () => {
       amount: 25,
       kind: 'expense',
       category: null,
-      checkedAt: null,
+      isChecked: false,
+      conversion: null,
     };
 
     component['onCreated'](transaction);

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -1,92 +1,47 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  computed,
+  ViewChild,
   inject,
-  signal,
-  viewChild,
 } from '@angular/core';
-import {
-  FormField,
-  form,
-  maxLength,
-  minLength,
-  required,
-} from '@angular/forms/signals';
 import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { MatButtonModule } from '@angular/material/button';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import type { SupportedCurrency, TransactionCreate } from 'pulpe-shared';
-import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
-import { TransactionLabelPipe } from '@ui/transaction-display';
-import { UserSettingsStore } from '@core/user-settings';
-import {
-  AppCurrencyPipe,
-  applyAmountValidators,
-  type AmountFormSlice,
-  createAmountSlice,
-  CurrencyConverterService,
-  runFormSubmit,
-  StaleRateNotifier,
-} from '@core/currency';
-import { Logger } from '@core/logging/logger';
-import { AmountInput } from '@app/pattern/amount-input/amount-input';
+import { TranslocoPipe } from '@jsverse/transloco';
+
 import { BlurOnVisibilityResumeDirective } from '@ui/blur-on-visibility-resume/blur-on-visibility-resume.directive';
+import { LoadingButton } from '@ui/loading-button/loading-button';
+import {
+  AddTransactionForm,
+  type TransactionFormData,
+} from './add-transaction-form';
 
-export type TransactionFormData = Pick<
-  TransactionCreate,
-  'name' | 'amount' | 'kind' | 'category' | 'checkedAt'
-> & {
-  originalAmount?: number;
-  originalCurrency?: SupportedCurrency;
-  targetCurrency?: SupportedCurrency;
-  exchangeRate?: number;
-};
-
-interface AddTransactionModel {
-  name: string;
-  money: AmountFormSlice;
-  kind: 'expense' | 'income' | 'saving';
-  category: string;
-  isChecked: boolean;
-}
+export type { TransactionFormData } from './add-transaction-form';
 
 @Component({
   selector: 'pulpe-add-transaction-bottom-sheet',
   imports: [
     MatButtonModule,
     MatIconModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule,
-    MatChipsModule,
-    MatSlideToggleModule,
     TranslocoPipe,
-    TransactionLabelPipe,
-    AppCurrencyPipe,
-    FormField,
-    AmountInput,
+    AddTransactionForm,
     BlurOnVisibilityResumeDirective,
+    LoadingButton,
   ],
   template: `
-    <div class="flex flex-col gap-4" pulpeBlurOnVisibilityResume>
-      <!-- Drag indicator -->
+    <div class="flex flex-col gap-4 pb-6" pulpeBlurOnVisibilityResume>
       <div
         class="w-9 h-1 bg-outline-variant rounded-sm mx-auto mt-3 mb-2"
       ></div>
 
-      <!-- Header -->
-      <div class="flex justify-between items-center">
-        <div>
-          <h2 class="text-title-large text-on-surface m-0">
+      <div class="flex justify-between items-center gap-4">
+        <div class="min-w-0">
+          <h2 class="text-title-large text-on-surface m-0 [text-wrap:balance]">
             {{ 'currentMonth.addTransactionTitle' | transloco }}
           </h2>
-          <p class="text-body-small text-on-surface-variant mt-0.5 mb-0">
+          <p
+            class="text-body-small text-on-surface-variant mt-0.5 mb-0 text-pretty"
+          >
             {{ 'currentMonth.addTransactionSubtitle' | transloco }}
           </p>
         </div>
@@ -99,136 +54,9 @@ interface AddTransactionModel {
         </button>
       </div>
 
-      <!-- Form -->
-      <form
-        (ngSubmit)="onSubmit()"
-        class="flex flex-col gap-4"
-        novalidate
-        data-testid="transaction-form"
-      >
-        <!-- Amount Field -->
-        <pulpe-amount-input [control]="transactionForm.money" />
+      <pulpe-add-transaction-form #form (created)="onCreated($event)" />
 
-        <!-- Predefined Amounts -->
-        <div class="flex flex-col gap-3">
-          <div class="text-sm font-medium text-on-surface-variant">
-            {{ 'currentMonth.addTransactionQuickAmounts' | transloco }}
-          </div>
-          <div class="flex flex-wrap gap-2">
-            @for (amount of predefinedAmounts; track amount) {
-              <button
-                matButton="tonal"
-                type="button"
-                (click)="selectPredefinedAmount(amount)"
-                class="min-w-20 h-10"
-              >
-                {{ amount | appCurrency: currency() : '1.0-0' }}
-              </button>
-            }
-          </div>
-        </div>
-
-        <!-- Name Field -->
-        <mat-form-field appearance="outline" subscriptSizing="dynamic">
-          <mat-label>{{
-            'currentMonth.addTransactionDescription' | transloco
-          }}</mat-label>
-          <input
-            matInput
-            [formField]="transactionForm.name"
-            data-testid="transaction-description-input"
-            placeholder="Ex: Courses chez Migros"
-          />
-          @if (nameRequiredError()) {
-            <mat-error>{{
-              'currentMonth.addTransactionDescriptionRequired' | transloco
-            }}</mat-error>
-          }
-          @if (nameMinLengthError()) {
-            <mat-error>{{
-              'currentMonth.addTransactionDescriptionMin' | transloco
-            }}</mat-error>
-          }
-        </mat-form-field>
-
-        <!-- Type Field -->
-        <mat-form-field class="w-full" subscriptSizing="dynamic">
-          <mat-label>{{
-            'currentMonth.addTransactionType' | transloco
-          }}</mat-label>
-          <mat-select
-            [formField]="transactionForm.kind"
-            [attr.aria-label]="'currentMonth.addTransactionType' | transloco"
-            data-testid="transaction-type-select"
-          >
-            <mat-option value="expense">
-              <mat-icon class="mr-2 icon-filled">remove_circle</mat-icon>
-              {{ 'expense' | transactionLabel }}
-            </mat-option>
-            <mat-option value="income">
-              <mat-icon class="mr-2 icon-filled">add_circle</mat-icon>
-              {{ 'income' | transactionLabel }}
-            </mat-option>
-            <mat-option value="saving">
-              <mat-icon class="mr-2 icon-filled">savings</mat-icon>
-              {{ 'saving' | transactionLabel }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        <!-- Category/Notes Field -->
-        <mat-form-field class="w-full" subscriptSizing="dynamic">
-          <mat-label>{{
-            'currentMonth.addTransactionNotes' | transloco
-          }}</mat-label>
-          <input
-            matInput
-            [formField]="transactionForm.category"
-            [placeholder]="
-              'currentMonth.addTransactionNotesPlaceholder' | transloco
-            "
-            aria-describedby="category-hint"
-          />
-          <mat-hint id="category-hint" align="end"
-            >{{ model().category.length }}/50
-            {{
-              'currentMonth.addTransactionNotesOptional' | transloco
-            }}</mat-hint
-          >
-          @if (categoryMaxLengthError()) {
-            <mat-error>{{
-              'currentMonth.addTransactionNotesMaxLength' | transloco
-            }}</mat-error>
-          }
-        </mat-form-field>
-
-        <!-- Date display (today by default) -->
-        <div
-          class="flex items-center gap-2 p-3 bg-surface-container rounded-lg text-on-surface-variant"
-        >
-          <mat-icon>event</mat-icon>
-          <span>{{ 'currentMonth.addTransactionToday' | transloco }}</span>
-        </div>
-
-        <div class="flex items-center justify-between py-2 px-1">
-          <span class="text-body-medium text-on-surface">{{
-            'transactionForm.checkedToggle' | transloco
-          }}</span>
-          <mat-slide-toggle
-            [formField]="transactionForm.isChecked"
-            [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
-          />
-        </div>
-      </form>
-
-      @if (conversionError()) {
-        <p role="alert" class="text-error text-body-small pb-2">
-          {{ 'common.conversionError' | transloco }}
-        </p>
-      }
-
-      <!-- Action Buttons -->
-      <div class="flex gap-3 pt-4 pb-6 px-6 border-t border-outline-variant">
+      <div class="flex gap-3 pt-4 border-t border-outline-variant">
         <button
           matButton
           (click)="close()"
@@ -237,133 +65,45 @@ interface AddTransactionModel {
         >
           {{ 'currentMonth.addTransactionCancel' | transloco }}
         </button>
-        <button
-          matButton="outlined"
-          (click)="onSubmit()"
-          [disabled]="!canSubmit()"
-          data-testid="transaction-submit-button"
+        <pulpe-loading-button
           class="flex-2"
+          type="button"
+          [loading]="form.isSubmitting()"
+          [disabled]="!form.canSubmit()"
+          [loadingText]="'common.loading' | transloco"
+          (click)="submit()"
+          testId="transaction-submit-button"
         >
           {{ 'currentMonth.addTransactionSubmit' | transloco }}
-        </button>
+        </pulpe-loading-button>
       </div>
     </div>
   `,
+  host: { class: 'block' },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AddTransactionBottomSheet {
   readonly #bottomSheetRef = inject(
-    MatBottomSheetRef<AddTransactionBottomSheet>,
+    MatBottomSheetRef<AddTransactionBottomSheet, TransactionFormData>,
   );
-  readonly #transloco = inject(TranslocoService);
-  readonly #userSettings = inject(UserSettingsStore);
-  readonly #converter = inject(CurrencyConverterService);
-  readonly #logger = inject(Logger);
-  readonly #staleRateNotifier = inject(StaleRateNotifier);
-
-  protected readonly amountInput = viewChild(AmountInput);
+  @ViewChild(AddTransactionForm)
+  private form?: AddTransactionForm;
 
   constructor() {
     this.#bottomSheetRef.afterOpened().subscribe(() => {
-      this.amountInput()?.focus();
-    });
-  }
-
-  protected readonly currency = this.#userSettings.currency;
-  protected readonly predefinedAmounts = [10, 15, 20, 30] as const;
-  protected readonly conversionError = signal(false);
-  protected readonly isSubmitting = signal(false);
-
-  protected readonly model = signal<AddTransactionModel>({
-    name: this.#transloco.translate('currentMonth.addTransactionDefaultName'),
-    money: createAmountSlice({
-      initialCurrency: this.#userSettings.currency(),
-    }),
-    kind: 'expense',
-    category: '',
-    isChecked: true,
-  });
-
-  protected readonly transactionForm = form(this.model, (path) => {
-    required(path.name, {
-      message: 'currentMonth.addTransactionDescriptionRequired',
-    });
-    minLength(path.name, 2, {
-      message: 'currentMonth.addTransactionDescriptionMin',
-    });
-    maxLength(path.name, 100);
-    applyAmountValidators(path.money);
-    required(path.kind);
-    maxLength(path.category, 50, {
-      message: 'currentMonth.addTransactionNotesMaxLength',
-    });
-  });
-
-  protected readonly canSubmit = computed(
-    () => this.transactionForm().valid() && !this.isSubmitting(),
-  );
-
-  protected readonly nameRequiredError = computed(
-    () =>
-      this.transactionForm.name().touched() &&
-      this.transactionForm
-        .name()
-        .errors()
-        .some((e) => e.kind === 'required'),
-  );
-  protected readonly nameMinLengthError = computed(
-    () =>
-      this.transactionForm.name().touched() &&
-      this.transactionForm
-        .name()
-        .errors()
-        .some((e) => e.kind === 'minLength'),
-  );
-  protected readonly categoryMaxLengthError = computed(
-    () =>
-      this.transactionForm.category().touched() &&
-      this.transactionForm
-        .category()
-        .errors()
-        .some((e) => e.kind === 'maxLength'),
-  );
-
-  protected selectPredefinedAmount(amount: number): void {
-    const amountField = this.transactionForm.money.amount();
-    amountField.value.set(amount);
-    amountField.markAsTouched();
-  }
-
-  protected async onSubmit(): Promise<void> {
-    await runFormSubmit({
-      form: this.transactionForm,
-      isSubmitting: this.isSubmitting,
-      conversionError: this.conversionError,
-      prepare: () => {
-        const m = this.model();
-        return {
-          amountSlice: m.money,
-          targetCurrency: this.#userSettings.currency(),
-          converter: this.#converter,
-          logger: this.#logger,
-          build: (amount, metadata): TransactionFormData => ({
-            name: m.name,
-            amount,
-            kind: m.kind,
-            category: m.category || null,
-            checkedAt: m.isChecked ? new Date().toISOString() : null,
-            ...metadata,
-          }),
-        };
-      },
-      onSuccess: (value, outcome) => {
-        this.#staleRateNotifier.notify(outcome);
-        this.#bottomSheetRef.dismiss(value);
-      },
+      this.form?.focusAmount();
     });
   }
 
   protected close(): void {
     this.#bottomSheetRef.dismiss();
+  }
+
+  protected submit(): void {
+    void this.form?.submit();
+  }
+
+  protected onCreated(tx: TransactionFormData): void {
+    this.#bottomSheetRef.dismiss(tx);
   }
 }

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-bottom-sheet.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ViewChild,
-  inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -15,8 +10,6 @@ import {
   AddTransactionForm,
   type TransactionFormData,
 } from './add-transaction-form';
-
-export type { TransactionFormData } from './add-transaction-form';
 
 @Component({
   selector: 'pulpe-add-transaction-bottom-sheet',
@@ -71,7 +64,7 @@ export type { TransactionFormData } from './add-transaction-form';
           [loading]="form.isSubmitting()"
           [disabled]="!form.canSubmit()"
           [loadingText]="'common.loading' | transloco"
-          (click)="submit()"
+          (click)="form.submit()"
           testId="transaction-submit-button"
         >
           {{ 'currentMonth.addTransactionSubmit' | transloco }}
@@ -86,21 +79,9 @@ export class AddTransactionBottomSheet {
   readonly #bottomSheetRef = inject(
     MatBottomSheetRef<AddTransactionBottomSheet, TransactionFormData>,
   );
-  @ViewChild(AddTransactionForm)
-  private form?: AddTransactionForm;
-
-  constructor() {
-    this.#bottomSheetRef.afterOpened().subscribe(() => {
-      this.form?.focusAmount();
-    });
-  }
 
   protected close(): void {
     this.#bottomSheetRef.dismiss();
-  }
-
-  protected submit(): void {
-    void this.form?.submit();
   }
 
   protected onCreated(tx: TransactionFormData): void {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-dialog.ts
@@ -21,30 +21,28 @@ import {
     LoadingButton,
   ],
   template: `
-    <div mat-dialog-title class="!flex items-center justify-between gap-4">
-      <div class="min-w-0">
-        <h2 class="text-headline-small text-on-surface m-0 [text-wrap:balance]">
-          {{ 'currentMonth.addTransactionTitle' | transloco }}
-        </h2>
-        <p
-          class="text-body-small text-on-surface-variant mt-0.5 mb-0 text-pretty"
-        >
-          {{ 'currentMonth.addTransactionSubtitle' | transloco }}
-        </p>
-      </div>
-      <button
-        matIconButton
-        (click)="close()"
-        [attr.aria-label]="'currentMonth.addTransactionClose' | transloco"
-      >
-        <mat-icon>close</mat-icon>
-      </button>
-    </div>
+    <button
+      matIconButton
+      class="absolute! top-3 right-3 z-10"
+      (click)="close()"
+      [attr.aria-label]="'currentMonth.addTransactionClose' | transloco"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+    <h2
+      mat-dialog-title
+      class="text-headline-small text-on-surface pr-20! [text-wrap:balance]"
+    >
+      {{ 'currentMonth.addTransactionTitle' | transloco }}
+    </h2>
 
     <mat-dialog-content>
+      <p class="text-body-small text-on-surface-variant mt-0 mb-4 text-pretty">
+        {{ 'currentMonth.addTransactionSubtitle' | transloco }}
+      </p>
       <pulpe-add-transaction-form
         #form
-        class="add-transaction-form-wide block pt-2"
+        class="add-transaction-form-wide block"
         (created)="onCreated($event)"
       />
     </mat-dialog-content>

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-dialog.ts
@@ -1,0 +1,105 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewChild,
+  inject,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { TranslocoPipe } from '@jsverse/transloco';
+
+import { LoadingButton } from '@ui/loading-button/loading-button';
+import {
+  AddTransactionForm,
+  type TransactionFormData,
+} from './add-transaction-form';
+
+@Component({
+  selector: 'pulpe-add-transaction-dialog',
+  imports: [
+    MatButtonModule,
+    MatDialogModule,
+    MatIconModule,
+    TranslocoPipe,
+    AddTransactionForm,
+    LoadingButton,
+  ],
+  template: `
+    <div mat-dialog-title class="!flex items-center justify-between gap-4">
+      <div class="min-w-0">
+        <h2 class="text-headline-small text-on-surface m-0 [text-wrap:balance]">
+          {{ 'currentMonth.addTransactionTitle' | transloco }}
+        </h2>
+        <p
+          class="text-body-small text-on-surface-variant mt-0.5 mb-0 text-pretty"
+        >
+          {{ 'currentMonth.addTransactionSubtitle' | transloco }}
+        </p>
+      </div>
+      <button
+        matIconButton
+        (click)="close()"
+        [attr.aria-label]="'currentMonth.addTransactionClose' | transloco"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+
+    <mat-dialog-content>
+      <pulpe-add-transaction-form
+        #form
+        class="add-transaction-form-wide block pt-2"
+        (created)="onCreated($event)"
+      />
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      <button
+        matButton
+        (click)="close()"
+        data-testid="transaction-cancel-button"
+      >
+        {{ 'currentMonth.addTransactionCancel' | transloco }}
+      </button>
+      <pulpe-loading-button
+        class="min-w-40"
+        type="button"
+        [fullWidth]="false"
+        [loading]="form.isSubmitting()"
+        [disabled]="!form.canSubmit()"
+        [loadingText]="'common.loading' | transloco"
+        (click)="submit()"
+        testId="transaction-submit-button"
+      >
+        {{ 'currentMonth.addTransactionSubmit' | transloco }}
+      </pulpe-loading-button>
+    </mat-dialog-actions>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AddTransactionDialog {
+  readonly #dialogRef = inject(
+    MatDialogRef<AddTransactionDialog, TransactionFormData>,
+  );
+  @ViewChild(AddTransactionForm)
+  private form?: AddTransactionForm;
+
+  constructor() {
+    this.#dialogRef.afterOpened().subscribe(() => {
+      this.form?.focusAmount();
+    });
+  }
+
+  protected close(): void {
+    this.#dialogRef.close();
+  }
+
+  protected submit(): void {
+    void this.form?.submit();
+  }
+
+  protected onCreated(tx: TransactionFormData): void {
+    this.#dialogRef.close(tx);
+  }
+}

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-dialog.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ViewChild,
-  inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
@@ -69,7 +64,7 @@ import {
         [loading]="form.isSubmitting()"
         [disabled]="!form.canSubmit()"
         [loadingText]="'common.loading' | transloco"
-        (click)="submit()"
+        (click)="form.submit()"
         testId="transaction-submit-button"
       >
         {{ 'currentMonth.addTransactionSubmit' | transloco }}
@@ -82,21 +77,9 @@ export class AddTransactionDialog {
   readonly #dialogRef = inject(
     MatDialogRef<AddTransactionDialog, TransactionFormData>,
   );
-  @ViewChild(AddTransactionForm)
-  private form?: AddTransactionForm;
-
-  constructor() {
-    this.#dialogRef.afterOpened().subscribe(() => {
-      this.form?.focusAmount();
-    });
-  }
 
   protected close(): void {
     this.#dialogRef.close();
-  }
-
-  protected submit(): void {
-    void this.form?.submit();
   }
 
   protected onCreated(tx: TransactionFormData): void {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  transactionCreateFromQuickFormSchema,
+  transactionFormDataSchema,
+  type TransactionFormData,
+} from './add-transaction-form.schema';
+
+const formData: TransactionFormData = {
+  name: 'Courses',
+  amount: 45,
+  kind: 'expense',
+  category: null,
+  isChecked: false,
+  conversion: null,
+};
+
+const context = {
+  budgetId: '00000000-0000-4000-8000-000000000001',
+  transactionDate: '2026-07-16T12:00:00+02:00',
+};
+
+describe('transactionFormDataSchema', () => {
+  it('validates the shared surface result', () => {
+    expect(transactionFormDataSchema.parse(formData)).toEqual(formData);
+  });
+});
+
+describe('transactionCreateFromQuickFormSchema', () => {
+  it('transforms the surface result and dashboard context into a transaction', () => {
+    const result = transactionCreateFromQuickFormSchema.parse({
+      ...formData,
+      ...context,
+      isChecked: true,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        budgetId: context.budgetId,
+        transactionDate: context.transactionDate,
+        name: 'Courses',
+        amount: 45,
+        checkedAt: expect.any(String),
+      }),
+    );
+  });
+
+  it('flattens conversion metadata into the transaction payload', () => {
+    const result = transactionCreateFromQuickFormSchema.parse({
+      ...formData,
+      ...context,
+      conversion: {
+        originalAmount: 50,
+        originalCurrency: 'EUR',
+        targetCurrency: 'CHF',
+        exchangeRate: 0.9,
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        originalAmount: 50,
+        originalCurrency: 'EUR',
+        targetCurrency: 'CHF',
+        exchangeRate: 0.9,
+      }),
+    );
+  });
+
+  it('rejects invalid dashboard context', () => {
+    const result = transactionCreateFromQuickFormSchema.safeParse({
+      ...formData,
+      ...context,
+      budgetId: 'not-a-uuid',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.spec.ts
@@ -24,6 +24,15 @@ describe('transactionFormDataSchema', () => {
   it('validates the shared surface result', () => {
     expect(transactionFormDataSchema.parse(formData)).toEqual(formData);
   });
+
+  it('rejects a one-character name', () => {
+    const result = transactionFormDataSchema.safeParse({
+      ...formData,
+      name: 'A',
+    });
+
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('transactionCreateFromQuickFormSchema', () => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.spec.ts
@@ -21,11 +21,11 @@ const context = {
 };
 
 describe('transactionFormDataSchema', () => {
-  it('validates the shared surface result', () => {
+  it('should validate the shared surface result', () => {
     expect(transactionFormDataSchema.parse(formData)).toEqual(formData);
   });
 
-  it('rejects a one-character name', () => {
+  it('should reject a one-character name', () => {
     const result = transactionFormDataSchema.safeParse({
       ...formData,
       name: 'A',
@@ -33,10 +33,37 @@ describe('transactionFormDataSchema', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('should reject a whitespace-only name', () => {
+    const result = transactionFormDataSchema.safeParse({
+      ...formData,
+      name: '   ',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a padded one-character name', () => {
+    const result = transactionFormDataSchema.safeParse({
+      ...formData,
+      name: ' A ',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should normalize whitespace-only notes to null', () => {
+    const result = transactionFormDataSchema.parse({
+      ...formData,
+      category: '   ',
+    });
+
+    expect(result.category).toBeNull();
+  });
 });
 
 describe('transactionCreateFromQuickFormSchema', () => {
-  it('transforms the surface result and dashboard context into a transaction', () => {
+  it('should transform the surface result and dashboard context into a transaction', () => {
     const result = transactionCreateFromQuickFormSchema.parse({
       ...formData,
       ...context,
@@ -54,7 +81,7 @@ describe('transactionCreateFromQuickFormSchema', () => {
     );
   });
 
-  it('flattens conversion metadata into the transaction payload', () => {
+  it('should flatten conversion metadata into the transaction payload', () => {
     const result = transactionCreateFromQuickFormSchema.parse({
       ...formData,
       ...context,
@@ -76,7 +103,7 @@ describe('transactionCreateFromQuickFormSchema', () => {
     );
   });
 
-  it('rejects invalid dashboard context', () => {
+  it('should reject invalid dashboard context', () => {
     const result = transactionCreateFromQuickFormSchema.safeParse({
       ...formData,
       ...context,

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.ts
@@ -4,7 +4,7 @@ import { transactionKindSchema, type TransactionCreate } from 'pulpe-shared';
 import { conversionFormSchema } from '@core/currency';
 
 export const transactionFormDataSchema = z.strictObject({
-  name: z.string().min(1).max(100).trim(),
+  name: z.string().min(2).max(100).trim(),
   amount: z.number().positive(),
   kind: transactionKindSchema,
   category: z.string().max(50).trim().nullable(),

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod/v4';
+import { transactionKindSchema, type TransactionCreate } from 'pulpe-shared';
+
+import { conversionFormSchema } from '@core/currency';
+
+export const transactionFormDataSchema = z.strictObject({
+  name: z.string().min(1).max(100).trim(),
+  amount: z.number().positive(),
+  kind: transactionKindSchema,
+  category: z.string().max(50).trim().nullable(),
+  isChecked: z.boolean(),
+  conversion: conversionFormSchema.nullable(),
+});
+
+export type TransactionFormData = z.input<typeof transactionFormDataSchema>;
+
+export const transactionCreateFromQuickFormSchema = transactionFormDataSchema
+  .extend({
+    budgetId: z.uuid(),
+    transactionDate: z.iso.datetime({ offset: true }),
+  })
+  .transform(
+    ({ isChecked, conversion, ...input }): TransactionCreate => ({
+      ...input,
+      checkedAt: isChecked ? new Date().toISOString() : null,
+      ...(conversion ?? {}),
+    }),
+  );

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.schema.ts
@@ -4,10 +4,15 @@ import { transactionKindSchema, type TransactionCreate } from 'pulpe-shared';
 import { conversionFormSchema } from '@core/currency';
 
 export const transactionFormDataSchema = z.strictObject({
-  name: z.string().min(2).max(100).trim(),
+  name: z.string().trim().min(2).max(100),
   amount: z.number().positive(),
   kind: transactionKindSchema,
-  category: z.string().max(50).trim().nullable(),
+  category: z
+    .string()
+    .trim()
+    .max(50)
+    .transform((value) => value || null)
+    .nullable(),
   isChecked: z.boolean(),
   conversion: conversionFormSchema.nullable(),
 });

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.spec.ts
@@ -164,7 +164,7 @@ describe('AddTransactionForm', () => {
   });
 
   describe('checked toggle', () => {
-    it('sets checkedAt when the transaction is checked', async () => {
+    it('emits the checked state when the transaction is checked', async () => {
       const { component, createdSpy } = configureForm();
       component['model'].update((model) => ({
         ...model,
@@ -175,12 +175,12 @@ describe('AddTransactionForm', () => {
 
       await component.submit();
 
-      const transaction = createdSpy.mock.calls[0][0];
-      expect(transaction.checkedAt).toBeDefined();
-      expect(typeof transaction.checkedAt).toBe('string');
+      expect(createdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ isChecked: true }),
+      );
     });
 
-    it('sets checkedAt to null when the transaction is unchecked', async () => {
+    it('emits the checked state when the transaction is unchecked', async () => {
       const { component, createdSpy } = configureForm();
       component['model'].update((model) => ({
         ...model,
@@ -192,7 +192,7 @@ describe('AddTransactionForm', () => {
       await component.submit();
 
       expect(createdSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ checkedAt: null }),
+        expect.objectContaining({ isChecked: false }),
       );
     });
   });
@@ -266,10 +266,12 @@ describe('AddTransactionForm', () => {
       expect(createdSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           amount: 108.97,
-          originalAmount: 100,
-          originalCurrency: 'EUR',
-          targetCurrency: 'CHF',
-          exchangeRate: 1.0897,
+          conversion: {
+            originalAmount: 100,
+            originalCurrency: 'EUR',
+            targetCurrency: 'CHF',
+            exchangeRate: 1.0897,
+          },
         }),
       );
     });

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.spec.ts
@@ -1,0 +1,277 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SupportedCurrency } from 'pulpe-shared';
+
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import { CurrencyConverterService } from '@core/currency';
+import { FeatureFlagsService } from '@core/feature-flags';
+import { UserSettingsStore } from '@core/user-settings';
+import {
+  AddTransactionForm,
+  type TransactionFormData,
+} from './add-transaction-form';
+
+interface FlagsMock {
+  isMultiCurrencyEnabled: ReturnType<typeof signal>;
+}
+
+interface SettingsMock {
+  currency: ReturnType<typeof signal<SupportedCurrency>>;
+  showCurrencySelector: ReturnType<typeof signal<boolean>>;
+}
+
+interface ConverterMock {
+  convertWithMetadata: ReturnType<typeof vi.fn>;
+}
+
+function configureForm({
+  userCurrency = 'CHF' as SupportedCurrency,
+  flagEnabled = false,
+  showCurrencyPref = true,
+}: {
+  userCurrency?: SupportedCurrency;
+  flagEnabled?: boolean;
+  showCurrencyPref?: boolean;
+} = {}) {
+  const flags: FlagsMock = {
+    isMultiCurrencyEnabled: signal(flagEnabled),
+  };
+  const settings: SettingsMock = {
+    currency: signal<SupportedCurrency>(userCurrency),
+    showCurrencySelector: signal(showCurrencyPref),
+  };
+  const converter: ConverterMock = {
+    convertWithMetadata: vi.fn().mockImplementation(async (amount: number) => ({
+      convertedAmount: amount,
+      metadata: null,
+    })),
+  };
+
+  TestBed.configureTestingModule({
+    imports: [AddTransactionForm],
+    providers: [
+      provideZonelessChangeDetection(),
+      provideAnimationsAsync(),
+      ...provideTranslocoForTest(),
+      { provide: FeatureFlagsService, useValue: flags },
+      { provide: UserSettingsStore, useValue: settings },
+      { provide: CurrencyConverterService, useValue: converter },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(AddTransactionForm);
+  const component = fixture.componentInstance;
+  const createdSpy = vi.fn<(tx: TransactionFormData) => void>();
+  component.created.subscribe(createdSpy);
+
+  return { fixture, component, createdSpy, converter };
+}
+
+describe('AddTransactionForm', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  describe('predefined amounts', () => {
+    it('renders the four quick amounts with 44px minimum targets', () => {
+      const { fixture } = configureForm();
+      fixture.detectChanges();
+
+      const buttons = fixture.nativeElement.querySelectorAll(
+        'button[matButton="tonal"]',
+      );
+      expect(buttons.length).toBe(4);
+      expect(buttons[0].classList).toContain('min-h-11');
+    });
+
+    it('updates and touches the amount field', () => {
+      const { component } = configureForm();
+
+      component['selectPredefinedAmount'](20);
+
+      expect(component['transactionForm'].money.amount().value()).toBe(20);
+      expect(component['transactionForm'].money.amount().touched()).toBe(true);
+    });
+  });
+
+  describe('submit', () => {
+    it('emits transaction data when the form is valid', async () => {
+      const { component, createdSpy } = configureForm();
+      component['model'].update((model) => ({
+        ...model,
+        name: 'Courses Migros',
+        money: { ...model.money, amount: 45.5 },
+        kind: 'expense',
+      }));
+
+      await component.submit();
+
+      expect(createdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Courses Migros',
+          amount: 45.5,
+          kind: 'expense',
+          category: null,
+        }),
+      );
+    });
+
+    it('does not emit when the form is invalid', async () => {
+      const { component, createdSpy } = configureForm();
+      component['model'].update((model) => ({
+        ...model,
+        name: '',
+        money: { ...model.money, amount: null },
+      }));
+
+      await component.submit();
+
+      expect(createdSpy).not.toHaveBeenCalled();
+    });
+
+    it('converts an empty category to null', async () => {
+      const { component, createdSpy } = configureForm();
+      component['model'].update((model) => ({
+        ...model,
+        name: 'Test',
+        money: { ...model.money, amount: 10 },
+        category: '',
+      }));
+
+      await component.submit();
+
+      expect(createdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ category: null }),
+      );
+    });
+
+    it('reports a conversion error without emitting', async () => {
+      const { component, createdSpy, converter } = configureForm();
+      converter.convertWithMetadata.mockRejectedValueOnce(
+        new Error('rate unavailable'),
+      );
+      component['model'].update((model) => ({
+        ...model,
+        name: 'Test',
+        money: { amount: 100, inputCurrency: 'CHF' },
+      }));
+
+      await component.submit();
+
+      expect(createdSpy).not.toHaveBeenCalled();
+      expect(component['conversionError']()).toBe(true);
+    });
+  });
+
+  describe('checked toggle', () => {
+    it('sets checkedAt when the transaction is checked', async () => {
+      const { component, createdSpy } = configureForm();
+      component['model'].update((model) => ({
+        ...model,
+        name: 'Test',
+        money: { ...model.money, amount: 10 },
+        isChecked: true,
+      }));
+
+      await component.submit();
+
+      const transaction = createdSpy.mock.calls[0][0];
+      expect(transaction.checkedAt).toBeDefined();
+      expect(typeof transaction.checkedAt).toBe('string');
+    });
+
+    it('sets checkedAt to null when the transaction is unchecked', async () => {
+      const { component, createdSpy } = configureForm();
+      component['model'].update((model) => ({
+        ...model,
+        name: 'Test',
+        money: { ...model.money, amount: 10 },
+        isChecked: false,
+      }));
+
+      await component.submit();
+
+      expect(createdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ checkedAt: null }),
+      );
+    });
+  });
+
+  describe('validation', () => {
+    it('requires a name', () => {
+      const { component } = configureForm();
+      component['model'].update((model) => ({ ...model, name: '' }));
+
+      expect(
+        component['transactionForm']
+          .name()
+          .errors()
+          .some((error) => error.kind === 'required'),
+      ).toBe(true);
+    });
+
+    it('rejects an amount below the minimum', () => {
+      const { component } = configureForm();
+      component['model'].update((model) => ({
+        ...model,
+        money: { ...model.money, amount: 0 },
+      }));
+
+      expect(
+        component['transactionForm'].money
+          .amount()
+          .errors()
+          .some((error) => error.kind === 'min'),
+      ).toBe(true);
+    });
+  });
+
+  describe('currency rules', () => {
+    it('initializes the amount with the user currency', () => {
+      const { component } = configureForm({ userCurrency: 'EUR' });
+
+      expect(component['model']().money).toEqual({
+        amount: null,
+        inputCurrency: 'EUR',
+      });
+    });
+
+    it('emits the converted amount and metadata', async () => {
+      const { component, createdSpy, converter } = configureForm({
+        userCurrency: 'CHF',
+        flagEnabled: true,
+      });
+      converter.convertWithMetadata.mockResolvedValueOnce({
+        convertedAmount: 108.97,
+        metadata: {
+          originalAmount: 100,
+          originalCurrency: 'EUR',
+          targetCurrency: 'CHF',
+          exchangeRate: 1.0897,
+        },
+      });
+      component['model'].update((model) => ({
+        ...model,
+        name: 'Test',
+        money: { amount: 100, inputCurrency: 'EUR' },
+      }));
+
+      await component.submit();
+
+      expect(converter.convertWithMetadata).toHaveBeenCalledWith(
+        100,
+        'EUR',
+        'CHF',
+      );
+      expect(createdSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: 108.97,
+          originalAmount: 100,
+          originalCurrency: 'EUR',
+          targetCurrency: 'CHF',
+          exchangeRate: 1.0897,
+        }),
+      );
+    });
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.spec.ts
@@ -73,18 +73,20 @@ describe('AddTransactionForm', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
   describe('predefined amounts', () => {
-    it('renders the four quick amounts with 44px minimum targets', () => {
+    it('should render the four quick amounts as single-line 44px targets', async () => {
       const { fixture } = configureForm();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const buttons = fixture.nativeElement.querySelectorAll(
         'button[matButton="tonal"]',
       );
       expect(buttons.length).toBe(4);
       expect(buttons[0].classList).toContain('min-h-11');
+      expect(buttons[0].classList).toContain('whitespace-nowrap');
+      expect(buttons[0].classList).toContain('px-2!');
     });
 
-    it('updates and touches the amount field', () => {
+    it('should update and touch the amount field', () => {
       const { component } = configureForm();
 
       component['selectPredefinedAmount'](20);
@@ -95,7 +97,7 @@ describe('AddTransactionForm', () => {
   });
 
   describe('submit', () => {
-    it('emits transaction data when the form is valid', async () => {
+    it('should emit transaction data when the form is valid', async () => {
       const { component, createdSpy } = configureForm();
       component['model'].update((model) => ({
         ...model,
@@ -116,7 +118,7 @@ describe('AddTransactionForm', () => {
       );
     });
 
-    it('does not emit when the form is invalid', async () => {
+    it('should not emit when the form is invalid', async () => {
       const { component, createdSpy } = configureForm();
       component['model'].update((model) => ({
         ...model,
@@ -129,7 +131,7 @@ describe('AddTransactionForm', () => {
       expect(createdSpy).not.toHaveBeenCalled();
     });
 
-    it('converts an empty category to null', async () => {
+    it('should convert an empty category to null', async () => {
       const { component, createdSpy } = configureForm();
       component['model'].update((model) => ({
         ...model,
@@ -145,7 +147,7 @@ describe('AddTransactionForm', () => {
       );
     });
 
-    it('reports a conversion error without emitting', async () => {
+    it('should report a conversion error without emitting', async () => {
       const { component, createdSpy, converter } = configureForm();
       converter.convertWithMetadata.mockRejectedValueOnce(
         new Error('rate unavailable'),
@@ -164,7 +166,7 @@ describe('AddTransactionForm', () => {
   });
 
   describe('checked toggle', () => {
-    it('emits the checked state when the transaction is checked', async () => {
+    it('should emit the checked state when the transaction is checked', async () => {
       const { component, createdSpy } = configureForm();
       component['model'].update((model) => ({
         ...model,
@@ -180,7 +182,7 @@ describe('AddTransactionForm', () => {
       );
     });
 
-    it('emits the checked state when the transaction is unchecked', async () => {
+    it('should emit the checked state when the transaction is unchecked', async () => {
       const { component, createdSpy } = configureForm();
       component['model'].update((model) => ({
         ...model,
@@ -198,7 +200,7 @@ describe('AddTransactionForm', () => {
   });
 
   describe('validation', () => {
-    it('requires a name', () => {
+    it('should require a name', () => {
       const { component } = configureForm();
       component['model'].update((model) => ({ ...model, name: '' }));
 
@@ -210,7 +212,45 @@ describe('AddTransactionForm', () => {
       ).toBe(true);
     });
 
-    it('rejects an amount below the minimum', () => {
+    it('should reject a whitespace-only name', async () => {
+      const { component, createdSpy } = configureForm();
+      component['model'].update((model) => ({
+        ...model,
+        name: '   ',
+        money: { ...model.money, amount: 10 },
+      }));
+
+      await component.submit();
+
+      expect(
+        component['transactionForm']
+          .name()
+          .errors()
+          .some((error) => error.kind === 'required'),
+      ).toBe(true);
+      expect(createdSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reject a padded one-character name', async () => {
+      const { component, createdSpy } = configureForm();
+      component['model'].update((model) => ({
+        ...model,
+        name: ' A ',
+        money: { ...model.money, amount: 10 },
+      }));
+
+      await component.submit();
+
+      expect(
+        component['transactionForm']
+          .name()
+          .errors()
+          .some((error) => error.kind === 'minLength'),
+      ).toBe(true);
+      expect(createdSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reject an amount below the minimum', () => {
       const { component } = configureForm();
       component['model'].update((model) => ({
         ...model,
@@ -227,7 +267,7 @@ describe('AddTransactionForm', () => {
   });
 
   describe('currency rules', () => {
-    it('initializes the amount with the user currency', () => {
+    it('should initialize the amount with the user currency', () => {
       const { component } = configureForm({ userCurrency: 'EUR' });
 
       expect(component['model']().money).toEqual({
@@ -236,7 +276,7 @@ describe('AddTransactionForm', () => {
       });
     });
 
-    it('emits the converted amount and metadata', async () => {
+    it('should emit the converted amount and metadata', async () => {
       const { component, createdSpy, converter } = configureForm({
         userCurrency: 'CHF',
         flagEnabled: true,

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
@@ -299,7 +299,7 @@ export class AddTransactionForm {
               name: m.name,
               amount,
               kind: m.kind,
-              category: m.category || null,
+              category: m.category,
               isChecked: m.isChecked,
               conversion: metadata,
             }),

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
@@ -5,7 +5,6 @@ import {
   inject,
   output,
   signal,
-  viewChild,
 } from '@angular/core';
 import {
   FormField,
@@ -21,7 +20,6 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
-import type { SupportedCurrency, TransactionCreate } from 'pulpe-shared';
 
 import { AmountInput } from '@app/pattern/amount-input/amount-input';
 import {
@@ -36,16 +34,12 @@ import {
 import { Logger } from '@core/logging/logger';
 import { UserSettingsStore } from '@core/user-settings';
 import { TransactionLabelPipe } from '@ui/transaction-display';
+import {
+  transactionFormDataSchema,
+  type TransactionFormData,
+} from './add-transaction-form.schema';
 
-export type TransactionFormData = Pick<
-  TransactionCreate,
-  'name' | 'amount' | 'kind' | 'category' | 'checkedAt'
-> & {
-  originalAmount?: number;
-  originalCurrency?: SupportedCurrency;
-  targetCurrency?: SupportedCurrency;
-  exchangeRate?: number;
-};
+export type { TransactionFormData } from './add-transaction-form.schema';
 
 interface AddTransactionModel {
   name: string;
@@ -111,7 +105,9 @@ interface AddTransactionModel {
             matInput
             [formField]="transactionForm.name"
             data-testid="transaction-description-input"
-            placeholder="Ex: Courses chez Migros"
+            [placeholder]="
+              'currentMonth.addTransactionDescriptionPlaceholder' | transloco
+            "
           />
           @if (nameRequiredError()) {
             <mat-error>{{
@@ -226,7 +222,6 @@ export class AddTransactionForm {
 
   readonly created = output<TransactionFormData>();
   readonly isSubmitting = signal(false);
-  private readonly amountInput = viewChild(AmountInput);
 
   protected readonly currency = this.#userSettings.currency;
   protected readonly predefinedAmounts = [10, 15, 20, 30] as const;
@@ -292,10 +287,6 @@ export class AddTransactionForm {
     amountField.markAsTouched();
   }
 
-  focusAmount(): void {
-    this.amountInput()?.focus();
-  }
-
   async submit(): Promise<void> {
     await runFormSubmit({
       form: this.transactionForm,
@@ -308,14 +299,15 @@ export class AddTransactionForm {
           targetCurrency: this.#userSettings.currency(),
           converter: this.#converter,
           logger: this.#logger,
-          build: (amount, metadata): TransactionFormData => ({
-            name: m.name,
-            amount,
-            kind: m.kind,
-            category: m.category || null,
-            checkedAt: m.isChecked ? new Date().toISOString() : null,
-            ...metadata,
-          }),
+          build: (amount, metadata): TransactionFormData =>
+            transactionFormDataSchema.parse({
+              name: m.name,
+              amount,
+              kind: m.kind,
+              category: m.category || null,
+              isChecked: m.isChecked,
+              conversion: metadata,
+            }),
         };
       },
       onSuccess: (value, outcome) => {

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
@@ -1,0 +1,327 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  FormField,
+  form,
+  maxLength,
+  minLength,
+  required,
+} from '@angular/forms/signals';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import type { SupportedCurrency, TransactionCreate } from 'pulpe-shared';
+
+import { AmountInput } from '@app/pattern/amount-input/amount-input';
+import {
+  AppCurrencyPipe,
+  applyAmountValidators,
+  type AmountFormSlice,
+  createAmountSlice,
+  CurrencyConverterService,
+  runFormSubmit,
+  StaleRateNotifier,
+} from '@core/currency';
+import { Logger } from '@core/logging/logger';
+import { UserSettingsStore } from '@core/user-settings';
+import { TransactionLabelPipe } from '@ui/transaction-display';
+
+export type TransactionFormData = Pick<
+  TransactionCreate,
+  'name' | 'amount' | 'kind' | 'category' | 'checkedAt'
+> & {
+  originalAmount?: number;
+  originalCurrency?: SupportedCurrency;
+  targetCurrency?: SupportedCurrency;
+  exchangeRate?: number;
+};
+
+interface AddTransactionModel {
+  name: string;
+  money: AmountFormSlice;
+  kind: 'expense' | 'income' | 'saving';
+  category: string;
+  isChecked: boolean;
+}
+
+@Component({
+  selector: 'pulpe-add-transaction-form',
+  imports: [
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSelectModule,
+    MatSlideToggleModule,
+    TranslocoPipe,
+    TransactionLabelPipe,
+    AppCurrencyPipe,
+    FormField,
+    AmountInput,
+  ],
+  template: `
+    <form
+      (ngSubmit)="submit()"
+      class="add-transaction-form-grid grid grid-cols-1 gap-4"
+      novalidate
+      data-testid="transaction-form"
+    >
+      <div class="flex flex-col gap-4">
+        <pulpe-amount-input
+          [control]="transactionForm.money"
+          class="block tabular-nums"
+        />
+
+        <div class="flex flex-col gap-3">
+          <div class="text-sm font-medium text-on-surface-variant">
+            {{ 'currentMonth.addTransactionQuickAmounts' | transloco }}
+          </div>
+          <div class="grid grid-cols-4 gap-2">
+            @for (amount of predefinedAmounts; track amount) {
+              <button
+                matButton="tonal"
+                type="button"
+                (click)="selectPredefinedAmount(amount)"
+                class="min-h-11 min-w-0 px-2 tabular-nums transition-transform duration-150 ease-out active:scale-[0.96] motion-reduce:transform-none motion-reduce:transition-none"
+              >
+                {{ amount | appCurrency: currency() : '1.0-0' }}
+              </button>
+            }
+          </div>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-4">
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>{{
+            'currentMonth.addTransactionDescription' | transloco
+          }}</mat-label>
+          <input
+            matInput
+            [formField]="transactionForm.name"
+            data-testid="transaction-description-input"
+            placeholder="Ex: Courses chez Migros"
+          />
+          @if (nameRequiredError()) {
+            <mat-error>{{
+              'currentMonth.addTransactionDescriptionRequired' | transloco
+            }}</mat-error>
+          }
+          @if (nameMinLengthError()) {
+            <mat-error>{{
+              'currentMonth.addTransactionDescriptionMin' | transloco
+            }}</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field class="w-full" subscriptSizing="dynamic">
+          <mat-label>{{
+            'currentMonth.addTransactionType' | transloco
+          }}</mat-label>
+          <mat-select
+            [formField]="transactionForm.kind"
+            [attr.aria-label]="'currentMonth.addTransactionType' | transloco"
+            data-testid="transaction-type-select"
+          >
+            <mat-option value="expense">
+              <mat-icon class="mr-2 icon-filled">remove_circle</mat-icon>
+              {{ 'expense' | transactionLabel }}
+            </mat-option>
+            <mat-option value="income">
+              <mat-icon class="mr-2 icon-filled">add_circle</mat-icon>
+              {{ 'income' | transactionLabel }}
+            </mat-option>
+            <mat-option value="saving">
+              <mat-icon class="mr-2 icon-filled">savings</mat-icon>
+              {{ 'saving' | transactionLabel }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field class="w-full" subscriptSizing="dynamic">
+          <mat-label>{{
+            'currentMonth.addTransactionNotes' | transloco
+          }}</mat-label>
+          <input
+            matInput
+            [formField]="transactionForm.category"
+            [placeholder]="
+              'currentMonth.addTransactionNotesPlaceholder' | transloco
+            "
+            aria-describedby="category-hint"
+          />
+          <mat-hint id="category-hint" align="end"
+            >{{ model().category.length }}/50
+            {{
+              'currentMonth.addTransactionNotesOptional' | transloco
+            }}</mat-hint
+          >
+          @if (categoryMaxLengthError()) {
+            <mat-error>{{
+              'currentMonth.addTransactionNotesMaxLength' | transloco
+            }}</mat-error>
+          }
+        </mat-form-field>
+      </div>
+
+      <div class="add-transaction-form-meta grid grid-cols-1 gap-3">
+        <div
+          class="flex items-center gap-2 p-3 bg-surface-container rounded-lg text-on-surface-variant"
+        >
+          <mat-icon>event</mat-icon>
+          <span>{{ 'currentMonth.addTransactionToday' | transloco }}</span>
+        </div>
+
+        <div class="flex items-center justify-between py-2 px-1">
+          <span class="text-body-medium text-on-surface">{{
+            'transactionForm.checkedToggle' | transloco
+          }}</span>
+          <mat-slide-toggle
+            [formField]="transactionForm.isChecked"
+            [attr.aria-label]="'transactionForm.checkedToggle' | transloco"
+          />
+        </div>
+      </div>
+    </form>
+
+    @if (conversionError()) {
+      <p role="alert" class="text-error text-body-small pt-2">
+        {{ 'common.conversionError' | transloco }}
+      </p>
+    }
+  `,
+  styles: `
+    @media (width >= 48rem) {
+      :host(.add-transaction-form-wide) .add-transaction-form-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        column-gap: 1.5rem;
+      }
+
+      :host(.add-transaction-form-wide) .add-transaction-form-meta {
+        grid-column: span 2 / span 2;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+  `,
+  host: { class: 'block' },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AddTransactionForm {
+  readonly #transloco = inject(TranslocoService);
+  readonly #userSettings = inject(UserSettingsStore);
+  readonly #converter = inject(CurrencyConverterService);
+  readonly #logger = inject(Logger);
+  readonly #staleRateNotifier = inject(StaleRateNotifier);
+
+  readonly created = output<TransactionFormData>();
+  readonly isSubmitting = signal(false);
+  private readonly amountInput = viewChild(AmountInput);
+
+  protected readonly currency = this.#userSettings.currency;
+  protected readonly predefinedAmounts = [10, 15, 20, 30] as const;
+  protected readonly conversionError = signal(false);
+
+  protected readonly model = signal<AddTransactionModel>({
+    name: this.#transloco.translate('currentMonth.addTransactionDefaultName'),
+    money: createAmountSlice({
+      initialCurrency: this.#userSettings.currency(),
+    }),
+    kind: 'expense',
+    category: '',
+    isChecked: true,
+  });
+
+  protected readonly transactionForm = form(this.model, (path) => {
+    required(path.name, {
+      message: 'currentMonth.addTransactionDescriptionRequired',
+    });
+    minLength(path.name, 2, {
+      message: 'currentMonth.addTransactionDescriptionMin',
+    });
+    maxLength(path.name, 100);
+    applyAmountValidators(path.money);
+    required(path.kind);
+    maxLength(path.category, 50, {
+      message: 'currentMonth.addTransactionNotesMaxLength',
+    });
+  });
+
+  readonly canSubmit = computed(
+    () => this.transactionForm().valid() && !this.isSubmitting(),
+  );
+
+  protected readonly nameRequiredError = computed(
+    () =>
+      this.transactionForm.name().touched() &&
+      this.transactionForm
+        .name()
+        .errors()
+        .some((e) => e.kind === 'required'),
+  );
+  protected readonly nameMinLengthError = computed(
+    () =>
+      this.transactionForm.name().touched() &&
+      this.transactionForm
+        .name()
+        .errors()
+        .some((e) => e.kind === 'minLength'),
+  );
+  protected readonly categoryMaxLengthError = computed(
+    () =>
+      this.transactionForm.category().touched() &&
+      this.transactionForm
+        .category()
+        .errors()
+        .some((e) => e.kind === 'maxLength'),
+  );
+
+  protected selectPredefinedAmount(amount: number): void {
+    const amountField = this.transactionForm.money.amount();
+    amountField.value.set(amount);
+    amountField.markAsTouched();
+  }
+
+  focusAmount(): void {
+    this.amountInput()?.focus();
+  }
+
+  async submit(): Promise<void> {
+    await runFormSubmit({
+      form: this.transactionForm,
+      isSubmitting: this.isSubmitting,
+      conversionError: this.conversionError,
+      prepare: () => {
+        const m = this.model();
+        return {
+          amountSlice: m.money,
+          targetCurrency: this.#userSettings.currency(),
+          converter: this.#converter,
+          logger: this.#logger,
+          build: (amount, metadata): TransactionFormData => ({
+            name: m.name,
+            amount,
+            kind: m.kind,
+            category: m.category || null,
+            checkedAt: m.isChecked ? new Date().toISOString() : null,
+            ...metadata,
+          }),
+        };
+      },
+      onSuccess: (value, outcome) => {
+        this.#staleRateNotifier.notify(outcome);
+        this.created.emit(value);
+      },
+    });
+  }
+}

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
@@ -195,7 +195,6 @@ interface AddTransactionModel {
       grid-template-columns: repeat(2, minmax(0, 1fr));
       column-gap: var(--pulpe-section-gap-md);
     }
-
     :host(.add-transaction-form-wide) .add-transaction-form-meta {
       grid-column: span 2 / span 2;
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -210,9 +209,10 @@ export class AddTransactionForm {
   readonly #converter = inject(CurrencyConverterService);
   readonly #logger = inject(Logger);
   readonly #staleRateNotifier = inject(StaleRateNotifier);
+  readonly #isSubmittingState = signal(false);
 
   readonly created = output<TransactionFormData>();
-  readonly isSubmitting = signal(false);
+  readonly isSubmitting = this.#isSubmittingState.asReadonly();
 
   protected readonly currency = this.#userSettings.currency;
   protected readonly predefinedAmounts = [10, 15, 20, 30] as const;
@@ -271,7 +271,7 @@ export class AddTransactionForm {
   async submit(): Promise<void> {
     await runFormSubmit({
       form: this.transactionForm,
-      isSubmitting: this.isSubmitting,
+      isSubmitting: this.#isSubmittingState,
       conversionError: this.conversionError,
       prepare: () => {
         const m = this.model();

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
@@ -76,7 +76,6 @@ interface AddTransactionModel {
           [control]="transactionForm.money"
           class="block tabular-nums"
         />
-
         <div class="flex flex-col gap-3">
           <div class="text-sm font-medium text-on-surface-variant">
             {{ 'currentMonth.addTransactionQuickAmounts' | transloco }}
@@ -95,7 +94,6 @@ interface AddTransactionModel {
           </div>
         </div>
       </div>
-
       <div class="flex flex-col gap-4">
         <mat-form-field appearance="outline" subscriptSizing="dynamic">
           <mat-label>{{
@@ -109,18 +107,17 @@ interface AddTransactionModel {
               'currentMonth.addTransactionDescriptionPlaceholder' | transloco
             "
           />
-          @if (nameRequiredError()) {
+          @if (nameError('required')) {
             <mat-error>{{
               'currentMonth.addTransactionDescriptionRequired' | transloco
             }}</mat-error>
           }
-          @if (nameMinLengthError()) {
+          @if (nameError('minLength')) {
             <mat-error>{{
               'currentMonth.addTransactionDescriptionMin' | transloco
             }}</mat-error>
           }
         </mat-form-field>
-
         <mat-form-field class="w-full" subscriptSizing="dynamic">
           <mat-label>{{
             'currentMonth.addTransactionType' | transloco
@@ -144,7 +141,6 @@ interface AddTransactionModel {
             </mat-option>
           </mat-select>
         </mat-form-field>
-
         <mat-form-field class="w-full" subscriptSizing="dynamic">
           <mat-label>{{
             'currentMonth.addTransactionNotes' | transloco
@@ -170,7 +166,6 @@ interface AddTransactionModel {
           }
         </mat-form-field>
       </div>
-
       <div class="add-transaction-form-meta grid grid-cols-1 gap-3">
         <div
           class="flex items-center gap-2 p-3 bg-surface-container rounded-lg text-on-surface-variant"
@@ -178,7 +173,6 @@ interface AddTransactionModel {
           <mat-icon>event</mat-icon>
           <span>{{ 'currentMonth.addTransactionToday' | transloco }}</span>
         </div>
-
         <div class="flex items-center justify-between py-2 px-1">
           <span class="text-body-medium text-on-surface">{{
             'transactionForm.checkedToggle' | transloco
@@ -190,7 +184,6 @@ interface AddTransactionModel {
         </div>
       </div>
     </form>
-
     @if (conversionError()) {
       <p role="alert" class="text-error text-body-small pt-2">
         {{ 'common.conversionError' | transloco }}
@@ -198,16 +191,14 @@ interface AddTransactionModel {
     }
   `,
   styles: `
-    @media (width >= 48rem) {
-      :host(.add-transaction-form-wide) .add-transaction-form-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        column-gap: 1.5rem;
-      }
+    :host(.add-transaction-form-wide) .add-transaction-form-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      column-gap: var(--pulpe-section-gap-md);
+    }
 
-      :host(.add-transaction-form-wide) .add-transaction-form-meta {
-        grid-column: span 2 / span 2;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
+    :host(.add-transaction-form-wide) .add-transaction-form-meta {
+      grid-column: span 2 / span 2;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   `,
   host: { class: 'block' },
@@ -256,30 +247,20 @@ export class AddTransactionForm {
     () => this.transactionForm().valid() && !this.isSubmitting(),
   );
 
-  protected readonly nameRequiredError = computed(
-    () =>
-      this.transactionForm.name().touched() &&
-      this.transactionForm
-        .name()
-        .errors()
-        .some((e) => e.kind === 'required'),
-  );
-  protected readonly nameMinLengthError = computed(
-    () =>
-      this.transactionForm.name().touched() &&
-      this.transactionForm
-        .name()
-        .errors()
-        .some((e) => e.kind === 'minLength'),
-  );
-  protected readonly categoryMaxLengthError = computed(
-    () =>
-      this.transactionForm.category().touched() &&
-      this.transactionForm
-        .category()
-        .errors()
-        .some((e) => e.kind === 'maxLength'),
-  );
+  protected nameError(kind: 'required' | 'minLength'): boolean {
+    const field = this.transactionForm.name();
+    return (
+      field.touched() && field.errors().some((error) => error.kind === kind)
+    );
+  }
+
+  protected categoryMaxLengthError(): boolean {
+    const field = this.transactionForm.category();
+    return (
+      field.touched() &&
+      field.errors().some((error) => error.kind === 'maxLength')
+    );
+  }
 
   protected selectPredefinedAmount(amount: number): void {
     const amountField = this.transactionForm.money.amount();

--- a/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/components/add-transaction-form.ts
@@ -6,13 +6,7 @@ import {
   output,
   signal,
 } from '@angular/core';
-import {
-  FormField,
-  form,
-  maxLength,
-  minLength,
-  required,
-} from '@angular/forms/signals';
+import { FormField, form, required, validate } from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -86,7 +80,7 @@ interface AddTransactionModel {
                 matButton="tonal"
                 type="button"
                 (click)="selectPredefinedAmount(amount)"
-                class="min-h-11 min-w-0 px-2 tabular-nums transition-transform duration-150 ease-out active:scale-[0.96] motion-reduce:transform-none motion-reduce:transition-none"
+                class="min-h-11 min-w-0 whitespace-nowrap px-2! tabular-nums transition-transform duration-150 ease-out active:scale-[0.96] motion-reduce:transform-none motion-reduce:transition-none"
               >
                 {{ amount | appCurrency: currency() : '1.0-0' }}
               </button>
@@ -232,15 +226,35 @@ export class AddTransactionForm {
     required(path.name, {
       message: 'currentMonth.addTransactionDescriptionRequired',
     });
-    minLength(path.name, 2, {
-      message: 'currentMonth.addTransactionDescriptionMin',
+    validate(path.name, ({ value }) => {
+      const name = value();
+      const length = name.trim().length;
+      if (length === 0) {
+        return name.length === 0
+          ? null
+          : {
+              kind: 'required',
+              message: 'currentMonth.addTransactionDescriptionRequired',
+            };
+      }
+      if (length < 2) {
+        return {
+          kind: 'minLength',
+          message: 'currentMonth.addTransactionDescriptionMin',
+        };
+      }
+      return length <= 100 ? null : { kind: 'maxLength' };
     });
-    maxLength(path.name, 100);
     applyAmountValidators(path.money);
     required(path.kind);
-    maxLength(path.category, 50, {
-      message: 'currentMonth.addTransactionNotesMaxLength',
-    });
+    validate(path.category, ({ value }) =>
+      value().trim().length <= 50
+        ? null
+        : {
+            kind: 'maxLength',
+            message: 'currentMonth.addTransactionNotesMaxLength',
+          },
+    );
   });
 
   readonly canSubmit = computed(

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.routes.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.routes.ts
@@ -1,11 +1,12 @@
 import { type Routes } from '@angular/router';
 import { PAGE_TITLES } from '@core/routing';
+import { AddTransactionDialogService } from './services/add-transaction-dialog.service';
 import { DashboardStore } from './services/dashboard-store';
 
 export const currentMonthRoutes: Routes = [
   {
     path: '',
-    providers: [DashboardStore],
+    providers: [AddTransactionDialogService, DashboardStore],
     children: [
       {
         path: '',

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.spec.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { type BudgetLine, type Transaction, type Budget } from 'pulpe-shared';
 import Dashboard from './current-month';
-import { type TransactionFormData } from './components/add-transaction-form';
+import { type TransactionFormData } from './components/add-transaction-form.schema';
 import { AddTransactionDialogService } from './services/add-transaction-dialog.service';
 import { DashboardStore } from './services/dashboard-store';
 
@@ -467,6 +467,8 @@ describe('CurrentMonth Component', () => {
 });
 
 describe('Dashboard (TestBed)', () => {
+  const budgetId = '00000000-0000-4000-8000-000000000001';
+
   function createMockStore(budgetId: string) {
     return {
       dashboardData: signal({ budget: { id: budgetId } }),
@@ -520,23 +522,25 @@ describe('Dashboard (TestBed)', () => {
 
   describe('#addTransaction forwards currency conversion metadata', () => {
     it('should include originalAmount, originalCurrency, targetCurrency, exchangeRate in store.addTransaction call when present on the surface payload', async () => {
-      const { component, mockStore } = await setup('budget-123', {
+      const { component, mockStore } = await setup(budgetId, {
         name: 'Test pour claude',
         amount: 108.97,
         kind: 'expense',
         category: null,
-        checkedAt: null,
-        originalAmount: 100,
-        originalCurrency: 'CHF',
-        targetCurrency: 'EUR',
-        exchangeRate: 1.0897,
+        isChecked: false,
+        conversion: {
+          originalAmount: 100,
+          originalCurrency: 'CHF',
+          targetCurrency: 'EUR',
+          exchangeRate: 1.0897,
+        },
       });
 
       await component['openAddTransaction']();
 
       expect(mockStore.addTransaction).toHaveBeenCalledWith(
         expect.objectContaining({
-          budgetId: 'budget-123',
+          budgetId,
           amount: 108.97,
           name: 'Test pour claude',
           kind: 'expense',
@@ -549,18 +553,19 @@ describe('Dashboard (TestBed)', () => {
     });
 
     it('should forward transaction payload without conversion metadata when the surface omits it', async () => {
-      const { component, mockStore } = await setup('budget-123', {
+      const { component, mockStore } = await setup(budgetId, {
         name: 'Courses',
         amount: 50,
         kind: 'expense',
         category: null,
-        checkedAt: null,
+        isChecked: false,
+        conversion: null,
       });
 
       await component['openAddTransaction']();
 
       const callArg = mockStore.addTransaction.mock.calls[0][0];
-      expect(callArg.budgetId).toBe('budget-123');
+      expect(callArg.budgetId).toBe(budgetId);
       expect(callArg.amount).toBe(50);
       expect(callArg.originalAmount).toBeUndefined();
       expect(callArg.originalCurrency).toBeUndefined();
@@ -569,7 +574,7 @@ describe('Dashboard (TestBed)', () => {
     });
 
     it('should not call store.addTransaction when the surface is dismissed without data', async () => {
-      const { component, mockStore } = await setup('budget-123', undefined);
+      const { component, mockStore } = await setup(budgetId, undefined);
 
       await component['openAddTransaction']();
 
@@ -582,7 +587,8 @@ describe('Dashboard (TestBed)', () => {
         amount: 10,
         kind: 'expense',
         category: null,
-        checkedAt: null,
+        isChecked: false,
+        conversion: null,
       });
 
       await component['openAddTransaction']();

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.spec.ts
@@ -6,14 +6,13 @@ import {
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { Router } from '@angular/router';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { type BudgetLine, type Transaction, type Budget } from 'pulpe-shared';
-import { of } from 'rxjs';
 import Dashboard from './current-month';
+import { type TransactionFormData } from './components/add-transaction-form';
+import { AddTransactionDialogService } from './services/add-transaction-dialog.service';
 import { DashboardStore } from './services/dashboard-store';
-import { type TransactionFormData } from './components/add-transaction-bottom-sheet';
 
 // Test data factories
 const createBudgetLine = (overrides: Partial<BudgetLine> = {}): BudgetLine => ({
@@ -80,7 +79,7 @@ describe('CurrentMonth Component', () => {
       const expectedComputed = ['fixedTransactions'];
       const expectedMethods = [
         'ngOnInit',
-        'openAddTransactionBottomSheet',
+        'openAddTransaction',
         'onAddTransaction',
         'deleteTransaction',
       ];
@@ -223,55 +222,6 @@ describe('CurrentMonth Component', () => {
 
       // Assert
       expect(mockRefreshData).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('openAddTransactionBottomSheet method behavior', () => {
-    it('should open bottom sheet with correct configuration', () => {
-      // Test the method logic without TestBed
-      const mockBottomSheet = { open: vi.fn() };
-      const bottomSheetRef = {
-        afterDismissed: vi.fn().mockReturnValue(of(undefined)),
-      };
-      mockBottomSheet.open.mockReturnValue(bottomSheetRef);
-
-      // Simulate the method behavior
-      const openAddTransactionBottomSheet = () => {
-        return mockBottomSheet.open(
-          expect.any(Function), // AddTransactionBottomSheet component
-          {
-            disableClose: false,
-            panelClass: 'add-transaction-bottom-sheet',
-          },
-        );
-      };
-
-      // Act
-      openAddTransactionBottomSheet();
-
-      // Assert
-      expect(mockBottomSheet.open).toHaveBeenCalledWith(expect.any(Function), {
-        disableClose: false,
-        panelClass: 'add-transaction-bottom-sheet',
-      });
-    });
-
-    it('should handle bottom sheet dismissal without transaction', () => {
-      // Test that the method handles empty dismissal correctly
-      const bottomSheetRef = {
-        afterDismissed: vi.fn().mockReturnValue(of(undefined)),
-      };
-      const onAddTransaction = vi.fn();
-
-      // Simulate subscription handling
-      bottomSheetRef.afterDismissed().subscribe((result: unknown) => {
-        if (result) {
-          onAddTransaction(result);
-        }
-      });
-
-      // Assert
-      expect(onAddTransaction).not.toHaveBeenCalled();
     });
   });
 
@@ -535,14 +485,11 @@ describe('Dashboard (TestBed)', () => {
 
   async function setup(
     budgetId: string,
-    afterDismissedValue: TransactionFormData | undefined,
+    dialogResult: TransactionFormData | undefined,
   ) {
     const mockStore = createMockStore(budgetId);
-    const bottomSheetRef = {
-      afterDismissed: () => of(afterDismissedValue),
-    };
-    const mockBottomSheet = {
-      open: vi.fn().mockReturnValue(bottomSheetRef),
+    const mockDialogService = {
+      open: vi.fn().mockResolvedValue(dialogResult),
     };
     const mockRouter = { navigate: vi.fn() };
 
@@ -554,34 +501,25 @@ describe('Dashboard (TestBed)', () => {
           provideAnimationsAsync(),
           ...provideTranslocoForTest(),
           { provide: DashboardStore, useValue: mockStore },
+          {
+            provide: AddTransactionDialogService,
+            useValue: mockDialogService,
+          },
           { provide: Router, useValue: mockRouter },
         ],
       })
       .compileComponents();
 
-    TestBed.overrideProvider(MatBottomSheet, { useValue: mockBottomSheet });
-    TestBed.overrideComponent(Dashboard, {
-      set: {
-        providers: [{ provide: MatBottomSheet, useValue: mockBottomSheet }],
-      },
-    });
-
     const fixture = TestBed.createComponent(Dashboard);
     return {
       component: fixture.componentInstance,
       mockStore,
-      mockBottomSheet,
+      mockDialogService,
     };
   }
 
-  async function flushMicrotasks(): Promise<void> {
-    for (let i = 0; i < 5; i++) {
-      await Promise.resolve();
-    }
-  }
-
   describe('#addTransaction forwards currency conversion metadata', () => {
-    it('should include originalAmount, originalCurrency, targetCurrency, exchangeRate in store.addTransaction call when present on the sheet payload', async () => {
+    it('should include originalAmount, originalCurrency, targetCurrency, exchangeRate in store.addTransaction call when present on the surface payload', async () => {
       const { component, mockStore } = await setup('budget-123', {
         name: 'Test pour claude',
         amount: 108.97,
@@ -594,8 +532,7 @@ describe('Dashboard (TestBed)', () => {
         exchangeRate: 1.0897,
       });
 
-      component['openAddTransactionBottomSheet']();
-      await flushMicrotasks();
+      await component['openAddTransaction']();
 
       expect(mockStore.addTransaction).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -611,7 +548,7 @@ describe('Dashboard (TestBed)', () => {
       );
     });
 
-    it('should forward transaction payload without conversion metadata when the sheet omits it', async () => {
+    it('should forward transaction payload without conversion metadata when the surface omits it', async () => {
       const { component, mockStore } = await setup('budget-123', {
         name: 'Courses',
         amount: 50,
@@ -620,8 +557,7 @@ describe('Dashboard (TestBed)', () => {
         checkedAt: null,
       });
 
-      component['openAddTransactionBottomSheet']();
-      await flushMicrotasks();
+      await component['openAddTransaction']();
 
       const callArg = mockStore.addTransaction.mock.calls[0][0];
       expect(callArg.budgetId).toBe('budget-123');
@@ -632,11 +568,10 @@ describe('Dashboard (TestBed)', () => {
       expect(callArg.exchangeRate).toBeUndefined();
     });
 
-    it('should not call store.addTransaction when the sheet is dismissed without data', async () => {
+    it('should not call store.addTransaction when the surface is dismissed without data', async () => {
       const { component, mockStore } = await setup('budget-123', undefined);
 
-      component['openAddTransactionBottomSheet']();
-      await flushMicrotasks();
+      await component['openAddTransaction']();
 
       expect(mockStore.addTransaction).not.toHaveBeenCalled();
     });
@@ -650,8 +585,7 @@ describe('Dashboard (TestBed)', () => {
         checkedAt: null,
       });
 
-      component['openAddTransactionBottomSheet']();
-      await flushMicrotasks();
+      await component['openAddTransaction']();
 
       expect(mockStore.addTransaction).not.toHaveBeenCalled();
     });

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -9,11 +9,6 @@ import {
   effect,
   inject,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  MatBottomSheet,
-  MatBottomSheetModule,
-} from '@angular/material/bottom-sheet';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
@@ -29,11 +24,9 @@ import {
 } from '@core/product-tour/product-tour.service';
 import { BaseLoading } from '@ui/loading';
 import { StateCard } from '@ui/state-card/state-card';
-import {
-  AddTransactionBottomSheet,
-  type TransactionFormData,
-} from './components/add-transaction-bottom-sheet';
+import type { TransactionFormData } from './components/add-transaction-form';
 import { DashboardError } from './components/dashboard-error';
+import { AddTransactionDialogService } from './services/add-transaction-dialog.service';
 import { DashboardStore } from './services/dashboard-store';
 
 import { DashboardHero } from '@ui/dashboard-hero/dashboard-hero';
@@ -50,7 +43,6 @@ import { CURRENCY_CONFIG } from '@core/currency';
   selector: 'pulpe-dashboard',
   imports: [
     MatButtonModule,
-    MatBottomSheetModule,
     MatIconModule,
     MatSnackBarModule,
     MatTooltipModule,
@@ -214,7 +206,7 @@ import { CURRENCY_CONFIG } from '@core/currency';
         <!-- FAB: only visible when budget data is loaded -->
         <button
           matFab
-          (click)="openAddTransactionBottomSheet()"
+          (click)="openAddTransaction()"
           class="fab-button"
           [attr.aria-label]="'budgetLine.addTransaction' | transloco"
           data-testid="add-transaction-fab"
@@ -331,7 +323,7 @@ export default class Dashboard {
   readonly #productTourService = inject(ProductTourService);
   readonly #destroyRef = inject(DestroyRef);
   readonly #loadingIndicator = inject(LoadingIndicator);
-  readonly #bottomSheet = inject(MatBottomSheet);
+  readonly #addTransactionDialog = inject(AddTransactionDialogService);
   readonly #router = inject(Router);
   readonly #snackBar = inject(MatSnackBar);
   readonly #transloco = inject(TranslocoService);
@@ -389,20 +381,11 @@ export default class Dashboard {
     }
   }
 
-  protected openAddTransactionBottomSheet(): void {
-    const bottomSheetRef = this.#bottomSheet.open(AddTransactionBottomSheet, {
-      disableClose: false,
-      panelClass: 'add-transaction-bottom-sheet',
-    });
-
-    bottomSheetRef
-      .afterDismissed()
-      .pipe(takeUntilDestroyed(this.#destroyRef))
-      .subscribe((transaction: TransactionFormData | undefined) => {
-        if (transaction) {
-          this.#addTransaction(transaction);
-        }
-      });
+  protected async openAddTransaction(): Promise<void> {
+    const transaction = await this.#addTransactionDialog.open();
+    if (transaction) {
+      await this.#addTransaction(transaction);
+    }
   }
 
   async #addTransaction(transaction: TransactionFormData): Promise<void> {

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -24,7 +24,10 @@ import {
 } from '@core/product-tour/product-tour.service';
 import { BaseLoading } from '@ui/loading';
 import { StateCard } from '@ui/state-card/state-card';
-import type { TransactionFormData } from './components/add-transaction-form';
+import {
+  transactionCreateFromQuickFormSchema,
+  type TransactionFormData,
+} from './components/add-transaction-form.schema';
 import { DashboardError } from './components/dashboard-error';
 import { AddTransactionDialogService } from './services/add-transaction-dialog.service';
 import { DashboardStore } from './services/dashboard-store';
@@ -393,13 +396,11 @@ export default class Dashboard {
     if (!budgetId) {
       return;
     }
-    await this.store.addTransaction({
+    const transactionCreate = transactionCreateFromQuickFormSchema.parse({
       ...transaction,
       budgetId,
-      amount: transaction.amount ?? 0,
       transactionDate: formatLocalDate(new Date()),
-      category: transaction.category ?? null,
-      checkedAt: transaction.checkedAt ?? null,
     });
+    await this.store.addTransaction(transactionCreate);
   }
 }

--- a/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.spec.ts
@@ -33,7 +33,7 @@ describe('AddTransactionDialogService', () => {
     service = TestBed.inject(AddTransactionDialogService);
   });
 
-  it('uses the bottom sheet on handsets', async () => {
+  it('should use the bottom sheet on handsets', async () => {
     const transaction = { name: 'Courses', amount: 50, kind: 'expense' };
     breakpointObserver.isMatched.mockReturnValue(true);
     bottomSheet.open.mockReturnValue({
@@ -52,7 +52,7 @@ describe('AddTransactionDialogService', () => {
     expect(dialog.open).not.toHaveBeenCalled();
   });
 
-  it('uses a constrained dialog on tablet and desktop', async () => {
+  it('should use a constrained dialog on tablet and desktop', async () => {
     breakpointObserver.isMatched.mockReturnValue(false);
     dialog.open.mockReturnValue({ afterClosed: () => of(undefined) });
 

--- a/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.spec.ts
@@ -1,0 +1,69 @@
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MatBottomSheet } from '@angular/material/bottom-sheet';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AddTransactionBottomSheet } from '../components/add-transaction-bottom-sheet';
+import { AddTransactionDialog } from '../components/add-transaction-dialog';
+import { AddTransactionDialogService } from './add-transaction-dialog.service';
+
+describe('AddTransactionDialogService', () => {
+  let service: AddTransactionDialogService;
+  let breakpointObserver: { isMatched: ReturnType<typeof vi.fn> };
+  let bottomSheet: { open: ReturnType<typeof vi.fn> };
+  let dialog: { open: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    breakpointObserver = { isMatched: vi.fn() };
+    bottomSheet = { open: vi.fn() };
+    dialog = { open: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        AddTransactionDialogService,
+        { provide: BreakpointObserver, useValue: breakpointObserver },
+        { provide: MatBottomSheet, useValue: bottomSheet },
+        { provide: MatDialog, useValue: dialog },
+      ],
+    });
+
+    service = TestBed.inject(AddTransactionDialogService);
+  });
+
+  it('uses the bottom sheet on handsets', async () => {
+    const transaction = { name: 'Courses', amount: 50, kind: 'expense' };
+    breakpointObserver.isMatched.mockReturnValue(true);
+    bottomSheet.open.mockReturnValue({
+      afterDismissed: () => of(transaction),
+    });
+
+    await expect(service.open()).resolves.toBe(transaction);
+
+    expect(breakpointObserver.isMatched).toHaveBeenCalledWith(
+      Breakpoints.Handset,
+    );
+    expect(bottomSheet.open).toHaveBeenCalledWith(AddTransactionBottomSheet, {
+      disableClose: false,
+    });
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('uses a constrained dialog on tablet and desktop', async () => {
+    breakpointObserver.isMatched.mockReturnValue(false);
+    dialog.open.mockReturnValue({ afterClosed: () => of(undefined) });
+
+    await expect(service.open()).resolves.toBeUndefined();
+
+    expect(dialog.open).toHaveBeenCalledWith(AddTransactionDialog, {
+      width: '720px',
+      maxWidth: 'calc(100vw - 48px)',
+      panelClass: 'add-transaction-dialog',
+      autoFocus: false,
+      disableClose: false,
+    });
+    expect(bottomSheet.open).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.spec.ts
@@ -46,6 +46,7 @@ describe('AddTransactionDialogService', () => {
       Breakpoints.Handset,
     );
     expect(bottomSheet.open).toHaveBeenCalledWith(AddTransactionBottomSheet, {
+      autoFocus: '[data-testid="amount-input-value"]',
       disableClose: false,
     });
     expect(dialog.open).not.toHaveBeenCalled();
@@ -61,7 +62,7 @@ describe('AddTransactionDialogService', () => {
       width: '720px',
       maxWidth: 'calc(100vw - 48px)',
       panelClass: 'add-transaction-dialog',
-      autoFocus: false,
+      autoFocus: '[data-testid="amount-input-value"]',
       disableClose: false,
     });
     expect(bottomSheet.open).not.toHaveBeenCalled();

--- a/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.spec.ts
@@ -46,7 +46,7 @@ describe('AddTransactionDialogService', () => {
       Breakpoints.Handset,
     );
     expect(bottomSheet.open).toHaveBeenCalledWith(AddTransactionBottomSheet, {
-      autoFocus: '[data-testid="amount-input-value"]',
+      autoFocus: '[inputmode="decimal"]',
       disableClose: false,
     });
     expect(dialog.open).not.toHaveBeenCalled();
@@ -62,7 +62,7 @@ describe('AddTransactionDialogService', () => {
       width: '720px',
       maxWidth: 'calc(100vw - 48px)',
       panelClass: 'add-transaction-dialog',
-      autoFocus: '[data-testid="amount-input-value"]',
+      autoFocus: '[inputmode="decimal"]',
       disableClose: false,
     });
     expect(bottomSheet.open).not.toHaveBeenCalled();

--- a/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.ts
@@ -16,6 +16,7 @@ export class AddTransactionDialogService {
   async open(): Promise<TransactionFormData | undefined> {
     if (this.#breakpointObserver.isMatched(Breakpoints.Handset)) {
       const bottomSheetRef = this.#bottomSheet.open(AddTransactionBottomSheet, {
+        autoFocus: '[data-testid="amount-input-value"]',
         disableClose: false,
       });
       return firstValueFrom(bottomSheetRef.afterDismissed());
@@ -25,7 +26,7 @@ export class AddTransactionDialogService {
       width: '720px',
       maxWidth: 'calc(100vw - 48px)',
       panelClass: 'add-transaction-dialog',
-      autoFocus: false,
+      autoFocus: '[data-testid="amount-input-value"]',
       disableClose: false,
     });
     return firstValueFrom(dialogRef.afterClosed());

--- a/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.ts
@@ -16,7 +16,7 @@ export class AddTransactionDialogService {
   async open(): Promise<TransactionFormData | undefined> {
     if (this.#breakpointObserver.isMatched(Breakpoints.Handset)) {
       const bottomSheetRef = this.#bottomSheet.open(AddTransactionBottomSheet, {
-        autoFocus: '[data-testid="amount-input-value"]',
+        autoFocus: '[inputmode="decimal"]',
         disableClose: false,
       });
       return firstValueFrom(bottomSheetRef.afterDismissed());
@@ -26,7 +26,7 @@ export class AddTransactionDialogService {
       width: '720px',
       maxWidth: 'calc(100vw - 48px)',
       panelClass: 'add-transaction-dialog',
-      autoFocus: '[data-testid="amount-input-value"]',
+      autoFocus: '[inputmode="decimal"]',
       disableClose: false,
     });
     return firstValueFrom(dialogRef.afterClosed());

--- a/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/add-transaction-dialog.service.ts
@@ -1,0 +1,33 @@
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { inject, Injectable } from '@angular/core';
+import { MatBottomSheet } from '@angular/material/bottom-sheet';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
+import { AddTransactionBottomSheet } from '../components/add-transaction-bottom-sheet';
+import { AddTransactionDialog } from '../components/add-transaction-dialog';
+import type { TransactionFormData } from '../components/add-transaction-form';
+
+@Injectable()
+export class AddTransactionDialogService {
+  readonly #breakpointObserver = inject(BreakpointObserver);
+  readonly #bottomSheet = inject(MatBottomSheet);
+  readonly #dialog = inject(MatDialog);
+
+  async open(): Promise<TransactionFormData | undefined> {
+    if (this.#breakpointObserver.isMatched(Breakpoints.Handset)) {
+      const bottomSheetRef = this.#bottomSheet.open(AddTransactionBottomSheet, {
+        disableClose: false,
+      });
+      return firstValueFrom(bottomSheetRef.afterDismissed());
+    }
+
+    const dialogRef = this.#dialog.open(AddTransactionDialog, {
+      width: '720px',
+      maxWidth: 'calc(100vw - 48px)',
+      panelClass: 'add-transaction-dialog',
+      autoFocus: false,
+      disableClose: false,
+    });
+    return firstValueFrom(dialogRef.afterClosed());
+  }
+}

--- a/frontend/projects/webapp/src/app/styles/_dialogs.scss
+++ b/frontend/projects/webapp/src/app/styles/_dialogs.scss
@@ -30,6 +30,14 @@
   }
 }
 
+.add-transaction-dialog {
+  @include mat.dialog-overrides(
+    (
+      container-max-width: 720px,
+    )
+  );
+}
+
 // As per [Material Design guidelines](https://m3.material.io/components/dialogs/specs),
 // dialog container should have a surface-container-high color.
 html {

--- a/frontend/projects/webapp/src/app/styles/_dialogs.scss
+++ b/frontend/projects/webapp/src/app/styles/_dialogs.scss
@@ -30,14 +30,6 @@
   }
 }
 
-.add-transaction-dialog {
-  @include mat.dialog-overrides(
-    (
-      container-max-width: 720px,
-    )
-  );
-}
-
 // As per [Material Design guidelines](https://m3.material.io/components/dialogs/specs),
 // dialog container should have a surface-container-high color.
 html {

--- a/frontend/projects/webapp/src/styles.scss
+++ b/frontend/projects/webapp/src/styles.scss
@@ -37,6 +37,14 @@ html {
   );
 }
 
+.add-transaction-dialog {
+  @include mat.dialog-overrides(
+    (
+      container-max-width: 720px,
+    )
+  );
+}
+
 html {
   width: 100%;
   // Desktop = NOT CDK Breakpoints.Handset (portrait ≥600, landscape ≥960), so it


### PR DESCRIPTION
# Adapt quick transaction dialog for larger screens

## ✅ Type of PR

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Adapts quick transaction entry to use a centered, two-column dialog on tablet and desktop while preserving the mobile bottom sheet and shared transaction behavior.

## 🚶‍➡️ Behavior

- Opens a constrained dialog on non-handset viewports, including the 600 px boundary.
- Keeps the bottom sheet on handset viewports.
- Preserves validation, currency conversion, checked state, initial focus, loading, recent transactions and recalculated totals.

## 🧪 Steps to test

- [ ] At 600×900, 768×1024 and 1440×900, open quick add and verify a centered two-column dialog with the submit action visible.
- [ ] At 390×844, verify quick add still opens a one-column bottom sheet.
- [ ] Add a free transaction and verify it appears in recent transactions and updates totals.