### PR TITLE
perf(auth): carry the pay day on the authenticated user

### DIFF
--- a/backend-nest/src/common/decorators/user.decorator.ts
+++ b/backend-nest/src/common/decorators/user.decorator.ts
@@ -7,6 +7,12 @@ export interface AuthenticatedUser {
   readonly lastName?: string;
   readonly accessToken: string;
   readonly clientKey: Buffer;
+  /**
+   * Jour de paie, déjà chargé par le guard avec le reste des métadonnées.
+   * Optionnel pour ne pas imposer sa présence aux fabriques de tests : absent
+   * vaut `null`, que `getBudgetPeriodForDate` traite en comportement calendaire.
+   */
+  readonly payDayOfMonth?: number | null;
 }
 
 export const User = createParamDecorator(

--- a/backend-nest/src/common/guards/auth.guard.spec.ts
+++ b/backend-nest/src/common/guards/auth.guard.spec.ts
@@ -6,10 +6,13 @@ import { ClsService } from 'nestjs-cls';
 import { AuthGuard } from './auth.guard';
 import { SupabaseService } from '@modules/supabase/supabase.service';
 import { BusinessException } from '@common/exceptions/business.exception';
+import { PAY_DAY_MAX } from 'pulpe-shared';
+import type { AuthenticatedUser } from '@common/decorators/user.decorator';
 import {
   createMockAuthenticatedUser,
   createMockSupabaseClient,
   expectErrorThrown,
+  MOCK_USER_ID,
   MockSupabaseClient,
 } from '../../test/test-mocks';
 
@@ -304,6 +307,66 @@ describe('AuthGuard', () => {
       expect(
         (mockRequest as typeof mockRequest & { user: unknown }).user,
       ).toEqual(mockUser);
+    });
+
+    // The guard already loads user_metadata for every request. Carrying the pay
+    // day here is what lets downstream code stop re-asking GoTrue for it.
+    it('should carry a clamped payDayOfMonth from the user metadata', async () => {
+      const mockRequest = {
+        headers: {
+          authorization: 'Bearer valid-token',
+          'x-client-key': 'ab'.repeat(32),
+        },
+      };
+      const mockContext = {
+        switchToHttp: () => ({ getRequest: () => mockRequest }),
+        getHandler: () => ({}),
+        getClass: () => ({}),
+      } as ExecutionContext;
+
+      mockSupabaseClient
+        .setMockData({
+          id: MOCK_USER_ID,
+          email: 'test@example.com',
+          user_metadata: { payDayOfMonth: 99 },
+        })
+        .setMockError(null);
+
+      await authGuard.canActivate(mockContext);
+
+      expect(
+        (mockRequest as typeof mockRequest & { user: AuthenticatedUser }).user
+          .payDayOfMonth,
+      ).toBe(PAY_DAY_MAX);
+    });
+
+    it('should carry a null payDayOfMonth when the metadata holds none', async () => {
+      const mockRequest = {
+        headers: {
+          authorization: 'Bearer valid-token',
+          'x-client-key': 'ab'.repeat(32),
+        },
+      };
+      const mockContext = {
+        switchToHttp: () => ({ getRequest: () => mockRequest }),
+        getHandler: () => ({}),
+        getClass: () => ({}),
+      } as ExecutionContext;
+
+      mockSupabaseClient
+        .setMockData({
+          id: MOCK_USER_ID,
+          email: 'test@example.com',
+          user_metadata: { firstName: 'John' },
+        })
+        .setMockError(null);
+
+      await authGuard.canActivate(mockContext);
+
+      expect(
+        (mockRequest as typeof mockRequest & { user: AuthenticatedUser }).user
+          .payDayOfMonth,
+      ).toBeNull();
     });
 
     it('should handle errors in cache branch gracefully', async () => {

--- a/backend-nest/src/common/guards/auth.guard.ts
+++ b/backend-nest/src/common/guards/auth.guard.ts
@@ -8,6 +8,7 @@ import { SupabaseService } from '@modules/supabase/supabase.service';
 import type { AuthenticatedUser } from '@common/decorators/user.decorator';
 import type { SupabaseClient } from '@/types/supabase-helpers';
 import { SKIP_CLIENT_KEY } from '@common/decorators/skip-client-key.decorator';
+import { resolvePayDayOfMonth } from '@common/utils/pay-day';
 import { ClsService } from 'nestjs-cls';
 
 interface RequestWithCache extends Request {
@@ -112,6 +113,7 @@ export class AuthGuard implements CanActivate {
         lastName: user.user_metadata?.lastName,
         accessToken,
         clientKey,
+        payDayOfMonth: resolvePayDayOfMonth(user.user_metadata),
       };
 
       request.user = authenticatedUser;

--- a/backend-nest/src/common/guards/user-throttler.guard.ts
+++ b/backend-nest/src/common/guards/user-throttler.guard.ts
@@ -12,6 +12,7 @@ import { Request } from 'express';
 import { SupabaseService } from '@modules/supabase/supabase.service';
 import { isDemoPath } from '@config/throttler.config';
 import type { AuthenticatedUser } from '@common/decorators/user.decorator';
+import { resolvePayDayOfMonth } from '@common/utils/pay-day';
 
 interface RequestWithThrottlerCache extends Request {
   __throttlerUserCache?: AuthenticatedUser | null;
@@ -112,6 +113,7 @@ export class UserThrottlerGuard extends ThrottlerGuard {
         email: user.email ?? '',
         firstName: user.user_metadata?.firstName,
         lastName: user.user_metadata?.lastName,
+        payDayOfMonth: resolvePayDayOfMonth(user.user_metadata),
         accessToken: token,
         clientKey,
       };

--- a/backend-nest/src/common/utils/pay-day.ts
+++ b/backend-nest/src/common/utils/pay-day.ts
@@ -1,0 +1,19 @@
+import { PAY_DAY_MIN, PAY_DAY_MAX } from 'pulpe-shared';
+
+/**
+ * `payDayOfMonth` lu depuis `auth.users.user_metadata`, borné, ou `null` quand
+ * il n'est pas exploitable — `getBudgetPeriodForDate` traite `null` comme le
+ * comportement calendaire.
+ *
+ * Les guards l'appellent sur l'utilisateur qu'ils viennent de charger, pour que
+ * la donnée voyage dans `AuthenticatedUser` : toute lecture ultérieure serait un
+ * appel GoTrue redondant dans la même requête.
+ */
+export function resolvePayDayOfMonth(metadata: unknown): number | null {
+  const raw = (metadata as { payDayOfMonth?: unknown } | null | undefined)
+    ?.payDayOfMonth;
+
+  if (typeof raw !== 'number' || !Number.isInteger(raw)) return null;
+
+  return Math.max(PAY_DAY_MIN, Math.min(PAY_DAY_MAX, raw));
+}

--- a/backend-nest/src/modules/budget/infrastructure/persistence/supabase-budget.repository.spec.ts
+++ b/backend-nest/src/modules/budget/infrastructure/persistence/supabase-budget.repository.spec.ts
@@ -308,17 +308,15 @@ describe('SupabaseBudgetRepository createBudgetFromTemplateRpc — savings goal 
   };
 
   /**
-   * Provider exposing the three surfaces the generation path touches: the
-   * savings_goal read, the payDay read, and the RPC itself.
+   * Provider exposing the two surfaces the generation path touches: the
+   * savings_goal read and the RPC. `auth.getUser` is wired as a spy that must
+   * stay untouched — the pay day now travels on the authenticated user.
    */
   function generationProvider(
     goals: { id: string; target_date: string }[],
     payDayOfMonth: number | null,
     rpc: ReturnType<typeof jest.fn>,
-    getUser: ReturnType<typeof jest.fn> = jest.fn().mockResolvedValue({
-      data: { user: { user_metadata: { payDayOfMonth } } },
-      error: null,
-    }),
+    getUser: ReturnType<typeof jest.fn> = jest.fn(),
   ): AuthenticatedSupabaseProvider {
     const client = {
       from: (table: string) => {
@@ -342,7 +340,7 @@ describe('SupabaseBudgetRepository createBudgetFromTemplateRpc — savings goal 
         return client;
       },
       get user() {
-        return { ...mockUser, id: USER_UUID };
+        return { ...mockUser, id: USER_UUID, payDayOfMonth };
       },
     } as unknown as AuthenticatedSupabaseProvider;
   }
@@ -399,13 +397,11 @@ describe('SupabaseBudgetRepository createBudgetFromTemplateRpc — savings goal 
     );
   });
 
-  it('fails the creation rather than bounding on a guessed pay day', async () => {
-    // Falling back to the calendar default would shift the horizon by one
-    // period for a custom payDay and silently drop a contribution.
+  it('never re-reads the pay day from GoTrue — the guard already carries it', async () => {
+    // The guard fetches user_metadata once per request; re-asking here cost
+    // `generate-budgets` up to 36 redundant round-trips.
     const rpc = jest.fn().mockResolvedValue({ data: rpcResponse, error: null });
-    const getUser = jest
-      .fn()
-      .mockResolvedValue({ data: null, error: { message: 'GoTrue down' } });
+    const getUser = jest.fn();
     const repo = new SupabaseBudgetRepository(
       generationProvider(
         [{ id: OVERDUE_GOAL_UUID, target_date: '2026-10-12' }],
@@ -416,23 +412,18 @@ describe('SupabaseBudgetRepository createBudgetFromTemplateRpc — savings goal 
       createMockEncryption(),
     );
 
-    let caught: unknown;
-    try {
-      await repo.createBudgetFromTemplateRpc(payload);
-    } catch (error) {
-      caught = error;
-    }
+    await repo.createBudgetFromTemplateRpc(payload);
 
-    expect(caught).toBeInstanceOf(BusinessException);
-    expect((caught as BusinessException).code).toBe(
-      ERROR_DEFINITIONS.BUDGET_CREATE_FAILED.code,
+    expect(getUser).not.toHaveBeenCalled();
+    expect(rpc).toHaveBeenCalledWith(
+      'create_budget_from_template',
+      expect.objectContaining({
+        p_excluded_savings_goal_ids: [OVERDUE_GOAL_UUID],
+      }),
     );
-    expect(rpc).not.toHaveBeenCalled();
   });
 
-  it('sends an empty exclusion list without reading payDay when the user has no active goal', async () => {
-    // Most users own no savings goal; paying a GoTrue round-trip per
-    // materialization would cost `generate-budgets` up to 36 of them.
+  it('sends an empty exclusion list when the user has no active goal', async () => {
     const rpc = jest.fn().mockResolvedValue({ data: rpcResponse, error: null });
     const getUser = jest.fn();
     const repo = new SupabaseBudgetRepository(

--- a/backend-nest/src/modules/budget/infrastructure/persistence/supabase-budget.repository.ts
+++ b/backend-nest/src/modules/budget/infrastructure/persistence/supabase-budget.repository.ts
@@ -10,8 +10,6 @@ import {
 } from '@modules/encryption/encryption.tokens';
 import {
   BudgetFormulas,
-  PAY_DAY_MAX,
-  PAY_DAY_MIN,
   getBudgetPeriodForDate,
   parseIsoDateLocal,
   periodIndex,
@@ -542,7 +540,7 @@ export class SupabaseBudgetRepository implements BudgetRepositoryPort {
     // enchaîne jusqu'à 36. C'est le cas de la majorité des utilisateurs.
     if (goals.length === 0) return [];
 
-    const payDayOfMonth = await this.getPayDayOfMonth();
+    const payDayOfMonth = this.supabaseProvider.user.payDayOfMonth ?? null;
     const budgetPeriodIndex = periodIndex(period);
     return goals
       .filter(
@@ -555,35 +553,6 @@ export class SupabaseBudgetRepository implements BudgetRepositoryPort {
           ) < budgetPeriodIndex,
       )
       .map((goal) => goal.id);
-  }
-
-  /**
-   * Contrairement aux lectures d'affichage du module, celle-ci décide quelles
-   * prévisions sont générées : un échec GoTrue silencieux retomberait sur le
-   * comportement calendaire et déplacerait la borne d'une période pour un
-   * utilisateur à payDay personnalisé. Même traitement que l'échec de lecture
-   * des objectifs juste au-dessus — les deux nourrissent la même décision.
-   */
-  private async getPayDayOfMonth(): Promise<number> {
-    const { data, error } = await this.supabaseProvider.client.auth.getUser();
-
-    if (error) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.BUDGET_CREATE_FAILED,
-        { reason: 'Unable to read the pay day' },
-        {
-          operation: 'fetchGoalIdsPastTarget.payDay',
-          userId: this.supabaseProvider.user.id,
-        },
-        { cause: error },
-      );
-    }
-
-    const raw = data?.user?.user_metadata?.payDayOfMonth;
-
-    if (typeof raw !== 'number' || !Number.isInteger(raw)) return PAY_DAY_MIN;
-
-    return Math.max(PAY_DAY_MIN, Math.min(PAY_DAY_MAX, raw));
   }
 
   async persistEndingBalance(

--- a/backend-nest/src/test/test-mocks.ts
+++ b/backend-nest/src/test/test-mocks.ts
@@ -20,6 +20,7 @@ export const createMockAuthenticatedUser = (
   lastName: 'Doe',
   accessToken: 'mock-access-token',
   clientKey: Buffer.from('ab'.repeat(32), 'hex'),
+  payDayOfMonth: null,
   ...overrides,
 });
 


### PR DESCRIPTION
Closes PUL-315 — https://linear.app/pulpe/issue/PUL-315/cesser-de-redemander-le-jour-de-paie-a-gotrue-a-chaque-materialisation

Indépendante du reste du chantier objectifs d'épargne, releasable seule.

## Le problème

`AuthGuard` appelle déjà `auth.getUser()` à chaque requête et n'en garde que le prénom et le nom —
`payDayOfMonth` est jeté. PUL-311 (mergé hier) le redemande ensuite à chaque matérialisation de
budget, et sur ce client c'est un vrai aller-retour HTTP : il est construit à partir d'un en-tête
d'autorisation, sans session locale, donc auth-js part sur le réseau à chaque appel.

Générer 36 mois payait 36 appels superflus, l'onboarding en paie 12. Avant PUL-311, zéro.

Trouvé en vérifiant le plan du ticket suivant, pas en production.

## Le correctif

Les deux guards posent le jour de paie sur `AuthenticatedUser`, normalisé par un helper partagé pour
qu'ils ne puissent pas diverger, et le repository budget le lit en mémoire.

Le champ est **optionnel**. Le rendre obligatoire imposerait de retoucher les 42 fichiers qui
construisent un `AuthenticatedUser` littéral, pour une correction de deux lignes. Son absence vaut
`null`, que `getBudgetPeriodForDate` traite déjà en comportement calendaire, et deux tests de guard
verrouillent le vrai mappage plutôt que de faire confiance au type.

## Vérification

- `bun test` backend : **1192 pass / 0 fail**.
- Le test qui compte : la spec du repository asserte que `auth.getUser` n'est **jamais** appelé sur
  le chemin de génération, avec la liste d'exclusion toujours correcte.
- Deux tests de guard : jour de paie hors bornes ramené dans les bornes, métadonnée absente → `null`.
- Le bornage livré par PUL-311 est inchangé — ses cas passent sans retouche.
- `bun run quality` : 0 error, dep-cruiser et prettier propres.

## Hors périmètre

Le module budget porte quatre autres copies de cette même lecture, côté affichage
(`export-all-budgets`, `find-all-budgets`, `find-all-sparse-budgets`, `find-budget-with-details`).
Elles peuvent suivre le même chemin plus tard ; aucune urgence, et les mêler ici gonflerait une PR
qui doit rester petite.
