### PR TITLE
fix(landing): fluidifier la continuité visuelle responsive

### DIFF
--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/phase-1.md
@@ -15,6 +15,8 @@ landing/
 │   ├── accessibility.test.tsx ✏️ — verrouiller le contrat responsive avant la correction
 │   └── globals.css ✏️ — construire les ellipses floutées par section
 └── components/
+    ├── ui/
+    │   └── Section.tsx ✏️ — partager la respiration entre sections adjacentes
     └── sections/
         ├── Hero.tsx ✏️ — raccourcir uniquement sa sortie mobile
         ├── PainPoints.tsx ✏️ — porter le fond diffus et clarifier les preuves
@@ -124,6 +126,15 @@ Mobile
 2. Exiger un contraste d'au moins `7:1` sur les zones verte et menthe observées dans le CTA.
 3. Verrouiller la classe locale dans le contrat d'accessibilité sans modifier le token partagé.
 
+### `8)` Corriger la cadence entre les sections
+
+> Interpréter `80/120 px` comme une frontière partagée, pas comme deux marges pleines.
+
+1. Ajouter un contrat qui échoue avec `py-20 lg:py-30` sur la primitive `Section`.
+2. Répartir la respiration documentée sur les deux côtés adjacents avec `40 px` par côté sur mobile et `60 px` à partir de `lg`.
+3. Conserver les transitions éditoriales explicitement surchargées, notamment le raccord hero → preuves et le CTA final.
+4. Vérifier que les espacements internes de `40–56 px` restent inchangés et que les sections ne fusionnent pas visuellement.
+
 ## Test acceptance criteria
 
 | Task | Acceptance criteria |
@@ -135,3 +146,4 @@ Mobile
 | 5 | `landing/DESIGN.md` décrit le même contrat que le rendu : halos sectionnels verts sur mobile, canvas neutre, aucune grille ni surface vitrée ajoutée. |
 | 6 | Les vues 320, 390, 440 et 767 px reproduisent la douceur et la continuité de Borumi; à 768 et 1440 px, le fond et la rangée restent inchangés tandis que le raccord desktop est resserré; tests landing, type-check et build réussissent sans nouvelle dépendance. |
 | 7 | Le sous-texte du CTA final conserve une hiérarchie secondaire, atteint au moins `7:1` sur le champ ambiant mesuré et le token `--color-text-secondary` reste inchangé ailleurs. |
+| 8 | Deux sections par défaut produisent une frontière cumulée de `80 px` sur mobile et `120 px` à partir de `lg`; les espacements internes et les transitions surchargées restent inchangés. |

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/phase-1.md
@@ -17,7 +17,8 @@ landing/
 └── components/
     └── sections/
         ├── Hero.tsx ✏️ — raccourcir uniquement sa sortie mobile
-        └── PainPoints.tsx ✏️ — porter le fond diffus et clarifier les preuves
+        ├── PainPoints.tsx ✏️ — porter le fond diffus et clarifier les preuves
+        └── FinalCTA.tsx ✏️ — renforcer le texte secondaire sur le champ ambiant
 ```
 
 ## User Journey
@@ -75,17 +76,17 @@ Mobile
 1. Désactiver sous 768 px les dégradés radiaux actuellement portés par `body`.
 2. Donner à `.hero-mesh` et à une classe dédiée de `PainPoints` deux pseudo-éléments elliptiques plein champ, non interactifs et placés derrière le contenu.
 3. Reprendre la géométrie mobile Borumi : côtés hors-cadre, ellipse droite en haut, ellipse gauche en bas, rotation et flou identiques.
-4. Mapper les ellipses sur `--ambient-leaf`, `--ambient-mint` et `--ambient-lime`; conserver `--color-background` comme base entre les halos.
-5. Faire se recouvrir les halos aux limites de section pour obtenir un fondu continu sans colonne neutre au centre.
+4. Mapper les ellipses sur des variantes mobiles plus denses de `--ambient-leaf`, `--ambient-mint` et `--ambient-lime`; conserver `--color-background` comme base entre les halos et deux teintes distinctes au raccord.
+5. Laisser les halos déborder entre `Hero` et `PainPoints`, puis couper uniquement le débordement extérieur au niveau de `#main-content`, afin d'éviter une rupture horizontale.
 6. Laisser les règles existantes inchangées à partir de 768 px.
 
 ### `3)` Rattacher les preuves au hero
 
 > Supprimer le vide qui fait croire à une section indépendante.
 
-1. Réduire uniquement le `padding-bottom` mobile de `Hero`; conserver les valeurs `md` et `lg`.
-2. Réduire uniquement le `padding-top` mobile de `PainPoints`.
-3. Ramener l'écart mobile entre la liste de preuves et la situation principale à un rythme de contenu, sans toucher à la respiration desktop.
+1. Réduire le `padding-bottom` mobile de `Hero`, conserver `md` et resserrer `lg` après validation visuelle desktop.
+2. Réduire le `padding-top` mobile de `PainPoints`, conserver `md` et resserrer `lg` après validation visuelle desktop.
+3. Ramener l'écart entre les preuves et les blocs voisins à un rythme de contenu : compact en mobile, inférieur ou égal à 120 px entre dashboard et preuves sur desktop.
 4. Ne pas modifier `Section`, afin de ne pas dérégler toutes les autres sections pour un seul cas.
 
 ### `4)` Clarifier les trois preuves
@@ -111,17 +112,26 @@ Mobile
 
 1. Capturer Borumi et Pulpe à 390 px sur les mêmes transitions `hero → preuve → récit` et comparer la couverture, le flou et la continuité.
 2. Vérifier à 320, 390, 440 et 767 px que les preuves tiennent sans débordement, que les halos se recouvrent et que le récit principal apparaît sans vide de viewport.
-3. Vérifier à 768 et 1440 px que le fond, la rangée de preuves et les espacements actuels restent stables.
+3. Vérifier à 768 et 1440 px que le fond et la rangée de preuves restent stables, avec un raccord dashboard → preuves inférieur ou égal à 120 px à partir de `lg`.
 4. Contrôler le début et la fin de `PainPoints`, pas seulement le bloc central.
 5. Valider les tests landing, le type-check et le build de production.
+
+### `7)` Renforcer le contraste du CTA final
+
+> Garder le texte secondaire lisible sur la zone la plus colorée du champ desktop.
+
+1. Conserver la hiérarchie secondaire sans réutiliser le gris global trop léger sur ce fond.
+2. Exiger un contraste d'au moins `7:1` sur les zones verte et menthe observées dans le CTA.
+3. Verrouiller la classe locale dans le contrat d'accessibilité sans modifier le token partagé.
 
 ## Test acceptance criteria
 
 | Task | Acceptance criteria |
 | ---- | ------------------- |
 | 1 | Le contrat échoue avec les dégradés mobiles portés par `body`, l'absence des ellipses Borumi et l'ancienne hiérarchie des preuves, puis passe après correction. |
