### PR TITLE
fix(ios): clarify savings goal plan gaps (PUL-8)

### DIFF
--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/phase-1.md
@@ -1,0 +1,104 @@
+---
+status: done
+---
+
+# Instruction: Verrouiller puis corriger la présentation mensuelle iOS
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/Features/SavingsGoals/Components/
+│   ├── ✏️ GoalPlanMonthRow.swift
+│   └── ✏️ GoalPlanTimelineSection.swift
+└── PulpeTests/Features/SavingsGoals/
+    └── ✅ GoalPlanTimelinePresentationTests.swift
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Ouvrir le détail d’un objectif"] --> B["Lire la fenêtre mensuelle autour du mois courant"]
+  B --> C{"Le mois contient une Prévision liée ?"}
+  C -->|Oui| D["Afficher son montant et son cumul"]
+  C -->|Non| E{"Le budget est connu comme absent ?"}
+  E -->|Oui| F["Signaler le budget absent"]
+  E -->|Non| G["Signaler seulement l’absence de Prévision liée"]
+  D --> H["Activer le contrôle d’expansion"]
+  F --> H
+  G --> H
+  H --> I["Consulter tous les mois jusqu’à l’échéance"]
+```
+
+## Wireframe
+
+```txt
+┌──────────────────────────────────────┐
+│ (1) En-tête : section · action       │
+│ ┌──────────────────────────────────┐ │
+│ │ (2) Mois avec montant et cumul   │ │
+│ ├──────────────────────────────────┤ │
+│ │ (3) Mois sans élément lié        │ │
+│ ├──────────────────────────────────┤ │
+│ │ (3) Mois sans élément lié        │ │
+│ └──────────────────────────────────┘ │
+│ (4) Contrôle de liste complète   [∨] │
+│ (5) Information récapitulative      │
+└──────────────────────────────────────┘
+```
+
+1. En-tête : identifie le plan mensuel et place son unique action au même niveau.
+2. Mois renseigné : présente la Prévision liée et le cumul de l’objectif.
+3. Mois vide : réserve un emplacement à une information d’état exacte.
+4. Contrôle : occupe une ligne complète afin d’être reconnu comme interactif.
+5. Récapitulatif : explique les mois sans Prévision liée sans confondre leur budget.
+
+## Tasks to do
+
+### `1)` Verrouiller la régression de présentation
+
+> Reproduire le cas de la capture avant de modifier les composants.
+
+1. Ajouter un test pur de présentation avec juillet et août porteurs d’une Prévision liée, septembre et octobre en `gap` avec `isProvisionable == false`, puis au moins un vrai budget absent avec `isProvisionable == true`.
+2. Prouver que le comportement actuel classe à tort septembre et octobre comme « Pas de budget » et les inclut dans le décompte des budgets absents.
+3. Couvrir le happy path : la fenêtre repliée reste bornée autour du mois courant, tandis que l’état développé retourne tous les mois jusqu’à l’échéance.
+
+### `2)` Séparer les deux états sans modifier le contrat API
+
+> Exploiter le signal déjà fourni par le serveur et éviter un changement backend inutile.
+
+1. Dans la couche de présentation des composants existants, réserver « Pas de budget » aux mois `gap` dont `isProvisionable` vaut `true`.
+2. Présenter les autres mois `gap` avec une formulation factuelle d’absence de Prévision liée à l’objectif ; cette formulation reste vraie que le budget existe ou que son absence ne soit pas provisionnable.
+3. Remplacer la grosse capsule d’état des mois vides par une ligne secondaire compacte avec SF Symbol ; réserver les chips aux vrais statuts et actions.
+4. Remplacer le récapitulatif « mois sans budget » par le nombre de mois sans Prévision liée, sans promettre qu’une simple création de budget ajoutera automatiquement une Prévision.
+5. Aligner le libellé d’accessibilité de chaque ligne sur le nouvel état visible.
+6. Garder inchangés les montants, cumuls, états pointés, règles de verrouillage et calculs du simulateur.
+
+### `3)` Rendre l’accès au plan complet explicite
+
+> Conserver la fenêtre courte par défaut, mais montrer clairement qu’elle est repliée.
+
+1. Réutiliser le pattern iOS existant de ligne pleine largeur avec libellé et chevron pour le contrôle d’expansion.
+2. Transformer l’ouverture à sens unique en bascule « voir tout / voir moins », avec chevron cohérent, cible tactile minimale de 44 pt et hint VoiceOver correspondant à l’état.
+3. Utiliser la typographie de titre de section existante et aligner « Ajuster » dans l’en-tête, au lieu d’empiler un gros titre puis un chip d’action.
+4. Conserver la fenêtre actuelle du mois courant et des trois mois futurs ; elle limite la densité mais ne doit plus ressembler à une fin de données.
+5. Faire passer le test de régression, puis exécuter le test iOS ciblé et un build `PulpeLocal` sur simulateur.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Le scénario reproduit échoue avant correction parce que septembre et octobre, budgets matérialisés sans Prévision liée, sont annoncés comme budgets absents. |
+| 1 | Le test distingue un mois sans Prévision liée d’un mois `isProvisionable`, et couvre la liste repliée puis développée. |
+| 2 | Septembre et octobre n’affichent plus « Pas de budget » ; ils indiquent seulement qu’aucune Prévision n’est liée à cet objectif. |
+| 2 | Un mois `gap` avec `isProvisionable == true` conserve l’état « Pas de budget ». |
+| 2 | Le récapitulatif compte les mois sans Prévision liée et ne les décrit plus comme autant de budgets absents. |
+| 2 | Les libellés VoiceOver, montants, cumuls et états pointés correspondent au contenu visible. |
+| 2 | Un mois vide utilise une information secondaire compacte, sans capsule surdimensionnée. |
+| 3 | Par défaut, la timeline reste courte et affiche un contrôle pleine largeur avec chevron ; son activation affiche tous les mois, dont novembre et décembre lorsqu’ils sont dans l’horizon. |
+| 3 | Le contrôle permet aussi de replier la liste, dispose d’une cible d’au moins 44 pt et annonce son action à VoiceOver. |
+| 3 | Le titre et l’action d’ajustement partagent une seule rangée et utilisent les primitives typographiques et interactives existantes. |
+| 3 | `GoalPlanTimelinePresentationTests`, puis le build `PulpeLocal`, passent sur le simulateur iPhone configuré par le projet. |

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/phase-2.md
@@ -1,0 +1,119 @@
+---
+status: pending
+---
+
+# Instruction: Distiller la hiérarchie du détail d’objectif
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/Features/SavingsGoals/
+│   ├── ✏️ SavingsGoalDetailView.swift
+│   ├── ✏️ GoalContributionsSection.swift
+│   └── Components/
+│       └── ✏️ GoalProjectionChart.swift
+└── PulpeTests/Features/SavingsGoals/
+    └── ✅ GoalProjectionSeriesTests.swift
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Ouvrir le détail d’un objectif"] --> B["Comprendre le montant épargné et le rythme"]
+  B --> C["Consulter la trajectoire"]
+  C --> D["Parcourir le plan mensuel"]
+  D --> E["Retrouver les contributions réelles"]
+```
+
+## Wireframe
+
+```txt
+┌──────────────────────────────────────┐
+│ (1) Navigation : titre · modification│
+├──────────────────────────────────────┤
+│ (2) Métadonnées : état · échéance    │
+│ ┌──────────────────────────────────┐ │
+│ │ (3) Résumé : montant · cible     │ │
+│ │     progression · rythme         │ │
+│ │     indicateurs essentiels       │ │
+│ └──────────────────────────────────┘ │
+│ (4) État contextuel éventuel         │
+│                                      │
+│ (5) Section trajectoire              │
+│ ┌──────────────────────────────────┐ │
+│ │ graphique · deux indicateurs     │ │
+│ └──────────────────────────────────┘ │
+│                                      │
+│ (6) Section plan mensuel             │
+│                                      │
+│ (7) Section contributions réelles    │
+│ ┌──────────────────────────────────┐ │
+│ │ contribution · lignes associées │ │
+│ └──────────────────────────────────┘ │
+└──────────────────────────────────────┘
+```
+
+1. Navigation : garde le détail dans la hiérarchie native et l’édition dans la toolbar.
+2. Métadonnées : rassemble les informations d’identité sans créer un second hero.
+3. Résumé : répond d’abord à « où j’en suis » avec une seule occurrence de chaque donnée.
+4. État contextuel : conserve les conseils conditionnels uniquement lorsqu’ils s’appliquent.
+5. Trajectoire : garde le graphique comme regroupement analytique secondaire.
+6. Plan mensuel : reste la prochaine étape logique après la vue d’ensemble.
+7. Contributions : conserve le détail réel en fin de page, sans conteneur imbriqué.
+
+## Tasks to do
+
+### `1)` Rétablir une hiérarchie iOS de page détail
+
+> Réduire l’intensité typographique sans inventer une nouvelle direction visuelle.
+
+1. Passer le titre de navigation en mode `inline`, comme les autres pages de détail iOS du projet ; conserver le mode large sur la liste d’objectifs.
+2. Remplacer la taille `headline` de hero par la taille `title` existante pour « Ta trajectoire » et « Ton suivi » ; la phase 1 applique le même niveau au plan mensuel.
+3. Conserver Manrope pour les montants et SF Pro pour la navigation, les titres de section et les libellés.
+4. Réutiliser exclusivement les tokens, couleurs, styles de boutons et SF Symbols existants ; ne créer ni token ni composant partagé pour ce polish ponctuel.
+
+### `2)` Dédupliquer le résumé de progression
+
+> Faire répondre le premier bloc à « combien, sur quelle cible, et à quel rythme ? ».
+
+1. Intégrer le verdict de rythme dans la carte de progression au lieu de le laisser flotter comme un chip entre deux blocs.
+2. Supprimer la ligne « Épargné » qui répète exactement le montant principal de la carte.
+3. Conserver la cible, la barre, le montant de départ lorsqu’il existe, le prévu cumulé et l’effort mensuel requis.
+4. Retirer du résumé la projection numérique à l’échéance, déjà expliquée par la trajectoire et son atteinte estimée juste après.
+5. Garder inchangés les calculs serveur, le masquage des montants et les libellés d’accessibilité de la barre.
+
+### `3)` Clarifier la trajectoire sans enrichissement décoratif
+
+> Corriger la collision visible des dates et laisser le graphique porter l’analyse.
+
+1. Adapter la sélection pure des repères horizontaux : lorsque l’ancrage et le mois courant sont trop proches pour afficher deux libellés lisibles, privilégier le mois courant et l’extrémité du plan.
+2. Ajouter un test de régression pour un objectif démarré deux périodes avant le mois courant et un happy path où les trois repères restent suffisamment espacés.
+3. Conserver les quatre séries, la cible, les deux indicateurs sous le graphique, les couleurs sémantiques et le comportement Reduce Motion existants.
+
+### `4)` Aplatir le suivi réel
+
+> Supprimer la carte imbriquée sans retirer les transactions utiles.
+
+1. Garder une carte par contribution, son état pointé, son mois et son montant.
+2. Remplacer le fond arrondi interne « Transactions réelles » par une liste simplement indentée, structurée par le libellé et des dividers.
+3. Conserver les états de chargement, d’erreur et de retry existants ainsi que les libellés VoiceOver des lignes.
+4. Vérifier le rendu en taille de texte standard et accessibilité, en clair et sombre, avec montants visibles puis masqués.
+5. Exécuter les tests ciblés, puis un build `PulpeLocal`; maintenir l’ensemble du polish sous environ 300 lignes nettes.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Le détail utilise un titre inline ; les trois sections ont le même niveau de titre secondaire et aucune taille de hero ne concurrence le nom de l’objectif. |
+| 1 | Aucun nouveau token, composant partagé, matériau ou couleur décorative n’est ajouté. |
+| 2 | Le montant épargné n’apparaît qu’une fois dans le résumé ; cible, progression, rythme, prévu cumulé et effort requis restent lisibles. |
+| 2 | Le montant de départ reste visible lorsqu’il est non nul, et tous les montants respectent le mode de confidentialité. |
+| 3 | Sur l’horizon reproduit par la capture, les libellés de l’ancrage et du mois courant ne se chevauchent plus ; un horizon suffisamment espacé conserve trois repères. |
+| 3 | Séries, cible, écart cumulé et atteinte estimée restent identiques avant et après le polish. |
+| 4 | Chaque contribution reste une carte unique ; ses transactions sont lisibles sans second fond arrondi imbriqué. |
+| 4 | Le détail reste complet en Dynamic Type, clair/sombre et avec montants masqués ; toutes les actions conservent une cible de 44 pt minimum. |
+| 4 | `GoalPlanTimelinePresentationTests`, `GoalProjectionSeriesTests`, puis le build `PulpeLocal`, passent sur le simulateur configuré par le projet. |

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/phase-2.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Distiller la hiérarchie du détail d’objectif

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Le détail d’un objectif iOS distingue correctement budgets et Prévisions liées, rend tout le plan accessible et présente la progression dans une hiérarchie plus légère."
-status: implemented
+status: in-progress
 ---
 
 # Plan: Corriger et alléger le détail d’un objectif iOS

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Le détail d’un objectif iOS distingue correctement budgets et Prévisions liées, rend tout le plan accessible et présente la progression dans une hiérarchie plus légère."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Corriger et alléger le détail d’un objectif iOS

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/plan.md
@@ -1,0 +1,20 @@
+---
+objective: "Le détail d’un objectif iOS distingue correctement budgets et Prévisions liées, rend tout le plan accessible et présente la progression dans une hiérarchie plus légère."
+status: in-progress
+---
+
+# Plan: Corriger et alléger le détail d’un objectif iOS
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| **Goal** | Corriger les faux mois sans budget, clarifier l’expansion du plan et réduire la charge visuelle sans refonte ni nouvelle fonctionnalité. |
+| **Source** | Demandes utilisateur et capture `/Users/maximedesogus/Downloads/Capture d’écran 2026-07-21 à 06.53.19.png` |
+
+## Phases
+
+| # | Phase | File |
+| --- | --- | --- |
+| 1 | Verrouiller puis corriger la présentation mensuelle iOS | [`phase-1.md`](./phase-1.md) |
+| 2 | Distiller la hiérarchie du détail d’objectif | [`phase-2.md`](./phase-2.md) |

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_budget_gaps/review.md
@@ -1,0 +1,48 @@
+# Review: Détail d’objectif iOS
+
+- **Verdict**: approve
+- **Diff**: `058d6ac5025bbe39aff9c709507c87729079f3d7...1967205fe7fce8ff49325ab8b1b81a618b68990e`
+- **Axes run**: code, functional, relevancy
+- **Date**: 2026_07_21
+- **Findings**: 0 critical, 0 warning, 0 minor
+
+## Phases
+
+### Phase 1 — Verrouiller puis corriger la présentation mensuelle iOS
+
+- [x] Le scénario matérialisé sans Prévision liée expose l’ancien faux « Pas de budget » — `ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift:6`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift:48`
+- [x] Le test distingue absence de Prévision, budget absent et liste repliée/développée — `ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift:6`, `ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift:18`
+- [x] Les mois matérialisés sans ligne liée affichent « Aucune prévision liée » — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:8`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift:48`
+- [x] Un mois provisionnable conserve « Pas de budget » — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:11`
+- [x] Le récapitulatif compte les mois sans Prévision liée — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:69`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:135`
+- [x] VoiceOver, montants, cumuls et états pointés suivent le contenu — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift:24`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift:80`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift:100`
+- [x] Les mois vides utilisent une information secondaire sans capsule — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift:48`
+- [x] La timeline courte possède un contrôle pleine largeur et l’état développé restitue tout l’horizon — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:51`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:115`
+- [x] Le contrôle replie la liste, expose 44 pt et adapte son hint VoiceOver — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:117`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:124`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:132`
+- [x] Le titre et l’ajustement partagent la même rangée avec les primitives existantes — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:95`
+- [x] Le test ciblé et le build `PulpeLocal` disposent des fixtures nécessaires — `ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift:4`
+
+### Phase 2 — Distiller la hiérarchie du détail d’objectif
+
+- [x] Le détail utilise une navigation inline et un niveau commun pour les trois sections — `ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift:54`, `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:96`, `ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift:160`, `ios/Pulpe/Features/SavingsGoals/GoalContributionsSection.swift:15`
+- [x] Aucun token, composant partagé, matériau ou accent décoratif n’est ajouté — `ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift:187`
+- [x] Le résumé ne répète plus le montant épargné et conserve cible, barre, rythme, prévu et effort requis — `ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift:187`
+- [x] Le montant de départ reste conditionnel et chaque montant garde `.sensitiveAmount()` — `ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift:190`, `ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift:212`, `ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift:262`
+- [x] La trajectoire proche retire le repère d’ancrage tandis que l’horizon espacé garde trois repères — `ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift:300`, `ios/PulpeTests/Features/SavingsGoals/GoalProjectionSeriesTests.swift:5`
+- [x] Les séries, cible, écart et atteinte estimée sont conservés — `ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift:164`, `ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift:246`
+- [x] Chaque contribution reste une carte et les transactions perdent leur fond imbriqué — `ios/Pulpe/Features/SavingsGoals/GoalContributionsSection.swift:40`, `ios/Pulpe/Features/SavingsGoals/GoalContributionsSection.swift:67`
+- [x] Typographies dynamiques, couleurs adaptatives, confidentialité et cible d’expansion sont conservées — `ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift:124`, `ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift:190`, `ios/Pulpe/Features/SavingsGoals/GoalContributionsSection.swift:60`
+- [x] Les deux suites ciblées couvrent la régression et le happy path — `ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift:4`, `ios/PulpeTests/Features/SavingsGoals/GoalProjectionSeriesTests.swift:4`
+
+## Findings
+
+None.
+
+## Verification
+
+| Metric        | Value |
+| ------------- | ----- |
+| Verified      | 100% (20/20) |
+| Files checked | `plan.md`, `phase-1.md`, `phase-2.md`, `GoalPlanMonthRow.swift`, `GoalPlanTimelineSection.swift`, `GoalProjectionChart.swift`, `GoalContributionsSection.swift`, `SavingsGoalDetailView.swift`, `GoalPlanTimelinePresentationTests.swift`, `GoalProjectionSeriesTests.swift`, `ios/DESIGN.md`, `Typography.swift` |
+| Unchecked     | none |
+| Unplanned     | none |

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_remaining_summary/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_remaining_summary/phase-1.md
@@ -1,0 +1,84 @@
+---
+status: done
+---
+
+# Instruction: Compter et nommer uniquement les mois restants
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/Features/SavingsGoals/Components/
+│   └── ✏️ GoalPlanTimelineSection.swift
+└── PulpeTests/Features/SavingsGoals/
+    └── ✏️ GoalPlanTimelinePresentationTests.swift
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Ouvrir le détail d’un objectif"] --> B["Lire le mois courant et les mois futurs"]
+  B --> C["Comprendre combien de mois restants n’ont aucune Prévision liée"]
+  C --> D["Développer le plan complet"]
+  D --> E["Retrouver les anciennes lignes avec leur explication factuelle"]
+```
+
+## Wireframe
+
+```txt
+┌──────────────────────────────────────┐
+│ (1) Titre de section · action        │
+│ ┌──────────────────────────────────┐ │
+│ │ (2) Lignes mensuelles du plan    │ │
+│ │     historique · courant · futur │ │
+│ └──────────────────────────────────┘ │
+│ (3) Contrôle du plan complet         │
+│ (4) Résumé prospectif des mois vides │
+└──────────────────────────────────────┘
+```
+
+1. En-tête : conserve l’identité et l’action actuelles.
+2. Timeline : garde les lignes historiques explicatives et le contenu existant.
+3. Contrôle : reste entre la timeline et son information complémentaire.
+4. Résumé : porte uniquement la situation depuis le mois courant.
+
+## Tasks to do
+
+### `1)` Verrouiller la portée temporelle du compteur
+
+> Prouver que l’historique reste consultable sans gonfler le résumé prospectif.
+
+1. Étendre le test pur de présentation avec au moins un mois passé sans ligne liée, le mois courant et des mois futurs sans ligne liée.
+2. Vérifier que le plan développé restitue toujours le mois historique et que `GoalPlanMonthAvailability` continue de l’expliquer comme sans Prévision liée.
+3. Faire échouer l’ancien compteur en attendant uniquement le nombre de mois vides depuis le mois courant.
+
+### `2)` Recentrer le résumé sur la suite du plan
+
+> Faire correspondre le nombre visible aux périodes encore pertinentes pour la planification.
+
+1. Renommer le compteur de présentation pour exprimer sa portée restante plutôt qu’un total sur tout l’horizon.
+2. Parcourir la timeline ordonnée à partir de `currentIndex` et compter les mois dont `lines` est vide, sans filtrer sur `state == .gap`.
+3. Remplacer le texte actuel par « X mois restants sans prévision liée à cet objectif. » et le masquer lorsque ce nombre vaut zéro.
+4. Conserver sans changement les libellés des lignes historiques, la distinction « Pas de budget », le fenêtrage, l’expansion et les calculs serveur.
+
+### `3)` Vérifier le comportement iOS
+
+> Valider la règle pure et l’intégration SwiftUI sans élargir le périmètre.
+
+1. Exécuter `GoalPlanTimelinePresentationTests` sur le simulateur iPhone configuré.
+2. Compiler le scheme `PulpeLocal` sur le même simulateur.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Un mois passé sans ligne liée reste présent dans `visibleMonths` lorsque le plan est développé et conserve l’état « Aucune prévision liée ». |
+| 1 | Le test échoue avec le compteur actuel parce que celui-ci inclut encore le mois historique. |
+| 2 | Le mois courant et les mois futurs sans ligne liée sont comptés ; les mois antérieurs au mois courant ne le sont pas. |
+| 2 | Le résumé affiche « X mois restants sans prévision liée à cet objectif. » pour un total positif et disparaît lorsque le total vaut zéro. |
+| 2 | Les lignes historiques du plan développé, « Pas de budget », « Voir tout / Voir moins » et les cumuls restent inchangés. |
+| 2 | Aucun contrat backend/shared, token de design ou composant partagé n’est ajouté ou modifié. |
+| 3 | `GoalPlanTimelinePresentationTests` et le build `PulpeLocal` réussissent sur le simulateur configuré. |

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_remaining_summary/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_remaining_summary/plan.md
@@ -1,0 +1,19 @@
+---
+objective: "Le résumé du plan mensuel iOS compte seulement les mois sans Prévision liée à partir du mois courant, tandis que le plan développé conserve son contexte historique."
+status: in-progress
+---
+
+# Plan: Centrer le résumé du plan iOS sur les mois restants
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| **Goal** | Rendre le résumé prospectif sans masquer l’explication des anciennes lignes du plan. |
+| **Source** | Décision utilisateur exprimée dans la tâche Codex du 2026-07-21. |
+
+## Phases
+
+| # | Phase | File |
+| --- | --- | --- |
+| 1 | Compter et nommer uniquement les mois restants | [`phase-1.md`](./phase-1.md) |

--- a/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_remaining_summary/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_21_ios_goal_plan_remaining_summary/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Le résumé du plan mensuel iOS compte seulement les mois sans Prévision liée à partir du mois courant, tandis que le plan développé conserve son contexte historique."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Centrer le résumé du plan iOS sur les mois restants

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift
@@ -1,5 +1,43 @@
 import SwiftUI
 
+enum GoalPlanMonthAvailability: Equatable {
+    case linkedForecast
+    case noLinkedForecast
+    case missingBudget
+
+    init(month: SavingsGoalPlanMonth) {
+        if !month.lines.isEmpty {
+            self = .linkedForecast
+        } else if month.isProvisionable {
+            self = .missingBudget
+        } else {
+            self = .noLinkedForecast
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .linkedForecast:
+            ""
+        case .noLinkedForecast:
+            "Aucune prévision liée"
+        case .missingBudget:
+            "Pas de budget"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .linkedForecast:
+            "checkmark.circle.fill"
+        case .noLinkedForecast:
+            "link"
+        case .missingBudget:
+            "calendar.badge.exclamationmark"
+        }
+    }
+}
+
 /// One month row of « Ton plan, mois par mois » (PUL-12+, pilier B). Cloned from
 /// `SpreadOccurrenceRow`: same grammar as the lissage timeline so there is zero new
 /// language to learn (`docs/SAVINGS.md` §10.1).

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift
@@ -26,10 +26,10 @@ enum GoalPlanMonthAvailability: Equatable {
         }
     }
 
-    var icon: String {
+    var icon: String? {
         switch self {
         case .linkedForecast:
-            "checkmark.circle.fill"
+            nil
         case .noLinkedForecast:
             "link"
         case .missingBudget:
@@ -83,8 +83,8 @@ struct GoalPlanMonthRow: View {
                         PulpeChip(label: "Ce mois", style: .muted)
                     }
 
-                    if !hasLinkedForecast {
-                        Label(availability.label, systemImage: availability.icon)
+                    if let availabilityIcon = availability.icon {
+                        Label(availability.label, systemImage: availabilityIcon)
                             .font(PulpeTypography.listRowSubtitle)
                             .foregroundStyle(Color.textSecondary)
                     }

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanMonthRow.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// `amount` / `cumulative` are injected so the same row serves read mode
 /// (`plannedAmount` / `plannedCumulative`) and the simulator (`simulatedAmount` /
 /// `simulatedCumulative`). Locked rows are dimmed + non-interactive; the current
-/// period carries a « Ce mois » chip; a `gap` month shows « Pas de budget ». Amount
+/// period carries a « Ce mois » chip; a month without a linked forecast states why. Amount
 /// is the ligne 2-decimal (`asCurrency`), cumulative the aggregation compact
 /// (`asCompactCurrency`, `→` prefix). Savings green + neutrals only (RG-002).
 struct GoalPlanMonthRow: View {
@@ -18,7 +18,8 @@ struct GoalPlanMonthRow: View {
     var isAdjusted: Bool = false
 
     private var isCurrentPeriod: Bool { month.state == .current }
-    private var isGap: Bool { month.state == .gap }
+    private var availability: GoalPlanMonthAvailability { GoalPlanMonthAvailability(month: month) }
+    private var hasLinkedForecast: Bool { availability == .linkedForecast }
 
     private var allChecked: Bool {
         !month.lines.isEmpty && month.lines.allSatisfy(\.isChecked)
@@ -39,10 +40,16 @@ struct GoalPlanMonthRow: View {
                     .font(PulpeTypography.listRowTitle)
                     .foregroundStyle(Color.textPrimary)
 
-                if isCurrentPeriod {
-                    PulpeChip(label: "Ce mois", style: .muted)
-                } else if isGap {
-                    PulpeChip(icon: "calendar.badge.exclamationmark", label: "Pas de budget", style: .muted)
+                HStack(spacing: DesignTokens.Spacing.sm) {
+                    if isCurrentPeriod {
+                        PulpeChip(label: "Ce mois", style: .muted)
+                    }
+
+                    if !hasLinkedForecast {
+                        Label(availability.label, systemImage: availability.icon)
+                            .font(PulpeTypography.listRowSubtitle)
+                            .foregroundStyle(Color.textSecondary)
+                    }
                 }
             }
 
@@ -72,7 +79,7 @@ struct GoalPlanMonthRow: View {
     @ViewBuilder
     private var amountView: some View {
         VStack(alignment: .trailing, spacing: DesignTokens.Spacing.xxs) {
-            if !isGap {
+            if hasLinkedForecast {
                 Text(amount.asCurrency(currency))
                     .font(PulpeTypography.amountCard)
                     .monospacedDigit()
@@ -92,10 +99,10 @@ struct GoalPlanMonthRow: View {
 
     private var accessibilityLabel: String {
         var parts = [monthLabel]
-        if isGap {
-            parts.append("pas de budget")
-        } else {
+        if hasLinkedForecast {
             parts.append(amount.asCurrency(currency))
+        } else {
+            parts.append(availability.label)
         }
         parts.append("cumulé \(cumulative.asCurrency(currency))")
         if isCurrentPeriod { parts.append("ce mois") }

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
@@ -28,8 +28,8 @@ struct GoalPlanTimelinePresentation {
         collapsedMonths.count < months.count
     }
 
-    var unlinkedMonthCount: Int {
-        months.count(where: { $0.lines.isEmpty })
+    var remainingUnlinkedMonthCount: Int {
+        months.dropFirst(currentIndex).count(where: { $0.lines.isEmpty })
     }
 }
 
@@ -95,8 +95,8 @@ struct GoalPlanTimelineSection: View {
                 .accessibilityHint(isExpanded ? "Réduit la liste des mois" : "Affiche tous les mois")
             }
 
-            if presentation.unlinkedMonthCount > 0 {
-                Text("\(presentation.unlinkedMonthCount) mois sans prévision liée à cet objectif.")
+            if presentation.remainingUnlinkedMonthCount > 0 {
+                Text("\(presentation.remainingUnlinkedMonthCount) mois restants sans prévision liée à cet objectif.")
                     .font(PulpeTypography.listRowSubtitle)
                     .foregroundStyle(Color.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
@@ -1,43 +1,5 @@
 import SwiftUI
 
-enum GoalPlanMonthAvailability: Equatable {
-    case linkedForecast
-    case noLinkedForecast
-    case missingBudget
-
-    init(month: SavingsGoalPlanMonth) {
-        if !month.lines.isEmpty {
-            self = .linkedForecast
-        } else if month.isProvisionable {
-            self = .missingBudget
-        } else {
-            self = .noLinkedForecast
-        }
-    }
-
-    var label: String {
-        switch self {
-        case .linkedForecast:
-            ""
-        case .noLinkedForecast:
-            "Aucune prévision liée"
-        case .missingBudget:
-            "Pas de budget"
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .linkedForecast:
-            "checkmark.circle.fill"
-        case .noLinkedForecast:
-            "link"
-        case .missingBudget:
-            "calendar.badge.exclamationmark"
-        }
-    }
-}
-
 struct GoalPlanTimelinePresentation {
     private static let openMonthsWindow = 3
 

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
@@ -1,5 +1,76 @@
 import SwiftUI
 
+enum GoalPlanMonthAvailability: Equatable {
+    case linkedForecast
+    case noLinkedForecast
+    case missingBudget
+
+    init(month: SavingsGoalPlanMonth) {
+        if !month.lines.isEmpty {
+            self = .linkedForecast
+        } else if month.isProvisionable {
+            self = .missingBudget
+        } else {
+            self = .noLinkedForecast
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .linkedForecast:
+            ""
+        case .noLinkedForecast:
+            "Aucune prévision liée"
+        case .missingBudget:
+            "Pas de budget"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .linkedForecast:
+            "checkmark.circle.fill"
+        case .noLinkedForecast:
+            "link"
+        case .missingBudget:
+            "calendar.badge.exclamationmark"
+        }
+    }
+}
+
+struct GoalPlanTimelinePresentation {
+    private static let openMonthsWindow = 3
+
+    let months: [SavingsGoalPlanMonth]
+    let isExpanded: Bool
+
+    private var currentIndex: Int {
+        months.firstIndex { $0.state == .current } ?? 0
+    }
+
+    private var collapsedMonths: [SavingsGoalPlanMonth] {
+        guard !months.isEmpty else { return [] }
+        let end = min(months.count, currentIndex + Self.openMonthsWindow + 1)
+        return Array(months[currentIndex..<end])
+    }
+
+    var visibleMonths: [SavingsGoalPlanMonth] {
+        isExpanded ? months : collapsedMonths
+    }
+
+    var hiddenCount: Int {
+        max(0, months.count - visibleMonths.count)
+    }
+
+    var canToggle: Bool {
+        collapsedMonths.count < months.count
+    }
+
+    var unlinkedMonthCount: Int {
+        months.count(where: { $0.lines.isEmpty })
+    }
+}
+
 /// « Ton plan, mois par mois » (PUL-12+, pilier B) — the read-mode timeline section
 /// on the goal detail. Windowed by default (last locked month for context + the
 /// upcoming open months) with a « Voir tout le plan » toggle; a full 24–96 row list
@@ -15,59 +86,54 @@ struct GoalPlanTimelineSection: View {
 
     @State private var isExpanded = false
 
-    /// Upcoming open months shown before the "Voir tout" fold, past the current one.
-    private let openMonthsWindow = 3
-
-    private var currentIndex: Int {
-        months.firstIndex { $0.state == .current } ?? 0
-    }
-
-    private var windowedMonths: [SavingsGoalPlanMonth] {
-        guard !isExpanded else { return months }
-        guard !months.isEmpty else { return [] }
-
-        let lastLockedIndex = months.lastIndex { $0.isLocked }
-        let start = min(lastLockedIndex ?? currentIndex, currentIndex)
-        let end = min(months.count - 1, currentIndex + openMonthsWindow)
-        guard start <= end else { return Array(months[currentIndex...currentIndex]) }
-        return Array(months[start...end])
-    }
-
-    private var gapCount: Int {
-        months.filter { $0.state == .gap }.count
-    }
-
-    private var hiddenCount: Int {
-        months.count - windowedMonths.count
+    private var presentation: GoalPlanTimelinePresentation {
+        GoalPlanTimelinePresentation(months: months, isExpanded: isExpanded)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
-            Text("Ton plan, mois par mois")
-                .font(PulpeTypography.headline)
-                .foregroundStyle(Color.textPrimary)
+            HStack(spacing: DesignTokens.Spacing.md) {
+                Text("Ton plan, mois par mois")
+                    .font(PulpeTypography.title)
+                    .foregroundStyle(Color.textPrimary)
 
-            if canAdjust {
-                Button(action: onAdjust) {
-                    PulpeChip(icon: "slider.horizontal.3", label: "Ajuster mon plan", style: .outlined)
+                Spacer(minLength: DesignTokens.Spacing.sm)
+
+                if canAdjust {
+                    Button(action: onAdjust) {
+                        Label("Ajuster", systemImage: "slider.horizontal.3")
+                            .font(PulpeTypography.buttonSecondary)
+                    }
+                    .frame(minHeight: DesignTokens.TapTarget.minimum)
+                    .textLinkButtonStyle()
+                    .accessibilityLabel("Ajuster le plan")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Ajuster mon plan")
             }
 
             timelineCard
 
-            if !isExpanded, hiddenCount > 0 {
+            if presentation.canToggle {
                 Button {
-                    withAnimation(DesignTokens.Animation.gentleSpring) { isExpanded = true }
+                    withAnimation(DesignTokens.Animation.gentleSpring) { isExpanded.toggle() }
                 } label: {
-                    Text("Voir tout le plan (\(months.count) mois)")
+                    HStack(spacing: DesignTokens.Spacing.sm) {
+                        Text(isExpanded ? "Voir moins" : "Voir tout le plan (\(months.count) mois)")
+                        Spacer()
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    }
+                    .frame(
+                        maxWidth: .infinity,
+                        minHeight: DesignTokens.TapTarget.minimum,
+                        alignment: .leading
+                    )
+                    .contentShape(Rectangle())
                 }
                 .textLinkButtonStyle()
+                .accessibilityHint(isExpanded ? "Réduit la liste des mois" : "Affiche tous les mois")
             }
 
-            if gapCount > 0 {
-                Text("\(gapCount) mois sans budget — ils s'ajouteront quand tu créeras ces budgets.")
+            if presentation.unlinkedMonthCount > 0 {
+                Text("\(presentation.unlinkedMonthCount) mois sans prévision liée à cet objectif.")
                     .font(PulpeTypography.listRowSubtitle)
                     .foregroundStyle(Color.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -77,7 +143,7 @@ struct GoalPlanTimelineSection: View {
 
     private var timelineCard: some View {
         VStack(spacing: 0) {
-            ForEach(Array(windowedMonths.enumerated()), id: \.element.id) { index, month in
+            ForEach(Array(presentation.visibleMonths.enumerated()), id: \.element.id) { index, month in
                 if index > 0 {
                     Divider().foregroundStyle(Color.textTertiary.opacity(DesignTokens.Opacity.secondary))
                 }

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
@@ -72,11 +72,11 @@ struct GoalPlanTimelinePresentation {
 }
 
 /// « Ton plan, mois par mois » (PUL-12+, pilier B) — the read-mode timeline section
-/// on the goal detail. Windowed by default (last locked month for context + the
-/// upcoming open months) with a « Voir tout le plan » toggle; a full 24–96 row list
+/// on the goal detail. Windowed by default (current month + three future months)
+/// with a « Voir tout le plan » toggle; a full 24–96 row list
 /// would burn the 30 s attention budget (`docs/SAVINGS.md` §10.1).
 ///
-/// The section header carries the « Ajuster mon plan » CTA (pilier C entry), shown
+/// The section header carries the « Ajuster » CTA (pilier C entry), shown
 /// only when the goal is actionable (`canAdjust`).
 struct GoalPlanTimelineSection: View {
     let months: [SavingsGoalPlanMonth]
@@ -94,7 +94,7 @@ struct GoalPlanTimelineSection: View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
             HStack(spacing: DesignTokens.Spacing.md) {
                 Text("Ton plan, mois par mois")
-                    .font(PulpeTypography.title)
+                    .font(PulpeTypography.title2)
                     .foregroundStyle(Color.textPrimary)
 
                 Spacer(minLength: DesignTokens.Spacing.sm)
@@ -121,13 +121,13 @@ struct GoalPlanTimelineSection: View {
                         Spacer()
                         Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                     }
-                    .frame(
-                        maxWidth: .infinity,
-                        minHeight: DesignTokens.TapTarget.minimum,
-                        alignment: .leading
-                    )
-                    .contentShape(Rectangle())
                 }
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: DesignTokens.TapTarget.minimum,
+                    alignment: .leading
+                )
+                .contentShape(Rectangle())
                 .textLinkButtonStyle()
                 .accessibilityHint(isExpanded ? "Réduit la liste des mois" : "Affiche tous les mois")
             }

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalPlanTimelineSection.swift
@@ -82,6 +82,7 @@ struct GoalPlanTimelineSection: View {
                         Text(isExpanded ? "Voir moins" : "Voir tout le plan (\(months.count) mois)")
                         Spacer()
                         Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .accessibilityHidden(true)
                     }
                 }
                 .frame(

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift
@@ -158,7 +158,7 @@ struct GoalTrajectorySection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
             Text("Ta trajectoire")
-                .font(PulpeTypography.title)
+                .font(PulpeTypography.title2)
                 .foregroundStyle(Color.textPrimary)
 
             GoalProjectionChart(series: series, currency: currency)

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift
@@ -158,7 +158,7 @@ struct GoalTrajectorySection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
             Text("Ta trajectoire")
-                .font(PulpeTypography.headline)
+                .font(PulpeTypography.title)
                 .foregroundStyle(Color.textPrimary)
 
             GoalProjectionChart(series: series, currency: currency)
@@ -219,6 +219,8 @@ private struct SensitiveIf: ViewModifier {
 /// Pre-computed, index-based series for `GoalProjectionChart`. Building lives off
 /// the view body so the chart stays a pure renderer (reused read + simulation).
 struct GoalProjectionSeries: Equatable {
+    private static let minimumTickSeparation = 3
+
     struct Point: Identifiable, Equatable {
         let index: Int
         let value: Double
@@ -295,9 +297,17 @@ struct GoalProjectionSeries: Equatable {
 
     // MARK: - Helpers
 
-    private static func ticks(for months: [SavingsGoalPlanMonth], currentIndex: Int) -> [Tick] {
-        let indices = Set([0, currentIndex, months.count - 1]).sorted()
-        return indices.compactMap { index in
+    static func ticks(for months: [SavingsGoalPlanMonth], currentIndex: Int) -> [Tick] {
+        guard !months.isEmpty else { return [] }
+
+        let lastIndex = months.count - 1
+        var indices = [currentIndex, lastIndex]
+        if currentIndex >= minimumTickSeparation {
+            indices.append(0)
+        }
+
+        let uniqueIndices = Set(indices).sorted()
+        return uniqueIndices.compactMap { index in
             guard months.indices.contains(index) else { return nil }
             let month = months[index]
             return Tick(index: index, label: tickLabel(month: month.month, year: month.year))

--- a/ios/Pulpe/Features/SavingsGoals/GoalContributionsSection.swift
+++ b/ios/Pulpe/Features/SavingsGoals/GoalContributionsSection.swift
@@ -13,7 +13,7 @@ struct GoalContributionsSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
             Text("Ton suivi")
-                .font(PulpeTypography.title)
+                .font(PulpeTypography.title2)
                 .foregroundStyle(Color.textPrimary)
 
             if isLoading, contributions.isEmpty {

--- a/ios/Pulpe/Features/SavingsGoals/GoalContributionsSection.swift
+++ b/ios/Pulpe/Features/SavingsGoals/GoalContributionsSection.swift
@@ -13,7 +13,7 @@ struct GoalContributionsSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
             Text("Ton suivi")
-                .font(PulpeTypography.headline)
+                .font(PulpeTypography.title)
                 .foregroundStyle(Color.textPrimary)
 
             if isLoading, contributions.isEmpty {
@@ -75,11 +75,7 @@ struct GoalContributionsSection: View {
                         contributionTransactionRow(transaction)
                     }
                 }
-                .padding(DesignTokens.Spacing.md)
-                .background(
-                    Color.surfaceContainerHigh,
-                    in: RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.sm)
-                )
+                .padding(.leading, DesignTokens.IconSize.compact + DesignTokens.Spacing.md)
             }
         }
         .pulpeCard()

--- a/ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift
+++ b/ios/Pulpe/Features/SavingsGoals/SavingsGoalDetailView.swift
@@ -52,7 +52,7 @@ struct SavingsGoalDetailView: View {
             }
         }
         .navigationTitle(currentGoal.name)
-        .navigationBarTitleDisplayMode(.large)
+        .navigationBarTitleDisplayMode(.inline)
         .pulpeBackground()
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -95,9 +95,6 @@ struct SavingsGoalDetailView: View {
                     GoalEmptyGuidanceCard()
                 } else {
                     progressCard(progress: progress)
-                    if let pace = progress.paceStatus {
-                        paceChip(pace)
-                    }
                 }
 
                 GoalDerivedStateCards(
@@ -207,18 +204,14 @@ struct SavingsGoalDetailView: View {
 
             layeredBar(progress: progress)
 
+            if let pace = progress.paceStatus {
+                paceIndicator(pace)
+            }
+
             VStack(spacing: DesignTokens.Spacing.sm) {
                 if progress.initialAmount > 0 {
                     statRow(label: "Montant de départ", value: progress.initialAmount.asCompactCurrency(currency))
                 }
-                statRow(
-                    // « Épargné », pas « Pointé » : le confirmé additionne le
-                    // montant de départ, qui n'a jamais été pointé. « Pointé »
-                    // reste exact ligne à ligne (état checked, cf. glossaire).
-                    label: "Épargné",
-                    value: progress.confirmed.asCompactCurrency(currency),
-                    swatch: Color.financialSavings
-                )
                 statRow(
                     label: "Prévu cumulé",
                     value: progress.plannedCumulative.asCompactCurrency(currency),
@@ -230,10 +223,6 @@ struct SavingsGoalDetailView: View {
                         value: "\(required.asCompactCurrency(currency)) / mois"
                     )
                 }
-                statRow(
-                    label: "Projection à l'échéance",
-                    value: progress.projected.asCompactCurrency(currency)
-                )
             }
         }
         .pulpeCard()
@@ -280,8 +269,10 @@ struct SavingsGoalDetailView: View {
 
     // MARK: - Pace verdict
 
-    private func paceChip(_ pace: SavingsGoalPaceStatus) -> some View {
-        PulpeChip(icon: paceIcon(pace), label: paceLabel(pace), style: .muted)
+    private func paceIndicator(_ pace: SavingsGoalPaceStatus) -> some View {
+        Label(paceLabel(pace), systemImage: paceIcon(pace))
+            .font(PulpeTypography.metricLabelBold)
+            .foregroundStyle(Color.textSecondary)
             .accessibilityLabel("Rythme : \(paceLabel(pace))")
     }
 

--- a/ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift
+++ b/ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift
@@ -32,7 +32,7 @@ struct GoalPlanTimelinePresentationTests {
 
         #expect(collapsed.visibleMonths.map(\.month) == [7, 8, 9, 10])
         #expect(collapsed.hiddenCount == 1)
-        #expect(collapsed.unlinkedMonthCount == 3)
+        #expect(collapsed.remainingUnlinkedMonthCount == 3)
         #expect(expanded.visibleMonths.map(\.month) == [7, 8, 9, 10, 11])
         #expect(expanded.hiddenCount == 0)
     }
@@ -56,9 +56,30 @@ struct GoalPlanTimelinePresentationTests {
         #expect(collapsed.hiddenCount == 4)
     }
 
+    @Test("counts unlinked forecasts from the current month while preserving history")
+    func countsRemainingUnlinkedForecasts() {
+        let months = [
+            makeMonth(month: 4, state: .gap, isLocked: true),
+            makeMonth(month: 5, state: .past, isLocked: true, hasLinkedForecast: true),
+            makeMonth(month: 6, state: .gap, isLocked: true),
+            makeMonth(month: 7, state: .current),
+            makeMonth(month: 8, state: .future, hasLinkedForecast: true),
+            makeMonth(month: 9, state: .gap),
+            makeMonth(month: 10, state: .gap, isProvisionable: true),
+        ]
+
+        let collapsed = GoalPlanTimelinePresentation(months: months, isExpanded: false)
+        let expanded = GoalPlanTimelinePresentation(months: months, isExpanded: true)
+
+        #expect(expanded.visibleMonths.map(\.month) == [4, 5, 6, 7, 8, 9, 10])
+        #expect(GoalPlanMonthAvailability(month: months[0]) == .noLinkedForecast)
+        #expect(collapsed.remainingUnlinkedMonthCount == 3)
+    }
+
     private func makeMonth(
         month: Int,
         state: SavingsPlanMonthState,
+        isLocked: Bool = false,
         isProvisionable: Bool = false,
         hasLinkedForecast: Bool = false
     ) -> SavingsGoalPlanMonth {
@@ -77,7 +98,7 @@ struct GoalPlanTimelinePresentationTests {
             month: month,
             year: 2026,
             state: state,
-            isLocked: false,
+            isLocked: isLocked,
             isProvisionable: isProvisionable,
             plannedAmount: hasLinkedForecast ? 500 : 0,
             confirmedAmount: 0,

--- a/ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift
+++ b/ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift
@@ -6,9 +6,11 @@ import Testing
 struct GoalPlanTimelinePresentationTests {
     @Test("distinguishes a materialized month without a linked forecast from a missing budget")
     func distinguishesUnlinkedForecastFromMissingBudget() {
+        let august = makeMonth(month: 8, state: .future, hasLinkedForecast: true)
         let september = makeMonth(month: 9, state: .gap)
         let november = makeMonth(month: 11, state: .gap, isProvisionable: true)
 
+        #expect(GoalPlanMonthAvailability(month: august).icon == nil)
         #expect(GoalPlanMonthAvailability(month: september) == .noLinkedForecast)
         #expect(GoalPlanMonthAvailability(month: september).label == "Aucune prévision liée")
         #expect(GoalPlanMonthAvailability(month: november) == .missingBudget)
@@ -33,6 +35,25 @@ struct GoalPlanTimelinePresentationTests {
         #expect(collapsed.unlinkedMonthCount == 3)
         #expect(expanded.visibleMonths.map(\.month) == [7, 8, 9, 10, 11])
         #expect(expanded.hiddenCount == 0)
+    }
+
+    @Test("starts the collapsed window at the current month when the plan contains history")
+    func excludesPastMonthsFromCollapsedWindow() {
+        let months = [
+            makeMonth(month: 4, state: .past, hasLinkedForecast: true),
+            makeMonth(month: 5, state: .past, hasLinkedForecast: true),
+            makeMonth(month: 6, state: .past, hasLinkedForecast: true),
+            makeMonth(month: 7, state: .current, hasLinkedForecast: true),
+            makeMonth(month: 8, state: .future, hasLinkedForecast: true),
+            makeMonth(month: 9, state: .gap),
+            makeMonth(month: 10, state: .gap),
+            makeMonth(month: 11, state: .gap, isProvisionable: true),
+        ]
+
+        let collapsed = GoalPlanTimelinePresentation(months: months, isExpanded: false)
+
+        #expect(collapsed.visibleMonths.map(\.month) == [7, 8, 9, 10])
+        #expect(collapsed.hiddenCount == 4)
     }
 
     private func makeMonth(

--- a/ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift
+++ b/ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import Pulpe
 import Testing
 
+@Suite("GoalPlanTimelinePresentation Tests")
 struct GoalPlanTimelinePresentationTests {
     @Test("distinguishes a materialized month without a linked forecast from a missing budget")
     func distinguishesUnlinkedForecastFromMissingBudget() {

--- a/ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift
+++ b/ios/PulpeTests/Features/SavingsGoals/GoalPlanTimelinePresentationTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+struct GoalPlanTimelinePresentationTests {
+    @Test("distinguishes a materialized month without a linked forecast from a missing budget")
+    func distinguishesUnlinkedForecastFromMissingBudget() {
+        let september = makeMonth(month: 9, state: .gap)
+        let november = makeMonth(month: 11, state: .gap, isProvisionable: true)
+
+        #expect(GoalPlanMonthAvailability(month: september) == .noLinkedForecast)
+        #expect(GoalPlanMonthAvailability(month: september).label == "Aucune prévision liée")
+        #expect(GoalPlanMonthAvailability(month: november) == .missingBudget)
+        #expect(GoalPlanMonthAvailability(month: november).label == "Pas de budget")
+    }
+
+    @Test("keeps the current month plus three future months collapsed and exposes the full plan expanded")
+    func windowsAndExpandsThePlan() {
+        let months = [
+            makeMonth(month: 7, state: .current, hasLinkedForecast: true),
+            makeMonth(month: 8, state: .future, hasLinkedForecast: true),
+            makeMonth(month: 9, state: .gap),
+            makeMonth(month: 10, state: .gap),
+            makeMonth(month: 11, state: .gap, isProvisionable: true),
+        ]
+
+        let collapsed = GoalPlanTimelinePresentation(months: months, isExpanded: false)
+        let expanded = GoalPlanTimelinePresentation(months: months, isExpanded: true)
+
+        #expect(collapsed.visibleMonths.map(\.month) == [7, 8, 9, 10])
+        #expect(collapsed.hiddenCount == 1)
+        #expect(collapsed.unlinkedMonthCount == 3)
+        #expect(expanded.visibleMonths.map(\.month) == [7, 8, 9, 10, 11])
+        #expect(expanded.hiddenCount == 0)
+    }
+
+    private func makeMonth(
+        month: Int,
+        state: SavingsPlanMonthState,
+        isProvisionable: Bool = false,
+        hasLinkedForecast: Bool = false
+    ) -> SavingsGoalPlanMonth {
+        let lines = hasLinkedForecast
+            ? [
+                SavingsGoalPlanLine(
+                    budgetLineId: "line-\(month)",
+                    amount: 500,
+                    checkedAt: nil,
+                    isManuallyAdjusted: false
+                ),
+            ]
+            : []
+
+        return SavingsGoalPlanMonth(
+            month: month,
+            year: 2026,
+            state: state,
+            isLocked: false,
+            isProvisionable: isProvisionable,
+            plannedAmount: hasLinkedForecast ? 500 : 0,
+            confirmedAmount: 0,
+            plannedCumulative: month <= 8 ? Decimal(month - 6) * 500 : 1_000,
+            confirmedCumulative: 1_000,
+            lines: lines
+        )
+    }
+}

--- a/ios/PulpeTests/Features/SavingsGoals/GoalProjectionSeriesTests.swift
+++ b/ios/PulpeTests/Features/SavingsGoals/GoalProjectionSeriesTests.swift
@@ -1,6 +1,7 @@
 @testable import Pulpe
 import Testing
 
+@Suite("GoalProjectionSeries Tests")
 struct GoalProjectionSeriesTests {
     @Test("drops the start tick when it would collide with the current month")
     func dropsCrowdedStartTick() {

--- a/ios/PulpeTests/Features/SavingsGoals/GoalProjectionSeriesTests.swift
+++ b/ios/PulpeTests/Features/SavingsGoals/GoalProjectionSeriesTests.swift
@@ -1,0 +1,37 @@
+@testable import Pulpe
+import Testing
+
+struct GoalProjectionSeriesTests {
+    @Test("drops the start tick when it would collide with the current month")
+    func dropsCrowdedStartTick() {
+        let ticks = GoalProjectionSeries.ticks(for: makeMonths(count: 20), currentIndex: 2)
+
+        #expect(ticks.map(\.index) == [2, 19])
+    }
+
+    @Test("keeps start, current, and end ticks when they are sufficiently spaced")
+    func keepsSpacedTicks() {
+        let ticks = GoalProjectionSeries.ticks(for: makeMonths(count: 20), currentIndex: 8)
+
+        #expect(ticks.map(\.index) == [0, 8, 19])
+    }
+
+    private func makeMonths(count: Int) -> [SavingsGoalPlanMonth] {
+        (0..<count).map { offset in
+            let monthIndex = 4 + offset
+            let year = 2026 + (monthIndex - 1) / 12
+            let month = (monthIndex - 1) % 12 + 1
+            return SavingsGoalPlanMonth(
+                month: month,
+                year: year,
+                state: offset == 2 ? .current : .future,
+                isLocked: false,
+                plannedAmount: 500,
+                confirmedAmount: 0,
+                plannedCumulative: 500,
+                confirmedCumulative: 0,
+                lines: []
+            )
+        }
+    }
+}


### PR DESCRIPTION
## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Corrige le faux état « Pas de budget » dans le détail d’un objectif iOS et allège la hiérarchie visuelle de l’écran.

Linear: [PUL-8](https://linear.app/pulpe/issue/PUL-8/suivre-la-progression-dun-objectif-depargne)

## 🚶‍➡️ Behavior

- Distingue un budget absent d’un budget sans Prévision liée à l’objectif.
- Permet d’afficher puis de replier tout le plan mensuel.
- Corrige les collisions de dates de la trajectoire.
- Allège le résumé et les contributions en respectant le DS iOS existant.

## 🧪 Steps to test

- [ ] Ouvrir un objectif avec des budgets sans Prévision liée.
- [ ] Vérifier que ces mois n’affichent plus « Pas de budget ».
- [ ] Développer puis replier le plan complet.
- [ ] Vérifier le résumé, la trajectoire et les contributions.
- [x] Tests Swift ciblés : 4/4.
- [x] Build `PulpeLocal` sur iPhone 17 Pro Max, iOS 26.5.