### PR TITLE
fix(pul-292): rendu — la chip remplit ce qu'elle affiche, la carte se fait discrète

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
@@ -42,29 +42,30 @@ const mockBudgetDetailsResponse = createMockBudgetDetailsResponse({
   transactions: [],
 });
 
-// Same month, but income and expense whose float difference leaves IEEE noise
-// on `remaining` (-196.96000000000004): the chip displays 197 while the raw
-// magnitude is not the number it shows.
-const mockNoisyDeficitDetailsResponse = createMockBudgetDetailsResponse({
-  budget: { id: mockBudgetId, month: 6, year: 2099 },
-  budgetLines: [
-    createMockBudgetLine({
-      id: 'income-1',
-      budgetId: mockBudgetId,
-      name: 'Salaire',
-      amount: 5000.04,
-      kind: 'income',
-    }),
-    createMockBudgetLine({
-      id: 'expense-1',
-      budgetId: mockBudgetId,
-      name: 'Loyer',
-      amount: 5197,
-      kind: 'expense',
-    }),
-  ],
-  transactions: [],
-});
+// Same month, built from an income and an expense whose float difference lands
+// on `remaining`: every amount below is picked so the subtraction leaves IEEE
+// noise, the very thing the chip used to leak into the amount input.
+const detailsWithDeficitFrom = (income: number, expense: number) =>
+  createMockBudgetDetailsResponse({
+    budget: { id: mockBudgetId, month: 6, year: 2099 },
+    budgetLines: [
+      createMockBudgetLine({
+        id: 'income-1',
+        budgetId: mockBudgetId,
+        name: 'Salaire',
+        amount: income,
+        kind: 'income',
+      }),
+      createMockBudgetLine({
+        id: 'expense-1',
+        budgetId: mockBudgetId,
+        name: 'Loyer',
+        amount: expense,
+        kind: 'expense',
+      }),
+    ],
+    transactions: [],
+  });
 
 const WITHDRAWAL_INPUT: BudgetLineSavingsWithdrawalCreate = {
   budgetId: mockBudgetId,
@@ -106,6 +107,18 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
     throw new Error('store did not stabilize in time');
+  };
+
+  // Swaps the loaded budget, then waits for the store to leave the default
+  // fixture's deficit of 1000 behind.
+  const reloadWith = async (
+    response: ReturnType<typeof detailsWithDeficitFrom>,
+  ): Promise<void> => {
+    vi.mocked(TestBed.inject(BudgetApi).getBudgetWithDetails$).mockReturnValue(
+      of(response),
+    );
+    store.reloadBudgetDetails();
+    await waitFor(() => store.savingsWithdrawalDeficit() !== 1000);
   };
 
   const makeCache = () => ({
@@ -232,14 +245,16 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
   });
 
   describe('savingsWithdrawalDeficit', () => {
-    it('rounds a float-noisy deficit to the whole amount the chip displays', async () => {
-      const budgetApi = TestBed.inject(BudgetApi);
-      vi.mocked(budgetApi.getBudgetWithDetails$).mockReturnValue(
-        of(mockNoisyDeficitDetailsResponse),
-      );
+    it('rounds a float-noisy deficit up to the whole amount the chip displays', async () => {
+      // remaining = -196.96000000000004
+      await reloadWith(detailsWithDeficitFrom(5000.04, 5197));
 
-      store.reloadBudgetDetails();
-      await waitFor(() => store.savingsWithdrawalDeficit() !== 1000);
+      expect(store.savingsWithdrawalDeficit()).toBe(197);
+    });
+
+    it('rounds a float-noisy deficit down to the whole amount the chip displays', async () => {
+      // remaining = -197.39999999999964 — the half `Math.ceil` would send to 198
+      await reloadWith(detailsWithDeficitFrom(5000.04, 5197.44));
 
       expect(store.savingsWithdrawalDeficit()).toBe(197);
     });
@@ -249,6 +264,14 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
     it('shows the card on a current/future month in deficit with no pioche yet', () => {
       expect(store.savingsWithdrawalDeficit()).toBe(1000);
       expect(store.shouldShowSavingsWithdrawalCard()).toBe(true);
+    });
+
+    it('hides the card when the deficit rounds away to nothing to pre-fill', async () => {
+      // remaining = -0.2999999999999545 — a month balanced to the cent
+      await reloadWith(detailsWithDeficitFrom(1000, 1000.3));
+
+      expect(store.savingsWithdrawalDeficit()).toBe(0);
+      expect(store.shouldShowSavingsWithdrawalCard()).toBe(false);
     });
 
     it('hides the card once dismissed for that budget', () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
@@ -42,6 +42,30 @@ const mockBudgetDetailsResponse = createMockBudgetDetailsResponse({
   transactions: [],
 });
 
+// Same month, but income and expense whose float difference leaves IEEE noise
+// on `remaining` (-196.96000000000004): the chip displays 197 while the raw
+// magnitude is not the number it shows.
+const mockNoisyDeficitDetailsResponse = createMockBudgetDetailsResponse({
+  budget: { id: mockBudgetId, month: 6, year: 2099 },
+  budgetLines: [
+    createMockBudgetLine({
+      id: 'income-1',
+      budgetId: mockBudgetId,
+      name: 'Salaire',
+      amount: 5000.04,
+      kind: 'income',
+    }),
+    createMockBudgetLine({
+      id: 'expense-1',
+      budgetId: mockBudgetId,
+      name: 'Loyer',
+      amount: 5197,
+      kind: 'expense',
+    }),
+  ],
+  transactions: [],
+});
+
 const WITHDRAWAL_INPUT: BudgetLineSavingsWithdrawalCreate = {
   budgetId: mockBudgetId,
   amount: 320,
@@ -204,6 +228,20 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
 
       expect(error).toBe(localizer.localizeApiError(conflictError));
       expect(store.error()).toBeNull();
+    });
+  });
+
+  describe('savingsWithdrawalDeficit', () => {
+    it('rounds a float-noisy deficit to the whole amount the chip displays', async () => {
+      const budgetApi = TestBed.inject(BudgetApi);
+      vi.mocked(budgetApi.getBudgetWithDetails$).mockReturnValue(
+        of(mockNoisyDeficitDetailsResponse),
+      );
+
+      store.reloadBudgetDetails();
+      await waitFor(() => store.savingsWithdrawalDeficit() !== 1000);
+
+      expect(store.savingsWithdrawalDeficit()).toBe(197);
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -391,11 +391,14 @@ export class BudgetDetailsStore {
   });
 
   // PUL-292 (CA1) — the "mois un peu juste" card shows only when the viewed
-  // current/future month runs a deficit, has no pioche yet, and wasn't dismissed.
+  // current/future month runs a deficit worth acting on, has no pioche yet, and
+  // wasn't dismissed. Gated on the rounded deficit rather than on raw
+  // `remaining`: a month balanced to the cent leaves float dust (-9e-13) that
+  // would nudge the user towards a dialog with nothing to pre-fill.
   readonly shouldShowSavingsWithdrawalCard = computed<boolean>(() => {
     const details = this.budgetDetails();
     if (!details) return false;
-    if (this.financialTotals().remaining >= 0) return false;
+    if (this.savingsWithdrawalDeficit() <= 0) return false;
     if (!this.#isViewedMonthCurrentOrFuture()) return false;
     const hasWithdrawal = this.displayBudgetLines().some(
       (line) => line.savingsWithdrawalGroupId != null,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -407,10 +407,14 @@ export class BudgetDetailsStore {
   });
 
   // The deficit to pre-fill the withdrawal amount chip (positive magnitude, 0
-  // when the month is not in deficit).
+  // when the month is not in deficit). Rounded to the whole unit here, at the
+  // single producer: `remaining` is a float sum, so its magnitude carries IEEE
+  // noise (196.95999999999913). The hero and the chip both display it via
+  // '1.0-0', so rounding once keeps what the chip shows, what the input gets
+  // and what the payload carries the same number.
   readonly savingsWithdrawalDeficit = computed<number>(() => {
     const remaining = this.financialTotals().remaining;
-    return remaining < 0 ? Math.abs(remaining) : 0;
+    return remaining < 0 ? Math.round(Math.abs(remaining)) : 0;
   });
 
   // PUL-292 — origin month label (month − 1, with year rollover) shared by every

--- a/frontend/projects/webapp/src/app/ui/savings-withdrawal-card/savings-withdrawal-card.ts
+++ b/frontend/projects/webapp/src/app/ui/savings-withdrawal-card/savings-withdrawal-card.ts
@@ -26,7 +26,7 @@ import { TranslocoPipe } from '@jsverse/transloco';
         <span>{{ 'budget.savingsWithdrawal.cardLine2' | transloco }}</span>
       </div>
 
-      <div class="flex items-center gap-2">
+      <div class="flex flex-wrap items-center gap-2">
         <button
           matButton="tonal"
           (click)="withdraw.emit()"

--- a/frontend/projects/webapp/src/app/ui/savings-withdrawal-card/savings-withdrawal-card.ts
+++ b/frontend/projects/webapp/src/app/ui/savings-withdrawal-card/savings-withdrawal-card.ts
@@ -14,10 +14,10 @@ import { TranslocoPipe } from '@jsverse/transloco';
   imports: [MatButtonModule, MatIconModule, TranslocoPipe],
   template: `
     <div
-      class="flex flex-col gap-3 rounded-corner-large bg-primary-container/40 p-5"
+      class="flex flex-col gap-3 rounded-corner-large bg-primary-container/40 p-4"
       data-testid="savings-withdrawal-card"
     >
-      <h3 class="text-title-medium font-medium text-on-surface">
+      <h3 class="text-title-small font-medium text-balance text-on-surface">
         {{ 'budget.savingsWithdrawal.cardTitle' | transloco }}
       </h3>
 
@@ -26,23 +26,24 @@ import { TranslocoPipe } from '@jsverse/transloco';
         <span>{{ 'budget.savingsWithdrawal.cardLine2' | transloco }}</span>
       </div>
 
-      <button
-        matButton="filled"
-        (click)="withdraw.emit()"
-        data-testid="savings-withdrawal-card-cta"
-      >
-        <mat-icon>savings</mat-icon>
-        {{ 'budget.savingsWithdrawal.cta' | transloco }}
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          matButton="tonal"
+          (click)="withdraw.emit()"
+          data-testid="savings-withdrawal-card-cta"
+        >
+          <mat-icon>savings</mat-icon>
+          {{ 'budget.savingsWithdrawal.cta' | transloco }}
+        </button>
 
-      <button
-        matButton
-        class="self-center"
-        (click)="dismiss.emit()"
-        data-testid="savings-withdrawal-card-dismiss"
-      >
-        {{ 'budget.savingsWithdrawal.later' | transloco }}
-      </button>
+        <button
+          matButton
+          (click)="dismiss.emit()"
+          data-testid="savings-withdrawal-card-dismiss"
+        >
+          {{ 'budget.savingsWithdrawal.later' | transloco }}
+        </button>
+      </div>
     </div>
   `,
   styles: `


### PR DESCRIPTION
Deux défauts de rendu de « piocher dans son épargne », remontés sur les écrans après le merge de #516.

## La chip remplissait un montant que personne n'avait vu

La chip affichait « Il te manque 197 € » et le clic remplissait l'input avec `196.95999999999913`. `savingsWithdrawalDeficit` sortait tel quel d'une somme flottante ; le hero et la chip l'arrondissaient à l'affichage (`'1.0-0'`), l'input non.

L'arrondi se fait maintenant une fois, chez le producteur : hero, chip, input et payload portent le même nombre. `Math.round` et pas `Math.ceil` — le hero affiche `Math.abs(remaining)` en `'1.0-0'`, donc `ceil` désynchroniserait la chip du hero sur les demi-euros.

## La carte gated sur le float brut

Le gate de la carte comparait `remaining >= 0` alors que le montant qu'elle prérempli était désormais arrondi : les deux se contredisaient par construction. Un mois équilibré au centime laisse de la poussière flottante (`-9e-13`) → la carte s'affichait, puis le dialog s'ouvrait sans chip et sans rien à préremplir. Le gate porte maintenant sur le déficit arrondi.

## La carte était trop dominante

Un nudge contextuel n'est pas le CTA primaire de l'écran (`DESIGN.md` « flat by default ») : le bouton `filled` étiré sur toute la largeur devient `tonal` en largeur naturelle, sur la même rangée que « Plus tard ». Titre en `text-title-small` + `text-balance`, padding `p-5` → `p-4`. La carte garde sa pleine largeur, sa teinte et sa copy (contractuelle, validée en test utilisateur) au mot près.

`flex-wrap` sur la rangée d'actions : Material ne met pas `nowrap` sur les labels et fige la hauteur du pill, donc sur écran étroit les labels wrappaient dans un pill de hauteur fixe. C'est ce que font déjà les autres rangées de boutons du repo.

## Vérification

Les deux corrections sont prouvées par un test qui échoue sans elles :
- sans l'arrondi : `expected 196.96000000000004 to be 197`
- sans le gate arrondi : `expected true to be false`

Les deux moitiés de l'arrondi sont épinglées (vers le haut et vers le bas), sinon une régression vers `ceil` passerait inaperçue.

Suite complète 2238/2238, `pnpm quality` 10/10, `ng build` sans erreur.

## Pas fait

- Le hero garde `isPositive = remaining >= 0` sur le float brut : après une pioche de 197 sur un manque de 197,40, il affiche « Déficit — 0 » en rouge. Pré-existant, et `budget-financial-overview` sert d'autres écrans → hors périmètre de cette PR.
- L'overflow de la rangée d'actions n'a pas été reproduit à 320px dans un vrai navigateur ; `flex-wrap` est ici un alignement sur la convention du repo, sans contrepartie.