### PR TITLE
chore(frontend): upgrade ngx-ziflux to 0.2.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "ngx-lottie": "^22.0.0",
     "ngx-turnstile": "^0.2.5",
     "ngx-unicode-spinners": "^2.0.0",
-    "ngx-ziflux": "^0.1.0",
+    "ngx-ziflux": "^0.2.0",
     "postcss": "^8.5.12",
     "posthog-js": "^1.364.4",
     "pulpe-shared": "workspace:*",

--- a/frontend/projects/webapp/src/app/core/lifecycle/resume-refresh.service.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/resume-refresh.service.ts
@@ -146,13 +146,9 @@ export class ResumeRefreshService {
 
       this.#budgetApi.cache.invalidate(['budget']);
       this.#budgetTemplatesApi.cache.invalidate(['templates']);
-      // Eager refetch, not an invalidation like the two above: settings drive
-      // currency and pay-day formatting across the app and are already painted
-      // by the time we resume, so leaving them stale would show the old values
-      // until something else happened to re-read them. Since ngx-ziflux 0.2.0
-      // this really does hit the network inside `staleTime`; that is wanted —
-      // resume only fires on bfcache/discarded restore, and the session refresh
-      // above has already paid a round-trip.
+      // Eager refetch rather than an invalidation like the two above: settings
+      // are already painted on resume, so stale currency and pay-day formatting
+      // would stay on screen until the next read.
       this.#userSettingsStore.reload();
       this.#logger.info('[ResumeRefresh] Soft refresh completed after resume', {
         reason,

--- a/frontend/projects/webapp/src/app/core/lifecycle/resume-refresh.service.ts
+++ b/frontend/projects/webapp/src/app/core/lifecycle/resume-refresh.service.ts
@@ -146,6 +146,13 @@ export class ResumeRefreshService {
 
       this.#budgetApi.cache.invalidate(['budget']);
       this.#budgetTemplatesApi.cache.invalidate(['templates']);
+      // Eager refetch, not an invalidation like the two above: settings drive
+      // currency and pay-day formatting across the app and are already painted
+      // by the time we resume, so leaving them stale would show the old values
+      // until something else happened to re-read them. Since ngx-ziflux 0.2.0
+      // this really does hit the network inside `staleTime`; that is wanted —
+      // resume only fires on bfcache/discarded restore, and the session refresh
+      // above has already paid a round-trip.
       this.#userSettingsStore.reload();
       this.#logger.info('[ResumeRefresh] Soft refresh completed after resume', {
         reason,

--- a/frontend/projects/webapp/src/app/core/tag/tag-store.spec.ts
+++ b/frontend/projects/webapp/src/app/core/tag/tag-store.spec.ts
@@ -1,24 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
-import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TagStore } from './tag-store';
 import { TagApi } from './tag-api';
 import { Logger } from '@core/logging/logger';
 import type { Tag } from 'pulpe-shared';
+import { createMockDataCache } from '@core/testing';
 
-const mockCache = {
-  get: vi.fn().mockReturnValue(null),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  prefetch: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockCache = createMockDataCache();
 
 const mockTags: Tag[] = [
   {

--- a/frontend/projects/webapp/src/app/core/testing/test-utils.ts
+++ b/frontend/projects/webapp/src/app/core/testing/test-utils.ts
@@ -66,6 +66,61 @@ export function createMockSupabaseClient(): MockSupabaseClient {
 }
 
 /**
+ * Mock interface for a ngx-ziflux `DataCache`.
+ *
+ * `_fetch` and `_settle` are `@internal` in ngx-ziflux and stripped from its
+ * published types, yet `cachedResource` calls them on every load. They have to
+ * be stubbed here and cannot be checked against the real `DataCache` type, so
+ * call sites cast this mock at the injection point.
+ */
+export interface MockDataCache {
+  get: Mock;
+  set: Mock;
+  has: Mock;
+  invalidate: Mock;
+  deduplicate: Mock;
+  prefetch: Mock;
+  clear: Mock;
+  _fetch: Mock;
+  _settle: Mock;
+  version: WritableSignal<number>;
+  _dataVersion: WritableSignal<number>;
+}
+
+/**
+ * Creates a mock DataCache carrying everything `cachedResource` and
+ * `cachedMutation` reach for: both version signals, the read/write methods, and
+ * the internal fetch pair.
+ *
+ * `_fetch` delegates to `deduplicate`, mirroring ngx-ziflux where `_fetch` is
+ * `deduplicate()` plus the record `_settle()` reads. A spec overriding
+ * `deduplicate` therefore still controls what the loader resolves with.
+ */
+export function createMockDataCache(): MockDataCache {
+  const mock: MockDataCache = {
+    get: vi.fn().mockReturnValue(null),
+    set: vi.fn(),
+    has: vi.fn().mockReturnValue(false),
+    invalidate: vi.fn(),
+    deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
+    prefetch: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
+    clear: vi.fn(),
+    _fetch: vi.fn(async (key: string[], fn: () => Promise<unknown>) => ({
+      data: await mock.deduplicate(key, fn),
+      record: { promise: Promise.resolve(), raced: false, superseded: false },
+    })),
+    // Mirrors the real `_settle`, which writes through to `set()`, so specs
+    // asserting on `set` keep observing the same calls they did before 0.2.0.
+    _settle: vi.fn((key: string[], result: { data: unknown }, write = true) => {
+      if (write) mock.set(key, result.data);
+    }),
+    version: signal(0),
+    _dataVersion: signal(0),
+  };
+  return mock;
+}
+
+/**
  * Creates a type-safe mock ResourceRef for testing
  * @param initialValue The initial value for the resource
  * @returns A mocked ResourceRef with all required methods

--- a/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.spec.ts
+++ b/frontend/projects/webapp/src/app/core/user-settings/user-settings-store.spec.ts
@@ -10,19 +10,9 @@ import { AuthStore } from '../auth/auth-store';
 import { ClientKeyService } from '../encryption/client-key.service';
 import { DemoModeService } from '../demo/demo-mode.service';
 import type { UserSettings } from 'pulpe-shared';
+import { createMockDataCache } from '@core/testing';
 
-const mockCache = {
-  get: vi.fn().mockReturnValue(null),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  prefetch: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockCache = createMockDataCache();
 
 describe('UserSettingsStore', () => {
   let store: UserSettingsStore;

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-details-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-details-store.spec.ts
@@ -1,23 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { of } from 'rxjs';
 import { TemplateDetailsStore } from './template-details-store';
 import { type BudgetTemplateDetailViewModel } from './template-details-store';
 import { BudgetTemplatesApi } from '@core/budget-template/budget-templates-api';
+import { createMockDataCache } from '@core/testing';
 
-const mockCache = {
-  get: vi.fn().mockReturnValue(null),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  prefetch: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockCache = createMockDataCache();
 
 describe('TemplateDetailsStore', () => {
   let store: TemplateDetailsStore;

--- a/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-line-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/details/services/template-line-store.spec.ts
@@ -17,6 +17,7 @@ import {
   type TemplateLineFormInput,
 } from './template-line-store';
 import { TemplateDetailsStore } from './template-details-store';
+import { createMockDataCache, type MockDataCache } from '@core/testing';
 
 const TEMPLATE_ID = 'template-1';
 
@@ -84,7 +85,7 @@ describe('TemplateLineStore', () => {
   >;
   let templatesApiMock: {
     bulkOperationsTemplateLines$: ReturnType<typeof vi.fn>;
-    cache: Record<string, unknown>;
+    cache: MockDataCache;
   };
   let budgetApiMock: { cache: { invalidate: ReturnType<typeof vi.fn> } };
   let detailsStoreMock: {
@@ -109,20 +110,7 @@ describe('TemplateLineStore', () => {
 
     templatesApiMock = {
       bulkOperationsTemplateLines$: vi.fn(),
-      cache: {
-        version: signal(0),
-        _dataVersion: signal(0),
-        get: vi.fn().mockReturnValue(null),
-        set: vi.fn(),
-        has: vi.fn().mockReturnValue(false),
-        invalidate: vi.fn(),
-        deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) =>
-          fn(),
-        ),
-        prefetch: vi.fn(),
-        clear: vi.fn(),
-        clearDirty: vi.fn(),
-      },
+      cache: createMockDataCache(),
     };
 
     budgetApiMock = {

--- a/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/services/budget-templates-store.spec.ts
@@ -1,24 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
-import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { BudgetTemplatesStore } from './budget-templates-store';
 import { BudgetTemplatesApi } from '@core/budget-template/budget-templates-api';
 import type { BudgetTemplate, BudgetTemplateCreate } from 'pulpe-shared';
+import { createMockDataCache } from '@core/testing';
 
-const mockCache = {
-  get: vi.fn().mockReturnValue(null),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  prefetch: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockCache = createMockDataCache();
 
 describe('BudgetTemplatesStore', () => {
   let store: BudgetTemplatesStore;

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import {
   provideHttpClientTesting,
@@ -22,6 +22,7 @@ import {
   createMockTransaction,
 } from '../../../../testing/mock-factories';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import { createMockDataCache, type MockDataCache } from '@core/testing';
 
 // Mock data
 const mockBudgetId = 'budget-123';
@@ -85,7 +86,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
     deleteTransaction$: ReturnType<typeof vi.fn>;
     toggleTransactionCheck$: ReturnType<typeof vi.fn>;
     postponeTransaction$: ReturnType<typeof vi.fn>;
-    cache: Record<string, unknown>;
+    cache: MockDataCache;
   };
   let mockLogger: {
     debug: ReturnType<typeof vi.fn>;
@@ -131,20 +132,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       deleteTransaction$: vi.fn(),
       toggleTransactionCheck$: vi.fn(),
       postponeTransaction$: vi.fn(),
-      cache: {
-        version: signal(0),
-        _dataVersion: signal(0),
-        get: vi.fn().mockReturnValue(null),
-        set: vi.fn(),
-        has: vi.fn().mockReturnValue(false),
-        invalidate: vi.fn(),
-        deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) =>
-          fn(),
-        ),
-        prefetch: vi.fn().mockResolvedValue(undefined),
-        clear: vi.fn(),
-        clearDirty: vi.fn(),
-      },
+      cache: createMockDataCache(),
     };
 
     mockLogger = {
@@ -176,20 +164,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
           provide: SavingsGoalApi,
           useValue: {
             getAll$: vi.fn().mockReturnValue(of({ success: true, data: [] })),
-            cache: {
-              version: signal(0),
-              _dataVersion: signal(0),
-              get: vi.fn().mockReturnValue(null),
-              set: vi.fn(),
-              has: vi.fn().mockReturnValue(false),
-              invalidate: vi.fn(),
-              deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) =>
-                fn(),
-              ),
-              prefetch: vi.fn(),
-              clear: vi.fn(),
-              clearDirty: vi.fn(),
-            },
+            cache: createMockDataCache(),
           },
         },
         { provide: Logger, useValue: mockLogger },

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
@@ -23,6 +23,7 @@ import {
   createMockBudgetLine,
 } from '../../../../testing/mock-factories';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import { createMockDataCache } from '@core/testing';
 
 const mockBudgetId = 'budget-savings-withdrawal-test';
 
@@ -121,18 +122,7 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
     await waitFor(() => store.savingsWithdrawalDeficit() !== 1000);
   };
 
-  const makeCache = () => ({
-    version: signal(0),
-    _dataVersion: signal(0),
-    get: vi.fn().mockReturnValue(null),
-    set: vi.fn(),
-    has: vi.fn().mockReturnValue(false),
-    invalidate: vi.fn(),
-    deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-    prefetch: vi.fn(),
-    clear: vi.fn(),
-    clearDirty: vi.fn(),
-  });
+  const makeCache = () => createMockDataCache();
 
   beforeEach(async () => {
     localStorage.clear();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-search.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-search.spec.ts
@@ -21,6 +21,7 @@ import {
   createMockTransaction,
 } from '../../../../testing/mock-factories';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import { createMockDataCache } from '@core/testing';
 
 const mockBudgetId = 'budget-search-test';
 
@@ -133,40 +134,14 @@ describe('BudgetDetailsStore - Search Filtering', () => {
               .fn()
               .mockReturnValue(of(mockBudgetDetailsResponse)),
             getAllBudgets$: vi.fn().mockReturnValue(of([])),
-            cache: {
-              version: signal(0),
-              _dataVersion: signal(0),
-              get: vi.fn().mockReturnValue(null),
-              set: vi.fn(),
-              has: vi.fn().mockReturnValue(false),
-              invalidate: vi.fn(),
-              deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) =>
-                fn(),
-              ),
-              prefetch: vi.fn(),
-              clear: vi.fn(),
-              clearDirty: vi.fn(),
-            },
+            cache: createMockDataCache(),
           },
         },
         {
           provide: SavingsGoalApi,
           useValue: {
             getAll$: vi.fn().mockReturnValue(of({ success: true, data: [] })),
-            cache: {
-              version: signal(0),
-              _dataVersion: signal(0),
-              get: vi.fn().mockReturnValue(null),
-              set: vi.fn(),
-              has: vi.fn().mockReturnValue(false),
-              invalidate: vi.fn(),
-              deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) =>
-                fn(),
-              ),
-              prefetch: vi.fn(),
-              clear: vi.fn(),
-              clearDirty: vi.fn(),
-            },
+            cache: createMockDataCache(),
           },
         },
         { provide: Logger, useValue: { error: vi.fn() } },

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-spread.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-spread.spec.ts
@@ -21,6 +21,7 @@ import { PostHogService } from '@core/analytics/posthog';
 import { UserSettingsStore } from '@core/user-settings';
 import { createMockBudgetDetailsResponse } from '../../../../testing/mock-factories';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import { createMockDataCache } from '@core/testing';
 
 /**
  * Integration: the réalisé tracker exposed by the store, the single source every
@@ -144,40 +145,14 @@ describe('BudgetDetailsStore — spread réalisé tracker', () => {
             createBudgetLineSpread$: vi
               .fn()
               .mockReturnValue(throwError(() => recalcError)),
-            cache: {
-              version: signal(0),
-              _dataVersion: signal(0),
-              get: vi.fn().mockReturnValue(null),
-              set: vi.fn(),
-              has: vi.fn().mockReturnValue(false),
-              invalidate: vi.fn(),
-              deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) =>
-                fn(),
-              ),
-              prefetch: vi.fn(),
-              clear: vi.fn(),
-              clearDirty: vi.fn(),
-            },
+            cache: createMockDataCache(),
           },
         },
         {
           provide: SavingsGoalApi,
           useValue: {
             getAll$: vi.fn().mockReturnValue(of({ success: true, data: [] })),
-            cache: {
-              version: signal(0),
-              _dataVersion: signal(0),
-              get: vi.fn().mockReturnValue(null),
-              set: vi.fn(),
-              has: vi.fn().mockReturnValue(false),
-              invalidate: vi.fn(),
-              deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) =>
-                fn(),
-              ),
-              prefetch: vi.fn(),
-              clear: vi.fn(),
-              clearDirty: vi.fn(),
-            },
+            cache: createMockDataCache(),
           },
         },
         { provide: Logger, useValue: { error: vi.fn() } },

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -194,9 +194,7 @@ export class BudgetDetailsStore {
       return id ? { spreadGroupId: id } : undefined;
     },
     loader: ({ params }) =>
-      firstValueFrom(
-        this.#budgetApi.getSpreadOccurrences$(params.spreadGroupId),
-      ),
+      this.#budgetApi.getSpreadOccurrences$(params.spreadGroupId),
   });
 
   readonly spreadOccurrences = computed(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-store.spec.ts
@@ -6,18 +6,9 @@ import { BudgetListStore } from './budget-list-store';
 import { BudgetApi } from '@core/budget/budget-api';
 import { UserSettingsStore } from '@core/user-settings';
 import { createMockBudget } from '@app/testing/mock-factories';
+import { createMockDataCache } from '@core/testing';
 
-const mockCache = {
-  get: vi.fn().mockReturnValue(null),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockCache = createMockDataCache();
 
 const mockUserSettingsStore = {
   payDayOfMonth: signal<number | null>(25),

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/budget-creation-dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/budget-creation-dialog.spec.ts
@@ -141,7 +141,7 @@ describe('CreateBudgetDialogComponent', () => {
     const selectedTemplateSignal = signal<BudgetTemplate | null>(null);
     const templateTotalsMapSignal = signal<Record<string, TemplateTotals>>({});
     const isLoadingSignal = signal<boolean>(false);
-    const errorSignal = signal<Error | null>(null);
+    const errorSignal = signal<Error | undefined>(undefined);
     const isCreatingBudgetSignal = signal<boolean>(false);
     const createBudgetErrorSignal = signal<unknown>(undefined);
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/services/template-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/services/template-store.spec.ts
@@ -1,35 +1,16 @@
 import { TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { of, switchMap } from 'rxjs';
 import { type TemplateLine } from 'pulpe-shared';
 import { TemplateStore } from './template-store';
 import { BudgetApi } from '@core/budget/budget-api';
 import { BudgetTemplatesApi } from '@core/budget-template/budget-templates-api';
 import { Logger } from '@core/logging/logger';
+import { createMockDataCache } from '@core/testing';
 
-const mockCache = {
-  get: vi.fn().mockReturnValue(undefined),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockCache = createMockDataCache();
 
-const mockBudgetCache = {
-  get: vi.fn().mockReturnValue(undefined),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockBudgetCache = createMockDataCache();
 
 describe('TemplateStore', () => {
   let store: TemplateStore;

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.spec.ts
@@ -7,6 +7,7 @@ import { BudgetApi } from '@core/budget';
 import { UserSettingsStore } from '@core/user-settings';
 import { Logger } from '@core/logging/logger';
 import { PostHogService } from '@core/analytics/posthog';
+import { createMockDataCache } from '@core/testing';
 import type { Budget, BudgetLine, Transaction } from 'pulpe-shared';
 import { BudgetFormulas } from 'pulpe-shared';
 
@@ -68,21 +69,22 @@ function createMockTransaction(overrides: Partial<Transaction>): Transaction {
 
 // ── Mock setup ──
 function createMocks() {
-  const deduplicate = (() => {
-    const inflight = new Map<string, Promise<unknown>>();
-    return vi
-      .fn()
-      .mockImplementation((key: string[], fn: () => Promise<unknown>) => {
-        const k = Array.isArray(key) ? key.join('|') : String(key);
-        const existing = inflight.get(k);
-        if (existing) return existing;
-        const p = Promise.resolve()
-          .then(() => fn())
-          .finally(() => inflight.delete(k));
-        inflight.set(k, p);
-        return p;
-      });
-  })();
+  // Real in-flight deduplication, so the specs exercise the shared-promise path.
+  // `_fetch` delegates to `deduplicate`, so overriding it here is enough.
+  const cache = createMockDataCache();
+  const inflight = new Map<string, Promise<unknown>>();
+  cache.deduplicate.mockImplementation(
+    (key: string[], fn: () => Promise<unknown>) => {
+      const k = Array.isArray(key) ? key.join('|') : String(key);
+      const existing = inflight.get(k);
+      if (existing) return existing;
+      const p = Promise.resolve()
+        .then(() => fn())
+        .finally(() => inflight.delete(k));
+      inflight.set(k, p);
+      return p;
+    },
+  );
 
   return {
     budgetApi: {
@@ -95,16 +97,7 @@ function createMocks() {
       getBudgetById$: vi.fn().mockReturnValue(of(createMockBudget())),
       createTransaction$: vi.fn(),
       toggleBudgetLineCheck$: vi.fn(),
-      cache: {
-        version: signal(0),
-        _dataVersion: signal(0),
-        get: vi.fn().mockReturnValue(null),
-        set: vi.fn(),
-        invalidate: vi.fn(),
-        deduplicate,
-        prefetch: vi.fn(),
-        clearDirty: vi.fn(),
-      },
+      cache,
     },
     logger: {
       error: vi.fn(),

--- a/frontend/projects/webapp/src/app/feature/savings-goals/services/savings-goals-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/services/savings-goals-store.spec.ts
@@ -10,8 +10,6 @@ import { BudgetTemplatesApi } from '@core/budget-template/budget-templates-api';
 import { ApiError } from '@core/api/api-error';
 import { createMockDataCache } from '@core/testing';
 
-// ngx-ziflux 0.0.13 DataCache mock — MUST carry both `version` and
-// `_dataVersion` signals or cachedResource crashes at first snapshot read.
 const mockCache = createMockDataCache();
 
 const mockBudgetCache = { invalidate: vi.fn() };

--- a/frontend/projects/webapp/src/app/feature/savings-goals/services/savings-goals-store.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/services/savings-goals-store.spec.ts
@@ -1,28 +1,18 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
-import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideZonelessChangeDetection } from '@angular/core';
 import type { SavingsGoal, SavingsGoalProgress } from 'pulpe-shared';
 import { SavingsGoalStore } from './savings-goals-store';
 import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
 import { BudgetApi } from '@core/budget/budget-api';
 import { BudgetTemplatesApi } from '@core/budget-template/budget-templates-api';
 import { ApiError } from '@core/api/api-error';
+import { createMockDataCache } from '@core/testing';
 
 // ngx-ziflux 0.0.13 DataCache mock — MUST carry both `version` and
 // `_dataVersion` signals or cachedResource crashes at first snapshot read.
-const mockCache = {
-  get: vi.fn().mockReturnValue(null),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  prefetch: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockCache = createMockDataCache();
 
 const mockBudgetCache = { invalidate: vi.fn() };
 const mockTemplateCache = { invalidate: vi.fn() };

--- a/frontend/projects/webapp/src/app/feature/savings-goals/services/savings-goals-store.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/services/savings-goals-store.ts
@@ -59,9 +59,7 @@ export class SavingsGoalStore {
       return id ? { goalId: id } : undefined;
     },
     loader: ({ params }) =>
-      firstValueFrom(
-        this.#api.getProgress$(params.goalId).pipe(map((res) => res.data)),
-      ),
+      this.#api.getProgress$(params.goalId).pipe(map((res) => res.data)),
   });
 
   readonly progress = computed<SavingsGoalProgress | null>(
@@ -82,9 +80,7 @@ export class SavingsGoalStore {
       return id ? { goalId: id } : undefined;
     },
     loader: ({ params }) =>
-      firstValueFrom(
-        this.#api.getContributions$(params.goalId).pipe(map((res) => res.data)),
-      ),
+      this.#api.getContributions$(params.goalId).pipe(map((res) => res.data)),
   });
 
   readonly contributions = computed<SavingsGoalContribution[]>(
@@ -210,11 +206,9 @@ export class SavingsGoalStore {
       return goal && goal.status !== 'ACTIVE' ? { goalId: goal.id } : undefined;
     },
     loader: ({ params }) =>
-      firstValueFrom(
-        this.#api
-          .getFutureLines$(params.goalId)
-          .pipe(map((res) => res.data ?? [])),
-      ),
+      this.#api
+        .getFutureLines$(params.goalId)
+        .pipe(map((res) => res.data ?? [])),
   });
 
   readonly futureLines = computed<SavingsGoalFutureLine[]>(

--- a/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.spec.ts
+++ b/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.spec.ts
@@ -1,4 +1,4 @@
-import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
@@ -9,19 +9,9 @@ import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { setTestInput } from '@app/testing/signal-test-utils';
 import { SavingsGoalPickerField } from './savings-goal-picker-field';
+import { createMockDataCache } from '@core/testing';
 
-const mockCache = {
-  get: vi.fn().mockReturnValue(null),
-  set: vi.fn(),
-  has: vi.fn().mockReturnValue(false),
-  invalidate: vi.fn(),
-  deduplicate: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  prefetch: vi.fn((_key: string[], fn: () => Promise<unknown>) => fn()),
-  clear: vi.fn(),
-  clearDirty: vi.fn(),
-  version: signal(0),
-  _dataVersion: signal(0),
-};
+const mockCache = createMockDataCache();
 
 const goal = {
   id: 'goal-1',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))
       ngx-ziflux:
-        specifier: ^0.1.0
-        version: 0.1.0(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2)
+        specifier: ^0.2.0
+        version: 0.2.0(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2)
       postcss:
         specifier: ^8.5.12
         version: 8.5.22
@@ -6651,8 +6651,8 @@ packages:
     peerDependencies:
       '@angular/core': ^22.0.0
 
-  ngx-ziflux@0.1.0:
-    resolution: {integrity: sha512-If5rtdcIVkOCOHEbBWK63XzaqLziMMF9XyAq/sI17SxExBvmBYQ9mepJh6jXcVXaaV77Jw19on+nO9omH8/GUw==}
+  ngx-ziflux@0.2.0:
+    resolution: {integrity: sha512-/D41lJAHx6jthc24dNDB6htdrgt0Hz3c+I3w7mh+X3NPah4QzutGcH1wSLGX4iJr8u2C8N8jmVvUnsARydZBEw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@angular/common': ^22.0.0
@@ -15077,12 +15077,11 @@ snapshots:
       '@angular/core': 22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)
       tslib: 2.8.1
 
-  ngx-ziflux@0.1.0(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2):
+  ngx-ziflux@0.2.0(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2):
     dependencies:
       '@angular/common': 22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2)
       '@angular/core': 22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)
       rxjs: 7.8.2
-      tslib: 2.8.1
 
   nice-try@1.0.5: {}
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -382,7 +382,7 @@
       "source": "neogenz/ziflux",
       "sourceType": "github",
       "skillPath": "skills/ziflux-expert/SKILL.md",
-      "computedHash": "23c935514e7ace8eff0b65367a53ceea616a603023d051fd28a5c85cdfe66a95"
+      "computedHash": "e511f14513be76d4dfc50612a99fe9ab8a6699c3d706d02af5fc5ad7da10b65f"
     }
   }
 }


### PR DESCRIPTION
Bumps the webapp from ngx-ziflux 0.1.0 to 0.2.0 and repairs what the release breaks.

## The break wasn't the one MIGRATION.md advertises

`cachedResource` swapped its internal cache API between the two versions:

```
0.1.0  cache.deduplicate(k, fn) -> cache.set(k, data) -> cache.clearDirty(k)
0.2.0  cache._fetch(k, fn) -> cache._settle(k, result, write)
```

Fourteen spec files hand-rolled a `DataCache` object literal stubbing the old pair. Thirteen
of them died on `cache._fetch is not a function` as soon as a loader ran: **13 files, 140
tests**. (`template-line-store.spec.ts` survived — its store only uses `cachedMutation`,
which still just calls `cache.invalidate()`.)

Every copy is replaced by one `createMockDataCache()` in `core/testing`, so the next ziflux
internal change is a one-file edit rather than a fourteen-file sweep. `_fetch` delegates to
`deduplicate` there, mirroring ziflux itself, which keeps the five specs that override
`deduplicate` working untouched — including the real in-flight dedup closure in
`dashboard-store.spec.ts`.

Worth knowing upstream: `_fetch` and `_settle` are `@internal` and stripped from the
published `.d.ts`, yet `cachedResource` calls them on every load. A consumer cannot type a
mock of them against `DataCache`.

## The five source-breaking changes, checked one by one

| Announced in MIGRATION.md | Found here |
| --- | --- |
| `cachedMutation` throws when `cache` and `invalidateKeys` aren't paired | all 30 call sites already pair them |
| `CacheEntry` gained a required `invalidated` | no `CacheEntry` literal exists |
| `hasValue()` became a type guard | the ~25 `value() ?? []` are in `computed`, not behind a guard — build is warning-free, no NG8102 |
| hand-written `hasValue` doubles break | the three found mock the *store*, not the ref |
| `error` is now typed | one real hit: `signal<Error \| null>(null)` no longer satisfies `Signal<Error \| undefined>` |

That last one was not in the plan's projection — it surfaced from `typecheck:spec`, which is
the only gate that compiles spec files.

## Behavior change: `reload()` actually refetches now

It used to return without a request inside `staleTime`. 15 call sites gain a real network
call, and fourteen of them are places where the old no-op was a latent bug —
`dashboard-store.refreshData()` did nothing when pressed within 30 s of load, and the tags
retry button did nothing within 60 s.

The fifteenth, `resume-refresh.service.ts`, is the only one that gains an unrequested
request. It is kept, with the reason in the file: `#runSoftRefresh` fires only on
`pageshow.persisted` or a discarded-tab restore — never on tab focus — and it already
awaits `refreshSession()` before that line.

Invalidation cost was measured on real `DataCache` instances rather than reasoned about:
one budget mutation costs **1** goal-progress refetch, three in the same tick cost **1**,
three across ticks cost **3**. `version` is bumped only by `invalidate()` and `clear()`.

Not adopted: `refetchOnWindowFocus` (listens on `visibilitychange`, the event iOS Safari
does *not* fire on app-switch restore — the reason `ResumeRefreshService` exists),
`refetchOnReconnect`, `id` (no SSR), `defaultValue` (would retire the `?? []` fallbacks —
a refactor, not an upgrade).

## Verification

`pnpm quality` (11/11), 195 spec files / 2360 tests, `pnpm build` warning-free.

---

## Ajouté après la première revue

**Quatre loaders rendus annulables.** 0.2.0 désabonne un loader Observable quand Angular abandonne la requête, ce qui annule l'appel `HttpClient` sous-jacent. L'envelopper dans `firstValueFrom()` jette ce bénéfice : ziflux reçoit une Promise qu'il ne peut pas annuler. Les quatre cas mono-appel (progression, contributions et lignes futures d'un objectif d'épargne, occurrences de lissage) passent maintenant l'Observable directement. Tous sont keyés sur un paramètre de route, donc ils s'abandonnent quand l'utilisateur change d'objectif ou de budget. Sémantique inchangée : ziflux pipe `take(1)`.

Pas touché : les loaders de `template-details-store` et `budget-details-store` composent deux appels derrière `Promise.all`/`async` — il faudrait les réécrire en `forkJoin` pour le même bénéfice.

**Skill `ziflux-expert` remis à jour** (`skills-lock.json`) : il était épinglé sur une révision documentant Angular 21+, `error: Signal<unknown>` et `hasValue(): boolean`.

Vérifié et laissé tel quel : `live-conversion-preview.ts` utilise `isLoading()` plutôt que `isInitialLoading()` — c'est délibéré, afficher un taux de change d'une autre paire pendant le reload serait faux, et le commentaire sur place le dit.