-| 2 | Sous 768 px, le hero et `PainPoints` utilisent chacun deux ellipses de `40vw × 60vh`, tournées à `-30deg`, floutées à `150px`, opacité `0.3–0.4` et placées sur des côtés opposés vers `10%` et `90%`; leurs verts se diffusent sur toute la largeur sans bande neutre centrale. |
-| 3 | Entre 320 et 440 px, la distance entre la démonstration du hero et la première preuve ne dépasse pas 80 px; la situation principale suit la dernière preuve en 48 px maximum. |
+| 2 | Sous 768 px, le hero et `PainPoints` utilisent chacun deux ellipses de `40vw × 60vh`, tournées à `-30deg`, floutées à `150px`, opacité `0.3–0.4` et placées sur des côtés opposés vers `10%` et `90%`; leurs verts débordent entre les sections sans coupure ni bande neutre centrale. |
+| 3 | Entre 320 et 440 px, la distance entre la démonstration du hero et la première preuve ne dépasse pas 80 px; la situation principale suit la dernière preuve en 48 px maximum; à partir de `lg`, le raccord dashboard → preuves ne dépasse pas 120 px. |
 | 4 | Chaque ligne mobile se lit dans l'ordre `valeur → explication`, sans débordement horizontal; à partir de `sm`, les trois preuves restent sur une rangée. |
 | 5 | `landing/DESIGN.md` décrit le même contrat que le rendu : halos sectionnels verts sur mobile, canvas neutre, aucune grille ni surface vitrée ajoutée. |
