### PR TITLE
feat(savings-goals): clarify planned goal trajectory

### DIFF
--- a/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-1.md
@@ -1,0 +1,93 @@
+---
+status: done
+---
+
+# Instruction: Adapter la grammaire Chart.js
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+frontend/projects/webapp/src/app/feature/savings-goals/detail/components/
+├── ✏️ goal-projection-chart.config.spec.ts
+├── ✏️ goal-projection-chart.config.ts
+├── ✅ goal-projection-chart.plugin.ts
+└── ✏️ goal-projection-chart.ts
+```
+
+- `goal-projection-chart.config.ts` : conserver les trois séries de solde et appliquer la hiérarchie cible / réalisé / futur.
+- `goal-projection-chart.config.spec.ts` : verrouiller la sémantique, les styles structurants et les cas limites.
+- `goal-projection-chart.plugin.ts` : dessiner uniquement la zone future et le repère de période courante.
+- `goal-projection-chart.ts` : fournir le plugin local au canvas sans modifier le contrat du composant.
+- Suppressions : aucune.
+
+## User Journey
+
+```mermaid
+flowchart LR
+  A["Ouvrir un objectif"] --> B["Lire l’épargne constatée"]
+  B --> C["Repérer la période courante"]
+  C --> D["Suivre la projection planifiée"]
+  D --> E["Comparer son terme à la cible"]
+```
+
+## Wireframe
+
+```txt
+┌──────────────────────────────────────────────────────────────┐
+│ (1) Zone graphique                                           │
+│                                                              │
+│  ─────────────────────────────── (2) Référence               │
+│       ━━━━━━━━━━━━━●                                         │
+│                    │┄┄┄┄┄┄┄┄┄┄┄●                            │
+│                    (3)                                       │
+│ (4) Repères de périodes                                      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+1. Zone graphique : superpose les trois séries sur une seule échelle de solde.
+2. Référence : matérialise la valeur de comparaison.
+3. Séparation temporelle : marque la jonction entre constat et horizon.
+4. Repères : borne la période sans grille dense.
+
+## Tasks to do
+
+### `1)` Isoler l’implémentation
+
+> Garder ce travail visuel hors du PR de correction fonctionnelle.
+
+1. Créer `codex/goal-trajectory-linear-chart` au-dessus du PR `#550`, puis la rebaser sur `preview` après son intégration.
+2. Vérifier que le graphe reçu contient déjà les séries Cible, Épargné et Projection planifiée ancrée sur l’épargne.
+
+### `2)` Verrouiller la sémantique avant le rendu
+
+> Préserver les données corrigées et tester uniquement la nouvelle présentation.
+
+1. Conserver la cible comme référence séparée sur tout l’horizon.
+2. Conserver l’épargne réelle jusqu’à la période courante, avec une queue `null`.
+3. Conserver la projection planifiée depuis le dernier point réel jusqu’au montant projeté à l’échéance, y compris en simulation.
+4. Ajouter les assertions de styles qui empêchent de confondre cible, réel et futur.
+5. Couvrir un objectif à échéance dépassée : aucun faux repère « période courante » ne doit être dessiné.
+
+### `3)` Appliquer le langage visuel minimal
+
+> Reprendre la clarté de Linear sans ajouter une quatrième mesure.
+
+1. Rendre la cible neutre, fine et continue.
+2. Rendre l’épargne solide en vert épargne, avec remplissage très léger et point terminal.
+3. Rendre la projection dans le même vert, pointillée, démarrant exactement au point terminal réel et finissant sur le montant de la carte.
+4. Masquer la grille et l’axe vertical ; garder des repères mensuels et annuels peu nombreux sur l’axe horizontal.
+5. Utiliser un plugin Chart.js local pour teinter discrètement l’horizon futur et tracer le repère courant, uniquement lorsqu’une période `current` existe.
+6. Respecter le thème clair/sombre et neutraliser l’animation sous `prefers-reduced-motion`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | La branche du graphe est distincte du PR `#550`, contient sa correction fonctionnelle et pourra être rebasée sur `preview` sans mêler les deux diffs. |
+| 2 | Les données du graphe restent `[réel…, null…]` pour l’épargne et `[null…, ancre réelle, projection…]` pour le futur ; le terme égale la projection à l’échéance en lecture comme en simulation. |
+| 2 | Un objectif sans période courante ne reçoit aucun repère temporel trompeur. |
+| 3 | La cible, le réalisé et la projection sont distinguables par libellé et forme de trait sans introduire de couleur ambre ou rouge. |
+| 3 | Le canvas reste net et lisible en thème clair, sombre et reduced motion, sans axe vertical ni grille dense. |
+| 3 | Les tests ciblés du configurateur Chart.js passent sans modification des calculateurs shared ou du contrat API. |

--- a/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-2.md
@@ -1,0 +1,135 @@
+---
+status: pending
+---
+
+# Instruction: Composer la synthèse responsive et accessible
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+frontend/
+├── e2e/tests/features/
+│   └── ✏️ savings-goals-progress.spec.ts
+└── projects/webapp/
+    ├── public/i18n/
+    │   └── ✏️ fr.json
+    └── src/app/feature/savings-goals/detail/components/
+        ├── ✏️ goal-projection-chart.config.ts
+        ├── ✅ goal-projection-chart.spec.ts
+        └── ✏️ goal-projection-chart.ts
+```
+
+- `goal-projection-chart.ts` : remplacer la légende canvas par une synthèse Angular latérale ou empilée et aligner l’alternative accessible.
+- `goal-projection-chart.config.ts` : désactiver la légende intégrée une fois la synthèse HTML en place.
+- `goal-projection-chart.spec.ts` : couvrir valeurs, simulation, confidentialité et structure sémantique.
+- `fr.json` : ajouter uniquement le libellé du repère courant et l’alternative sans montants ; réutiliser les libellés existants pour les trois séries.
+- `savings-goals-progress.spec.ts` : vérifier le parcours réel sur desktop et mobile.
+- Suppressions : aucune.
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Consulter la trajectoire"] --> B{"Largeur disponible"}
+  B -->|Desktop| C["Graphe et synthèse côte à côte"]
+  B -->|Mobile| D["Graphe puis synthèse empilée"]
+  C --> E["Lire cible, épargne et projection"]
+  D --> E
+  E --> F{"Montants masqués ?"}
+  F -->|Non| G["Afficher les valeurs formatées"]
+  F -->|Oui| H["Masquer les valeurs visuelles et accessibles"]
+```
+
+## Wireframe
+
+```txt
+Desktop
+┌──────────────────────────────────────────────────────────────────┐
+│ (1) En-tête de section                                           │
+├──────────────────────────────────────────────┬───────────────────┤
+│ (2) Zone graphique                           │ (3) Synthèse      │
+│                                              │ indicateur + valeur│
+│     ───────────── série de référence         │ indicateur + valeur│
+│        ━━━━━━━ série réalisée                │ indicateur + valeur│
+│                 ┄┄┄┄ série future            │                   │
+│                   │                          │                   │
+│                   (4) Repère temporel        │                   │
+│ (5) Repères de périodes                      │                   │
+├──────────────────────────────────────────────┴───────────────────┤
+│ (6) Alternative textuelle accessible                            │
+└──────────────────────────────────────────────────────────────────┘
+
+Mobile
+┌──────────────────────────────────────┐
+│ (1) En-tête de section               │
+├──────────────────────────────────────┤
+│ (2) Zone graphique                   │
+│   ────────                           │
+│      ━━━━━━━                         │
+│           ┄┄┄┄┄┄                    │
+│          (4)│                        │
+│ (5) Repères de périodes              │
+├──────────────────────────────────────┤
+│ (3) Synthèse en liste                │
+│ indicateur + libellé + valeur        │
+│ indicateur + libellé + valeur        │
+│ indicateur + libellé + valeur        │
+├──────────────────────────────────────┤
+│ (6) Alternative textuelle accessible │
+└──────────────────────────────────────┘
+```
+
+1. En-tête : conserve la place actuelle de la trajectoire dans le détail.
+2. Graphe : porte la comparaison temporelle.
+3. Synthèse : expose les trois valeurs hors du canvas.
+4. Repère : sépare constat et projection.
+5. Périodes : donnent les bornes temporelles.
+6. Alternative : annonce les mêmes informations sans dépendre de la vision.
+
+## Tasks to do
+
+### `1)` Remplacer la légende canvas par une synthèse Angular
+
+> Garder Chart.js responsable du dessin et Angular responsable du contenu.
+
+1. Désactiver la légende intégrée Chart.js.
+2. Construire trois lignes depuis les inputs existants : Cible, Épargné et le libellé déjà utilisé pour Projection à l’échéance.
+3. Représenter chaque série avec sa forme de trait et son libellé, jamais par la couleur seule.
+4. Formater les montants avec la devise du compte et des chiffres tabulaires.
+5. Utiliser `draft.simulatedFinal` comme valeur projetée pendant la simulation, sinon `projected`.
+6. Placer la synthèse à droite sur desktop et sous le canvas sur mobile, sans débordement horizontal.
+
+### `2)` Aligner confidentialité et accessibilité
+
+> Une nouvelle valeur visible ne doit créer ni fuite ni divergence.
+
+1. Réutiliser `AmountsVisibilityService` pour masquer les trois valeurs de la synthèse et des tooltips.
+2. Lorsque les montants sont masqués, remplacer la phrase `aria-live` chiffrée par une phrase dédiée sans montant.
+3. Lorsque les montants sont visibles, annoncer Épargné, Projection à l’échéance et Cible dans le même ordre que la synthèse.
+4. Garder le canvas décoratif pour les lecteurs d’écran et la synthèse HTML sémantique.
+5. Conserver un contraste WCAG AA, un focus inchangé et aucune information portée uniquement par une teinte.
+
+### `3)` Vérifier la surface complète
+
+> Prouver le rendu sans installer une infrastructure de snapshots absente du dépôt.
+
+1. Ajouter un test composant ciblé pour les trois lignes, la projection simulée et le masquage.
+2. Étendre le scénario Playwright existant pour confirmer que le terme de la projection du graphe égale la carte Projection à l’échéance.
+3. Vérifier manuellement les viewports `390 × 844`, `768 × 1024` et `1440 × 900`, en thèmes clair et sombre.
+4. Vérifier le graphe avec un horizon court, un horizon multi-années, une cible dépassée et un objectif à échéance dépassée.
+5. Exécuter les tests frontend ciblés, le scénario Playwright concerné puis `pnpm quality`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Desktop affiche le graphe et les trois valeurs côte à côte ; mobile place les mêmes valeurs sous le graphe sans scroll horizontal. |
+| 1 | La valeur de projection affichée dans la synthèse correspond à `projected`, ou à `draft.simulatedFinal` pendant une simulation. |
+| 1 | Les trois séries restent identifiables sans couleur grâce au trait, au libellé et à leur valeur. |
+| 2 | Le mode montants masqués ne révèle aucune somme dans la synthèse, les tooltips ou l’annonce `aria-live`. |
+| 2 | Le mode visible annonce Épargné, Projection à l’échéance et Cible avec la devise active, dans le même ordre que l’interface. |
+| 3 | La carte Projection à l’échéance, le dernier point projeté et la synthèse affichent le même montant dans le scénario E2E. |
+| 3 | Les trois viewports, les deux thèmes et les horizons court ou long restent lisibles sans chevauchement ni troncature trompeuse. |
+| 3 | Les tests ciblés, le scénario Playwright et la qualité du dépôt passent sans nouvelle dépendance ni modification backend, shared ou iOS. |

