### PR TITLE
feat: re-show the savings withdrawal nudge on deficit + reach the pioche from the + dialog

### DIFF
--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog-result.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog-result.ts
@@ -8,8 +8,10 @@ import type {
  * Discriminated result of the add-forecast dialog (PUL-17, PUL-292).
  * `single` → one budget line in the current month.
  * `spread` → N independent `one_off` lines, one per picked month.
- * `savingsWithdrawal` → the income "remise le mois prochain" toggle was ON: the
- *   caller opens the withdrawal dialog at its preview step, prefilled. Carries
+ * `savingsWithdrawal` → the income "remise le mois prochain" toggle was ON, or
+ *   the saving-kind "piocher dans mon épargne" shortcut was clicked: the caller
+ *   opens the withdrawal dialog, at its preview step when a prefill is carried
+ *   (no prefill → the dialog starts at its amount step). Carries
  *   `inputCurrency` so an amount typed in a foreign currency is not re-read as
  *   the user's currency by the withdrawal dialog.
  */
@@ -18,7 +20,7 @@ export type AddBudgetLineDialogResult =
   | { readonly mode: 'spread'; readonly value: BudgetLineSpreadCreate }
   | {
       readonly mode: 'savingsWithdrawal';
-      readonly prefill: {
+      readonly prefill?: {
         readonly amount: number;
         readonly source: string;
         readonly inputCurrency: SupportedCurrency;

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
@@ -60,6 +62,8 @@ function configureDialog({
     imports: [AddBudgetLineDialog],
     providers: [
       provideZonelessChangeDetection(),
+      provideHttpClient(),
+      provideHttpClientTesting(),
       provideAnimationsAsync(),
       ...provideTranslocoForTest(),
       {
@@ -376,6 +380,55 @@ describe('AddBudgetLineDialog', () => {
       expect(dto).not.toHaveProperty('originalCurrency');
       expect(dto).not.toHaveProperty('targetCurrency');
       expect(dto).not.toHaveProperty('exchangeRate');
+    });
+  });
+
+  describe('savings withdrawal shortcut (saving kind)', () => {
+    it('should render the pioche button only for the saving kind', () => {
+      const { fixture, component } = configureDialog();
+
+      component['model'].update((m) => ({ ...m, kind: 'saving' }));
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="open-savings-withdrawal"]',
+        ),
+      ).not.toBeNull();
+
+      component['model'].update((m) => ({ ...m, kind: 'expense' }));
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="open-savings-withdrawal"]',
+        ),
+      ).toBeNull();
+    });
+
+    it('should close with savingsWithdrawal mode and no prefill when no amount was typed', () => {
+      const { component, dialogRef } = configureDialog();
+
+      component['requestSavingsWithdrawal']();
+
+      expect(dialogRef.close).toHaveBeenCalledWith({
+        mode: 'savingsWithdrawal',
+      });
+    });
+
+    it('should carry the typed amount, trimmed name and input currency as prefill', () => {
+      const { component, dialogRef } = configureDialog();
+      component['model'].update((m) => ({
+        ...m,
+        name: '  Vacances  ',
+        kind: 'saving',
+        money: { amount: 250, inputCurrency: 'CHF' },
+      }));
+
+      component['requestSavingsWithdrawal']();
+
+      expect(dialogRef.close).toHaveBeenCalledWith({
+        mode: 'savingsWithdrawal',
+        prefill: { amount: 250, source: 'Vacances', inputCurrency: 'CHF' },
+      });
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.ts
@@ -655,14 +655,14 @@ export class AddBudgetLineDialog {
       await this.#submitSpread();
       return;
     }
-    const m = this.model();
-    if (m.kind === 'income' && this.repayNextMonth()) {
+    const lineDraft = this.model();
+    if (lineDraft.kind === 'income' && this.repayNextMonth()) {
       this.#dialogRef.close({
         mode: 'savingsWithdrawal',
         prefill: {
-          amount: m.money.amount ?? 0,
-          source: m.name.trim(),
-          inputCurrency: m.money.inputCurrency,
+          amount: lineDraft.money.amount ?? 0,
+          source: lineDraft.name.trim(),
+          inputCurrency: lineDraft.money.inputCurrency,
         },
       });
       return;
@@ -675,16 +675,16 @@ export class AddBudgetLineDialog {
   // hands over a prefill when an amount was actually typed (the withdrawal
   // dialog otherwise starts at its amount step with the deficit chip).
   protected requestSavingsWithdrawal(): void {
-    const m = this.model();
-    const amount = m.money.amount ?? 0;
+    const lineDraft = this.model();
+    const typedAmount = lineDraft.money.amount ?? 0;
     this.#dialogRef.close({
       mode: 'savingsWithdrawal',
-      ...(amount > 0
+      ...(typedAmount > 0
         ? {
             prefill: {
-              amount,
-              source: m.name.trim(),
-              inputCurrency: m.money.inputCurrency,
+              amount: typedAmount,
+              source: lineDraft.name.trim(),
+              inputCurrency: lineDraft.money.inputCurrency,
             },
           }
         : {}),
@@ -697,22 +697,23 @@ export class AddBudgetLineDialog {
       isSubmitting: this.isSubmitting,
       conversionError: this.conversionError,
       prepare: () => {
-        const m = this.model();
+        const lineDraft = this.model();
         return {
-          amountSlice: m.money,
+          amountSlice: lineDraft.money,
           targetCurrency: this.#settings.currency(),
           converter: this.#converter,
           logger: this.#logger,
           build: (amount, metadata) =>
             budgetLineCreateFromFormSchema.parse({
               budgetId: this.#data.budgetId,
-              name: m.name.trim(),
+              name: lineDraft.name.trim(),
               amount,
-              kind: m.kind,
-              recurrence: m.recurrence,
-              isChecked: m.isChecked,
-              tagIds: m.tagIds,
-              savingsGoalId: m.kind === 'saving' ? m.savingsGoalId : null,
+              kind: lineDraft.kind,
+              recurrence: lineDraft.recurrence,
+              isChecked: lineDraft.isChecked,
+              tagIds: lineDraft.tagIds,
+              savingsGoalId:
+                lineDraft.kind === 'saving' ? lineDraft.savingsGoalId : null,
               conversion: metadata,
             }),
         };
@@ -730,16 +731,16 @@ export class AddBudgetLineDialog {
       isSubmitting: this.isSubmitting,
       conversionError: this.conversionError,
       prepare: () => {
-        const m = this.model();
+        const lineDraft = this.model();
         return {
-          amountSlice: m.money,
+          amountSlice: lineDraft.money,
           targetCurrency: this.#settings.currency(),
           converter: this.#converter,
           logger: this.#logger,
           build: (amount, metadata) =>
             budgetLineSpreadCreateFromFormSchema.parse({
-              name: m.name.trim(),
-              kind: m.kind,
+              name: lineDraft.name.trim(),
+              kind: lineDraft.kind,
               mode: this.#amountMode(),
               amount,
               months: this.selectedMonths(),

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.ts
@@ -348,6 +348,15 @@ interface AddBudgetLineModel {
                   model.update((m) => ({ ...m, savingsGoalId: $event }))
                 "
               />
+              <button
+                matButton="tonal"
+                type="button"
+                (click)="requestSavingsWithdrawal()"
+                data-testid="open-savings-withdrawal"
+              >
+                <mat-icon>savings</mat-icon>
+                {{ 'budget.savingsWithdrawal.cta' | transloco }}
+              </button>
             }
             @if (model().kind === 'income') {
               <div class="flex items-center justify-between py-2 px-1">
@@ -659,6 +668,27 @@ export class AddBudgetLineDialog {
       return;
     }
     await this.#submitSingle();
+  }
+
+  // PUL-292 — saving-kind shortcut into the two-month withdrawal flow. Bypasses
+  // form validation on purpose: it redirects instead of submitting, and only
+  // hands over a prefill when an amount was actually typed (the withdrawal
+  // dialog otherwise starts at its amount step with the deficit chip).
+  protected requestSavingsWithdrawal(): void {
+    const m = this.model();
+    const amount = m.money.amount ?? 0;
+    this.#dialogRef.close({
+      mode: 'savingsWithdrawal',
+      ...(amount > 0
+        ? {
+            prefill: {
+              amount,
+              source: m.name.trim(),
+              inputCurrency: m.money.inputCurrency,
+            },
+          }
+        : {}),
+    });
   }
 
   async #submitSingle(): Promise<void> {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
@@ -261,8 +261,37 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
   });
 
   describe('shouldShowSavingsWithdrawalCard', () => {
-    it('shows the card on a current/future month in deficit with no pioche yet', () => {
+    it('shows the card on a current/future month in deficit', () => {
       expect(store.savingsWithdrawalDeficit()).toBe(1000);
+      expect(store.shouldShowSavingsWithdrawalCard()).toBe(true);
+    });
+
+    it('shows the card again when a pioche exists and the month is back in deficit', async () => {
+      const detailsWithExistingWithdrawal = createMockBudgetDetailsResponse({
+        budget: { id: mockBudgetId, month: 6, year: 2099 },
+        budgetLines: [
+          createMockBudgetLine({
+            id: 'expense-1',
+            budgetId: mockBudgetId,
+            name: 'Loyer',
+            amount: 1000,
+            kind: 'expense',
+          }),
+          createMockBudgetLine({
+            id: 'withdrawal-income-1',
+            budgetId: mockBudgetId,
+            name: 'compte maison',
+            amount: 500,
+            kind: 'income',
+            savingsWithdrawalGroupId: '00000000-0000-4000-8000-0000000000bb',
+          }),
+        ],
+        transactions: [],
+      });
+
+      await reloadWith(detailsWithExistingWithdrawal);
+
+      expect(store.savingsWithdrawalDeficit()).toBe(500);
       expect(store.shouldShowSavingsWithdrawalCard()).toBe(true);
     });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -390,9 +390,10 @@ export class BudgetDetailsStore {
     return compareBudgetPeriods(reference, this.#spreadLivePeriod()) >= 0;
   });
 
-  // PUL-292 (CA1) — the "mois un peu juste" card shows only when the viewed
-  // current/future month runs a deficit worth acting on, has no pioche yet, and
-  // wasn't dismissed. Gated on the rounded deficit rather than on raw
+  // PUL-292 (CA1) — the "mois un peu juste" card shows whenever the viewed
+  // current/future month runs a deficit worth acting on and wasn't dismissed —
+  // an existing pioche does NOT hide it: a month can dip back into deficit
+  // after a first withdrawal. Gated on the rounded deficit rather than on raw
   // `remaining`: a month balanced to the cent leaves float dust (-9e-13) that
   // would nudge the user towards a dialog with nothing to pre-fill.
   readonly shouldShowSavingsWithdrawalCard = computed<boolean>(() => {
@@ -400,10 +401,6 @@ export class BudgetDetailsStore {
     if (!details) return false;
     if (this.savingsWithdrawalDeficit() <= 0) return false;
     if (!this.#isViewedMonthCurrentOrFuture()) return false;
-    const hasWithdrawal = this.displayBudgetLines().some(
-      (line) => line.savingsWithdrawalGroupId != null,
-    );
-    if (hasWithdrawal) return false;
     return !this.#dismissedSavingsWithdrawalCardBudgetIds().includes(
       details.id,
     );

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsProjector.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsProjector.swift
@@ -169,7 +169,6 @@ final class BudgetDetailsProjector {
             isShowingOnlyUnchecked: ctx.filtersStore.isShowingOnlyUnchecked,
             canPostpone: ctx.dataStore.hasNextMonthBudget,
             nextMonthLabel: ctx.dataStore.nextMonthLabel,
-            hasSavingsWithdrawalLine: ctx.dataStore.budgetLines.contains { $0.savingsWithdrawalGroupId != nil },
             firstSectionKind: ctx.sections.first?.kind,
             canShowEmptyChecked: makeCanShowEmptyChecked(
                 dataStore: ctx.dataStore,

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsScreenState.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsScreenState.swift
@@ -68,11 +68,6 @@ struct BudgetDetailsScreenState: Equatable {
     /// confirmation / menu copy. Routed through the DTO for the same reason.
     let nextMonthLabel: String?
 
-    /// `true` when any line of the month already carries a
-    /// `savingsWithdrawalGroupId` (PUL-292). Gates the "mois un peu juste" card
-    /// out once a withdrawal exists — derived here so the view never scans lines.
-    let hasSavingsWithdrawalLine: Bool
-
     /// Kind of the first non-empty section after all filters. Drives the
     /// "first section gets the gestures tip" rule.
     let firstSectionKind: TransactionKind?
@@ -124,7 +119,6 @@ struct BudgetDetailsScreenState: Equatable {
         isShowingOnlyUnchecked: true,
         canPostpone: false,
         nextMonthLabel: nil,
-        hasSavingsWithdrawalLine: false,
         firstSectionKind: nil,
         canShowEmptyChecked: false,
         consumptionByLineId: [:],

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/SavingsWithdrawal/BudgetDetailsView+SavingsWithdrawalCard.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/SavingsWithdrawal/BudgetDetailsView+SavingsWithdrawalCard.swift
@@ -15,9 +15,9 @@ extension BudgetDetailsView {
     }
 
     /// Non-nil prefill when the deficit card should surface for the viewed month
-    /// (PUL-292, CA1/CA3): a current-or-future deficit, no existing withdrawal in
-    /// the month, not dismissed for this budget. The card offers |available| via
-    /// the sheet's quick-fill chip rather than imposing it.
+    /// (PUL-292, CA1/CA3): a current-or-future deficit, not dismissed for this
+    /// budget — an existing withdrawal does not hide it. The card offers
+    /// |available| via the sheet's quick-fill chip rather than imposing it.
     var tightMonthCardPrefill: SavingsWithdrawalPrefill? {
         let screenState = projector.screenState
         guard let month = screenState.hero.month, let year = screenState.hero.year else { return nil }
@@ -38,7 +38,6 @@ extension BudgetDetailsView {
         guard SavingsWithdrawalCardGate.shouldPresent(
             available: available,
             isCurrentOrFutureMonth: isCurrentOrFutureMonth,
-            hasWithdrawalLine: screenState.hasSavingsWithdrawalLine,
             isDismissed: isDismissed
         ) else { return nil }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/SavingsWithdrawal/TightMonthCard.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/SavingsWithdrawal/TightMonthCard.swift
@@ -1,20 +1,20 @@
 import SwiftUI
 
 /// Decides + persists whether the "mois un peu juste" card shows (PUL-292, CA1).
-/// Pure so the "current-or-future deficit, not already withdrawn, not dismissed"
-/// rule is testable without a view — mirrors `SavingsGoalsIntroGate`. Dismissal
-/// is keyed per budget id in a comma-joined `@AppStorage` string; the card
-/// surfaces at most once per month until the user acts or taps "Plus tard".
+/// Pure so the "current-or-future deficit, not dismissed" rule is testable
+/// without a view — mirrors `SavingsGoalsIntroGate`. An existing pioche does
+/// NOT hide the card: a month can dip back into deficit after a first
+/// withdrawal. Dismissal is keyed per budget id in a comma-joined `@AppStorage`
+/// string; "Plus tard" silences the card for that month.
 enum SavingsWithdrawalCardGate {
     static let storageKey = "dismissedSavingsWithdrawalCardBudgetIds"
 
     static func shouldPresent(
         available: Decimal,
         isCurrentOrFutureMonth: Bool,
-        hasWithdrawalLine: Bool,
         isDismissed: Bool
     ) -> Bool {
-        available < 0 && isCurrentOrFutureMonth && !hasWithdrawalLine && !isDismissed
+        available < 0 && isCurrentOrFutureMonth && !isDismissed
     }
 
     static func isDismissed(budgetId: String, in raw: String) -> Bool {

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/SavingsWithdrawalCardGateTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/SavingsWithdrawalCardGateTests.swift
@@ -1,0 +1,39 @@
+@testable import Pulpe
+import Testing
+
+/// The "mois un peu juste" card rule (PUL-292). Pure so it locks without a
+/// view. An existing pioche is deliberately NOT an input: the card returns
+/// whenever the current/future month dips back into deficit.
+struct SavingsWithdrawalCardGateTests {
+    @Test func presentsOnCurrentOrFutureDeficit() {
+        #expect(SavingsWithdrawalCardGate.shouldPresent(
+            available: -500,
+            isCurrentOrFutureMonth: true,
+            isDismissed: false
+        ))
+    }
+
+    @Test func hiddenWithoutDeficit() {
+        #expect(!SavingsWithdrawalCardGate.shouldPresent(
+            available: 0,
+            isCurrentOrFutureMonth: true,
+            isDismissed: false
+        ))
+    }
+
+    @Test func hiddenOnPastMonth() {
+        #expect(!SavingsWithdrawalCardGate.shouldPresent(
+            available: -500,
+            isCurrentOrFutureMonth: false,
+            isDismissed: false
+        ))
+    }
+
+    @Test func hiddenOnceDismissed() {
+        #expect(!SavingsWithdrawalCardGate.shouldPresent(
+            available: -500,
+            isCurrentOrFutureMonth: true,
+            isDismissed: true
+        ))
+    }
+}


### PR DESCRIPTION
## Contexte

Test preview (juillet 2026, déficit 2 000 € malgré une pioche de 197 €) : la carte « Un mois un peu juste ? » n'apparaissait plus, et le dialog + n'offrait aucun chemin visible vers la pioche quand on choisit Type = Épargne.

## Changements

- **Webapp — nudge** : `shouldShowSavingsWithdrawalCard` perd le guard one-shot `hasWithdrawal` — la carte revient tant que le mois courant/futur reste en déficit, pioche existante ou non. Dismissal « Plus tard » inchangée (persistée par budget).
- **Webapp — dialog +** : bouton « Piocher dans mon épargne » (`matButton="tonal"`) quand Type = Épargne, qui ferme le dialog en mode `savingsWithdrawal` et reprend montant/nom saisis comme prefill (`prefill` devient optionnel : sans lui, le dialog pioche démarre à l'étape montant avec le chip déficit). Zéro i18n nouveau (réutilise `budget.savingsWithdrawal.cta`).
- **iOS — parité** : `SavingsWithdrawalCardGate.shouldPresent` perd `hasWithdrawalLine` ; `hasSavingsWithdrawalLine` (consommateur unique) supprimé du ScreenState/Projector.
- **Refactor** : `const m = this.model()` → `lineDraft` sur les 4 méthodes du dialog (nit de review).

Aucun changement backend : l'index UNIQUE est par `(savings_withdrawal_group_id, kind)`, plusieurs pioches par budget sont déjà acceptées.

## Tests

- Frontend : suite complète verte (2346 tests), dont `budget-details-store-savings-withdrawal.spec.ts` (carte re-visible avec pioche existante + déficit) et `create/dialog.spec.ts` 20/20 (bouton rendu pour saving uniquement, payloads avec/sans prefill).
- iOS : build `PulpeLocal` vert + `SavingsWithdrawalCardGateTests` 4/4.
- `pnpm quality` : 11/11 tasks, 0 erreur.