-| 6 | Les vues 320, 390, 440 et 767 px reproduisent la douceur et la continuité de Borumi; à 768 et 1440 px, le rendu actuel reste inchangé; tests landing, type-check et build réussissent sans nouvelle dépendance. |
+| 6 | Les vues 320, 390, 440 et 767 px reproduisent la douceur et la continuité de Borumi; à 768 et 1440 px, le fond et la rangée restent inchangés tandis que le raccord desktop est resserré; tests landing, type-check et build réussissent sans nouvelle dépendance. |
+| 7 | Le sous-texte du CTA final conserve une hiérarchie secondaire, atteint au moins `7:1` sur le champ ambiant mesuré et le token `--color-text-secondary` reste inchangé ailleurs. |

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/phase-1.md
@@ -1,0 +1,127 @@
+---
+status: done
+---
+
+# Instruction: Continuité visuelle et narrative sur mobile
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+landing/
+├── DESIGN.md ✏️ — documenter le champ diffus mobile dérivé de Borumi
+├── app/
+│   ├── accessibility.test.tsx ✏️ — verrouiller le contrat responsive avant la correction
+│   └── globals.css ✏️ — construire les ellipses floutées par section
+└── components/
+    └── sections/
+        ├── Hero.tsx ✏️ — raccourcir uniquement sa sortie mobile
+        └── PainPoints.tsx ✏️ — porter le fond diffus et clarifier les preuves
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Démonstration produit du hero"] --> B["Trois preuves compactes"]
+  B --> C["Situation principale"]
+  C --> D["Deux cas d'appui"]
+  D --> E["Parcours en trois étapes"]
+```
+
+## Wireframe
+
+```txt
+Mobile
+┌──────────────────────────────┐
+│ (1) Fin de la preuve produit │
+├──────────────────────────────┤
+│ (2) Preuve · explication     │
+│     Preuve · explication     │
+│     Preuve · explication     │
+├──────────────────────────────┤
+│ (3) Situation principale     │
+│     repère · titre · texte   │
+├──────────────────────────────┤
+│ (4) Cas d'appui empilés      │
+├──────────────────────────────┤
+│ (5) Section suivante         │
+└──────────────────────────────┘
+```
+
+1. Fin du hero : la démonstration produit reste la dernière preuve de la promesse.
+2. Preuves : trois lignes courtes prolongent le hero sans occuper un écran entier.
+3. Situation principale : le récit commence immédiatement après les preuves.
+4. Cas d'appui : les deux exemples conservent leur hiérarchie actuelle.
+5. Section suivante : la transition vers le parcours reste identifiable.
+
+## Tasks to do
+
+### `1)` Écrire le contrat de régression mobile
+
+> Reproduire le défaut avant de modifier le rendu.
+
+1. Étendre `accessibility.test.tsx` avec la source de `PainPoints`.
+2. Exiger l'absence de dégradé global sur `body` sous 768 px et la présence de deux ellipses floutées sur le hero et `PainPoints`.
+3. Verrouiller les paramètres observés sur le hero et les témoignages Borumi : `40vw × 60vh`, rotation `-30deg`, `blur(150px)`, opacité comprise entre `0.3` et `0.4`, entrées opposées à `10%` et `90%`.
+4. Exiger une hiérarchie sémantique et visuelle `preuve → explication`, compacte par défaut puis en trois colonnes à partir de `sm`.
+5. Constater l'échec du contrat sur l'implémentation actuelle avant la correction.
+
+### `2)` Reproduire le fondu Borumi avec la palette Pulpe
+
+> Copier la mécanique de diffusion, pas l'identité visuelle de Borumi.
+
+1. Désactiver sous 768 px les dégradés radiaux actuellement portés par `body`.
+2. Donner à `.hero-mesh` et à une classe dédiée de `PainPoints` deux pseudo-éléments elliptiques plein champ, non interactifs et placés derrière le contenu.
+3. Reprendre la géométrie mobile Borumi : côtés hors-cadre, ellipse droite en haut, ellipse gauche en bas, rotation et flou identiques.
+4. Mapper les ellipses sur `--ambient-leaf`, `--ambient-mint` et `--ambient-lime`; conserver `--color-background` comme base entre les halos.
+5. Faire se recouvrir les halos aux limites de section pour obtenir un fondu continu sans colonne neutre au centre.
+6. Laisser les règles existantes inchangées à partir de 768 px.
+
+### `3)` Rattacher les preuves au hero
+
+> Supprimer le vide qui fait croire à une section indépendante.
+
+1. Réduire uniquement le `padding-bottom` mobile de `Hero`; conserver les valeurs `md` et `lg`.
+2. Réduire uniquement le `padding-top` mobile de `PainPoints`.
+3. Ramener l'écart mobile entre la liste de preuves et la situation principale à un rythme de contenu, sans toucher à la respiration desktop.
+4. Ne pas modifier `Section`, afin de ne pas dérégler toutes les autres sections pour un seul cas.
+
+### `4)` Clarifier les trois preuves
+
+> Faire lire chaque métrique comme une phrase courte plutôt que comme trois blocs isolés.
+
+1. Nommer explicitement `value` et `label` dans les données de preuve.
+2. Présenter la valeur comme terme dominant et son explication comme description.
+3. Utiliser trois lignes compactes sur mobile, puis conserver la rangée de trois colonnes à partir de `sm`.
+4. Garder les séparateurs structurels; ne créer ni carte, ni effet vitré, ni nouveau texte.
+
+### `5)` Documenter la variante mobile
+
+> Aligner la règle écrite avec la nouvelle direction validée.
+
+1. Remplacer dans `landing/DESIGN.md` l'hypothèse d'un unique champ radial mobile par la mécanique de halos sectionnels diffus.
+2. Préciser que le canvas reste neutre, que seuls les verts Pulpe sont permis et que le fond ne doit produire ni bande centrale ni rupture entre sections.
+3. Conserver l'interdiction de la grille décorative et des surfaces de contenu vitrées.
+
+### `6)` Vérifier le récit responsive
+
+> Comparer la continuité à Borumi sans régression desktop.
+
+1. Capturer Borumi et Pulpe à 390 px sur les mêmes transitions `hero → preuve → récit` et comparer la couverture, le flou et la continuité.
+2. Vérifier à 320, 390, 440 et 767 px que les preuves tiennent sans débordement, que les halos se recouvrent et que le récit principal apparaît sans vide de viewport.
+3. Vérifier à 768 et 1440 px que le fond, la rangée de preuves et les espacements actuels restent stables.
+4. Contrôler le début et la fin de `PainPoints`, pas seulement le bloc central.
+5. Valider les tests landing, le type-check et le build de production.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Le contrat échoue avec les dégradés mobiles portés par `body`, l'absence des ellipses Borumi et l'ancienne hiérarchie des preuves, puis passe après correction. |
+| 2 | Sous 768 px, le hero et `PainPoints` utilisent chacun deux ellipses de `40vw × 60vh`, tournées à `-30deg`, floutées à `150px`, opacité `0.3–0.4` et placées sur des côtés opposés vers `10%` et `90%`; leurs verts se diffusent sur toute la largeur sans bande neutre centrale. |
+| 3 | Entre 320 et 440 px, la distance entre la démonstration du hero et la première preuve ne dépasse pas 80 px; la situation principale suit la dernière preuve en 48 px maximum. |
+| 4 | Chaque ligne mobile se lit dans l'ordre `valeur → explication`, sans débordement horizontal; à partir de `sm`, les trois preuves restent sur une rangée. |
+| 5 | `landing/DESIGN.md` décrit le même contrat que le rendu : halos sectionnels verts sur mobile, canvas neutre, aucune grille ni surface vitrée ajoutée. |
+| 6 | Les vues 320, 390, 440 et 767 px reproduisent la douceur et la continuité de Borumi; à 768 et 1440 px, le rendu actuel reste inchangé; tests landing, type-check et build réussissent sans nouvelle dépendance. |

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Sur mobile, la fin du hero, les trois preuves et le récit de PainPoints forment une séquence compacte portée par le même fondu diffus que Borumi, adapté aux couleurs Pulpe et sans bande blanche centrale."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Reproduire le fondu mobile de Borumi sur la landing

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/plan.md
@@ -1,5 +1,5 @@
 ---
-objective: "Sur mobile, la fin du hero, les trois preuves et le récit de PainPoints forment une séquence compacte portée par le même fondu diffus que Borumi, adapté aux couleurs Pulpe et sans bande blanche centrale."
+objective: "La fin du hero, les trois preuves et le récit de PainPoints forment une séquence continue : fondu Borumi adapté aux couleurs Pulpe sur mobile, aucune coupure de fond, preuves rattachées au dashboard sur desktop et texte secondaire final lisible sur le champ ambiant."
 status: implemented
 ---
 
@@ -10,7 +10,7 @@ status: implemented
 | Field      | Value                                                                 |
 | ---------- | --------------------------------------------------------------------- |
 | **Goal**   | Reprendre fidèlement la mécanique de fond Borumi tout en resserrant la transition mobile entre le hero et le récit produit. |
-| **Source** | Demande utilisateur du 19 juillet 2026 + capture `Screenshot 2026-07-19 at 18.58.19.png` + https://borumi.com/ |
+| **Source** | Demande utilisateur du 19 juillet 2026 + captures de 18:58, 19:44 et 20:21 + https://borumi.com/ |
 
 ## Phases
 
@@ -29,6 +29,7 @@ status: implemented
 
 | Decision | Why |
 | -------- | --- |
-| Reprendre les dimensions, positions, rotation, opacités et flou de Borumi, mais remplacer son violet/corail par les tokens verts Pulpe | Le rendu demandé reste fidèle à la référence sans introduire des couleurs décoratives étrangères à la marque. |
-| Appliquer la nouvelle mécanique sous 768 px et conserver le fond desktop actuel | Le défaut est mobile; cette limite évite une régression desktop et respecte la préférence exprimée. |
+| Reprendre les dimensions, positions, rotation, opacités et flou de Borumi, mais remplacer son violet/corail par des tokens mobiles Pulpe plus denses | Le flou reste fidèle à la référence sans laver les couleurs ni introduire des teintes décoratives étrangères à la marque. |
+| Appliquer la nouvelle mécanique sous 768 px, conserver le fond desktop et resserrer uniquement son raccord dashboard → preuves | Le contrôle visuel final a confirmé le besoin d'un fondu mobile non coupé et d'un espacement desktop moins détaché, sans redessiner le reste du desktop. |
+| Renforcer uniquement le texte secondaire du CTA final au lieu de modifier le token global | Le texte passe déjà AA ailleurs; le champ ambiant du CTA exige une densité supérieure sans aplatir toute la hiérarchie secondaire. |
 | Ne pas reprendre la grille décorative de Borumi | Le besoin porte sur le dégradé et le fondu; la grille contredit la règle landing qui l'interdit et n'aide pas la continuité narrative. |

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/plan.md
@@ -1,5 +1,5 @@
 ---
-objective: "La fin du hero, les trois preuves et le récit de PainPoints forment une séquence continue : fondu Borumi adapté aux couleurs Pulpe sur mobile, aucune coupure de fond, preuves rattachées au dashboard sur desktop et texte secondaire final lisible sur le champ ambiant."
+objective: "La landing suit une séquence continue : fondu Borumi adapté aux couleurs Pulpe sur mobile, aucune coupure de fond, preuves rattachées au dashboard, rythme inter-sections non doublé et texte secondaire final lisible sur le champ ambiant."
 status: implemented
 ---
 
@@ -32,4 +32,5 @@ status: implemented
 | Reprendre les dimensions, positions, rotation, opacités et flou de Borumi, mais remplacer son violet/corail par des tokens mobiles Pulpe plus denses | Le flou reste fidèle à la référence sans laver les couleurs ni introduire des teintes décoratives étrangères à la marque. |
 | Appliquer la nouvelle mécanique sous 768 px, conserver le fond desktop et resserrer uniquement son raccord dashboard → preuves | Le contrôle visuel final a confirmé le besoin d'un fondu mobile non coupé et d'un espacement desktop moins détaché, sans redessiner le reste du desktop. |
 | Renforcer uniquement le texte secondaire du CTA final au lieu de modifier le token global | Le texte passe déjà AA ailleurs; le champ ambiant du CTA exige une densité supérieure sans aplatir toute la hiérarchie secondaire. |
+| Partager l'espacement de frontière entre deux sections adjacentes | La primitive appliquait `80/120 px` sur chaque côté, créant `160/240 px` entre contenus alors que le contrat désigne la distance cumulée; Borumi utilise lui aussi des respirations cumulées, pas deux marges pleines. |
 | Ne pas reprendre la grille décorative de Borumi | Le besoin porte sur le dégradé et le fondu; la grille contredit la règle landing qui l'interdit et n'aide pas la continuité narrative. |

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/plan.md
@@ -1,0 +1,34 @@
+---
+objective: "Sur mobile, la fin du hero, les trois preuves et le récit de PainPoints forment une séquence compacte portée par le même fondu diffus que Borumi, adapté aux couleurs Pulpe et sans bande blanche centrale."
+status: in-progress
+---
+
+# Plan: Reproduire le fondu mobile de Borumi sur la landing
+
+## Overview
+
+| Field      | Value                                                                 |
+| ---------- | --------------------------------------------------------------------- |
+| **Goal**   | Reprendre fidèlement la mécanique de fond Borumi tout en resserrant la transition mobile entre le hero et le récit produit. |
+| **Source** | Demande utilisateur du 19 juillet 2026 + capture `Screenshot 2026-07-19 at 18.58.19.png` + https://borumi.com/ |
+
+## Phases
+
+| #   | Phase                                           | File                         |
+| --- | ----------------------------------------------- | ---------------------------- |
+| 1   | Continuité visuelle et narrative sur mobile     | [`phase-1.md`](./phase-1.md) |
+
+## Resources
+
+| Source | Verified |
+| ------ | -------- |
+| https://borumi.com/ | En mobile, chaque section superpose deux ellipses hors-cadre de `40–60vw × 50–60vh`, tournées à `-30deg`, opacité `0.3–0.4` et `blur(150px)`, placées vers `top: 10%` et `top: 90%`; leur recouvrement produit le fondu continu. |
+| https://pulpe-landing-git-preview-maximes-projects-56d66b35.vercel.app/ | La preview correspond à `origin/preview`; son accès automatisé redirige vers le SSO Vercel, donc la capture fournie reste la référence visuelle du défaut déployé. |
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Reprendre les dimensions, positions, rotation, opacités et flou de Borumi, mais remplacer son violet/corail par les tokens verts Pulpe | Le rendu demandé reste fidèle à la référence sans introduire des couleurs décoratives étrangères à la marque. |
+| Appliquer la nouvelle mécanique sous 768 px et conserver le fond desktop actuel | Le défaut est mobile; cette limite évite une régression desktop et respecte la préférence exprimée. |
+| Ne pas reprendre la grille décorative de Borumi | Le besoin porte sur le dégradé et le fondu; la grille contredit la règle landing qui l'interdit et n'aide pas la continuité narrative. |

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/review.md
@@ -1,4 +1,4 @@
-# Review: Continuité visuelle et contraste de la landing
+# Review: Continuité visuelle, contraste et cadence de la landing
 
 - **Verdict**: approve
 - **Diff**: `origin/preview...codex/landing-mobile-borumi-fade`
@@ -10,13 +10,14 @@
 
 ### Phase 1 — Continuité visuelle et narrative sur mobile
 
-- [x] Les contrats de régression distinguent l'ancien fond global, le clipping des halos, l'ancienne hiérarchie des preuves et l'espacement desktop détaché du rendu attendu — `landing/app/accessibility.test.tsx:109`, `landing/app/accessibility.test.tsx:170`
+- [x] Les contrats de régression distinguent l'ancien fond global, le clipping des halos, l'ancienne hiérarchie des preuves et l'espacement desktop détaché du rendu attendu — `landing/app/accessibility.test.tsx:113`, `landing/app/accessibility.test.tsx:178`
 - [x] Le hero et `PainPoints` portent chacun deux ellipses mobiles `40vw × 60vh`, tournées à `-30deg`, floutées à `150px`, avec une opacité de `0.4`; elles débordent entre les sections et sont coupées uniquement par `#main-content` — `landing/app/globals.css:140`
 - [x] Le raccord mobile vaut `72px`, le récit suit les preuves après `40px` et le raccord dashboard → preuves est borné à `112px` à partir de `lg`, sans modifier le palier `md` — `landing/components/sections/Hero.tsx:86`, `landing/app/globals.css:147`, `landing/components/sections/PainPoints.tsx:27`, `landing/components/sections/PainPoints.tsx:47`
 - [x] Les preuves utilisent la hiérarchie `value → label`, une grille mobile bornée et la rangée existante dès `sm` — `landing/components/sections/PainPoints.tsx:4`, `landing/components/sections/PainPoints.tsx:29`
 - [x] Le contrat landing décrit les halos verts sectionnels, leur débordement interne, le clipping au canvas et maintient l'interdiction de la grille et du verre sur le contenu — `landing/DESIGN.md:29`, `landing/DESIGN.md:80`