--- a/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-2.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Composer la synthèse responsive et accessible
@@ -107,7 +107,7 @@ Mobile
 
 1. Réutiliser `AmountsVisibilityService` pour masquer les trois valeurs de la synthèse et des tooltips.
 2. Lorsque les montants sont masqués, remplacer la phrase `aria-live` chiffrée par une phrase dédiée sans montant.
-3. Lorsque les montants sont visibles, annoncer Épargné, Projection à l’échéance et Cible dans le même ordre que la synthèse.
+3. Lorsque les montants sont visibles, annoncer Cible, Épargné et Projection à l’échéance dans le même ordre que la synthèse.
 4. Garder le canvas décoratif pour les lecteurs d’écran et la synthèse HTML sémantique.
 5. Conserver un contraste WCAG AA, un focus inchangé et aucune information portée uniquement par une teinte.
 
@@ -129,7 +129,7 @@ Mobile
 | 1 | La valeur de projection affichée dans la synthèse correspond à `projected`, ou à `draft.simulatedFinal` pendant une simulation. |
 | 1 | Les trois séries restent identifiables sans couleur grâce au trait, au libellé et à leur valeur. |
 | 2 | Le mode montants masqués ne révèle aucune somme dans la synthèse, les tooltips ou l’annonce `aria-live`. |
-| 2 | Le mode visible annonce Épargné, Projection à l’échéance et Cible avec la devise active, dans le même ordre que l’interface. |
+| 2 | Le mode visible annonce Cible, Épargné et Projection à l’échéance avec la devise active, dans le même ordre que l’interface. |
 | 3 | La carte Projection à l’échéance, le dernier point projeté et la synthèse affichent le même montant dans le scénario E2E. |
 | 3 | Les trois viewports, les deux thèmes et les horizons court ou long restent lisibles sans chevauchement ni troncature trompeuse. |
 | 3 | Les tests ciblés, le scénario Playwright et la qualité du dépôt passent sans nouvelle dépendance ni modification backend, shared ou iOS. |

--- a/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-2.md
@@ -17,12 +17,14 @@ frontend/
     │   └── ✏️ fr.json
     └── src/app/feature/savings-goals/detail/components/
         ├── ✏️ goal-projection-chart.config.ts
+        ├── ✏️ goal-projection-chart.plugin.ts
         ├── ✅ goal-projection-chart.spec.ts
         └── ✏️ goal-projection-chart.ts
 ```
 
 - `goal-projection-chart.ts` : remplacer la légende canvas par une synthèse Angular latérale ou empilée et aligner l’alternative accessible.
 - `goal-projection-chart.config.ts` : désactiver la légende intégrée une fois la synthèse HTML en place.
+- `goal-projection-chart.plugin.ts` : ajouter le libellé visuel du repère courant sans exposer de nouvelle donnée.
 - `goal-projection-chart.spec.ts` : couvrir valeurs, simulation, confidentialité et structure sémantique.
 - `fr.json` : ajouter uniquement le libellé du repère courant et l’alternative sans montants ; réutiliser les libellés existants pour les trois séries.
 - `savings-goals-progress.spec.ts` : vérifier le parcours réel sur desktop et mobile.

--- a/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Le détail web d’un objectif présente une trajectoire aussi lisible que la référence Linear, avec le réalisé, la projection planifiée et la cible clairement distincts et accessibles."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Clarifier la trajectoire d’un objectif

--- a/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/plan.md
@@ -1,0 +1,39 @@
+---
+objective: "Le détail web d’un objectif présente une trajectoire aussi lisible que la référence Linear, avec le réalisé, la projection planifiée et la cible clairement distincts et accessibles."
+status: in-progress
+---
+
+# Plan: Clarifier la trajectoire d’un objectif
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| **Goal** | Adapter le graphe Chart.js existant au langage visuel de la référence Linear sans changer les calculs métier ni ajouter de dépendance. |
+| **Source** | Demande utilisateur, capture `Screenshot 2026-07-26 at 11.06.06.png` et DOM joint `pasted-text.txt`. |
+
+## Phases
+
+| # | Phase | File |
+| --- | --- | --- |
+| 1 | Adapter la grammaire Chart.js | [`phase-1.md`](./phase-1.md) |
+| 2 | Composer la synthèse responsive et accessible | [`phase-2.md`](./phase-2.md) |
+
+## Resources
+
+| Source | Verified |
+| --- | --- |
+| https://www.chartjs.org/docs/latest/charts/line.html | Chart.js 4 couvre nativement les lignes pleines ou pointillées, les points terminaux, les remplissages et l’interpolation adaptée aux séries. |
+| https://www.chartjs.org/docs/latest/developers/plugins.html | Un plugin local peut dessiner un repère et une zone de fond sur le canvas sans dépendance externe ni enregistrement global. |
+| https://www.chartjs.org/docs/latest/configuration/responsive.html | Le canvas doit rester dans un conteneur dédié et positionné, avec `responsive` et `maintainAspectRatio: false`. |
+| https://www.chartjs.org/docs/latest/general/accessibility.html | Le canvas ne porte pas seul une information accessible ; une alternative textuelle ou HTML doit restituer les valeurs. |
+| https://www.chartjs.org/docs/latest/samples/legend/html.html | Une légende HTML est le motif recommandé quand la légende canvas ne permet pas la composition voulue. |
+
+## Decisions
+
+| Decision | Why |
+| --- | --- |
+| Conserver Chart.js 4.5.1 et ng2-charts 8, sans ajouter de plugin npm. | Les datasets et l’API `Plugin<'line'>` installés couvrent tout le rendu demandé ; une dépendance d’annotation ou de hachures serait superflue. |
+| Rendre la synthèse avec le template Angular, alimenté par les mêmes inputs que le canvas. | Cela garde le DOM, le responsive, le masquage des montants et l’accessibilité sous le contrôle idiomatique d’Angular, sans mutation DOM depuis Chart.js. |
+| Adapter la référence Linear à la sémantique Pulpe au lieu de la copier littéralement. | Le gris représente la cible, le vert l’épargne, le pointillé le futur ; les hachures de week-end et les couleurs “started/completed” de Linear n’ont pas d’équivalent métier dans un objectif mensuel. |
+| Limiter ce plan au détail web. | La demande vise explicitement Chart.js ; l’écran iOS utilise Swift Charts et nécessite une décision visuelle séparée, pas un refactor opportuniste. |

--- a/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/review.md
@@ -1,7 +1,7 @@
 # Review: Clarifier la trajectoire d’un objectif
 
 - **Verdict**: approve
-- **Diff**: `fe920bffc...HEAD`
+- **Diff**: `fe920bffc...WORKTREE`
 - **Axes run**: code, functional, relevancy
 - **Date**: 2026_07_26
 - **Findings**: 0 critical, 0 warning, 0 minor
@@ -11,22 +11,22 @@
 ### Phase 1 — Adapter la grammaire Chart.js
 
 - [x] Le travail reste isolé sur `codex/goal-trajectory-linear-chart`, au-dessus du correctif fonctionnel `fe920bffc` — `aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-1.md:56`
-- [x] Les séries gardent le réel jusqu’à la période courante et ancrent la projection sur son dernier point — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:165`
+- [x] Les séries gardent le réel jusqu’à la période courante et ancrent la projection sur son dernier point canonique — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:122`
 - [x] Une échéance dépassée ne reçoit pas de faux repère courant — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts:190`
