### PR TITLE
fix(ios): faire remplir l'écran aux états vides au lieu d'une bande

### DIFF
--- a/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetList/BudgetListView.swift
@@ -30,24 +30,14 @@ struct BudgetListView: View {
                 }
                 .transition(.opacity)
             } else if store.budgets.isEmpty {
-                VStack(spacing: DesignTokens.Spacing.lg) {
-                    Image(systemName: "chart.bar.doc.horizontal")
-                        .font(PulpeTypography.emojiDisplay)
-                        .foregroundStyle(Color.textTertiary)
-                        .symbolEffect(.pulse, options: .nonRepeating)
-                    Text("Pas encore de budget")
-                        .font(PulpeTypography.stepTitle)
-                        .foregroundStyle(Color.textPrimary)
-                    Text("Crée-en un pour commencer à suivre tes dépenses")
-                        .font(PulpeTypography.bodyLarge)
-                        .foregroundStyle(Color.textTertiary)
-                        .multilineTextAlignment(.center)
-                    Button("Créer un budget") {
-                        createBudgetTarget = store.nextAvailableMonth
-                    }
-                    .primaryButtonStyle()
+                PulpeEmptyState(
+                    systemImage: "chart.bar.doc.horizontal",
+                    title: "Pas encore de budget",
+                    message: "Crée-en un pour commencer à suivre tes dépenses",
+                    actionTitle: "Créer un budget"
+                ) {
+                    createBudgetTarget = store.nextAvailableMonth
                 }
-                .padding(DesignTokens.Spacing.xxxl)
                 .transition(.opacity)
             } else {
                 budgetList

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -56,26 +56,15 @@ struct CurrentMonthView: View {
                 }
                 .transition(.opacity)
             case .empty:
-                VStack(spacing: DesignTokens.Spacing.lg) {
-                    Image(systemName: "calendar.badge.plus")
-                        .font(PulpeTypography.emojiDisplay)
-                        .foregroundStyle(Color.textTertiary)
-                        .symbolEffect(.pulse, options: .nonRepeating)
-                        .accessibilityHidden(true)
-                    Text("Pas encore de budget ce mois-ci")
-                        .font(PulpeTypography.stepTitle)
-                        .foregroundStyle(Color.textPrimary)
-                    Text("Crée-le pour voir ton tableau de bord")
-                        .font(PulpeTypography.bodyLarge)
-                        .foregroundStyle(Color.textTertiary)
-                        .multilineTextAlignment(.center)
-                    Button("Créer un budget") {
-                        activeSheet = .createBudget
-                    }
-                    .disabled(!canCreateBudget)
-                    .primaryButtonStyle(isEnabled: canCreateBudget)
+                PulpeEmptyState(
+                    systemImage: "calendar.badge.plus",
+                    title: "Pas encore de budget ce mois-ci",
+                    message: "Crée-le pour voir ton tableau de bord",
+                    actionTitle: "Créer un budget",
+                    isActionEnabled: canCreateBudget
+                ) {
+                    activeSheet = .createBudget
                 }
-                .padding(DesignTokens.Spacing.xxxl)
                 .transition(.opacity)
             case .loaded:
                 dashboardContent

--- a/ios/Pulpe/Features/SavingsGoals/SavingsGoalsListView.swift
+++ b/ios/Pulpe/Features/SavingsGoals/SavingsGoalsListView.swift
@@ -77,24 +77,14 @@ struct SavingsGoalsListView: View {
     // MARK: - Empty state
 
     private var emptyState: some View {
-        VStack(spacing: DesignTokens.Spacing.lg) {
-            Image(systemName: "target")
-                .font(PulpeTypography.emojiDisplay)
-                .foregroundStyle(Color.textTertiary)
-                .symbolEffect(.pulse, options: .nonRepeating)
-            Text("Fixe ton premier objectif")
-                .font(PulpeTypography.stepTitle)
-                .foregroundStyle(Color.textPrimary)
-            Text("Suis tes projets d'épargne long terme, sans recalculer à la main")
-                .font(PulpeTypography.bodyLarge)
-                .foregroundStyle(Color.textTertiary)
-                .multilineTextAlignment(.center)
-            Button("Créer un objectif") {
-                isCreatingGoal = true
-            }
-            .primaryButtonStyle()
+        PulpeEmptyState(
+            systemImage: "target",
+            title: "Fixe ton premier objectif",
+            message: "Suis tes projets d'épargne long terme, sans recalculer à la main",
+            actionTitle: "Créer un objectif"
+        ) {
+            isCreatingGoal = true
         }
-        .padding(DesignTokens.Spacing.xxxl)
     }
 
     // MARK: - List

--- a/ios/Pulpe/Features/Templates/TemplateList/TemplateListView.swift
+++ b/ios/Pulpe/Features/Templates/TemplateList/TemplateListView.swift
@@ -22,24 +22,14 @@ struct TemplateListView: View {
                 }
                 .transition(.opacity)
             } else if viewModel.templates.isEmpty {
-                VStack(spacing: DesignTokens.Spacing.lg) {
-                    Image(systemName: "doc.on.doc")
-                        .font(PulpeTypography.emojiDisplay)
-                        .foregroundStyle(Color.textTertiary)
-                        .symbolEffect(.pulse, options: .nonRepeating)
-                    Text("Pas encore de modèle")
-                        .font(PulpeTypography.stepTitle)
-                        .foregroundStyle(Color.textPrimary)
-                    Text("Crée-en un pour préparer tes prochains budgets plus vite")
-                        .font(PulpeTypography.bodyLarge)
-                        .foregroundStyle(Color.textTertiary)
-                        .multilineTextAlignment(.center)
-                    Button("Créer un modèle") {
-                        showCreateTemplate = true
-                    }
-                    .primaryButtonStyle()
+                PulpeEmptyState(
+                    systemImage: "doc.on.doc",
+                    title: "Pas encore de modèle",
+                    message: "Crée-en un pour préparer tes prochains budgets plus vite",
+                    actionTitle: "Créer un modèle"
+                ) {
+                    showCreateTemplate = true
                 }
-                .padding(DesignTokens.Spacing.xxxl)
                 .transition(.opacity)
             } else {
                 templateList

--- a/ios/Pulpe/Shared/Components/PulpeEmptyState.swift
+++ b/ios/Pulpe/Shared/Components/PulpeEmptyState.swift
@@ -10,6 +10,7 @@ struct PulpeEmptyState: View {
     let title: String
     let message: String
     let actionTitle: String?
+    let isActionEnabled: Bool
     let action: (() -> Void)?
 
     init(
@@ -17,12 +18,14 @@ struct PulpeEmptyState: View {
         title: String,
         message: String,
         actionTitle: String? = nil,
+        isActionEnabled: Bool = true,
         action: (() -> Void)? = nil
     ) {
         self.systemImage = systemImage
         self.title = title
         self.message = message
         self.actionTitle = actionTitle
+        self.isActionEnabled = isActionEnabled
         self.action = action
     }
 
@@ -32,6 +35,9 @@ struct PulpeEmptyState: View {
                 .font(PulpeTypography.emojiDisplay)
                 .foregroundStyle(Color.textTertiary)
                 .symbolEffect(.pulse, options: .nonRepeating)
+                // Decorative: VoiceOver would otherwise read the SF Symbol name
+                // before the title.
+                .accessibilityHidden(true)
             Text(title)
                 .font(PulpeTypography.stepTitle)
                 .foregroundStyle(Color.textPrimary)
@@ -41,7 +47,8 @@ struct PulpeEmptyState: View {
                 .multilineTextAlignment(.center)
             if let actionTitle, let action {
                 Button(actionTitle, action: action)
-                    .primaryButtonStyle()
+                    .disabled(!isActionEnabled)
+                    .primaryButtonStyle(isEnabled: isActionEnabled)
             }
         }
         .padding(DesignTokens.Spacing.xxxl)

--- a/ios/Pulpe/Shared/Components/PulpeEmptyState.swift
+++ b/ios/Pulpe/Shared/Components/PulpeEmptyState.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// Branded full-screen empty state: pulsing glyph, title, guidance, optional CTA.
+///
+/// Fills the available space and paints the app background itself, like
+/// `LoadingView` — a placeholder that only hugs its content leaves the rest of
+/// the screen on the system background, showing as a band behind the text.
+struct PulpeEmptyState: View {
+    let systemImage: String
+    let title: String
+    let message: String
+    let actionTitle: String?
+    let action: (() -> Void)?
+
+    init(
+        systemImage: String,
+        title: String,
+        message: String,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) {
+        self.systemImage = systemImage
+        self.title = title
+        self.message = message
+        self.actionTitle = actionTitle
+        self.action = action
+    }
+
+    var body: some View {
+        VStack(spacing: DesignTokens.Spacing.lg) {
+            Image(systemName: systemImage)
+                .font(PulpeTypography.emojiDisplay)
+                .foregroundStyle(Color.textTertiary)
+                .symbolEffect(.pulse, options: .nonRepeating)
+            Text(title)
+                .font(PulpeTypography.stepTitle)
+                .foregroundStyle(Color.textPrimary)
+            Text(message)
+                .font(PulpeTypography.bodyLarge)
+                .foregroundStyle(Color.textTertiary)
+                .multilineTextAlignment(.center)
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .primaryButtonStyle()
+            }
+        }
+        .padding(DesignTokens.Spacing.xxxl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .pulpeBackground()
+    }
+}
+
+#Preview("With action") {
+    PulpeEmptyState(
+        systemImage: "target",
+        title: "Fixe ton premier objectif",
+        message: "Suis tes projets d'épargne long terme, sans recalculer à la main",
+        actionTitle: "Créer un objectif"
+    ) {}
+}
+
+#Preview("Without action") {
+    PulpeEmptyState(
+        systemImage: "doc.on.doc",
+        title: "Pas encore de modèle",
+        message: "Crée-en un pour préparer tes prochains budgets plus vite"
+    )
+}


### PR DESCRIPTION
Ferme [PUL-318](https://linear.app/pulpe/issue/PUL-318).

## Le bug

Sur « Objectifs d'épargne » vide, le fond de l'app ne s'appliquait qu'à la hauteur du contenu : une bande grise flottait au milieu, blanc au-dessus et en dessous.

`pulpeBackground()` peint le fond de la vue à laquelle il s'applique. L'état vide était un `VStack` qui n'occupait que sa taille intrinsèque — il n'y avait donc rien d'autre à couvrir. La branche `ProgressView` du même écran portait déjà `frame(maxWidth: .infinity, maxHeight: .infinity)`, ce qui explique que seul l'état vide soit touché.

## Le balayage

Le même état vide était recopié à l'identique sur **trois** écrans : objectifs, budgets, modèles. Même `VStack`, même glyphe pulsé, même typo, même CTA — seuls le texte et l'action changent. Trois usages : le seuil d'extraction du projet.

D'où `PulpeEmptyState` dans `Shared/Components/`, qui remplit l'espace disponible **et** peint son propre fond, comme `LoadingView` le fait déjà pour le chargement plein écran.

Le fond porté par le composant n'est pas de la ceinture-bretelles : sur la liste des budgets, `pulpeBackground()` est posé sur la `ScrollView` de la liste, pas sur le `Group` — sa branche vide n'avait donc **aucun** fond.

`ErrorView` et `EmptyStateView` reposent sur `ContentUnavailableView`, qui remplit l'espace tout seul : ils n'avaient pas le bug et ne changent pas.

## Rendu

Inchangé : mêmes glyphe, typographie, espacements et bouton. Seule la surface peinte s'étend.

## Vérification

`xcodebuild build -scheme PulpeLocal` : **BUILD SUCCEEDED**. `PulpeTests` : **1860 tests / 189 suites passés** sur le simulateur dédié.

Je n'ai pas de capture de l'écran corrigé : l'atteindre demande un compte sans aucun objectif, et les captures fidèles depuis le CLI sont bloquées sur ce projet. Le correctif est structurel et calqué sur un composant existant, mais l'œil reste à faire au moment de la revue.

## Reste ouvert

`EmptyStateView` (style `ContentUnavailableView`, utilisé par les réglages de tags) et `PulpeEmptyState` (style Pulpe) coexistent désormais. Deux composants nommés « état vide », c'est un de trop — mais les unifier change l'apparence de l'écran des tags, ce qui est une décision de design, pas un correctif de bug.