-- [x] Le breakpoint mobile s'arrête à `767px`, le fond desktop reste distinct et les tests couvrent le champ diffus, le raccord desktop et la structure responsive sans nouvelle dépendance — `landing/app/globals.css:140`, `landing/components/sections/Hero.tsx:86`, `landing/app/accessibility.test.tsx:109`, `landing/app/accessibility.test.tsx:174`
-- [x] Le sous-texte du CTA final utilise le texte principal à 80 % d'opacité pour rester lisible sur le champ ambiant, avec un contrat de régression dédié — `landing/components/sections/FinalCTA.tsx:18`, `landing/app/accessibility.test.tsx:346`
+- [x] Le breakpoint mobile s'arrête à `767px`, le fond desktop reste distinct et les tests couvrent le champ diffus, le raccord desktop et la structure responsive sans nouvelle dépendance — `landing/app/globals.css:140`, `landing/components/sections/Hero.tsx:86`, `landing/app/accessibility.test.tsx:113`, `landing/app/accessibility.test.tsx:178`
+- [x] Le sous-texte du CTA final utilise le texte principal à 80 % d'opacité pour rester lisible sur le champ ambiant, avec un contrat de régression dédié — `landing/components/sections/FinalCTA.tsx:18`, `landing/app/accessibility.test.tsx:357`
+- [x] La primitive partage la frontière entre sections avec `40px` par côté sur mobile et `60px` à partir de `lg`; le contrat interdit le retour aux valeurs doublées et la documentation exprime la distance cumulée — `landing/components/ui/Section.tsx:23`, `landing/app/accessibility.test.tsx:205`, `landing/DESIGN.md:70`
 
 ## Findings
 
@@ -26,7 +27,7 @@ None.
 
 | Metric | Value |
 | --- | --- |
-| Verified | 100% (7/7) |
-| Files checked | `landing/app/globals.css`, `landing/components/sections/Hero.tsx`, `landing/components/sections/PainPoints.tsx`, `landing/components/sections/FinalCTA.tsx`, `landing/app/accessibility.test.tsx`, `landing/DESIGN.md` |
+| Verified | 100% (8/8) |
+| Files checked | `landing/app/globals.css`, `landing/components/sections/Hero.tsx`, `landing/components/sections/PainPoints.tsx`, `landing/components/sections/FinalCTA.tsx`, `landing/components/ui/Section.tsx`, `landing/app/accessibility.test.tsx`, `landing/DESIGN.md` |
 | Unchecked | none |
 | Unplanned | none |

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/review.md
@@ -1,4 +1,4 @@
-# Review: Continuité visuelle et narrative mobile de la landing
+# Review: Continuité visuelle et contraste de la landing
 
 - **Verdict**: approve
 - **Diff**: `origin/preview...codex/landing-mobile-borumi-fade`
@@ -10,12 +10,13 @@
 
 ### Phase 1 — Continuité visuelle et narrative sur mobile
 