-- [x] Cible, épargne et projection restent distinguables par libellé et forme de trait — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:205`
-- [x] Le rendu conserve les thèmes clair/sombre et neutralise l’animation en reduced motion — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:41`
-- [x] Les calculateurs shared et le contrat API ne sont pas modifiés — `aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/plan.md:12`
+- [x] Cible, épargne et projection restent distinguables par libellé, forme de trait et deux couleurs contrastées — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:208`
+- [x] Le rendu conserve les thèmes clair/sombre et neutralise l’animation en reduced motion — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:40`
+- [x] Les calculateurs shared et le contrat API ne sont pas modifiés — `shared/src/calculators/savings-goal-progress.ts:278`
 
 ### Phase 2 — Composer la synthèse responsive et accessible
 
 - [x] Le graphe et la synthèse sont côte à côte sur desktop puis empilés sous `lg` sans largeur fixe du canvas — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:55`
 - [x] La synthèse utilise `draft.simulatedFinal` pendant la simulation, sinon `projected` — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:220`
-- [x] Les trois séries sont identifiables par leur trait, leur libellé et leur valeur — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:79`
-- [x] Le mode masqué protège la synthèse, les tooltips et l’annonce accessible — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:101`
-- [x] Le mode visible annonce Cible, Épargné et Projection à l’échéance dans l’ordre du DOM — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:238`
-- [x] La carte et la synthèse affichent le même montant, et le configurateur verrouille ce montant au dernier point projeté — `frontend/e2e/tests/features/savings-goals-progress.spec.ts:162`, `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts:130`
-- [x] Les viewports `1440 × 900`, `768 × 1024` et `390 × 844` utilisent une timeline mensuelle continue jusqu’en août 2027, sans débordement — `frontend/e2e/tests/features/savings-goals-progress.spec.ts:18`
-- [x] Les tests ciblés restent contenus au frontend, sans nouvelle dépendance ni modification backend, shared ou iOS — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.spec.ts:1`
+- [x] Les trois séries sont identifiables par leur trait, leur libellé, leur valeur et leur couleur — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:79`
+- [x] Le mode masqué protège la synthèse, les tooltips et l’annonce accessible — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:238`
+- [x] Le mode visible annonce Cible, Épargné et Projection à l’échéance dans l’ordre du DOM — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:244`
+- [x] La carte Projection à l’échéance, le dernier point projeté et la synthèse utilisent le même endpoint canonique — `frontend/projects/webapp/src/app/feature/savings-goals/detail/savings-goal-detail-page.ts:713`, `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:150`
+- [x] Les viewports `1440 × 900`, `768 × 1024` et `390 × 844` utilisent une timeline mensuelle continue sans débordement — `frontend/e2e/tests/features/savings-goals-progress.spec.ts:133`
+- [x] Le correctif n’ajoute aucune dépendance et la parité iOS demandée reprend les mêmes couleurs et formes — `ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift:59`
 
 ## Findings
 
@@ -37,6 +37,6 @@ None.
 | Metric        | Value                                             |
 | ------------- | ------------------------------------------------- |
 | Verified      | 100% (14/14) |
-| Files checked | `plan.md`, `phase-1.md`, `phase-2.md`, `goal-projection-chart.ts`, `goal-projection-chart.config.ts`, `goal-projection-chart.plugin.ts`, `goal-projection-chart.spec.ts`, `goal-projection-chart.config.spec.ts`, `fr.json`, `savings-goals-progress.spec.ts` |
+| Files checked | `plan.md`, `phase-1.md`, `phase-2.md`, `goal-projection-chart.ts`, `goal-projection-chart.config.ts`, `goal-projection-chart.plugin.ts`, `goal-projection-chart.spec.ts`, `goal-projection-chart.config.spec.ts`, `savings-goal-detail-page.ts`, `savings-goal-detail-page.spec.ts`, `GoalProjectionChart.swift`, `GoalProgressCard.swift` |
 | Unchecked     | none |
-| Unplanned     | none |
+| Unplanned     | parité iOS et différenciation bleu/vert, explicitement demandées après le plan |

--- a/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/review.md
@@ -1,0 +1,42 @@
+# Review: Clarifier la trajectoire d’un objectif
+
+- **Verdict**: approve
+- **Diff**: `fe920bffc...HEAD`
+- **Axes run**: code, functional, relevancy
+- **Date**: 2026_07_26
+- **Findings**: 0 critical, 0 warning, 0 minor
+
+## Phases
+
+### Phase 1 — Adapter la grammaire Chart.js
+
+- [x] Le travail reste isolé sur `codex/goal-trajectory-linear-chart`, au-dessus du correctif fonctionnel `fe920bffc` — `aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/phase-1.md:56`
+- [x] Les séries gardent le réel jusqu’à la période courante et ancrent la projection sur son dernier point — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:165`
+- [x] Une échéance dépassée ne reçoit pas de faux repère courant — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts:190`
+- [x] Cible, épargne et projection restent distinguables par libellé et forme de trait — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:205`
+- [x] Le rendu conserve les thèmes clair/sombre et neutralise l’animation en reduced motion — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts:41`
+- [x] Les calculateurs shared et le contrat API ne sont pas modifiés — `aidd_docs/tasks/2026_07/2026_07_26_goal_trajectory_linear_chart/plan.md:12`
+
+### Phase 2 — Composer la synthèse responsive et accessible
+
+- [x] Le graphe et la synthèse sont côte à côte sur desktop puis empilés sous `lg` sans largeur fixe du canvas — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:55`
+- [x] La synthèse utilise `draft.simulatedFinal` pendant la simulation, sinon `projected` — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:220`
+- [x] Les trois séries sont identifiables par leur trait, leur libellé et leur valeur — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:79`
+- [x] Le mode masqué protège la synthèse, les tooltips et l’annonce accessible — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:101`
+- [x] Le mode visible annonce Cible, Épargné et Projection à l’échéance dans l’ordre du DOM — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts:238`
+- [x] La carte et la synthèse affichent le même montant, et le configurateur verrouille ce montant au dernier point projeté — `frontend/e2e/tests/features/savings-goals-progress.spec.ts:162`, `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts:130`
+- [x] Les viewports `1440 × 900`, `768 × 1024` et `390 × 844` utilisent une timeline mensuelle continue jusqu’en août 2027, sans débordement — `frontend/e2e/tests/features/savings-goals-progress.spec.ts:18`
+- [x] Les tests ciblés restent contenus au frontend, sans nouvelle dépendance ni modification backend, shared ou iOS — `frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.spec.ts:1`
+
+## Findings
+
+None.
+
+## Verification
+
+| Metric        | Value                                             |
+| ------------- | ------------------------------------------------- |
+| Verified      | 100% (14/14) |
+| Files checked | `plan.md`, `phase-1.md`, `phase-2.md`, `goal-projection-chart.ts`, `goal-projection-chart.config.ts`, `goal-projection-chart.plugin.ts`, `goal-projection-chart.spec.ts`, `goal-projection-chart.config.spec.ts`, `fr.json`, `savings-goals-progress.spec.ts` |
+| Unchecked     | none |
+| Unplanned     | none |

--- a/frontend/e2e/tests/features/savings-goals-progress.spec.ts
+++ b/frontend/e2e/tests/features/savings-goals-progress.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../../fixtures/test-fixtures';
 import type {
   SavingsGoalContribution,
+  SavingsGoalPlanMonth,
   SavingsGoalProgress,
 } from 'pulpe-shared';
 
@@ -14,6 +15,34 @@ const GOAL_ID = '00000000-0000-4000-a000-000000000301';
 const USER_ID = '00000000-0000-4000-a000-000000000201';
 const GOAL_NAME = 'Vacances été 2027';
 