-- [x] Le contrat de régression distingue l'ancien fond global et l'ancienne hiérarchie des preuves du nouveau rendu — `landing/app/accessibility.test.tsx:109`
-- [x] Le hero et `PainPoints` portent chacun deux ellipses mobiles `40vw × 60vh`, tournées à `-30deg`, floutées à `150px`, avec une opacité de `0.35` et des positions opposées — `landing/app/globals.css:137`
-- [x] La sortie mobile du hero vaut `48px`, l'entrée de `PainPoints` vaut `24px` et le récit suit les preuves après `40px`, sans modifier les rythmes `md` et `lg` — `landing/components/sections/Hero.tsx:86`, `landing/app/globals.css:147`, `landing/components/sections/PainPoints.tsx:47`
+- [x] Les contrats de régression distinguent l'ancien fond global, le clipping des halos, l'ancienne hiérarchie des preuves et l'espacement desktop détaché du rendu attendu — `landing/app/accessibility.test.tsx:109`, `landing/app/accessibility.test.tsx:170`
+- [x] Le hero et `PainPoints` portent chacun deux ellipses mobiles `40vw × 60vh`, tournées à `-30deg`, floutées à `150px`, avec une opacité de `0.4`; elles débordent entre les sections et sont coupées uniquement par `#main-content` — `landing/app/globals.css:140`
+- [x] Le raccord mobile vaut `72px`, le récit suit les preuves après `40px` et le raccord dashboard → preuves est borné à `112px` à partir de `lg`, sans modifier le palier `md` — `landing/components/sections/Hero.tsx:86`, `landing/app/globals.css:147`, `landing/components/sections/PainPoints.tsx:27`, `landing/components/sections/PainPoints.tsx:47`
 - [x] Les preuves utilisent la hiérarchie `value → label`, une grille mobile bornée et la rangée existante dès `sm` — `landing/components/sections/PainPoints.tsx:4`, `landing/components/sections/PainPoints.tsx:29`
-- [x] Le contrat landing décrit les halos verts sectionnels, le canvas neutre et maintient l'interdiction de la grille et du verre sur le contenu — `landing/DESIGN.md:29`, `landing/DESIGN.md:80`
-- [x] Le breakpoint mobile s'arrête à `767px`, les valeurs desktop restent explicites et les tests couvrent le champ diffus ainsi que la structure responsive sans nouvelle dépendance — `landing/app/globals.css:137`, `landing/components/sections/Hero.tsx:86`, `landing/app/accessibility.test.tsx:109`
+- [x] Le contrat landing décrit les halos verts sectionnels, leur débordement interne, le clipping au canvas et maintient l'interdiction de la grille et du verre sur le contenu — `landing/DESIGN.md:29`, `landing/DESIGN.md:80`
+- [x] Le breakpoint mobile s'arrête à `767px`, le fond desktop reste distinct et les tests couvrent le champ diffus, le raccord desktop et la structure responsive sans nouvelle dépendance — `landing/app/globals.css:140`, `landing/components/sections/Hero.tsx:86`, `landing/app/accessibility.test.tsx:109`, `landing/app/accessibility.test.tsx:174`
+- [x] Le sous-texte du CTA final utilise le texte principal à 80 % d'opacité pour rester lisible sur le champ ambiant, avec un contrat de régression dédié — `landing/components/sections/FinalCTA.tsx:18`, `landing/app/accessibility.test.tsx:346`
 
 ## Findings
 
@@ -25,7 +26,7 @@ None.
 
 | Metric | Value |
 | --- | --- |
-| Verified | 100% (6/6) |
-| Files checked | `landing/app/globals.css`, `landing/components/sections/Hero.tsx`, `landing/components/sections/PainPoints.tsx`, `landing/app/accessibility.test.tsx`, `landing/DESIGN.md` |
+| Verified | 100% (7/7) |
+| Files checked | `landing/app/globals.css`, `landing/components/sections/Hero.tsx`, `landing/components/sections/PainPoints.tsx`, `landing/components/sections/FinalCTA.tsx`, `landing/app/accessibility.test.tsx`, `landing/DESIGN.md` |
 | Unchecked | none |
 | Unplanned | none |

--- a/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_19_landing-mobile-continuity/review.md
@@ -1,0 +1,31 @@
+# Review: Continuité visuelle et narrative mobile de la landing
+
+- **Verdict**: approve
+- **Diff**: `origin/preview...codex/landing-mobile-borumi-fade`
+- **Axes run**: code, functional, relevancy
+- **Date**: 2026_07_19
+- **Findings**: 0 critical, 0 warning, 0 minor
+
+## Phases
+
+### Phase 1 — Continuité visuelle et narrative sur mobile
+
+- [x] Le contrat de régression distingue l'ancien fond global et l'ancienne hiérarchie des preuves du nouveau rendu — `landing/app/accessibility.test.tsx:109`
+- [x] Le hero et `PainPoints` portent chacun deux ellipses mobiles `40vw × 60vh`, tournées à `-30deg`, floutées à `150px`, avec une opacité de `0.35` et des positions opposées — `landing/app/globals.css:137`
+- [x] La sortie mobile du hero vaut `48px`, l'entrée de `PainPoints` vaut `24px` et le récit suit les preuves après `40px`, sans modifier les rythmes `md` et `lg` — `landing/components/sections/Hero.tsx:86`, `landing/app/globals.css:147`, `landing/components/sections/PainPoints.tsx:47`
+- [x] Les preuves utilisent la hiérarchie `value → label`, une grille mobile bornée et la rangée existante dès `sm` — `landing/components/sections/PainPoints.tsx:4`, `landing/components/sections/PainPoints.tsx:29`
+- [x] Le contrat landing décrit les halos verts sectionnels, le canvas neutre et maintient l'interdiction de la grille et du verre sur le contenu — `landing/DESIGN.md:29`, `landing/DESIGN.md:80`
+- [x] Le breakpoint mobile s'arrête à `767px`, les valeurs desktop restent explicites et les tests couvrent le champ diffus ainsi que la structure responsive sans nouvelle dépendance — `landing/app/globals.css:137`, `landing/components/sections/Hero.tsx:86`, `landing/app/accessibility.test.tsx:109`
+
+## Findings
+
+None.
+
+## Verification
+
+| Metric | Value |
+| --- | --- |
+| Verified | 100% (6/6) |
+| Files checked | `landing/app/globals.css`, `landing/components/sections/Hero.tsx`, `landing/components/sections/PainPoints.tsx`, `landing/app/accessibility.test.tsx`, `landing/DESIGN.md` |
+| Unchecked | none |
+| Unplanned | none |

--- a/landing/DESIGN.md
+++ b/landing/DESIGN.md
@@ -77,7 +77,7 @@ Content is flat by default. A surface uses tone, a hairline outline or a short s
 
 **The Single Family Rule.** Poppins covers display, body, button and label. Distinction comes from scale, weight and spacing, never a second family.
 
-**The Mobile Diffuse Field Rule.** Below `768px`, keep the body neutral and place two blurred brand-green ellipses inside both the hero and opening narrative. Offset them to opposite sides and ends of each section so their fade bridges the content blocks. No neutral vertical stripe, decorative grid, glass panel or hard gradient edge.
+**The Mobile Diffuse Field Rule.** Below `768px`, keep the body neutral and place two blurred brand-green ellipses inside both the hero and opening narrative. Their source colors use denser mobile ambient tokens so the `150px` blur does not wash them out; opposite sides keep distinct leaf and mint hues. Offset them to opposite sides and ends of each section, let them overflow their internal boundary and clip only at the outer canvas so their fade bridges the content blocks. No neutral vertical stripe, decorative grid, glass panel or hard gradient edge.
 
 ## 6. Do's and Don'ts
 

--- a/landing/DESIGN.md
+++ b/landing/DESIGN.md
@@ -26,7 +26,7 @@ Pulpe landing is Next.js + Tailwind v4. Marketing-first: a large promise, a wide
 **Landing-specific characteristics:**
 
 - **Single font family:** Poppins. No display/body split.
-- **Two-zone canvas:** a pale green radial emotion field dissolves into the warm `#F7F6F3` content canvas.
+- **Two-zone canvas:** the warm `#F7F6F3` base carries the content. Desktop uses a shared radial field; below `768px`, the hero and opening narrative use paired, section-scoped green ellipses whose blur overlaps the transition.
 - **Product signature:** the live annual-budget dashboard is the one memorable visual moment.
 - **Brand-tinted elevation:** `rgba(0, 60, 20, 0.06)` instead of generic black shadows.
 - **Restrained motion:** `--ease-smooth`, 150–300 ms interactions and no overshoot.
@@ -76,6 +76,8 @@ Content is flat by default. A surface uses tone, a hairline outline or a short s
 **The Navigation Glass Rule.** Backdrop blur and translucent shine are reserved for the floating navbar. Content surfaces use tone, outline or restrained elevation.
 
 **The Single Family Rule.** Poppins covers display, body, button and label. Distinction comes from scale, weight and spacing, never a second family.
+
+**The Mobile Diffuse Field Rule.** Below `768px`, keep the body neutral and place two blurred brand-green ellipses inside both the hero and opening narrative. Offset them to opposite sides and ends of each section so their fade bridges the content blocks. No neutral vertical stripe, decorative grid, glass panel or hard gradient edge.
 
 ## 6. Do's and Don'ts
 

--- a/landing/DESIGN.md
+++ b/landing/DESIGN.md
@@ -67,7 +67,7 @@ Content is flat by default. A surface uses tone, a hairline outline or a short s
 - **Hero CTA:** solid Pulpe Forest capsule, Poppins 600, hover lift over `--ease-smooth`, exact press feedback `scale(0.96)`.
 - **Feature surface:** tonal or near-white, `border-radius: 16px`, no glass.
 - **Navbar:** floating full-width pill, one translucent layer, 44 px minimum targets, keyboard-accessible mobile panel.
-- **Section spacing:** 120 px between major desktop sections, 80 px on mobile.
+- **Section spacing:** adjacent default sections share 120 px on desktop and 80 px on mobile. The `Section` primitive contributes half of that boundary on each side; do not apply the full value twice.
 
 ### Landing-Specific Named Rules
 

--- a/landing/app/accessibility.test.tsx
+++ b/landing/app/accessibility.test.tsx
@@ -25,6 +25,14 @@ const componentSources = {
     new URL("../components/sections/Header.tsx", import.meta.url),
     "utf8",
   ),