+function buildPlanMonths(): SavingsGoalPlanMonth[] {
+  const plannedAmounts = [
+    600,
+    600,
+    ...Array.from({ length: 12 }, () => 250),
+    300,
+  ];
+  let plannedCumulative = 0;
+
+  return plannedAmounts.map((plannedAmount, index) => {
+    plannedCumulative += plannedAmount;
+    const monthIndex = 5 + index;
+    const confirmedAmount = index === 0 ? 600 : index === 1 ? 300 : 0;
+
+    return {
+      month: (monthIndex % 12) + 1,
+      year: 2026 + Math.floor(monthIndex / 12),
+      state: index === 0 ? 'past' : index === 1 ? 'current' : 'future',
+      isLocked: index === 0,
+      plannedAmount,
+      confirmedAmount,
+      plannedCumulative,
+      confirmedCumulative: index === 0 ? 600 : 900,
+      lines: [],
+    };
+  });
+}
+
 const goal = {
   id: GOAL_ID,
   userId: USER_ID,
@@ -21,8 +50,8 @@ const goal = {
   targetAmount: 3000,
   targetDate: '2027-08-01',
   status: 'ACTIVE',
-  createdAt: '2026-01-01T00:00:00.000Z',
-  updatedAt: '2026-01-01T00:00:00.000Z',
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
 };
 
 const progress = {
@@ -34,54 +63,19 @@ const progress = {
   plannedCumulative: 1200,
   confirmed: 900,
   achievementPercent: 30,
-  monthsElapsed: 3,
-  monthsRemaining: 12,
+  monthsElapsed: 2,
+  monthsRemaining: 14,
   isOverdue: false,
-  pace: 400,
-  confirmedPace: 300,
-  required: 175,
+  pace: 600,
+  confirmedPace: 450,
+  required: 150,
   projected: 4500,
-  paceStatus: 'on_track',
-  // D2 — surface the "mark completed" suggestion.
-  suggestCompletion: true,
+  paceStatus: 'ahead',
+  suggestCompletion: false,
   linkedLineCount: 2,
   cumulativeGap: 300,
-  estimatedCompletion: { month: 6, year: 2027 },
-  months: [
-    {
-      month: 6,
-      year: 2026,
-      state: 'past',
-      isLocked: true,
-      plannedAmount: 300,
-      confirmedAmount: 300,
-      plannedCumulative: 600,
-      confirmedCumulative: 600,
-      lines: [],
-    },
-    {
-      month: 7,
-      year: 2026,
-      state: 'current',
-      isLocked: false,
-      plannedAmount: 400,
-      confirmedAmount: 300,
-      plannedCumulative: 1000,
-      confirmedCumulative: 900,
-      lines: [],
-    },
-    {
-      month: 8,
-      year: 2027,
-      state: 'future',
-      isLocked: false,
-      plannedAmount: 3500,
-      confirmedAmount: 0,
-      plannedCumulative: 4500,
-      confirmedCumulative: 900,
-      lines: [],
-    },
-  ],
+  estimatedCompletion: { month: 12, year: 2026 },
+  months: buildPlanMonths(),
   originalTargetAmount: null,
   originalCurrency: null,
   targetCurrency: null,
@@ -110,7 +104,7 @@ const contributions = [
 ] satisfies SavingsGoalContribution[];
 
 test.describe('Savings goal progression (PUL-8)', () => {
-  test('navigates list → detail and shows the progress bar, Épargné label and D2 CTA', async ({
+  test('navigates list → detail and shows a coherent responsive trajectory', async ({
     authenticatedPage: page,
   }) => {
     // Registered after the global fixture mocks → matched first (LIFO).
@@ -136,6 +130,7 @@ test.describe('Savings goal progression (PUL-8)', () => {
       }),
     );
 
+    await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto('/savings-goals');
     await page.waitForLoadState('domcontentloaded');
 
@@ -153,7 +148,10 @@ test.describe('Savings goal progression (PUL-8)', () => {
     await expect(page.getByTestId('savings-goal-detail-page')).toContainText(
       'Épargné',
     );
-    await expect(page.getByTestId('goal-projection-panel')).toBeVisible();
+    const projectionPanel = page.getByTestId('goal-projection-panel');
+    const projectionCanvas = projectionPanel.locator('canvas');
+    const projectionSummary = page.getByTestId('goal-projection-summary');
+    await expect(projectionPanel).toBeVisible();
     await expect(
       page.getByTestId('goal-projection-summary-target'),
     ).toContainText(/3[\s’']?000/);
@@ -167,9 +165,43 @@ test.describe('Savings goal progression (PUL-8)', () => {
       /4[\s’']?500/,
     );
 
-    // D2 — completion suggestion CTA is visible.
-    await expect(
-      page.getByTestId('savings-goal-mark-completed-button'),
-    ).toBeVisible();
+    const [desktopCanvas, desktopSummary] = await Promise.all([
+      projectionCanvas.boundingBox(),
+      projectionSummary.boundingBox(),
+    ]);
+    expect(desktopCanvas).not.toBeNull();
+    expect(desktopSummary).not.toBeNull();
+    if (!desktopCanvas || !desktopSummary) {
+      throw new Error('Desktop projection geometry is unavailable');
+    }
+    expect(desktopSummary.x).toBeGreaterThan(
+      desktopCanvas.x + desktopCanvas.width,
+    );
+
+    for (const viewport of [
+      { width: 768, height: 1024 },
+      { width: 390, height: 844 },
+    ]) {
+      await page.setViewportSize(viewport);
+      await expect
+        .poll(() =>
+          projectionPanel.evaluate(
+            (element) => element.scrollWidth - element.clientWidth,
+          ),
+        )
+        .toBeLessThanOrEqual(0);
+      const [stackedCanvas, stackedSummary] = await Promise.all([
+        projectionCanvas.boundingBox(),
+        projectionSummary.boundingBox(),
+      ]);
+      expect(stackedCanvas).not.toBeNull();
+      expect(stackedSummary).not.toBeNull();
+      if (!stackedCanvas || !stackedSummary) {
+        throw new Error('Stacked projection geometry is unavailable');
+      }
+      expect(stackedSummary.y).toBeGreaterThan(
+        stackedCanvas.y + stackedCanvas.height,
+      );
+    }
   });
 });

--- a/frontend/e2e/tests/features/savings-goals-progress.spec.ts
+++ b/frontend/e2e/tests/features/savings-goals-progress.spec.ts
@@ -47,7 +47,41 @@ const progress = {
   linkedLineCount: 2,
   cumulativeGap: 300,
   estimatedCompletion: { month: 6, year: 2027 },
-  months: [],
+  months: [
+    {
+      month: 6,
+      year: 2026,
+      state: 'past',
+      isLocked: true,
+      plannedAmount: 300,
+      confirmedAmount: 300,
+      plannedCumulative: 600,
+      confirmedCumulative: 600,
+      lines: [],
+    },
+    {
+      month: 7,
+      year: 2026,
+      state: 'current',
+      isLocked: false,
+      plannedAmount: 400,
+      confirmedAmount: 300,
+      plannedCumulative: 1000,
+      confirmedCumulative: 900,
+      lines: [],
+    },
+    {
+      month: 8,
+      year: 2027,
+      state: 'future',
+      isLocked: false,
+      plannedAmount: 3500,
+      confirmedAmount: 0,
+      plannedCumulative: 4500,
+      confirmedCumulative: 900,
+      lines: [],
+    },
+  ],
   originalTargetAmount: null,
   originalCurrency: null,
   targetCurrency: null,
@@ -118,6 +152,19 @@ test.describe('Savings goal progression (PUL-8)', () => {
     await expect(page.getByTestId('progress-projected-layer')).toBeVisible();
     await expect(page.getByTestId('savings-goal-detail-page')).toContainText(
       'Épargné',
+    );
+    await expect(page.getByTestId('goal-projection-panel')).toBeVisible();
+    await expect(
+      page.getByTestId('goal-projection-summary-target'),
+    ).toContainText(/3[\s’']?000/);
+    await expect(
+      page.getByTestId('goal-projection-summary-confirmed'),
+    ).toContainText('900');
+    await expect(
+      page.getByTestId('goal-projection-summary-projection'),
+    ).toContainText(/4[\s’']?500/);
+    await expect(page.getByTestId('stat-projected')).toContainText(
+      /4[\s’']?500/,
     );
 
     // D2 — completion suggestion CTA is visible.

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -1006,7 +1006,9 @@
       "chartTarget": "Cible",
       "chartConfirmed": "Épargné",
       "chartProjection": "Projection planifiée",
-      "chartAria": "Trajectoire d'épargne : épargné {{ confirmed }}, projection planifiée {{ projected }}, cible {{ target }}."
+      "chartCurrentPeriod": "Maintenant",
+      "chartAria": "Trajectoire d'épargne : cible {{ target }}, épargné {{ confirmed }}, projection à l'échéance {{ projected }}.",
+      "chartAriaHidden": "Trajectoire d'épargne : les montants sont masqués."
     },
     "simulate": {
       "everyMonth": "Chaque mois, je mets",

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts
@@ -107,7 +107,9 @@ describe('buildGoalProjectionChartData', () => {
     >[];
     expect(target.borderDash).toBeUndefined();
     expect(confirmed.pointRadius).toEqual([0, 3, 0]);
+    expect(confirmed.borderColor).toBe(theme.savings);
     expect(projection.borderDash).toEqual([4, 4]);
+    expect(projection.borderColor).toBe(theme.income);
     expect(projection.pointRadius).toEqual([0, 0, 3]);
   });
 

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts
@@ -4,8 +4,13 @@ import type {
   SavingsPlanSimulatedMonth,
   SavingsPlanSimulationResult,
 } from 'pulpe-shared';
+import type { ChartDataset } from 'chart.js';
 import type { ChartThemeColors } from '@core/chart/chart-theme';
-import { buildGoalProjectionChartData } from './goal-projection-chart.config';
+import {
+  buildGoalProjectionChartData,
+  buildGoalProjectionChartOptions,
+} from './goal-projection-chart.config';
+import { findCurrentPeriodIndex } from './goal-projection-chart.plugin';
 
 const theme: ChartThemeColors = {
   income: 'rgb(76, 175, 80)',
@@ -96,6 +101,14 @@ describe('buildGoalProjectionChartData', () => {
       'Épargné',
       'Projection planifiée',
     ]);
+    const [target, confirmed, projection] = data.datasets as ChartDataset<
+      'line',
+      (number | null)[]
+    >[];
+    expect(target.borderDash).toBeUndefined();
+    expect(confirmed.pointRadius).toEqual([0, 3, 0]);
+    expect(projection.borderDash).toEqual([4, 4]);
+    expect(projection.pointRadius).toEqual([0, 0, 3]);
   });
 
   it('nulls the pointé series after the current month', () => {
@@ -160,5 +173,26 @@ describe('buildGoalProjectionChartData', () => {
       (d) => d.label === 'Projection planifiée',
     );
     expect(projection?.data).toEqual([null, 180, 420]);
+  });
+});
+
+describe('buildGoalProjectionChartOptions', () => {
+  it('keeps the timeline sparse and hides the vertical accounting axis', () => {
+    const options = buildGoalProjectionChartOptions(theme);
+
+    expect(options?.scales?.['x']?.grid?.display).toBe(false);
+    expect(options?.scales?.['y']?.display).toBe(false);
+    expect(options?.elements?.line?.cubicInterpolationMode).toBe('monotone');
+  });
+});
+
+describe('findCurrentPeriodIndex', () => {
+  it('returns only a real current period', () => {
+    expect(findCurrentPeriodIndex(months)).toBe(1);
+    expect(
+      findCurrentPeriodIndex(
+        months.map((month) => ({ ...month, state: 'past' })),
+      ),
+    ).toBe(-1);
   });
 });

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.spec.ts
@@ -183,6 +183,7 @@ describe('buildGoalProjectionChartOptions', () => {
     expect(options?.scales?.['x']?.grid?.display).toBe(false);
     expect(options?.scales?.['y']?.display).toBe(false);
     expect(options?.elements?.line?.cubicInterpolationMode).toBe('monotone');
+    expect(options?.plugins?.legend?.display).toBe(false);
   });
 });
 

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts
@@ -12,7 +12,7 @@ import {
   CHART_FONT_FAMILY,
 } from '@core/chart/chart-theme';
 
-const MASKED_VALUE = '•••••';
+export const MASKED_VALUE = '•••••';
 
 export interface GoalProjectionChartLabels {
   target: string;
@@ -47,14 +47,14 @@ export function buildGoalProjectionChartOptions(
     maintainAspectRatio: false,
     animation: reducedMotion ? false : undefined,
     interaction: { mode: 'index', intersect: false },
-    layout: { padding: { top: 8, right: 4, left: 4 } },
+    layout: { padding: { top: 8, right: 16, left: 4 } },
     elements: {
       line: { cubicInterpolationMode: 'monotone', borderWidth: 2 },
       point: { radius: 0, hoverRadius: 4 },
     },
     plugins: {
       legend: {
-        display: true,
+        display: false,
         position: 'top',
         align: 'end',
         labels: {

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts
@@ -12,7 +12,6 @@ import {
   CHART_FONT_FAMILY,
 } from '@core/chart/chart-theme';
 
-const AXIS_ABBREVIATION_THRESHOLD = 1000;
 const MASKED_VALUE = '•••••';
 
 export interface GoalProjectionChartLabels {
@@ -48,8 +47,9 @@ export function buildGoalProjectionChartOptions(
     maintainAspectRatio: false,
     animation: reducedMotion ? false : undefined,
     interaction: { mode: 'index', intersect: false },
+    layout: { padding: { top: 8, right: 4, left: 4 } },
     elements: {
-      line: { tension: 0.2, borderWidth: 2 },
+      line: { cubicInterpolationMode: 'monotone', borderWidth: 2 },
       point: { radius: 0, hoverRadius: 4 },
     },
     plugins: {
@@ -90,27 +90,19 @@ export function buildGoalProjectionChartOptions(
     },
     scales: {
       x: {
-        grid: { display: false },
+        border: { display: false },
+        grid: { display: false, drawTicks: false },
         ticks: {
           font: { family: CHART_FONT_FAMILY, size: 11 },
           color: tickColor,
           maxRotation: 0,
           autoSkipPadding: 12,
+          padding: 8,
         },
       },
       y: {
-        grid: { color: gridColor },
-        ticks: {
-          font: { family: CHART_FONT_FAMILY, size: 11 },
-          color: tickColor,
-          callback: function (value: string | number) {
-            if (amountsHidden) return '•';
-            const num = Number(value);
-            if (num >= AXIS_ABBREVIATION_THRESHOLD)
-              return num / AXIS_ABBREVIATION_THRESHOLD + 'k';
-            return num;
-          },
-        },
+        display: false,
+        grid: { display: false, color: gridColor },
       },
     },
   };
@@ -154,6 +146,14 @@ function buildPlannedProjection(
   // The server owns the canonical endpoint; this also absorbs float rounding.
   data[lastIndex] = projected;
   return data;
+}
+
+function terminalPointRadii(data: readonly (number | null)[]): number[] {
+  let lastValueIndex = -1;
+  data.forEach((value, index) => {
+    if (value !== null) lastValueIndex = index;
+  });
+  return data.map((_, index) => (index === lastValueIndex ? 3 : 0));
 }
 
 /**
@@ -207,8 +207,7 @@ export function buildGoalProjectionChartData(
       data: targetData,
       label: labels.target,
       borderColor: colorWithAlpha(theme.tickColor, 0.5),
-      borderWidth: 1,
-      borderDash: [4, 4],
+      borderWidth: 1.5,
       pointRadius: 0,
       pointHoverRadius: 0,
       fill: false,
@@ -219,6 +218,9 @@ export function buildGoalProjectionChartData(
       borderColor: theme.savings,
       backgroundColor: colorWithAlpha(theme.savings, 0.12),
       pointBackgroundColor: theme.savings,
+      pointBorderColor: theme.savings,
+      pointBorderWidth: 2,
+      pointRadius: terminalPointRadii(confirmedData),
       spanGaps: false,
       fill: 'origin',
     } as ChartConfiguration['data']['datasets'][number],
@@ -226,9 +228,12 @@ export function buildGoalProjectionChartData(
       data: projectionData,
       label: labels.projection,
       borderColor: theme.savings,
-      borderDash: [6, 4],
+      borderDash: [4, 4],
       backgroundColor: 'transparent',
       pointBackgroundColor: theme.savings,
+      pointBorderColor: theme.savings,
+      pointBorderWidth: 2,
+      pointRadius: terminalPointRadii(projectionData),
       fill: false,
     } as ChartConfiguration['data']['datasets'][number],
   ];

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.config.ts
@@ -39,7 +39,6 @@ export function buildGoalProjectionChartOptions(
   reducedMotion = false,
 ): ChartConfiguration['options'] {
   const tickColor = theme?.tickColor || undefined;
-  const gridColor = theme?.gridColor || undefined;
   const tooltipBg = theme?.tooltipBg || undefined;
 
   return {
@@ -102,7 +101,7 @@ export function buildGoalProjectionChartOptions(
       },
       y: {
         display: false,
-        grid: { display: false, color: gridColor },
+        grid: { display: false },
       },
     },
   };
@@ -157,10 +156,9 @@ function terminalPointRadii(data: readonly (number | null)[]): number[] {
 }
 
 /**
- * Three balance series over the anchor → target axis (RG-002 — savings never
- * amber/red): cible, réalité épargnée through the current month, and planned
- * projection anchored on that reality. Simulation replaces the projection with
- * the sandbox trajectory.
+ * Three balance series over the anchor → target axis: neutral target, savings
+ * green for confirmed reality, and tertiary blue for the planned projection.
+ * Simulation replaces the projection with the sandbox trajectory.
  */
 export function buildGoalProjectionChartData(
   input: GoalProjectionChartInput,
@@ -227,11 +225,11 @@ export function buildGoalProjectionChartData(
     {
       data: projectionData,
       label: labels.projection,
-      borderColor: theme.savings,
+      borderColor: theme.income,
       borderDash: [4, 4],
       backgroundColor: 'transparent',
-      pointBackgroundColor: theme.savings,
-      pointBorderColor: theme.savings,
+      pointBackgroundColor: theme.income,
+      pointBorderColor: theme.income,
       pointBorderWidth: 2,
       pointRadius: terminalPointRadii(projectionData),
       fill: false,

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.plugin.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'chart.js';
+import type { Chart, Plugin } from 'chart.js';
 import type { SavingsGoalPlanMonth } from 'pulpe-shared';
 import {
   type ChartThemeColors,
@@ -10,6 +10,16 @@ export function findCurrentPeriodIndex(
   months: readonly SavingsGoalPlanMonth[],
 ): number {
   return months.findIndex((month) => month.state === 'current');
+}
+
+function resolveGuidePosition(chart: Chart, currentIndex: number) {
+  if (currentIndex < 0) return null;
+  const xScale = chart.scales['x'];
+  const { ctx, chartArea } = chart;
+  if (!xScale || !chartArea) return null;
+
+  const x = xScale.getPixelForValue(currentIndex);
+  return Number.isFinite(x) ? { ctx, chartArea, x } : null;
 }
 
 export function buildGoalProjectionGuidePlugin(
@@ -24,13 +34,9 @@ export function buildGoalProjectionGuidePlugin(
   return {
     id: 'goal-projection-guide',
     beforeDatasetsDraw(chart) {
-      if (currentIndex < 0) return;
-      const xScale = chart.scales['x'];
-      const { ctx, chartArea } = chart;
-      if (!xScale || !chartArea) return;
-
-      const x = xScale.getPixelForValue(currentIndex);
-      if (!Number.isFinite(x)) return;
+      const guide = resolveGuidePosition(chart, currentIndex);
+      if (!guide) return;
+      const { ctx, chartArea, x } = guide;
 
       ctx.save();
       ctx.fillStyle = futureBackground;
@@ -43,13 +49,9 @@ export function buildGoalProjectionGuidePlugin(
       ctx.restore();
     },
     afterDatasetsDraw(chart) {
-      if (currentIndex < 0) return;
-      const xScale = chart.scales['x'];
-      const { ctx, chartArea } = chart;
-      if (!xScale || !chartArea) return;
-
-      const x = xScale.getPixelForValue(currentIndex);
-      if (!Number.isFinite(x)) return;
+      const guide = resolveGuidePosition(chart, currentIndex);
+      if (!guide) return;
+      const { ctx, chartArea, x } = guide;
 
       ctx.save();
       ctx.beginPath();
@@ -62,13 +64,10 @@ export function buildGoalProjectionGuidePlugin(
       ctx.restore();
     },
     afterDraw(chart) {
-      if (currentIndex < 0 || !label) return;
-      const xScale = chart.scales['x'];
-      const { ctx, chartArea } = chart;
-      if (!xScale || !chartArea) return;
-
-      const x = xScale.getPixelForValue(currentIndex);
-      if (!Number.isFinite(x)) return;
+      if (!label) return;
+      const guide = resolveGuidePosition(chart, currentIndex);
+      if (!guide) return;
+      const { ctx, chartArea, x } = guide;
 
       ctx.save();
       ctx.font = `600 11px ${CHART_FONT_FAMILY}`;

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.plugin.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.plugin.ts
@@ -1,6 +1,10 @@
 import type { Plugin } from 'chart.js';
 import type { SavingsGoalPlanMonth } from 'pulpe-shared';
-import { type ChartThemeColors, colorWithAlpha } from '@core/chart/chart-theme';
+import {
+  type ChartThemeColors,
+  CHART_FONT_FAMILY,
+  colorWithAlpha,
+} from '@core/chart/chart-theme';
 
 export function findCurrentPeriodIndex(
   months: readonly SavingsGoalPlanMonth[],
@@ -11,9 +15,11 @@ export function findCurrentPeriodIndex(
 export function buildGoalProjectionGuidePlugin(
   currentIndex: number,
   theme: ChartThemeColors,
+  label: string,
 ): Plugin {
   const futureBackground = colorWithAlpha(theme.tickColor, 0.035);
   const markerColor = colorWithAlpha(theme.tickColor, 0.35);
+  const labelBackground = colorWithAlpha(theme.tickColor, 0.1);
 
   return {
     id: 'goal-projection-guide',
@@ -53,6 +59,35 @@ export function buildGoalProjectionGuidePlugin(
       ctx.moveTo(x, chartArea.top);
       ctx.lineTo(x, chartArea.bottom);
       ctx.stroke();
+      ctx.restore();
+    },
+    afterDraw(chart) {
+      if (currentIndex < 0 || !label) return;
+      const xScale = chart.scales['x'];
+      const { ctx, chartArea } = chart;
+      if (!xScale || !chartArea) return;
+
+      const x = xScale.getPixelForValue(currentIndex);
+      if (!Number.isFinite(x)) return;
+
+      ctx.save();
+      ctx.font = `600 11px ${CHART_FONT_FAMILY}`;
+      const width = ctx.measureText(label).width + 14;
+      const height = 20;
+      const centerX = Math.min(
+        chartArea.right - width / 2,
+        Math.max(chartArea.left + width / 2, x),
+      );
+      const top = chartArea.top + 4;
+
+      ctx.fillStyle = labelBackground;
+      ctx.beginPath();
+      ctx.roundRect(centerX - width / 2, top, width, height, 5);
+      ctx.fill();
+      ctx.fillStyle = theme.tickColor;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(label, centerX, top + height / 2);
       ctx.restore();
     },
   };

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.plugin.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.plugin.ts
@@ -1,0 +1,59 @@
+import type { Plugin } from 'chart.js';
+import type { SavingsGoalPlanMonth } from 'pulpe-shared';
+import { type ChartThemeColors, colorWithAlpha } from '@core/chart/chart-theme';
+
+export function findCurrentPeriodIndex(
+  months: readonly SavingsGoalPlanMonth[],
+): number {
+  return months.findIndex((month) => month.state === 'current');
+}
+
+export function buildGoalProjectionGuidePlugin(
+  currentIndex: number,
+  theme: ChartThemeColors,
+): Plugin {
+  const futureBackground = colorWithAlpha(theme.tickColor, 0.035);
+  const markerColor = colorWithAlpha(theme.tickColor, 0.35);
+
+  return {
+    id: 'goal-projection-guide',
+    beforeDatasetsDraw(chart) {
+      if (currentIndex < 0) return;
+      const xScale = chart.scales['x'];
+      const { ctx, chartArea } = chart;
+      if (!xScale || !chartArea) return;
+
+      const x = xScale.getPixelForValue(currentIndex);
+      if (!Number.isFinite(x)) return;
+
+      ctx.save();
+      ctx.fillStyle = futureBackground;
+      ctx.fillRect(
+        x,
+        chartArea.top,
+        Math.max(0, chartArea.right - x),
+        chartArea.height,
+      );
+      ctx.restore();
+    },
+    afterDatasetsDraw(chart) {
+      if (currentIndex < 0) return;
+      const xScale = chart.scales['x'];
+      const { ctx, chartArea } = chart;
+      if (!xScale || !chartArea) return;
+
+      const x = xScale.getPixelForValue(currentIndex);
+      if (!Number.isFinite(x)) return;
+
+      ctx.save();
+      ctx.beginPath();
+      ctx.setLineDash([2, 3]);
+      ctx.strokeStyle = markerColor;
+      ctx.lineWidth = 1;
+      ctx.moveTo(x, chartArea.top);
+      ctx.lineTo(x, chartArea.bottom);
+      ctx.stroke();
+      ctx.restore();
+    },
+  };
+}

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.spec.ts
@@ -1,0 +1,170 @@
+import {
+  Directive,
+  Input,
+  LOCALE_ID,
+  provideZonelessChangeDetection,
+} from '@angular/core';
+import { registerLocaleData } from '@angular/common';
+import localeDeCh from '@angular/common/locales/de-CH';
+import { TestBed } from '@angular/core/testing';
+import { AmountsVisibilityService } from '@core/amounts-visibility/amounts-visibility.service';
+import { BaseChartDirective } from 'ng2-charts';
+import type {
+  SavingsGoalPlanMonth,
+  SavingsPlanSimulationResult,
+} from 'pulpe-shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
+import { setTestInput } from '@app/testing/signal-test-utils';
+import { GoalProjectionChart } from './goal-projection-chart';
+
+registerLocaleData(localeDeCh, 'de-CH');
+
+// Mirrors ng2-charts' third-party selector so the component template stays unchanged.
+// eslint-disable-next-line @angular-eslint/directive-selector
+@Directive({ selector: 'canvas[baseChart]' })
+class StubBaseChartDirective {
+  @Input() data: unknown;
+  @Input() options: unknown;
+  @Input() plugins: unknown;
+  @Input() type: unknown;
+}
+
+const months: SavingsGoalPlanMonth[] = [
+  {
+    month: 1,
+    year: 2026,
+    state: 'past',
+    isLocked: true,
+    plannedAmount: 100,
+    confirmedAmount: 100,
+    plannedCumulative: 100,
+    confirmedCumulative: 100,
+    lines: [],
+  },
+  {
+    month: 2,
+    year: 2026,
+    state: 'current',
+    isLocked: false,
+    plannedAmount: 100,
+    confirmedAmount: 20,
+    plannedCumulative: 200,
+    confirmedCumulative: 180,
+    lines: [],
+  },
+  {
+    month: 3,
+    year: 2026,
+    state: 'future',
+    isLocked: false,
+    plannedAmount: 180,
+    confirmedAmount: 0,
+    plannedCumulative: 380,
+    confirmedCumulative: 180,
+    lines: [],
+  },
+];
+
+const draft: SavingsPlanSimulationResult = {
+  months: months.map((month, index) => ({
+    ...month,
+    simulatedAmount: [100, 100, 240][index],
+    simulatedCumulative: [100, 180, 420][index],
+    isAdjusted: index === 2,
+  })),
+  simulatedFinal: 420,
+  gapToTarget: -120,
+  isTargetMet: true,
+  attainedPeriod: { month: 3, year: 2026 },
+};
+
+describe('GoalProjectionChart', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GoalProjectionChart],
+      providers: [
+        provideZonelessChangeDetection(),
+        ...provideTranslocoForTest(),
+        { provide: LOCALE_ID, useValue: 'fr-CH' },
+      ],
+    })
+      .overrideComponent(GoalProjectionChart, {
+        remove: { imports: [BaseChartDirective] },
+        add: { imports: [StubBaseChartDirective] },
+      })
+      .compileComponents();
+  });
+
+  afterEach(() => {
+    document.body.classList.remove('amounts-hidden');
+  });
+
+  function render(simulation: SavingsPlanSimulationResult | null = null) {
+    const fixture = TestBed.createComponent(GoalProjectionChart);
+    const component = fixture.componentInstance;
+    setTestInput(component.months, months);
+    setTestInput(component.draft, simulation);
+    setTestInput(component.targetAmount, 300);
+    setTestInput(component.currency, 'CHF');
+    setTestInput(component.confirmed, 180);
+    setTestInput(component.projected, 360);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders target, confirmed savings and deadline projection as a semantic summary', () => {
+    const fixture = render();
+    const summary = fixture.nativeElement.querySelector(
+      '[data-testid="goal-projection-summary"]',
+    );
+    const rows = summary?.querySelectorAll('div');
+
+    expect(summary?.tagName).toBe('DL');
+    expect(rows).toHaveLength(3);
+    expect(summary?.textContent).toContain('Cible');
+    expect(summary?.textContent).toContain('Épargné');
+    expect(summary?.textContent).toContain("Projection à l'échéance");
+    expect(
+      fixture.nativeElement.querySelector(
+        '[data-testid="goal-projection-summary-projection"]',
+      )?.textContent,
+    ).toContain('360');
+    expect(
+      fixture.nativeElement.querySelector(
+        '[data-testid="goal-projection-aria"]',
+      )?.textContent,
+    ).toMatch(
+      /cible 300(?:\.00)? CHF.+épargné 180(?:\.00)? CHF.+projection à l'échéance 360(?:\.00)? CHF/i,
+    );
+  });
+
+  it('uses the simulated endpoint in the summary', () => {
+    const fixture = render(draft);
+
+    expect(
+      fixture.nativeElement.querySelector(
+        '[data-testid="goal-projection-summary-projection"]',
+      )?.textContent,
+    ).toContain('420');
+  });
+
+  it('hides visual and accessible amounts together', () => {
+    const fixture = render();
+    TestBed.inject(AmountsVisibilityService).toggle();
+    fixture.detectChanges();
+
+    const values = [
+      ...fixture.nativeElement.querySelectorAll(
+        '[data-testid^="goal-projection-summary-"]',
+      ),
+    ].map((element: Element) => element.textContent?.trim());
+    const aria = fixture.nativeElement.querySelector(
+      '[data-testid="goal-projection-aria"]',
+    )?.textContent;
+
+    expect(values).toEqual(['•••••', '•••••', '•••••']);
+    expect(aria).toContain('montants sont masqués');
+    expect(aria).not.toMatch(/180|300|360|CHF/);
+  });
+});

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts
@@ -18,6 +18,7 @@ import {
   type SupportedCurrency,
 } from 'pulpe-shared';
 import { AmountsVisibilityService } from '@core/amounts-visibility/amounts-visibility.service';
+import { AppCurrencyPipe } from '@core/currency';
 import {
   type ChartThemeColors,
   formatCurrency,
@@ -27,6 +28,7 @@ import {
 import {
   buildGoalProjectionChartData,
   buildGoalProjectionChartOptions,
+  MASKED_VALUE,
 } from './goal-projection-chart.config';
 import {
   buildGoalProjectionGuidePlugin,
@@ -42,20 +44,76 @@ import {
  */
 @Component({
   selector: 'pulpe-goal-projection-chart',
-  imports: [BaseChartDirective],
+  imports: [AppCurrencyPipe, BaseChartDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="flex flex-col gap-2">
-      <div class="relative h-[260px] w-full">
-        <canvas
-          baseChart
-          aria-hidden="true"
-          [data]="chartData()"
-          [options]="chartOptions()"
-          [plugins]="chartPlugins()"
-          [type]="chartType"
-        ></canvas>
+    <div
+      class="min-w-0 rounded-2xl bg-surface-container-low p-3 sm:p-4"
+      data-testid="goal-projection-panel"
+    >
+      <div
+        class="grid min-w-0 gap-3 lg:grid-cols-[minmax(0,1fr)_19rem] lg:gap-4"
+      >
+        <div class="relative h-[220px] min-w-0 w-full sm:h-[260px]">
+          <canvas
+            baseChart
+            aria-hidden="true"
+            [data]="chartData()"
+            [options]="chartOptions()"
+            [plugins]="chartPlugins()"
+            [type]="chartType"
+          ></canvas>
+        </div>
+
+        <dl
+          class="min-w-0 border-t border-outline-variant/50 lg:border-t-0 lg:border-l"
+          data-testid="goal-projection-summary"
+        >
+          @for (item of summaryItems(); track item.series) {
+            <div
+              class="flex min-w-0 items-center gap-3 border-t border-outline-variant/50 py-3 first:border-t-0 lg:px-4"
+            >
+              <dt
+                class="flex min-w-0 items-center gap-2 text-body-medium text-on-surface-variant"
+              >
+                @switch (item.series) {
+                  @case ('target') {
+                    <span
+                      class="h-px w-5 shrink-0 bg-on-surface-variant/60"
+                      aria-hidden="true"
+                    ></span>
+                  }
+                  @case ('confirmed') {
+                    <span
+                      class="h-0.5 w-5 shrink-0 rounded-full bg-financial-savings"
+                      aria-hidden="true"
+                    ></span>
+                  }
+                  @case ('projection') {
+                    <span
+                      class="w-5 shrink-0 border-t-2 border-dashed border-financial-savings"
+                      aria-hidden="true"
+                    ></span>
+                  }
+                }
+                <span class="truncate">{{ item.label }}</span>
+              </dt>
+              <dd
+                class="ph-no-capture ml-auto shrink-0 text-body-medium font-semibold tabular-nums"
+                [class.amounts-visible]="amountsHidden()"
+                [attr.data-testid]="'goal-projection-summary-' + item.series"
+              >
+                @if (amountsHidden()) {
+                  {{ maskedValue }}
+                } @else {
+                  {{ item.amount | appCurrency: currency() : '1.0-0' }}
+                }
+              </dd>
+            </div>
+          }
+        </dl>
       </div>
+
       <p class="sr-only" aria-live="polite" data-testid="goal-projection-aria">
         {{ ariaSentence() }}
       </p>
@@ -64,6 +122,7 @@ import {
   styles: `
     :host {
       display: block;
+      min-width: 0;
     }
     .sr-only {
       position: absolute;
@@ -95,12 +154,22 @@ export class GoalProjectionChart {
   readonly #reducedMotion = signal(false);
 
   readonly chartType = 'line' as const;
+  protected readonly amountsHidden = this.#amountsVisibility.amountsHidden;
+  protected readonly maskedValue = MASKED_VALUE;
 
   readonly #labels = {
     target: this.#transloco.translate('savingsGoals.plan.chartTarget'),
     confirmed: this.#transloco.translate('savingsGoals.plan.chartConfirmed'),
     projection: this.#transloco.translate('savingsGoals.plan.chartProjection'),
   };
+  readonly #summaryLabels = {
+    target: this.#labels.target,
+    confirmed: this.#labels.confirmed,
+    projection: this.#transloco.translate('savingsGoals.detail.projected'),
+  };
+  readonly #currentPeriodLabel = this.#transloco.translate(
+    'savingsGoals.plan.chartCurrentPeriod',
+  );
 
   constructor() {
     afterNextRender(() => {
@@ -143,13 +212,35 @@ export class GoalProjectionChart {
       buildGoalProjectionGuidePlugin(
         findCurrentPeriodIndex(this.months()),
         theme,
+        this.#currentPeriodLabel,
       ),
     ];
   });
 
+  protected readonly summaryItems = computed(() => [
+    {
+      series: 'target' as const,
+      label: this.#summaryLabels.target,
+      amount: this.targetAmount(),
+    },
+    {
+      series: 'confirmed' as const,
+      label: this.#summaryLabels.confirmed,
+      amount: this.confirmed(),
+    },
+    {
+      series: 'projection' as const,
+      label: this.#summaryLabels.projection,
+      amount: this.draft()?.simulatedFinal ?? this.projected(),
+    },
+  ]);
+
   protected readonly ariaSentence = computed(() => {
     const months = this.months();
     if (months.length === 0) return '';
+    if (this.#amountsVisibility.amountsHidden()) {
+      return this.#transloco.translate('savingsGoals.plan.chartAriaHidden');
+    }
     const draft = this.draft();
     const currency = this.currency();
     const projectedFinal = draft?.simulatedFinal ?? this.projected();

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts
@@ -10,7 +10,7 @@ import {
   signal,
 } from '@angular/core';
 import { BaseChartDirective } from 'ng2-charts';
-import type { ChartType } from 'chart.js';
+import type { Plugin } from 'chart.js';
 import { TranslocoService } from '@jsverse/transloco';
 import {
   type SavingsGoalPlanMonth,
@@ -28,6 +28,10 @@ import {
   buildGoalProjectionChartData,
   buildGoalProjectionChartOptions,
 } from './goal-projection-chart.config';
+import {
+  buildGoalProjectionGuidePlugin,
+  findCurrentPeriodIndex,
+} from './goal-projection-chart.plugin';
 
 /**
  * « Ta trajectoire » (docs/SAVINGS.md §10.1). Read-only cumulated
@@ -48,6 +52,7 @@ import {
           aria-hidden="true"
           [data]="chartData()"
           [options]="chartOptions()"
+          [plugins]="chartPlugins()"
           [type]="chartType"
         ></canvas>
       </div>
@@ -89,7 +94,7 @@ export class GoalProjectionChart {
   readonly #theme = signal<ChartThemeColors | null>(null);
   readonly #reducedMotion = signal(false);
 
-  readonly chartType: ChartType = 'line';
+  readonly chartType = 'line' as const;
 
   readonly #labels = {
     target: this.#transloco.translate('savingsGoals.plan.chartTarget'),
@@ -129,6 +134,18 @@ export class GoalProjectionChart {
       labels: this.#labels,
     }),
   );
+
+  readonly chartPlugins = computed<Plugin[]>(() => {
+    const theme = this.#theme();
+    if (!theme) return [];
+
+    return [
+      buildGoalProjectionGuidePlugin(
+        findCurrentPeriodIndex(this.months()),
+        theme,
+      ),
+    ];
+  });
 
   protected readonly ariaSentence = computed(() => {
     const months = this.months();

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/components/goal-projection-chart.ts
@@ -37,10 +37,10 @@ import {
 
 /**
  * « Ta trajectoire » (docs/SAVINGS.md §10.1). Read-only cumulated
- * chart (savings green only, RG-002 — never amber/red). Switches its data source
- * to the simulation sandbox when `draft` is provided. The canvas is paired with
- * an offscreen `aria-live` sentence so screen readers get the trajectory without
- * the visual.
+ * chart: confirmed savings in green, planned projection in tertiary blue, and a
+ * neutral target. Switches its data source to the simulation sandbox when
+ * `draft` is provided. The canvas is paired with an offscreen `aria-live`
+ * sentence so screen readers get the trajectory without the visual.
  */
 @Component({
   selector: 'pulpe-goal-projection-chart',
@@ -91,7 +91,7 @@ import {
                   }
                   @case ('projection') {
                     <span
-                      class="w-5 shrink-0 border-t-2 border-dashed border-financial-savings"
+                      class="w-5 shrink-0 border-t-2 border-dashed border-tertiary"
                       aria-hidden="true"
                     ></span>
                   }

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/savings-goal-detail-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/savings-goal-detail-page.spec.ts
@@ -294,8 +294,10 @@ describe('SavingsGoalDetailPage', () => {
     expect(projected).toBeTruthy();
     // Confirmed layer uses the server-provided achievementPercent (30%).
     expect(confirmed.nativeElement.style.width).toBe('30%');
+    expect(confirmed.nativeElement.classList).toContain('bg-financial-savings');
     // Projected balance layer uses the server endpoint: 2400/3000 = 80%.
     expect(projected.nativeElement.style.width).toBe('80%');
+    expect(projected.nativeElement.classList).toContain('bg-tertiary');
 
     const bar = query('savings-goal-progress-bar');
     expect(bar.attributes['aria-valuenow']).toBe('30');

--- a/frontend/projects/webapp/src/app/feature/savings-goals/detail/savings-goal-detail-page.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/detail/savings-goal-detail-page.ts
@@ -235,7 +235,7 @@ type DetailViewState = 'loading' | 'error' | 'notFound' | 'ready';
                   data-testid="savings-goal-progress-bar"
                 >
                   <div
-                    class="absolute inset-y-0 left-0 rounded-full bg-financial-savings/35 motion-safe:transition-[width] motion-safe:duration-700"
+                    class="absolute inset-y-0 left-0 rounded-full bg-tertiary motion-safe:transition-[width] motion-safe:duration-700"
                     [style.width.%]="projectedPercent()"
                     data-testid="progress-projected-layer"
                   ></div>
@@ -333,7 +333,7 @@ type DetailViewState = 'loading' | 'error' | 'notFound' | 'ready';
                     class="flex items-center gap-1.5 text-body-small text-on-surface-variant"
                   >
                     <span
-                      class="inline-block size-2.5 rounded-full bg-financial-savings/35"
+                      class="inline-block size-2.5 rounded-full bg-tertiary"
                       aria-hidden="true"
                     ></span>
                     {{ 'savingsGoals.detail.projected' | transloco }}

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalProgressCard.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalProgressCard.swift
@@ -46,7 +46,7 @@ struct GoalProgressCard: View {
                 )
                 statRow(
                     label: "Projection à l'échéance", value: progress.projected.asCompactCurrency(currency),
-                    swatch: Color.financialSavings.opacity(DesignTokens.Opacity.strong)
+                    swatch: Color.financialIncome
                 )
                 if let required = progress.required, hasClosedPlanMonth {
                     if SavingsGoalDetailViewModel.requiredMatchesPlannedPace(
@@ -72,7 +72,7 @@ struct GoalProgressCard: View {
                 .fill(Color.progressTrack)
 
             ProgressBarShape(progress: CGFloat(progress.projectedFraction))
-                .fill(Color.financialSavings.opacity(DesignTokens.Opacity.strong))
+                .fill(Color.financialIncome)
                 .animation(DesignTokens.Animation.gentleSpring, value: progress.projectedFraction)
 
             ProgressBarShape(progress: CGFloat(progress.confirmedFraction))

--- a/ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift
+++ b/ios/Pulpe/Features/SavingsGoals/Components/GoalProjectionChart.swift
@@ -6,8 +6,8 @@ import SwiftUI
 /// Three balance series anchored → target (`docs/SAVINGS.md` §10.1):
 /// **Épargné** (reality, stops at current month), **Projection planifiée**
 /// (confirmed balance + remaining planned contributions), and a flat **Cible**
-/// rule. Savings green + neutrals only — never
-/// amber/red (RG-002). Cloned from `RealizedBalanceSheet.BalanceTrendChart`.
+/// rule. Confirmed savings stay green; the planned future uses the existing
+/// blue income/information token. Cloned from `RealizedBalanceSheet.BalanceTrendChart`.
 struct GoalProjectionChart: View {
     let series: GoalProjectionSeries
     let currency: SupportedCurrency
@@ -67,7 +67,7 @@ struct GoalProjectionChart: View {
                 )
                 .interpolationMethod(.monotone)
                 .lineStyle(StrokeStyle(lineWidth: DesignTokens.BorderWidth.medium, lineCap: .round, dash: [5, 4]))
-                .foregroundStyle(Color.financialSavings.opacity(DesignTokens.Opacity.strong))
+                .foregroundStyle(Color.financialIncome)
             }
         }
         .chartXAxis {


### PR DESCRIPTION
# Clarify the planned savings-goal trajectory

## ✅ Type of PR

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Refines the web goal-detail trajectory with the existing Chart.js stack. The chart now presents the target, confirmed savings, and the planned deadline projection as three distinct, accessible balances.

This PR is stacked on #550 so its diff remains limited to the visualization. Its base can move to `preview` after #550 merges.

## 🚶‍➡️ Behavior

- Shows confirmed savings as a solid green trajectory and the future planned balance as a dashed continuation from the confirmed amount.
- Keeps the target as a neutral reference and aligns the chart endpoint with “Projection à l’échéance”.
- Adds an accessible HTML summary that respects currency, simulation mode, and hidden-amount privacy.
- Places the summary beside the chart on desktop and below it on tablet/mobile without horizontal overflow.

## 🧪 Steps to test

- [x] Run the 10 targeted Chart.js/component tests.
- [x] Run `savings-goals-progress.spec.ts` and verify 1440, 768, and 390 px layouts.
- [x] Run `pnpm quality`.
- [ ] Open an active savings goal and compare Cible, Épargné, and Projection à l’échéance.
- [ ] Toggle hidden amounts and confirm no amount remains in the summary, tooltip, or accessible sentence.
- [ ] Start a plan simulation and confirm the dashed endpoint and summary use the simulated projection.