+  hero: readFileSync(
+    new URL("../components/sections/Hero.tsx", import.meta.url),
+    "utf8",
+  ),
+  painPoints: readFileSync(
+    new URL("../components/sections/PainPoints.tsx", import.meta.url),
+    "utf8",
+  ),
   imageLightbox: readFileSync(
     new URL("../components/ui/ImageLightbox.tsx", import.meta.url),
     "utf8",
@@ -96,6 +104,59 @@ describe("landing accessibility contracts", () => {
       globalsCss,
       /at\s+[-\d.%]+\s+[-\d.%]+\s+var\(--gradient-interpolation\)/,
     );
+  });
+
+  it("uses Borumi-style section fields instead of the page gradient on mobile", () => {
+    const sectionFields = globalsCss.match(
+      /\.hero-mesh::before,[\s\S]*?\.pain-points-mesh::after\s*\{([\s\S]*?)\}/,
+    )?.[1];
+
+    assert.match(
+      globalsCss,
+      /@media \(max-width: 767px\)[\s\S]*body\s*\{[\s\S]*background-image:\s*none;/,
+    );
+    assert.match(
+      globalsCss,
+      /\.hero-mesh,\s*\.pain-points-mesh\s*\{[\s\S]*isolation:\s*isolate;/,
+    );
+    assert.ok(sectionFields, "The shared mobile section field is missing");
+    assert.match(sectionFields, /width:\s*40vw;/);
+    assert.match(sectionFields, /height:\s*60vh;/);
+    assert.match(
+      sectionFields,
+      /transform:\s*translateY\(-50%\) rotate\(-30deg\);/,
+    );
+    assert.match(sectionFields, /filter:\s*blur\(150px\);/);
+    assert.match(sectionFields, /opacity:\s*0\.35;/);
+    assert.match(
+      globalsCss,
+      /\.hero-mesh::before,[\s\S]*?\.pain-points-mesh::before\s*\{(?=[\s\S]*?left:\s*-10%;)(?=[\s\S]*?top:\s*90%;)/,
+    );
+    assert.match(
+      globalsCss,
+      /\.hero-mesh::after,[\s\S]*?\.pain-points-mesh::after\s*\{(?=[\s\S]*?right:\s*-10%;)(?=[\s\S]*?top:\s*10%;)/,
+    );
+    assert.match(componentSources.painPoints, /pain-points-mesh/);
+  });
+
+  it("keeps the mobile proof strip compact and value-first", () => {
+    assert.match(componentSources.hero, /\bpb-12\b/);
+    assert.match(componentSources.hero, /\bmd:pb-28\b/);
+    assert.match(
+      componentSources.painPoints,
+      /PROOFS = \[[\s\S]*value:[\s\S]*label:/,
+    );
+    assert.match(
+      componentSources.painPoints,
+      /grid-cols-\[7rem_minmax\(0,1fr\)\]/,
+    );
+    assert.match(componentSources.painPoints, /\bsm:grid-cols-3\b/);
+    assert.match(
+      componentSources.painPoints,
+      /<dt[^>]*>\s*\{proof\.value\}\s*<\/dt>[\s\S]*<dd[^>]*>\s*\{proof\.label\}\s*<\/dd>/,
+    );
+    assert.match(componentSources.painPoints, /\bmt-10\b/);
+    assert.match(componentSources.painPoints, /\bmd:mt-20\b/);
   });
 
   it("hides a collapsed accordion panel from assistive technology", () => {

--- a/landing/app/accessibility.test.tsx
+++ b/landing/app/accessibility.test.tsx
@@ -119,6 +119,14 @@ describe("landing accessibility contracts", () => {
       globalsCss,
       /\.hero-mesh,\s*\.pain-points-mesh\s*\{[\s\S]*isolation:\s*isolate;/,
     );
+    assert.match(
+      globalsCss,
+      /@media \(max-width: 767px\)[\s\S]*#main-content\s*\{[\s\S]*overflow:\s*clip;/,
+    );
+    assert.match(
+      globalsCss,
+      /@media \(max-width: 767px\)[\s\S]*\.hero-mesh,\s*\.pain-points-mesh\s*\{[\s\S]*overflow:\s*visible;/,
+    );
     assert.ok(sectionFields, "The shared mobile section field is missing");
     assert.match(sectionFields, /width:\s*40vw;/);
     assert.match(sectionFields, /height:\s*60vh;/);
@@ -127,7 +135,19 @@ describe("landing accessibility contracts", () => {
       /transform:\s*translateY\(-50%\) rotate\(-30deg\);/,
     );
     assert.match(sectionFields, /filter:\s*blur\(150px\);/);
-    assert.match(sectionFields, /opacity:\s*0\.35;/);
+    assert.match(sectionFields, /opacity:\s*0\.4;/);
+    assert.match(
+      globalsCss,
+      /--ambient-mobile-leaf:\s*oklch\(70% 0\.2 145\);/,
+    );
+    assert.match(
+      globalsCss,
+      /--ambient-mobile-mint:\s*oklch\(75% 0\.18 164\);/,
+    );
+    assert.match(
+      globalsCss,
+      /--ambient-mobile-lime:\s*oklch\(82% 0\.19 121\);/,
+    );
     assert.match(
       globalsCss,
       /\.hero-mesh::before,[\s\S]*?\.pain-points-mesh::before\s*\{(?=[\s\S]*?left:\s*-10%;)(?=[\s\S]*?top:\s*90%;)/,
@@ -135,6 +155,18 @@ describe("landing accessibility contracts", () => {
     assert.match(
       globalsCss,
       /\.hero-mesh::after,[\s\S]*?\.pain-points-mesh::after\s*\{(?=[\s\S]*?right:\s*-10%;)(?=[\s\S]*?top:\s*10%;)/,
+    );
+    assert.match(
+      globalsCss,
+      /\.hero-mesh::before,[\s\S]*?background-color:\s*var\(--ambient-mobile-leaf\);/,
+    );
+    assert.match(
+      globalsCss,
+      /\.hero-mesh::after,[\s\S]*?background-color:\s*var\(--ambient-mobile-mint\);/,
+    );
+    assert.doesNotMatch(
+      globalsCss,
+      /\.pain-points-mesh::after\s*\{[^}]*background-color:\s*var\(--ambient-mobile-leaf\);/,
     );
     assert.match(componentSources.painPoints, /pain-points-mesh/);
   });
@@ -157,6 +189,13 @@ describe("landing accessibility contracts", () => {
     );
     assert.match(componentSources.painPoints, /\bmt-10\b/);
     assert.match(componentSources.painPoints, /\bmd:mt-20\b/);
+  });
+
+  it("keeps the desktop proof strip attached to the dashboard", () => {
+    assert.match(componentSources.hero, /\blg:pb-20\b/);
+    assert.match(componentSources.painPoints, /\blg:pt-8\b/);
+    assert.match(componentSources.hero, /\bmd:pb-28\b/);
+    assert.match(componentSources.painPoints, /\bmd:pt-10\b/);
   });
 
   it("hides a collapsed accordion panel from assistive technology", () => {
@@ -301,6 +340,17 @@ describe("landing accessibility contracts", () => {
     assert.match(
       componentSources.finalCta,
       /mois d&apos;avance sur ce qu&apos;il te restera/i,
+    );
+  });
+
+  it("keeps final CTA supporting copy legible over the ambient field", () => {
+    assert.match(
+      componentSources.finalCta,
+      /max-w-2xl[^"\n]*text-text\/80/,
+    );
+    assert.doesNotMatch(
+      componentSources.finalCta,
+      /max-w-2xl[^"\n]*text-text-secondary/,
     );
   });
 });

--- a/landing/app/accessibility.test.tsx
+++ b/landing/app/accessibility.test.tsx
@@ -41,6 +41,10 @@ const componentSources = {
     new URL("../components/ui/Screenshot.tsx", import.meta.url),
     "utf8",
   ),
+  section: readFileSync(
+    new URL("../components/ui/Section.tsx", import.meta.url),
+    "utf8",
+  ),
   roadmap: readFileSync(
     new URL("../components/sections/Roadmap.tsx", import.meta.url),
     "utf8",
@@ -196,6 +200,13 @@ describe("landing accessibility contracts", () => {
     assert.match(componentSources.painPoints, /\blg:pt-8\b/);
     assert.match(componentSources.hero, /\bmd:pb-28\b/);
     assert.match(componentSources.painPoints, /\bmd:pt-10\b/);
+  });
+
+  it("treats section spacing as a shared boundary instead of doubling it", () => {
+    assert.match(componentSources.section, /\bpy-10\b/);
+    assert.match(componentSources.section, /\blg:py-15\b/);
+    assert.doesNotMatch(componentSources.section, /\bpy-20\b/);
+    assert.doesNotMatch(componentSources.section, /\blg:py-30\b/);
   });
 
   it("hides a collapsed accordion panel from assistive technology", () => {

--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -42,6 +42,9 @@
   --ambient-lime: oklch(93% 0.13 121);
   --ambient-leaf: oklch(88% 0.15 145);
   --ambient-mint: oklch(90% 0.12 164);
+  --ambient-mobile-lime: oklch(82% 0.19 121);
+  --ambient-mobile-leaf: oklch(70% 0.2 145);
+  --ambient-mobile-mint: oklch(75% 0.18 164);
   --gradient-interpolation: ;
 }
 
@@ -139,9 +142,14 @@ body {
     background-image: none;
   }
 
+  #main-content {
+    overflow: clip;
+  }
+
   .hero-mesh,
   .pain-points-mesh {
     isolation: isolate;
+    overflow: visible;
   }
 
   .pain-points-mesh {
@@ -159,7 +167,7 @@ body {
     border-radius: 50%;
     content: "";
     filter: blur(150px);
-    opacity: 0.35;
+    opacity: 0.4;
     pointer-events: none;
     transform: translateY(-50%) rotate(-30deg);
   }
@@ -168,22 +176,18 @@ body {
   .pain-points-mesh::before {
     top: 90%;
     left: -10%;
-    background-color: var(--ambient-leaf);
+    background-color: var(--ambient-mobile-leaf);
   }
 
   .hero-mesh::after,
   .pain-points-mesh::after {
     top: 10%;
     right: -10%;
-    background-color: var(--ambient-mint);
+    background-color: var(--ambient-mobile-mint);
   }
 
   .pain-points-mesh::before {
-    background-color: var(--ambient-lime);
-  }
-
-  .pain-points-mesh::after {
-    background-color: var(--ambient-leaf);
+    background-color: var(--ambient-mobile-lime);
   }
 }
 

--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -128,10 +128,63 @@ body {
   }
 }
 
-/* The page shares one ambient field. Sections stay transparent so the color
-   fades never become full-width bands. */
-.hero-mesh {
+/* Desktop shares one ambient field. Mobile scopes its halos to the opening sections. */
+.hero-mesh,
+.pain-points-mesh {
   background: transparent;
+}
+
+@media (max-width: 767px) {
+  body {
+    background-image: none;
+  }
+
+  .hero-mesh,
+  .pain-points-mesh {
+    isolation: isolate;
+  }
+
+  .pain-points-mesh {
+    padding-top: 1.5rem;
+  }
+
+  .hero-mesh::before,
+  .hero-mesh::after,
+  .pain-points-mesh::before,
+  .pain-points-mesh::after {
+    position: absolute;
+    z-index: -1;
+    width: 40vw;
+    height: 60vh;
+    border-radius: 50%;
+    content: "";
+    filter: blur(150px);
+    opacity: 0.35;
+    pointer-events: none;
+    transform: translateY(-50%) rotate(-30deg);
+  }
+
+  .hero-mesh::before,
+  .pain-points-mesh::before {
+    top: 90%;
+    left: -10%;
+    background-color: var(--ambient-leaf);
+  }
+
+  .hero-mesh::after,
+  .pain-points-mesh::after {
+    top: 10%;
+    right: -10%;
+    background-color: var(--ambient-mint);
+  }
+
+  .pain-points-mesh::before {
+    background-color: var(--ambient-lime);
+  }
+
+  .pain-points-mesh::after {
+    background-color: var(--ambient-leaf);
+  }
 }
 
 section[id] {

--- a/landing/components/sections/FinalCTA.tsx
+++ b/landing/components/sections/FinalCTA.tsx
@@ -15,7 +15,7 @@ export function FinalCTA() {
           <h2 className="mt-5 text-[clamp(2.75rem,7vw,6rem)] font-bold leading-[0.98] tracking-[-0.05em] text-text">
             Prends des mois d&apos;avance sur ce qu&apos;il te restera.
           </h2>
-          <p className="mx-auto mt-7 max-w-2xl text-lg leading-relaxed text-text-secondary sm:text-xl">
+          <p className="mx-auto mt-7 max-w-2xl text-lg leading-relaxed text-text/80 sm:text-xl">
             Gratuit aujourd&apos;hui. Sans connexion bancaire. Tes montants sont
             chiffrés.
           </p>

--- a/landing/components/sections/Hero.tsx
+++ b/landing/components/sections/Hero.tsx
@@ -83,7 +83,7 @@ export function Hero() {
   const unit = currency === "CHF" ? "CHF" : "€";
 
   return (
-    <section className="hero-mesh relative overflow-hidden pb-24 pt-36 md:pb-28 md:pt-40 lg:pb-36 lg:pt-44">
+    <section className="hero-mesh relative overflow-hidden pb-12 pt-36 md:pb-28 md:pt-40 lg:pb-36 lg:pt-44">
       <div className="relative z-10 mx-auto w-full max-w-6xl px-4 md:px-6 lg:px-8">
         <div className="mx-auto max-w-5xl text-center">
           <p className="mb-6 inline-flex items-center rounded-full border border-primary/12 bg-primary/8 px-4 py-2 text-sm font-semibold text-primary">

--- a/landing/components/sections/Hero.tsx
+++ b/landing/components/sections/Hero.tsx
@@ -83,7 +83,7 @@ export function Hero() {
   const unit = currency === "CHF" ? "CHF" : "€";
 
   return (
-    <section className="hero-mesh relative overflow-hidden pb-12 pt-36 md:pb-28 md:pt-40 lg:pb-36 lg:pt-44">
+    <section className="hero-mesh relative overflow-hidden pb-12 pt-36 md:pb-28 md:pt-40 lg:pb-20 lg:pt-44">
       <div className="relative z-10 mx-auto w-full max-w-6xl px-4 md:px-6 lg:px-8">
         <div className="mx-auto max-w-5xl text-center">
           <p className="mb-6 inline-flex items-center rounded-full border border-primary/12 bg-primary/8 px-4 py-2 text-sm font-semibold text-primary">

--- a/landing/components/sections/PainPoints.tsx
+++ b/landing/components/sections/PainPoints.tsx
@@ -24,7 +24,7 @@ export function PainPoints() {
   return (
     <Section
       id="pain-points"
-      className="pain-points-mesh relative overflow-hidden md:pt-10 lg:pt-16"
+      className="pain-points-mesh relative overflow-hidden md:pt-10 lg:pt-8"
     >
       <dl className="grid border-y border-text/10 sm:grid-cols-3">
         {PROOFS.map((proof, index) => (

--- a/landing/components/sections/PainPoints.tsx
+++ b/landing/components/sections/PainPoints.tsx
@@ -2,9 +2,9 @@ import { CalendarX, House, Wallet } from "lucide-react";
 import { Section } from "@/components/ui";
 
 const PROOFS = [
-  ["12 mois", "visibles d’un coup"],
-  ["3 minutes", "pour poser ton année"],
-  ["Web + iOS", "le même budget partout"],
+  { value: "12 mois", label: "visibles d’un coup" },
+  { value: "3 minutes", label: "pour poser ton année" },
+  { value: "Web + iOS", label: "le même budget partout" },
 ];
 
 const SUPPORTING = [
@@ -22,24 +22,29 @@ const SUPPORTING = [
 
 export function PainPoints() {
   return (
-    <Section id="pain-points" className="pt-10 lg:pt-16">
+    <Section
+      id="pain-points"
+      className="pain-points-mesh relative overflow-hidden md:pt-10 lg:pt-16"
+    >
       <dl className="grid border-y border-text/10 sm:grid-cols-3">
-        {PROOFS.map(([value, label], index) => (
+        {PROOFS.map((proof, index) => (
           <div
-            key={value}
-            className={`py-5 sm:px-6 sm:text-center ${
+            key={proof.value}
+            className={`grid grid-cols-[7rem_minmax(0,1fr)] items-baseline gap-x-4 py-4 sm:block sm:px-6 sm:py-5 sm:text-center ${
               index > 0
                 ? "border-t border-text/10 sm:border-l sm:border-t-0"
                 : ""
             }`}
           >
-            <dt className="text-sm text-text-secondary">{label}</dt>
-            <dd className="mt-1 text-xl font-semibold text-text">{value}</dd>
+            <dt className="text-xl font-semibold text-text">{proof.value}</dt>
+            <dd className="pretty text-sm leading-relaxed text-text-secondary sm:mt-1">
+              {proof.label}
+            </dd>
           </div>
         ))}
       </dl>
 
-      <div className="mt-20 grid items-stretch gap-8 lg:grid-cols-5 lg:gap-12">
+      <div className="mt-10 grid items-stretch gap-8 md:mt-20 lg:grid-cols-5 lg:gap-12">
         <div className="relative overflow-hidden rounded-[var(--radius-large)] bg-surface-alt p-7 sm:p-10 lg:col-span-3 lg:p-12">
           <div
             aria-hidden="true"

--- a/landing/components/ui/Section.tsx
+++ b/landing/components/ui/Section.tsx
@@ -20,7 +20,7 @@ export const Section = memo(function Section({
 }: SectionProps) {
   return (
     <section
-      className={`py-20 lg:py-30 ${BACKGROUND_STYLES[background]} ${className}`}
+      className={`py-10 lg:py-15 ${BACKGROUND_STYLES[background]} ${className}`}
       {...props}
     >
       <Container className="relative z-10">{children}</Container>


### PR DESCRIPTION
## Type

Bug Fix

## Description

Fluidifie la transition entre le hero, les preuves et le récit de la landing, puis corrige la cadence verticale partagée entre les sections.

## Changements

- Remplace le fond mobile global par des halos verts sectionnels inspirés de Borumi.
- Rattache visuellement les trois preuves au dashboard.
- Clarifie leur hiérarchie et leur lecture sur mobile.
- Resserre le raccord sur desktop.
- Renforce le contraste du texte secondaire du CTA final.
- Corrige le doublement de l’espacement entre sections : 80 px cumulés sur mobile, 120 px sur desktop.
- Préserve les espacements internes et les transitions éditoriales explicitement surchargées.

## Vérification

- pnpm quality
- pnpm --filter pulpe-landing test
- pnpm --filter pulpe-landing build
- Vérification responsive mobile et desktop
- Review AIDD : approve, 8/8