### PR TITLE
Add tag support to iOS budgets and transactions

### DIFF
--- a/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/phase-1.md
@@ -1,0 +1,98 @@
+---
+status: done
+---
+
+# Instruction: Contrat iOS et catalogue utilisateur
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/
+│   ├── App/
+│   │   ├── ✏️ PulpeApp.swift                         # injecter le catalogue à la racine
+│   │   └── ✏️ SessionDataResetting.swift             # vider les tags à la déconnexion
+│   ├── Core/
+│   │   ├── Config/
+│   │   │   └── ✏️ AppConfiguration.swift             # déclarer la limite de dix tags
+│   │   └── Network/
+│   │       └── ✏️ APIError.swift                     # localiser le conflit de nom
+│   └── Domain/
+│       ├── Models/
+│       │   ├── ✏️ Tag.swift                          # ajouter le DTO de création
+│       │   ├── ✏️ BudgetLine.swift                   # lire/écrire et préserver tagIds
+│       │   ├── ✏️ Transaction.swift                  # lire/écrire et préserver tagIds
+│       │   └── ✏️ BudgetTemplate.swift               # tagIds sur ligne et propagation bulk
+│       ├── Services/
+│       │   └── ✏️ TagService.swift                   # exposer POST /tags
+│       └── Store/
+│           └── ✅ TagStore.swift                     # catalogue utilisateur partagé
+└── PulpeTests/
+    ├── App/
+    │   └── ✏️ SessionDataResetterTests.swift         # prouver l’effacement inter-session
+    └── Domain/
+        ├── Models/
+        │   └── ✅ TagCodableTests.swift              # verrouiller les formes JSON
+        ├── Services/
+        │   └── ✏️ TagServiceTests.swift              # vérifier GET et POST /tags
+        └── Store/
+            └── ✅ TagStoreTests.swift                # chargement, création, cache et reset
+
+❌ aucun fichier
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Réponse budget, transaction ou modèle"] --> B["Modèle iOS avec tagIds optionnel"]
+  C["GET /tags"] --> D["TagStore utilisateur"]
+  E["POST /tags"] --> D
+  B --> F["Surfaces iOS"]
+  D --> F
+  G["Déconnexion"] --> H["Reset du catalogue"]
+```
+
+## Tasks to do
+
+### `1)` Aligner les modèles et DTO sur le contrat existant
+
+> Transporter les ids sans modifier le backend et sans casser les réponses qui omettent encore le champ.
+
+1. Ajouter `TagCreate` avec le seul nom en clair.
+2. Ajouter `tagIds` optionnel à `BudgetLine`, `Transaction` et `TemplateLine`.
+3. Préserver `tagIds` dans les copies `toggled()`.
+4. Ajouter `tagIds` optionnel aux DTO de création et de mise à jour, y compris `TemplateLineUpdateWithId`.
+5. Garder la distinction JSON PATCH: clé absente pour préserver, tableau vide pour détacher.
+
+### `2)` Centraliser le catalogue utilisateur
+
+> Charger et enrichir une seule liste de tags pour toutes les surfaces.
+
+1. Étendre `TagServicing` et `TagService` avec `create(_:)` sur l’endpoint `.tags` en POST.
+2. Ajouter `AppConfiguration.maxTagsPerTransaction = 10`.
+3. Mapper `ERR_TAG_ALREADY_EXISTS` vers une erreur française exploitable par le formulaire.
+4. Créer `TagStore` sur le pattern minimal de `SavingsGoalStore`: chargement court, tri alphabétique, création locale après succès, dictionnaire id→nom, invalidation et reset.
+5. Injecter le store dans `PulpeApp` et l’ajouter au reset de session.
+
+### `3)` Verrouiller le contrat
+
+> Laisser un test exécutable pour chaque sémantique qui pourrait supprimer silencieusement des tags.
+
+1. Tester le décodage avec et sans `tagIds` pour les trois modèles.
+2. Tester l’encodage des créations et les trois états PATCH: absent, ids, tableau vide.
+3. Tester que `toggled()` conserve les ids.
+4. Tester la requête POST de création, l’ajout au catalogue et le reset inter-session.
+5. Générer avec `xcodegen generate --use-cache`, puis exécuter les suites ciblées avec `xcodebuild test -scheme PulpeLocal`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Une réponse contenant `tagIds` est décodée; une réponse qui l’omet reste valide; pointer/dépointer ne modifie pas les ids |
+| 1 | Un PATCH sans `tagIds` n’encode aucune clé et un PATCH avec `[]` encode bien un tableau vide |
+| 2 | Le catalogue charge les tags triés, ajoute immédiatement le tag créé et ne conserve rien après déconnexion |
+| 2 | Un nom déjà utilisé produit un message français sans altérer le catalogue |
+| 3 | Les tests ciblés du contrat, du service, du store et du reset passent sur le simulateur configuré |

--- a/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/phase-2.md
@@ -1,0 +1,161 @@
+---
+status: done
+---
+
+# Instruction: Sélection, création et mutations
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/
+│   ├── Shared/
+│   │   └── Components/
+│   │       ├── ✅ TagPickerField.swift               # champ, sous-feuille et logique de sélection
+│   │       ├── ✅ TagChips.swift                     # rendu commun via PulpeChip
+│   │       └── ✏️ EditBudgetLineSheet.swift          # édition d’une prévision
+│   └── Features/
+│       ├── Budgets/
+│       │   └── BudgetDetails/
+│       │       ├── ✏️ AddBudgetLineSheet.swift       # création standard d’une prévision
+│       │       ├── ✏️ AddAllocatedTransactionLogic.swift # DTO d’un réel lié
+│       │       ├── ✏️ AddAllocatedTransactionPage.swift  # création d’un réel lié
+│       │       ├── ✏️ EditTransactionLogic.swift     # PATCH d’un réel
+│       │       └── ✏️ EditTransactionPage.swift      # édition d’un réel
+│       ├── CurrentMonth/
+│       │   └── Components/
+│       │       └── ✏️ AddTransactionSheet.swift      # création d’un réel libre
+│       └── Templates/
+│           └── TemplateDetails/
+│               └── ✏️ EditTemplateLineSheet.swift   # édition et propagation d’une ligne modèle
+└── PulpeTests/
+    ├── Shared/
+    │   └── Components/
+    │       ├── ✅ TagPickerFieldTests.swift          # limite, unicité et payload différentiel
+    │       ├── ✅ TagChipsTests.swift                # résumé et débordement des chips
+    │       └── ✏️ EditBudgetLineSheetTests.swift     # pré-sélection et CA8
+    └── Features/
+        ├── Budgets/
+        │   └── BudgetDetails/
+        │       └── ✏️ EditTransactionLogicTests.swift # PATCH tags d’un réel
+        └── Templates/
+            └── ✏️ EditTemplateLineSheetTests.swift   # PATCH direct et bulk
+
+❌ aucun fichier
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Ouvrir un formulaire"] --> B["Charger le catalogue partagé"]
+  B --> C["Voir les tags pré-sélectionnés"]
+  C --> D["Sélectionner ou retirer jusqu’à dix tags"]
+  C --> E["Créer un tag dans la sous-feuille"]
+  E --> D
+  D --> F["Valider le formulaire"]
+  F --> G{"Sélection modifiée ?"}
+  G -->|Non| H["Omettre tagIds sur PATCH"]
+  G -->|Oui| I["Envoyer la liste unique, éventuellement vide"]
+```
+
+## Wireframe
+
+```txt
+┌────────────────────────────────────┐
+│ (1) Barre du formulaire            │
+├────────────────────────────────────┤
+│ (2) Type · montant · description   │
+│                                    │
+│ (3) Champ tags                     │
+│     [tag] [tag] [compteur]   [>]   │
+│                                    │
+│ (4) Champs propres à la ligne      │
+├────────────────────────────────────┤
+│ (5) Action principale              │
+└────────────────────────────────────┘
+
+1. Barre: titre et fermeture ou retour.
+2. Données financières déjà présentes.
+3. Résumé de la sélection et accès au composant partagé.
+4. Date, récurrence, pointage ou objectif selon le formulaire.
+5. Création ou enregistrement.
+
+┌────────────────────────────────────┐
+│ (1) Barre du sélecteur             │
+├────────────────────────────────────┤
+│ (2) Sélection courante · limite    │
+│                                    │
+│ (3) Nouveau tag [____________] [+] │
+│                                    │
+│ (4) Catalogue                      │
+│     [✓] Tag                         │
+│     [ ] Tag                         │
+│     [✓] Tag                         │
+├────────────────────────────────────┤
+│ (5) Validation                     │
+└────────────────────────────────────┘
+
+1. Sous-feuille conservant le formulaire parent.
+2. Nombre sélectionné sur le maximum.
+3. Création intégrée au flux.
+4. Liste multi-sélection et états de chargement, erreur ou vide.
+5. Retour de la sélection au formulaire.
+```
+
+## Tasks to do
+
+### `1)` Construire le sélecteur partagé
+
+> Offrir une seule implémentation multi-sélection et création pour tous les formulaires.
+
+1. Créer `TagPickerField` avec binding sur un `Set<String>`, chargement via `TagStore` et sous-feuille standard.
+2. Afficher le catalogue avec état sélectionné, compteur `n/10`, retry et état vide.
+3. Valider le nom après trim, longueur 1…30 et doublon insensible à la casse avant POST.
+4. Sélectionner automatiquement le tag créé et conserver le formulaire parent ouvert.
+5. Bloquer une onzième sélection sans supprimer les dix choix existants.
+6. Utiliser `PulpeChip` et `DesignTokens.ChipMetrics`; aucun chip ad hoc.
+7. Centraliser la normalisation en ids uniques triés et le calcul du payload: `nil` si inchangé, `[]` si tout est retiré.
+
+### `2)` Rattacher les tags aux créations
+
+> Couvrir les créations standard de prévision et les deux chemins de création d’un réel.
+
+1. Ajouter le champ à `AddBudgetLineSheet` uniquement en mode ligne simple; le masquer en mode lissage dont le contrat ne transporte pas `tagIds`.
+2. Envoyer `nil` quand aucune sélection n’existe et une liste unique sinon.
+3. Ajouter le même champ à `AddTransactionSheet`.
+4. Ajouter le champ à `AddAllocatedTransactionPage` et transporter les ids via `AddAllocatedTransactionLogic.FormInput`.
+
+### `3)` Rattacher les tags aux éditions
+
+> Pré-sélectionner l’existant et ne toucher aux associations que si le résultat diffère.
+
+1. Initialiser la sélection depuis `BudgetLine.tagIds`, `Transaction.tagIds` et `TemplateLine.tagIds`.
+2. Ajouter le champ à `EditBudgetLineSheet`, `EditTransactionPage` et `EditTemplateLineSheet`.
+3. Transmettre `nil` au builder PATCH quand les ensembles initial et final sont égaux.
+4. Transmettre la liste finale, y compris `[]`, quand elle change.
+5. Recopier `tagIds` dans `TemplateLineUpdateWithId` pour le chemin « Appliquer aux mois suivants ».
+
+### `4)` Tester les invariants de formulaire
+
+> Prouver la limite, l’unicité, la création inline et surtout CA8.
+
+1. Tester trim, longueur, doublon exact insensible à la casse et plafond de dix.
+2. Tester que la création réussie ajoute et sélectionne le nouveau tag.
+3. Tester le payload différentiel inchangé, modifié et entièrement vidé.
+4. Étendre les tests des builders BudgetLine, Transaction et Template, incluant la propagation bulk.
+5. Exécuter les suites ciblées du sélecteur et des trois builders avec `xcodebuild test -scheme PulpeLocal`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Le même champ sélectionne plusieurs tags, crée un tag sans fermer le formulaire et refuse une onzième sélection |
+| 1 | Les noms vides, supérieurs à 30 caractères ou déjà présents sans distinction de casse ne déclenchent pas de création |
+| 2 | Une prévision simple, un réel libre et un réel lié nouvellement créés reçoivent exactement les ids choisis |
+| 3 | Les éditions pré-sélectionnent les associations serveur et permettent ajout, retrait partiel ou détachement total |
+| 3 | Enregistrer sans modifier la sélection omet `tagIds`; le backend conserve donc les associations existantes |
+| 3 | La propagation d’une ligne modèle transporte la même sélection que le PATCH direct |
+| 4 | Les tests ciblés de sélection et de payload passent sur le simulateur configuré |

--- a/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/phase-3.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/phase-3.md
@@ -119,10 +119,10 @@ flowchart TD
 
 > Faire tenir jusqu’à dix associations sans casser les rows compactes.
 
-1. Dans les listes, afficher les deux premiers noms puis un chip de débordement.
+1. Dans les listes, afficher une icône de tag avec le nombre d'associations.
 2. Dans les pages détail et le sélecteur, rendre tous les noms disponibles.
 3. Donner à VoiceOver la liste complète des tags, même quand le visuel est résumé.
-4. Tester l’ordre stable, le nombre masqué et le libellé d’accessibilité.
+4. Tester l’ordre stable, le compteur et le libellé d’accessibilité.
 5. Exécuter les tests `TagChips`, les invariants d’architecture Budget Details et un build `PulpeLocal`.
 
 ## Test acceptance criteria

--- a/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/phase-3.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/phase-3.md
@@ -1,0 +1,136 @@
+---
+status: done
+---
+
+# Instruction: Consultation sur les surfaces de ligne
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/
+│   └── Features/
+│       ├── Budgets/
+│       │   └── BudgetDetails/
+│       │       ├── ✏️ BudgetDetailsView.swift                # charger et distribuer le catalogue
+│       │       ├── ✏️ BudgetDetailsView+Routing.swift        # fournir les noms à la page détail
+│       │       ├── ✏️ BudgetMixedSection.swift               # résoudre les tags de prévision
+│       │       ├── ✏️ BudgetLineMixedRow.swift               # afficher les tags de prévision
+│       │       ├── ✏️ BudgetDetailsFreeTransactionsList.swift # afficher les tags des réels libres
+│       │       ├── ✏️ BudgetLineDetailPage.swift             # afficher les tags de la prévision détaillée
+│       │       └── ✏️ BudgetLineDetailTransactionRow.swift   # afficher les tags des réels liés
+│       ├── CurrentMonth/
+│       │   ├── ✏️ CurrentMonthView.swift                     # charger et distribuer le catalogue
+│       │   └── Components/
+│       │       ├── ✏️ ActivityCard.swift                     # tags des réels récents
+│       │       ├── ✏️ UncheckedOperationsCard.swift          # tags des réels et prévisions à pointer
+│       │       └── ✏️ DriftCard.swift                        # tags des prévisions en dérive
+│       └── Templates/
+│           └── TemplateDetails/
+│               └── ✏️ TemplateDetailsView.swift              # tags sur les lignes de modèle
+└── PulpeTests/
+    └── Shared/
+        └── Components/
+            └── ✏️ TagChipsTests.swift                        # ordre, limite visuelle et accessibilité
+
+✅ aucun nouveau fichier
+❌ aucun fichier
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Ouvrir Budget Details, Mois en cours ou un modèle"] --> B["Charger TagStore"]
+  B --> C["Construire le dictionnaire id vers nom"]
+  C --> D["Résoudre les ids de chaque ligne"]
+  D --> E["Afficher les chips sous l’identité de la ligne"]
+  E --> F["Résumer les listes compactes"]
+  E --> G["Afficher tous les tags dans le détail"]
+```
+
+## Wireframe
+
+```txt
+┌────────────────────────────────────┐
+│ (1) Budget Details                 │
+├────────────────────────────────────┤
+│ (2) Prévision ou réel      montant │
+│     [tag] [tag]                     │
+│     métadonnée                     │
+└────────────────────────────────────┘
+
+1. Structure actuelle de Budget Details.
+2. Tags sous l’identité de la ligne, avant les métadonnées secondaires.
+
+┌────────────────────────────────────┐
+│ (1) Mois en cours                  │
+├────────────────────────────────────┤
+│ (2) Carte d’activité ou pointage   │
+│     Ligne                  montant │
+│     [tag] [tag]                     │
+└────────────────────────────────────┘
+
+1. Tableau de bord actuel.
+2. Tags associés à l’opération visible sans ouvrir le web.
+
+┌────────────────────────────────────┐
+│ (1) Détail du modèle               │
+├────────────────────────────────────┤
+│ (2) Ligne du modèle        montant │
+│     [tag] [tag]                     │
+└────────────────────────────────────┘
+
+1. Liste des lignes du modèle.
+2. Tags persistés visibles avant l’édition.
+```
+
+## Tasks to do
+
+### `1)` Afficher les tags dans Budget Details
+
+> Résoudre les noms une fois au niveau écran et conserver des rows à entrées primitives.
+
+1. Charger `TagStore` dans `BudgetDetailsView` et passer son dictionnaire id→nom.
+2. Afficher le résumé des tags dans `BudgetLineMixedRow` et les transactions libres.
+3. Afficher tous les tags de la prévision dans `BudgetLineDetailPage`.
+4. Afficher les tags de chaque transaction liée dans `BudgetLineDetailTransactionRow`.
+5. Garder les transformations hors des bodies de la feature et chaque fichier sous 350 lignes.
+
+### `2)` Afficher les tags dans Mois en cours
+
+> Rendre les associations visibles sur les opérations réellement rendues par le dashboard actuel.
+
+1. Charger le même catalogue dans `CurrentMonthView`.
+2. Passer le dictionnaire à `ActivityCard`, `UncheckedOperationsCard` et `DriftCard`.
+3. Montrer les tags des transactions récentes, des opérations à pointer et des prévisions en dérive.
+
+### `3)` Afficher les tags des lignes de modèle
+
+> Permettre de consulter les associations avant d’ouvrir l’éditeur.
+
+1. Charger le catalogue avec le détail du modèle.
+2. Passer le dictionnaire à `TemplateLineRow`.
+3. Afficher les chips sous le nom et la récurrence sans modifier les totaux.
+
+### `4)` Garder les listes lisibles et accessibles
+
+> Faire tenir jusqu’à dix associations sans casser les rows compactes.
+
+1. Dans les listes, afficher les deux premiers noms puis un chip de débordement.
+2. Dans les pages détail et le sélecteur, rendre tous les noms disponibles.
+3. Donner à VoiceOver la liste complète des tags, même quand le visuel est résumé.
+4. Tester l’ordre stable, le nombre masqué et le libellé d’accessibilité.
+5. Exécuter les tests `TagChips`, les invariants d’architecture Budget Details et un build `PulpeLocal`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Budget Details montre les tags d’une prévision, d’un réel libre et d’un réel lié sans observation de store dans les rows |
+| 2 | Mois en cours montre les tags dans Activité, À pointer et Ça dérive lorsque les lignes concernées en possèdent |
+| 3 | Une ligne de modèle montre ses tags avant l’ouverture de l’éditeur |
+| 4 | Dix tags ne débordent pas horizontalement; les listes restent compactes et le détail permet de tous les consulter |
+| 4 | VoiceOver annonce tous les noms et les tests d’architecture, de composant et de build passent |

--- a/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Les utilisateurs iOS peuvent créer, sélectionner et consulter jusqu’à dix tags sur les prévisions, réels et lignes de modèle sans perdre les associations lors d’une modification inchangée."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Ajouter et consulter les tags sur iOS

--- a/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Les utilisateurs iOS peuvent créer, sélectionner et consulter jusqu’à dix tags sur les prévisions, réels et lignes de modèle sans perdre les associations lors d’une modification inchangée."
-status: implemented
+status: in-progress
 ---
 
 # Plan: Ajouter et consulter les tags sur iOS

--- a/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/plan.md
@@ -1,0 +1,30 @@
+---
+objective: "Les utilisateurs iOS peuvent créer, sélectionner et consulter jusqu’à dix tags sur les prévisions, réels et lignes de modèle sans perdre les associations lors d’une modification inchangée."
+status: in-progress
+---
+
+# Plan: Ajouter et consulter les tags sur iOS
+
+## Overview
+
+| Field      | Value                   |
+| ---------- | ----------------------- |
+| **Goal**   | Rendre les tags utilisables de bout en bout dans les formulaires et lignes iOS existants |
+| **Source** | Ticket Linear `PUL-294` |
+
+## Phases
+
+| #   | Phase                                  | File                         |
+| --- | -------------------------------------- | ---------------------------- |
+| 1   | Contrat iOS et catalogue utilisateur   | [`phase-1.md`](./phase-1.md) |
+| 2   | Sélection, création et mutations       | [`phase-2.md`](./phase-2.md) |
+| 3   | Consultation sur les surfaces de ligne | [`phase-3.md`](./phase-3.md) |
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Porter le catalogue dans un `TagStore` applicatif réinitialisé à la déconnexion | Les formulaires, Budget Details, Mois en cours et modèles doivent résoudre les mêmes ids sans multiplier les chargements ni exposer les tags d’un utilisateur précédent |
+| Garder `tagIds` optionnel dans les modèles de lecture et les DTO PATCH | Les réponses de projection peuvent omettre le champ; côté PATCH, `nil` préserve les tags et `[]` les détache explicitement |
+| Couvrir les six formulaires réels plutôt que les trois noms historiques du ticket | La création d’un réel lié et l’édition d’un réel ont été séparées en pages distinctes; les ignorer laisserait CA3 partiellement faux |
+| Ne pas rattacher des tags après un lissage par une rafale de PATCH | `POST /budget-lines/spread` n’accepte pas `tagIds`; une compensation client serait non atomique et contredirait le hors-périmètre backend |

--- a/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/phase-1.md
@@ -1,0 +1,74 @@
+---
+status: done
+---
+
+# Instruction: Isoler les créations de tag par session
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/
+│   └── Domain/
+│       └── Store/
+│           └── ✏️ TagStore.swift          # invalider les mutations terminées après un reset
+└── PulpeTests/
+    └── Domain/
+        └── Store/
+            └── ✏️ TagStoreTests.swift     # reproduire la création suspendue entre deux sessions
+
+✅ aucun nouveau fichier
+❌ aucun fichier
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Créer un tag"] --> B["Requête suspendue"]
+  B --> C{"La session a-t-elle été réinitialisée ?"}
+  C -->|Oui| D["Rejeter le résultat obsolète"]
+  C -->|Non| E["Ajouter le tag au catalogue trié"]
+  D --> F["Conserver intact le catalogue de la nouvelle session"]
+  E --> G["Retourner le tag créé"]
+```
+
+## Tasks to do
+
+### `1)` Reproduire la fuite inter-session
+
+> Verrouiller le scénario exact signalé par la revue avant de modifier le store.
+
+1. Ajouter au mock de `TagStoreTests` une barrière contrôlable qui suspend `create`.
+2. Démarrer une création pour la session A, attendre son entrée dans le service, puis appeler `reset()`.
+3. Charger un catalogue de session B avant de libérer la création A.
+4. Prouver que le résultat A ne rejoint jamais le catalogue B.
+
+### `2)` Distinguer session et chargement
+
+> Invalider uniquement les mutations qui traversent un reset utilisateur.
+
+1. Ajouter une génération de session indépendante de `loadGeneration`.
+2. Capturer cette génération avant `await service.create`.
+3. Après la réponse, vérifier la génération avant toute mutation de `tags`.
+4. Signaler l’annulation au caller quand la session a changé.
+5. Incrémenter la génération de session dans `reset()` sans modifier le comportement de refresh.
+
+### `3)` Préserver les créations légitimes
+
+> Éviter qu’un refresh du catalogue soit confondu avec un changement d’utilisateur.
+
+1. Tester qu’une création suspendue reste applicable après un `forceRefresh()` dans la même session.
+2. Conserver le tri alphabétique et le retour du tag créé sur le chemin normal.
+3. Exécuter les suites ciblées `TagStoreTests` et `SessionDataResetterTests`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Une création de la session A qui termine après `reset()` ne modifie pas le catalogue déjà chargé de la session B |
+| 2 | Le caller reçoit une annulation et aucun nom de tag de la session A ne devient visible ou sélectionnable après le reset |
+| 3 | Un `forceRefresh()` dans la même session n’annule pas une création valide |
+| 3 | Une création normale ajoute une seule fois le tag au catalogue trié et les tests ciblés passent |

--- a/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/phase-2.md
@@ -1,0 +1,132 @@
+---
+status: pending
+---
+
+# Instruction: Sécuriser le sélecteur et le flux de prévision
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/
+│   ├── Shared/
+│   │   └── Components/
+│   │       └── ✏️ TagPickerField.swift       # rendre la création inline atomique côté interface
+│   └── Features/
+│       └── Budgets/
+│           └── BudgetDetails/
+│               └── ✏️ AddBudgetLineSheet.swift # masquer le champ dans les flux sans tagIds
+└── PulpeTests/
+    ├── Shared/
+    │   └── Components/
+    │       └── ✏️ TagPickerFieldTests.swift   # verrouiller la limite après création
+    └── Features/
+        └── Budgets/
+            └── BudgetDetails/
+                └── ✅ AddBudgetLineSheetTests.swift # verrouiller la visibilité par mode
+
+❌ aucun fichier
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Ouvrir la création d’une prévision"] --> B{"Flux du formulaire"}
+  B -->|Prévision simple| C["Champ de tags"]
+  B -->|Lissage ou retrait d’épargne| D["Champs propres au flux"]
+  C --> E["Ouvrir le sélecteur"]
+  E --> F["Catalogue et création inline"]
+  F --> G["État de création en cours"]
+  G --> H["Sélection bornée à dix"]
+  H --> I["Retour au formulaire"]
+```
+
+## Wireframe
+
+```txt
+┌────────────────────────────────────┐
+│ (1) Données de la prévision        │
+├────────────────────────────────────┤
+│ (2) Champ tags                     │
+│ (3) Option de retrait d’épargne    │
+├────────────────────────────────────┤
+│ (4) Action principale              │
+└────────────────────────────────────┘
+
+┌────────────────────────────────────┐
+│ (1) Données de la prévision        │
+├────────────────────────────────────┤
+│ (3) Option de retrait d’épargne    │
+├────────────────────────────────────┤
+│ (4) Action principale              │
+└────────────────────────────────────┘
+
+┌────────────────────────────────────┐
+│ (5) Barre du sélecteur             │
+├────────────────────────────────────┤
+│ (6) Sélection courante             │
+│ (7) Catalogue                      │
+│ (8) Création en cours              │
+└────────────────────────────────────┘
+```
+
+1. Données de la prévision: type, montant et description existants.
+2. Champ tags: présent uniquement quand le flux sauvegarde `tagIds`.
+3. Option de retrait d’épargne: conserve sa place dans le formulaire revenu.
+4. Action principale: validation du flux actuellement choisi.
+5. Barre du sélecteur: titre et confirmation.
+6. Sélection courante: tags déjà choisis et compteur.
+7. Catalogue: tags existants.
+8. Création en cours: progression de l’ajout inline.
+
+## Tasks to do
+
+### `1)` Borner la complétion d’une création
+
+> Faire respecter la limite de dix même si l’état change pendant un appel réseau.
+
+1. Écrire le test où la complétion reçoit une sélection déjà pleine.
+2. Réutiliser la logique bornée de sélection pour intégrer le tag créé.
+3. Garantir qu’aucun chemin du composant ne produit onze ids.
+
+### `2)` Rendre la création inline atomique
+
+> Empêcher le formulaire de poursuivre ou de changer de sélection avant la réponse.
+
+1. Désactiver le catalogue, la saisie et la confirmation pendant `isCreating`.
+2. Bloquer le swipe de fermeture avec le pattern `interactiveDismissDisabled`.
+3. Réactiver toutes les interactions après succès ou erreur.
+4. Conserver la sélection automatique du tag créé sur le chemin normal.
+
+### `3)` Masquer le champ dans les flux incompatibles
+
+> Ne montrer le sélecteur que lorsque le submit transporte réellement `tagIds`.
+
+1. Centraliser la décision de visibilité à partir des modes simple, lissage et retrait d’épargne.
+2. Garder le champ visible pour une prévision simple.
+3. Le masquer pour le lissage et quand `isSavingsWithdrawalMode` est actif.
+4. Ne modifier ni `SavingsWithdrawalPrefill`, ni `SavingsWithdrawalCreate`, ni le schéma shared.
+5. Préserver la sélection locale si l’utilisateur revient au mode simple.
+6. Garder `AddBudgetLineSheet.swift` sous la limite d’architecture de 350 lignes sans créer de fichier de production dédié à cette seule condition.
+
+### `4)` Vérifier les deux régressions UI
+
+> Couvrir la limite et la visibilité sans introduire de dépendance de test UI.
+
+1. Étendre `TagPickerFieldTests` avec le cas de complétion à dix tags.
+2. Ajouter un test pur de visibilité pour les trois modes de `AddBudgetLineSheet`.
+3. Générer le projet Xcode puis exécuter les suites ciblées et un build `PulpeLocal`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | La complétion d’une création ne fait jamais passer la sélection de dix à onze ids |
+| 2 | Tant que la création est en cours, le catalogue, la confirmation et la fermeture interactive ne permettent aucune action concurrente |
+| 2 | Après succès ou erreur, le sélecteur redevient utilisable et une création normale sélectionne son tag |
+| 3 | Le champ tags est visible pour une prévision simple et absent en mode lissage ou retrait d’épargne |
+| 3 | Revenir du retrait d’épargne au mode simple restaure la sélection locale sans modifier le contrat `SavingsWithdrawalCreate` |
+| 4 | Les tests ciblés de store, sélection, visibilité et architecture ainsi que le build `PulpeLocal` passent |

--- a/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/phase-2.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Sécuriser le sélecteur et le flux de prévision

--- a/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Les résultats asynchrones liés aux tags respectent la session et la limite de dix, et aucun formulaire iOS n’affiche une sélection que son flux de sauvegarde ignore."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Corriger les findings de revue PUL-294

--- a/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_corriger-revue-pul-294-tags-ios/plan.md
@@ -1,0 +1,27 @@
+---
+objective: "Les résultats asynchrones liés aux tags respectent la session et la limite de dix, et aucun formulaire iOS n’affiche une sélection que son flux de sauvegarde ignore."
+status: in-progress
+---
+
+# Plan: Corriger les findings de revue PUL-294
+
+## Overview
+
+| Field      | Value                                      |
+| ---------- | ------------------------------------------ |
+| **Goal**   | Fermer les trois défauts bloquant la PR iOS des tags |
+| **Source** | PR GitHub `#552` et rapport de revue PUL-294 |
+
+## Phases
+
+| #   | Phase                                         | File                         |
+| --- | --------------------------------------------- | ---------------------------- |
+| 1   | Isoler les créations de tag par session       | [`phase-1.md`](./phase-1.md) |
+| 2   | Sécuriser le sélecteur et le flux de prévision | [`phase-2.md`](./phase-2.md) |
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Séparer la génération de session de la génération de chargement | Un refresh du catalogue dans la même session ne doit pas invalider une création légitime, alors qu’un reset doit interdire toute mutation tardive |
+| Masquer les tags dans le flux `savings-withdrawal` | Son contrat strict ne transporte aucun `tagIds`; l’étendre dépasserait PUL-294 et imposerait une évolution backend/shared |

--- a/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/phase-1.md
@@ -1,0 +1,72 @@
+---
+status: done
+---
+
+# Instruction: Rendre le catalogue idempotent et réactif
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/
+│   ├── Domain/
+│   │   └── Store/
+│   │       └── ✏️ TagStore.swift                    # upsert de création et résolution des ids inconnus
+│   └── Features/
+│       ├── CurrentMonth/
+│       │   └── ✏️ CurrentMonthView.swift            # réagir aux ids présents après retry ou refresh
+│       └── Templates/
+│           └── TemplateDetails/
+│               └── ✏️ TemplateDetailsView.swift     # réagir aux ids présents après retry ou refresh
+└── PulpeTests/
+    └── Domain/
+        └── Store/
+            └── ✏️ TagStoreTests.swift                # reproduire la duplication et verrouiller la résolution
+
+✅ aucun nouveau fichier
+❌ aucun fichier
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Prévisions, réels ou lignes de modèle rechargés"] --> B["Collecter les ids de tags référencés"]
+  B --> C{"Tous les ids sont connus ?"}
+  C -->|Oui| D["Réutiliser le catalogue"]
+  C -->|Non| E["Rafraîchir le catalogue"]
+  E --> F["Résoudre les noms sans doublon"]
+  G["Création terminée après un GET concurrent"] --> H["Remplacer ou ajouter par id"]
+  H --> F
+```
+
+## Tasks to do
+
+### `1)` Reproduire puis supprimer la duplication
+
+> Garantir un seul élément par `Tag.id`, quel que soit l’ordre de fin du GET et du POST.
+
+1. Étendre le test de concurrence existant avec un GET qui contient déjà l’id retourné par la création suspendue.
+2. Remplacer l’ajout brut dans `TagStore.create` par un upsert minimal sur l’id, puis conserver le tri existant.
+3. Vérifier que `namesById` reste constructible et que le tag créé apparaît exactement une fois.
+
+### `2)` Charger les noms requis par les données visibles
+
+> Réagir aux ids chargés plutôt qu’aux seuls cycles de vie initiaux des écrans.
+
+1. Ajouter au store une opération ciblée qui ne fait rien pour une liste vide ou entièrement connue et force un refresh lorsqu’un id référencé manque.
+2. Tester les trois cas : aucun id, ids connus, id inconnu malgré un cache récent.
+3. Dans Mois en cours, dériver l’ensemble des ids depuis les prévisions et réels puis appeler l’opération via une tâche identifiée par cet ensemble.
+4. Dans le détail d’un modèle, dériver l’ensemble depuis les lignes et appliquer le même mécanisme.
+5. Retirer les chargements conditionnels initiaux devenus redondants.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Un GET concurrent contenant le tag créé puis la fin du POST laisse un seul élément pour cet id, trié, et `namesById` ne rencontre aucune clé dupliquée |
+| 2 | Une liste vide ou entièrement connue ne déclenche aucun GET supplémentaire; un id inconnu rafraîchit le catalogue même si son cache est encore valide |
+| 2 | Après un retry, un pull-to-refresh ou un retour d’onglet qui introduit des ids, Mois en cours et Modèles résolvent leurs noms sans recréer les vues |
+| 1, 2 | Les tests ciblés du `TagStore` et le build `PulpeLocal` passent |

--- a/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/phase-2.md
@@ -1,0 +1,99 @@
+---
+status: done
+---
+
+# Instruction: Conformer le sélecteur et l’affichage
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+├── aidd_docs/
+│   └── tasks/2026_07/2026_07_26_ajouter-consulter-tags-ios/
+│       └── ✏️ phase-3.md                            # aligner le rendu documenté sur icône + compteur
+└── ios/
+    └── Pulpe/
+        └── Shared/
+            └── Components/
+                ├── ✏️ TagPickerField.swift          # cibles 44 pt, styles partagés et libellés VoiceOver
+                └── ✏️ TagChips.swift                # style lisible sur cartes et fond d’application
+
+✅ aucun nouveau fichier
+❌ aucun fichier
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Ouvrir le champ Tags"] --> B["Sélecteur"]
+  B --> C["Créer depuis l’action dédiée"]
+  B --> D["Parcourir les tags"]
+  D --> E["Sélectionner ou retirer"]
+  E --> F["Revenir au formulaire"]
+  G["Consulter une ligne"] --> H["Icône tag et compteur"]
+  G --> I["Noms complets dans le détail"]
+```
+
+## Wireframe
+
+```txt
+┌────────────────────────────────────┐
+│ (1) Barre du sélecteur             │
+├────────────────────────────────────┤
+│ (2) Nouveau tag [____________] [+] │
+├────────────────────────────────────┤
+│ (3) Catalogue               n / 10 │
+│     [tag] Nom               [état] │
+│     [tag] Nom               [état] │
+└────────────────────────────────────┘
+
+┌────────────────────────────────────┐
+│ (4) Ligne                  montant │
+│     [tag · compteur]               │
+└────────────────────────────────────┘
+```
+
+1. Barre: titre et action de fermeture.
+2. Création: champ texte et action dédiée.
+3. Catalogue: liste des noms et état de chaque ligne.
+4. Ligne: métadonnée compacte sous son identité.
+
+## Tasks to do
+
+### `1)` Corriger les interactions et VoiceOver
+
+> Appliquer les primitives déjà présentes sans nouveau style ni composant.
+
+1. Déplacer les frames minimales et `contentShape` des labels vers les `Button`.
+2. Remplacer les styles système bruts par `plainPressedButtonStyle` pour le champ et les lignes.
+3. Appliquer `circleIconButtonStyle` au bouton de création.
+4. Donner à chaque ligne le nom du tag comme libellé VoiceOver et garder son état dans la valeur.
+
+### `2)` Utiliser un rendu de tag sûr sur tous les fonds
+
+> Garder un seul rendu partagé, lisible sur les cartes comme sur `appBackground`.
+
+1. Utiliser le style `outlined` existant pour les noms et les compteurs de `TagChips`.
+2. Conserver l’icône + compteur sur les lignes denses et tous les noms dans le détail.
+3. Aligner la phase 3 du plan PUL-294 sur ce rendu validé et retirer les attentes « deux noms + débordement ».
+
+### `3)` Vérifier sans élargir le périmètre
+
+> Prouver le rendu et les invariants existants sans ajouter de nouvelle infrastructure de test.
+
+1. Exécuter les tests ciblés `TagPickerFieldTests` et `TagChipsTests`.
+2. Exécuter SwiftLint sur les fichiers Swift modifiés et l’invariant d’architecture iOS.
+3. Construire `PulpeLocal` puis vérifier le sélecteur et les deux présentations de tags sur simulateur.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Le champ, chaque ligne et le bouton de création ont une cible tactile d’au moins 44×44 pt avec feedback pressé |
+| 1 | VoiceOver annonce une fois le nom du tag puis « Sélectionné » ou « Non sélectionné », sans lire les symboles décoratifs |
+| 2 | Les tags restent lisibles sur `appBackground` et sur les cartes; les lignes denses gardent l’icône + compteur et le détail garde tous les noms |
+| 2 | Le plan PUL-294 décrit le rendu effectivement validé |
+| 3 | Les tests ciblés, SwiftLint, l’invariant d’architecture et le build `PulpeLocal` passent; les captures simulateur ne montrent aucune régression de mise en page |

--- a/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "La PR PUL-294 conserve un catalogue de tags unique et résout les tags après chaque évolution des données, avec un sélecteur conforme aux règles tactiles, visuelles et VoiceOver d’iOS."
-status: implemented
+status: in-progress
 ---
 
 # Plan: Stabiliser les tags iOS avant merge

--- a/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "La PR PUL-294 conserve un catalogue de tags unique et résout les tags après chaque évolution des données, avec un sélecteur conforme aux règles tactiles, visuelles et VoiceOver d’iOS."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Stabiliser les tags iOS avant merge

--- a/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_27_stabiliser-tags-ios-avant-merge/plan.md
@@ -1,0 +1,20 @@
+---
+objective: "La PR PUL-294 conserve un catalogue de tags unique et résout les tags après chaque évolution des données, avec un sélecteur conforme aux règles tactiles, visuelles et VoiceOver d’iOS."
+status: in-progress
+---
+
+# Plan: Stabiliser les tags iOS avant merge
+
+## Overview
+
+| Field      | Value |
+| ---------- | ----- |
+| **Goal**   | Corriger les findings de revue avec le minimum de logique et sans modifier les contrats API |
+| **Source** | [`review.md`](../2026_07_26_ajouter-consulter-tags-ios/review.md) |
+
+## Phases
+
+| #   | Phase | File |
+| --- | ----- | ---- |
+| 1   | Rendre le catalogue idempotent et réactif | [`phase-1.md`](./phase-1.md) |
+| 2   | Conformer le sélecteur et l’affichage | [`phase-2.md`](./phase-2.md) |

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -23,6 +23,7 @@ struct PulpeApp: App {
     @State private var userSettingsStore: UserSettingsStore
     @State private var featureFlagsStore: FeatureFlagsStore
     @State private var savingsGoalStore: SavingsGoalStore
+    @State private var tagStore: TagStore
     @State private var runtimeCoordinator: AppRuntimeCoordinator
     @State private var deepLinkDestination: DeepLinkDestination?
     @State private var appVersionStore = AppVersionStore()
@@ -36,13 +37,15 @@ struct PulpeApp: App {
         let featureFlagsStore = FeatureFlagsStore()
         let userSettingsStore = UserSettingsStore(featureFlags: featureFlagsStore)
         let savingsGoalStore = SavingsGoalStore()
+        let tagStore = TagStore()
 
         appState.sessionDataResetter = LiveSessionDataResetter(
             currentMonthStore: currentMonthStore,
             budgetListStore: budgetListStore,
             dashboardStore: dashboardStore,
             userSettingsStore: userSettingsStore,
-            savingsGoalStore: savingsGoalStore
+            savingsGoalStore: savingsGoalStore,
+            tagStore: tagStore
         )
 
         // Cross-store consistency (PUL-270): any amount-changing mutation on
@@ -77,6 +80,7 @@ struct PulpeApp: App {
         _userSettingsStore = State(initialValue: userSettingsStore)
         _featureFlagsStore = State(initialValue: featureFlagsStore)
         _savingsGoalStore = State(initialValue: savingsGoalStore)
+        _tagStore = State(initialValue: tagStore)
         _runtimeCoordinator = State(initialValue: AppRuntimeCoordinator(
             appState: appState,
             currentMonthStore: currentMonthStore,
@@ -110,6 +114,7 @@ struct PulpeApp: App {
                     .environment(userSettingsStore)
                     .environment(featureFlagsStore)
                     .environment(savingsGoalStore)
+                    .environment(tagStore)
                     .environment(appVersionStore)
                     .environment(whatsNewStore)
                     .overlay(alignment: .topLeading) {

--- a/ios/Pulpe/App/SessionDataResetting.swift
+++ b/ios/Pulpe/App/SessionDataResetting.swift
@@ -14,19 +14,22 @@ final class LiveSessionDataResetter: SessionDataResetting {
     private let dashboardStore: DashboardStore
     private let userSettingsStore: UserSettingsStore
     private let savingsGoalStore: SavingsGoalStore
+    private let tagStore: TagStore
 
     init(
         currentMonthStore: CurrentMonthStore,
         budgetListStore: BudgetListStore,
         dashboardStore: DashboardStore,
         userSettingsStore: UserSettingsStore,
-        savingsGoalStore: SavingsGoalStore
+        savingsGoalStore: SavingsGoalStore,
+        tagStore: TagStore
     ) {
         self.currentMonthStore = currentMonthStore
         self.budgetListStore = budgetListStore
         self.dashboardStore = dashboardStore
         self.userSettingsStore = userSettingsStore
         self.savingsGoalStore = savingsGoalStore
+        self.tagStore = tagStore
     }
 
     func resetStores() {
@@ -35,5 +38,6 @@ final class LiveSessionDataResetter: SessionDataResetting {
         dashboardStore.reset()
         userSettingsStore.reset()
         savingsGoalStore.reset()
+        tagStore.reset()
     }
 }

--- a/ios/Pulpe/Core/Config/AppConfiguration.swift
+++ b/ios/Pulpe/Core/Config/AppConfiguration.swift
@@ -98,6 +98,7 @@ enum AppConfiguration {
 
     static let maxTemplates = 5
     static let maxBudgetYearsAhead = 3
+    static let maxTagsPerTransaction = 10
 
     // MARK: - Cache Durations
 

--- a/ios/Pulpe/Core/Network/APIError.swift
+++ b/ios/Pulpe/Core/Network/APIError.swift
@@ -34,6 +34,7 @@ enum APIError: LocalizedError {
     case savingsWithdrawalRecalculationFailed
     case savingsGoalBaselineRecalculationFailed
     case savingsGoalGenerationStopRecalculationFailed
+    case tagAlreadyExists
 
     var errorDescription: String? {
         switch self {
@@ -102,6 +103,8 @@ enum APIError: LocalizedError {
         case .savingsGoalGenerationStopRecalculationFailed:
             return "La décision a bien été enregistrée, mais les soldes n'ont pas pu être actualisés — "
                 + "recharge la page sans réessayer"
+        case .tagAlreadyExists:
+            return "Un tag porte déjà ce nom — choisis-en un autre"
         }
     }
 
@@ -135,6 +138,7 @@ enum APIError: LocalizedError {
         "ERR_SAVINGS_WITHDRAWAL_RECALCULATION_FAILED": .savingsWithdrawalRecalculationFailed,
         "ERR_SAVINGS_GOAL_BASELINE_RECALCULATION_FAILED": .savingsGoalBaselineRecalculationFailed,
         "ERR_SAVINGS_GOAL_GENERATION_STOP_RECALCULATION_FAILED": .savingsGoalGenerationStopRecalculationFailed,
+        "ERR_TAG_ALREADY_EXISTS": .tagAlreadyExists,
     ]
 
     /// Create APIError from server error code

--- a/ios/Pulpe/Domain/Models/BudgetLine.swift
+++ b/ios/Pulpe/Domain/Models/BudgetLine.swift
@@ -15,6 +15,8 @@ struct BudgetLine: Codable, Identifiable, Hashable, Sendable {
     let createdAt: Date
     let updatedAt: Date
 
+    var tagIds: [String]?
+
     /// Shared identifier of the spread group when this line is one occurrence of a
     /// "Lisser" expense (PUL-17). Non-financial UUID — never encrypted. `nil` for
     /// ordinary lines. Generated server-side by `POST /budget-lines/spread`.
@@ -98,6 +100,7 @@ struct BudgetLine: Codable, Identifiable, Hashable, Sendable {
             checkedAt: isChecked ? nil : Date(),
             createdAt: createdAt,
             updatedAt: Date(),
+            tagIds: tagIds,
             spreadGroupId: spreadGroupId,
             savingsWithdrawalGroupId: savingsWithdrawalGroupId,
             originalAmount: originalAmount,
@@ -139,6 +142,7 @@ struct BudgetLineCreate: Encodable {
     let originalCurrency: SupportedCurrency?
     let targetCurrency: SupportedCurrency?
     let exchangeRate: Decimal?
+    let tagIds: [String]?
 
     init(
         budgetId: String,
@@ -153,7 +157,8 @@ struct BudgetLineCreate: Encodable {
         originalAmount: Decimal? = nil,
         originalCurrency: SupportedCurrency? = nil,
         targetCurrency: SupportedCurrency? = nil,
-        exchangeRate: Decimal? = nil
+        exchangeRate: Decimal? = nil,
+        tagIds: [String]? = nil
     ) {
         self.budgetId = budgetId
         self.templateLineId = templateLineId
@@ -168,6 +173,7 @@ struct BudgetLineCreate: Encodable {
         self.originalCurrency = originalCurrency
         self.targetCurrency = targetCurrency
         self.exchangeRate = exchangeRate
+        self.tagIds = tagIds
     }
 }
 
@@ -187,6 +193,7 @@ struct BudgetLineUpdate: Encodable {
     var originalCurrency: SupportedCurrency?
     var targetCurrency: SupportedCurrency?
     var exchangeRate: Decimal?
+    var tagIds: [String]?
 }
 
 // MARK: - Collection Helpers

--- a/ios/Pulpe/Domain/Models/BudgetTemplate.swift
+++ b/ios/Pulpe/Domain/Models/BudgetTemplate.swift
@@ -29,6 +29,7 @@ struct TemplateLine: Codable, Identifiable, Hashable, Sendable {
 
     // Savings goal link (PUL-12) — the primary tagging surface lives on the template
     var savingsGoalId: String?
+    var tagIds: [String]?
 
     // Currency conversion metadata
     var originalAmount: Decimal?
@@ -75,6 +76,7 @@ struct TemplateLineCreate: Encodable {
     let originalCurrency: SupportedCurrency?
     let targetCurrency: SupportedCurrency?
     let exchangeRate: Decimal?
+    let tagIds: [String]?
 
     init(
         name: String,
@@ -86,7 +88,8 @@ struct TemplateLineCreate: Encodable {
         originalAmount: Decimal? = nil,
         originalCurrency: SupportedCurrency? = nil,
         targetCurrency: SupportedCurrency? = nil,
-        exchangeRate: Decimal? = nil
+        exchangeRate: Decimal? = nil,
+        tagIds: [String]? = nil
     ) {
         self.name = name
         self.amount = amount
@@ -98,6 +101,7 @@ struct TemplateLineCreate: Encodable {
         self.originalCurrency = originalCurrency
         self.targetCurrency = targetCurrency
         self.exchangeRate = exchangeRate
+        self.tagIds = tagIds
     }
 }
 
@@ -113,6 +117,7 @@ struct TemplateLineUpdate: Encodable {
     var originalCurrency: SupportedCurrency?
     var targetCurrency: SupportedCurrency?
     var exchangeRate: Decimal?
+    var tagIds: [String]?
 }
 
 // MARK: - Bulk Operations
@@ -149,6 +154,7 @@ struct TemplateLineUpdateWithId: Encodable {
     var originalCurrency: SupportedCurrency?
     var targetCurrency: SupportedCurrency?
     var exchangeRate: Decimal?
+    var tagIds: [String]?
 }
 
 // MARK: - Response Types

--- a/ios/Pulpe/Domain/Models/Tag.swift
+++ b/ios/Pulpe/Domain/Models/Tag.swift
@@ -7,3 +7,7 @@ struct Tag: Codable, Sendable, Identifiable, Equatable {
     let createdAt: Date
     let updatedAt: Date
 }
+
+struct TagCreate: Encodable, Sendable {
+    let name: String
+}

--- a/ios/Pulpe/Domain/Models/Transaction.swift
+++ b/ios/Pulpe/Domain/Models/Transaction.swift
@@ -14,6 +14,8 @@ struct Transaction: Codable, Identifiable, Hashable, Sendable {
     let createdAt: Date
     let updatedAt: Date
 
+    var tagIds: [String]?
+
     // Currency conversion metadata
     var originalAmount: Decimal?
     var originalCurrency: SupportedCurrency?
@@ -48,6 +50,7 @@ struct Transaction: Codable, Identifiable, Hashable, Sendable {
             checkedAt: isChecked ? nil : Date(),
             createdAt: createdAt,
             updatedAt: Date(),
+            tagIds: tagIds,
             originalAmount: originalAmount,
             originalCurrency: originalCurrency,
             targetCurrency: targetCurrency,
@@ -71,6 +74,7 @@ struct TransactionCreate: Encodable {
     let originalCurrency: SupportedCurrency?
     let targetCurrency: SupportedCurrency?
     let exchangeRate: Decimal?
+    let tagIds: [String]?
 
     init(
         budgetId: String,
@@ -84,7 +88,8 @@ struct TransactionCreate: Encodable {
         originalAmount: Decimal? = nil,
         originalCurrency: SupportedCurrency? = nil,
         targetCurrency: SupportedCurrency? = nil,
-        exchangeRate: Decimal? = nil
+        exchangeRate: Decimal? = nil,
+        tagIds: [String]? = nil
     ) {
         self.budgetId = budgetId
         self.budgetLineId = budgetLineId
@@ -98,6 +103,7 @@ struct TransactionCreate: Encodable {
         self.originalCurrency = originalCurrency
         self.targetCurrency = targetCurrency
         self.exchangeRate = exchangeRate
+        self.tagIds = tagIds
     }
 }
 
@@ -111,4 +117,5 @@ struct TransactionUpdate: Encodable {
     var originalCurrency: SupportedCurrency?
     var targetCurrency: SupportedCurrency?
     var exchangeRate: Decimal?
+    var tagIds: [String]?
 }

--- a/ios/Pulpe/Domain/Services/TagService.swift
+++ b/ios/Pulpe/Domain/Services/TagService.swift
@@ -1,5 +1,6 @@
 protocol TagServicing: Sendable {
     func getAll() async throws -> [Tag]
+    func create(_ data: TagCreate) async throws -> Tag
 }
 
 actor TagService: TagServicing {
@@ -13,5 +14,9 @@ actor TagService: TagServicing {
 
     func getAll() async throws -> [Tag] {
         try await apiClient.request(.tags, method: .get)
+    }
+
+    func create(_ data: TagCreate) async throws -> Tag {
+        try await apiClient.request(.tags, body: data, method: .post)
     }
 }

--- a/ios/Pulpe/Domain/Store/TagStore.swift
+++ b/ios/Pulpe/Domain/Store/TagStore.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+@Observable @MainActor
+final class TagStore: StoreProtocol {
+    private(set) var tags: [Tag] = []
+    private(set) var isLoading = false
+    private(set) var error: APIError?
+    private(set) var hasLoadedOnce = false
+
+    var hasError: Bool {
+        error != nil && tags.isEmpty
+    }
+
+    var namesById: [String: String] {
+        Dictionary(uniqueKeysWithValues: tags.map { ($0.id, $0.name) })
+    }
+
+    private var lastLoadTime: Date?
+    private var loadTask: Task<Void, Never>?
+    private var loadGeneration = 0
+    private let service: any TagServicing
+
+    init(service: any TagServicing = TagService.shared) {
+        self.service = service
+    }
+
+    func loadIfNeeded() async {
+        if let lastLoadTime,
+           Date().timeIntervalSince(lastLoadTime) < AppConfiguration.shortCacheValidity {
+            return
+        }
+        await forceRefresh()
+    }
+
+    func forceRefresh() async {
+        loadTask?.cancel()
+        loadGeneration += 1
+        let generation = loadGeneration
+
+        let task = Task(name: "Tags.load") {
+            guard loadGeneration == generation else { return }
+            isLoading = true
+            error = nil
+            defer {
+                if loadGeneration == generation { isLoading = false }
+            }
+
+            do {
+                let fetched = try await service.getAll()
+                try Task.checkCancellation()
+                guard loadGeneration == generation else { return }
+                tags = fetched.sortedForDisplay()
+                lastLoadTime = Date()
+                hasLoadedOnce = true
+            } catch where error.isCancellationOrURLCancellation {
+                // Keep the current catalog when a newer load or logout cancels this one.
+            } catch let apiError as APIError {
+                if loadGeneration == generation { self.error = apiError }
+            } catch {
+                if loadGeneration == generation { self.error = .networkError(error) }
+            }
+        }
+
+        loadTask = task
+        await task.value
+        if loadGeneration == generation { loadTask = nil }
+    }
+
+    @discardableResult
+    func create(name: String) async throws -> Tag {
+        let created = try await service.create(TagCreate(name: name))
+        tags = (tags + [created]).sortedForDisplay()
+        return created
+    }
+
+    func invalidateCache() {
+        lastLoadTime = nil
+    }
+
+    func reset() {
+        loadTask?.cancel()
+        loadTask = nil
+        loadGeneration += 1
+        tags = []
+        isLoading = false
+        error = nil
+        hasLoadedOnce = false
+        lastLoadTime = nil
+    }
+}
+
+private extension Array where Element == Tag {
+    func sortedForDisplay() -> [Tag] {
+        sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+}

--- a/ios/Pulpe/Domain/Store/TagStore.swift
+++ b/ios/Pulpe/Domain/Store/TagStore.swift
@@ -72,6 +72,10 @@ final class TagStore: StoreProtocol {
         let generation = sessionGeneration
         let created = try await service.create(TagCreate(name: name))
         guard sessionGeneration == generation else { throw CancellationError() }
+        loadTask?.cancel()
+        loadTask = nil
+        loadGeneration += 1
+        isLoading = false
         tags = (tags + [created]).sortedForDisplay()
         return created
     }

--- a/ios/Pulpe/Domain/Store/TagStore.swift
+++ b/ios/Pulpe/Domain/Store/TagStore.swift
@@ -18,6 +18,7 @@ final class TagStore: StoreProtocol {
     private var lastLoadTime: Date?
     private var loadTask: Task<Void, Never>?
     private var loadGeneration = 0
+    private var sessionGeneration = 0
     private let service: any TagServicing
 
     init(service: any TagServicing = TagService.shared) {
@@ -68,7 +69,9 @@ final class TagStore: StoreProtocol {
 
     @discardableResult
     func create(name: String) async throws -> Tag {
+        let generation = sessionGeneration
         let created = try await service.create(TagCreate(name: name))
+        guard sessionGeneration == generation else { throw CancellationError() }
         tags = (tags + [created]).sortedForDisplay()
         return created
     }
@@ -81,6 +84,7 @@ final class TagStore: StoreProtocol {
         loadTask?.cancel()
         loadTask = nil
         loadGeneration += 1
+        sessionGeneration += 1
         tags = []
         isLoading = false
         error = nil

--- a/ios/Pulpe/Domain/Store/TagStore.swift
+++ b/ios/Pulpe/Domain/Store/TagStore.swift
@@ -33,6 +33,13 @@ final class TagStore: StoreProtocol {
         await forceRefresh()
     }
 
+    func loadIfNeeded(for referencedIds: Set<String>) async {
+        guard !referencedIds.isEmpty else { return }
+        let knownIds = Set(tags.map(\.id))
+        guard !referencedIds.isSubset(of: knownIds) else { return }
+        await forceRefresh()
+    }
+
     func forceRefresh() async {
         loadTask?.cancel()
         loadGeneration += 1
@@ -76,7 +83,7 @@ final class TagStore: StoreProtocol {
         loadTask = nil
         loadGeneration += 1
         isLoading = false
-        tags = (tags + [created]).sortedForDisplay()
+        tags = (tags.filter { $0.id != created.id } + [created]).sortedForDisplay()
         return created
     }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionLogic.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionLogic.swift
@@ -14,6 +14,7 @@ enum AddAllocatedTransactionLogic {
         let transactionDate: Date
         let isChecked: Bool
         let conversion: CurrencyConversion?
+        let tagIds: [String]?
     }
 
     static func isFormValid(name: String, amount: Decimal?, isLoading: Bool) -> Bool {
@@ -60,7 +61,8 @@ enum AddAllocatedTransactionLogic {
             originalAmount: input.conversion?.originalAmount,
             originalCurrency: input.conversion?.originalCurrency,
             targetCurrency: input.conversion?.targetCurrency,
-            exchangeRate: input.conversion?.exchangeRate
+            exchangeRate: input.conversion?.exchangeRate,
+            tagIds: input.tagIds
         )
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionPage.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddAllocatedTransactionPage.swift
@@ -28,6 +28,7 @@ struct AddAllocatedTransactionPage: View {
     @State private var isLoading = false
     @State private var submitSuccessTrigger = false
     @State private var didAutofocus = false
+    @State private var selectedTagIds: Set<String> = []
     @FocusState private var focusedField: AmountDescriptionField?
 
     private let conversionService = CurrencyConversionService.shared
@@ -121,6 +122,7 @@ struct AddAllocatedTransactionPage: View {
             TransactionDateSelector(date: $transactionDate, currency: userSettingsStore.currency)
 
             CheckedToggle(isOn: $isChecked, tintColor: line.kind.color)
+            TagPickerField(selection: $selectedTagIds)
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -201,7 +203,8 @@ struct AddAllocatedTransactionPage: View {
                     amount: amount,
                     transactionDate: transactionDate,
                     isChecked: isChecked,
-                    conversion: conversion
+                    conversion: conversion,
+                    tagIds: TagPickerField.createdTagIds(from: selectedTagIds)
                 )
             )
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -40,7 +40,6 @@ struct AddBudgetLineSheet: View {
     private let anchorYear: Int
     private let dependencies: AddBudgetLineDependencies
     private let conversionService = CurrencyConversionService.shared
-
     init(
         budgetId: String,
         anchorMonth: Int,
@@ -68,8 +67,7 @@ struct AddBudgetLineSheet: View {
     /// Income "remets le mois prochain" ON — the CTA reroutes to the withdrawal preview (PUL-292).
     private var isSavingsWithdrawalMode: Bool { kind == .income && remitNextMonth }
 
-    /// Hero hint follows the amount mode in spread mode — "Montant total" when the
-    /// server divides, "Montant par mois" when it replicates. `nil` outside spread.
+    /// Hero hint follows the amount mode in spread mode.
     private var amountFieldHint: String? {
         guard isSpreadMode else { return nil }
         return amountMode == .total ? "Montant total" : "Montant par mois"
@@ -124,7 +122,6 @@ struct AddBudgetLineSheet: View {
             )
             .animation(.snappy(duration: DesignTokens.Animation.fast), value: kind)
 
-            // Spread toggle hidden for income — revenu lissé is out of scope (PUL-17).
             if kind != .income {
                 SpreadModeToggle(selection: $mode, accentColor: kind.color)
             }
@@ -234,8 +231,7 @@ struct AddBudgetLineSheet: View {
         }
     }
 
-    /// Hands a prefilled withdrawal intent to the router (PUL-292): the typed
-    /// name becomes the optional source, the sheet opens at its preview step.
+    /// Hands a prefilled withdrawal intent to the router (PUL-292).
     private func routeToSavingsWithdrawal() {
         guard let amount, amount > 0 else { return }
         let trimmed = name.trimmingCharacters(in: .whitespaces)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -4,9 +4,7 @@ import SwiftUI
 struct AddBudgetLineSheet: View {
     let budgetId: String
     let onAdd: (BudgetLine) -> Void
-    /// When the income "remets le mois prochain" toggle is ON, the CTA routes
-    /// here with a prefilled withdrawal intent instead of creating a plain
-    /// income (PUL-292). `nil` outside BudgetDetails (e.g. previews).
+    /// PUL-292: routes the CTA to a prefilled withdrawal instead of creating plain income.
     let onRequestSavingsWithdrawal: ((SavingsWithdrawalPrefill) -> Void)?
 
     @Environment(\.dismiss) private var dismiss
@@ -64,10 +62,10 @@ struct AddBudgetLineSheet: View {
 
     private var isSpreadMode: Bool { mode == .spread }
 
-    /// Income "remets le mois prochain" ON — the CTA reroutes to the withdrawal preview (PUL-292).
+    static func showsTagPicker(spread: Bool, withdrawal: Bool) -> Bool { !spread && !withdrawal }
+
     private var isSavingsWithdrawalMode: Bool { kind == .income && remitNextMonth }
 
-    /// Hero hint follows the amount mode in spread mode.
     private var amountFieldHint: String? {
         guard isSpreadMode else { return nil }
         return amountMode == .total ? "Montant total" : "Montant par mois"
@@ -141,7 +139,9 @@ struct AddBudgetLineSheet: View {
                 if kind == .saving {
                     SavingsGoalPickerField(selection: $savingsGoalId)
                 }
-                TagPickerField(selection: $selectedTagIds)
+                if Self.showsTagPicker(spread: isSpreadMode, withdrawal: isSavingsWithdrawalMode) {
+                    TagPickerField(selection: $selectedTagIds)
+                }
                 if kind == .income {
                     remitToggle
                 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -17,6 +17,7 @@ struct AddBudgetLineSheet: View {
     @State private var amount: Decimal?
     @State private var kind: TransactionKind = .expense
     @State private var savingsGoalId: String?
+    @State private var selectedTagIds: Set<String> = []
     @State private var isChecked = false
     @State private var isLoading = false
     @State private var error: Error?
@@ -143,6 +144,7 @@ struct AddBudgetLineSheet: View {
                 if kind == .saving {
                     SavingsGoalPickerField(selection: $savingsGoalId)
                 }
+                TagPickerField(selection: $selectedTagIds)
                 if kind == .income {
                     remitToggle
                 }
@@ -275,7 +277,8 @@ struct AddBudgetLineSheet: View {
                 originalAmount: conversion?.originalAmount,
                 originalCurrency: conversion?.originalCurrency,
                 targetCurrency: conversion?.targetCurrency,
-                exchangeRate: conversion?.exchangeRate
+                exchangeRate: conversion?.exchangeRate,
+                tagIds: TagPickerField.createdTagIds(from: selectedTagIds)
             )
 
             let budgetLine = try await dependencies.createBudgetLine(data)
@@ -346,4 +349,5 @@ struct AddBudgetLineSheet: View {
     .environment(UserSettingsStore())
     .environment(BudgetListStore())
     .environment(SavingsGoalStore())
+    .environment(TagStore())
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
@@ -17,6 +17,7 @@ import SwiftUI
 struct BudgetDetailsFreeTransactionsList: View {
     let items: [BudgetDetailsScreenState.FreeTransactionItem]
     let currency: SupportedCurrency
+    let tagNamesById: [String: String]
     let onTap: (Transaction) -> Void
     let onTogglePointed: (Transaction) -> Void
 
@@ -59,6 +60,7 @@ struct BudgetDetailsFreeTransactionsList: View {
                     transaction: item.transaction,
                     isSyncing: item.isSyncing,
                     currency: currency,
+                    tagNames: TagChips.names(for: item.transaction.tagIds, namesById: tagNamesById),
                     onTap: { onTap(item.transaction) },
                     onTogglePointed: { onTogglePointed(item.transaction) }
                 )
@@ -100,6 +102,7 @@ private struct BudgetDetailsFreeTransactionRow: View {
     let transaction: Transaction
     let isSyncing: Bool
     let currency: SupportedCurrency
+    let tagNames: [String]
     let onTap: () -> Void
     let onTogglePointed: () -> Void
 
@@ -146,7 +149,8 @@ private struct BudgetDetailsFreeTransactionRow: View {
         let amount = transaction.amount.asCurrency(currency)
         let pointed = isPointed ? "Pointé" : "À pointer"
         let date = transaction.transactionDate.dayMonthFormatted
-        return "\(kind.label) · \(transaction.name) · \(amount) · \(date) · \(pointed)"
+        let tags = tagNames.isEmpty ? "" : " · Tags : \(tagNames.joined(separator: ", "))"
+        return "\(kind.label) · \(transaction.name) · \(amount) · \(date) · \(pointed)\(tags)"
     }
 
     private func handleTogglePointed() {
@@ -205,6 +209,10 @@ private struct BudgetDetailsFreeTransactionRow: View {
                 .strikethrough(isPointed, color: Color.textTertiary)
                 .lineLimit(1)
                 .truncationMode(.tail)
+
+            if !tagNames.isEmpty {
+                TagChips(names: tagNames, maxVisible: 2)
+            }
 
             Text(transaction.transactionDate.dayInMonthFormatted)
                 .font(PulpeTypography.metricLabelBold)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsFreeTransactionsList.swift
@@ -211,7 +211,7 @@ private struct BudgetDetailsFreeTransactionRow: View {
                 .truncationMode(.tail)
 
             if !tagNames.isEmpty {
-                TagChips(names: tagNames, maxVisible: 2)
+                TagChips(names: tagNames, presentation: .count)
             }
 
             Text(transaction.transactionDate.dayInMonthFormatted)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Previews.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Previews.swift
@@ -14,6 +14,7 @@ import TipKit
     .environment(DashboardStore())
     .environment(CurrentMonthStore())
     .environment(SavingsGoalStore())
+    .environment(TagStore())
 }
 
 #Preview("Gestures Tip") {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Routing.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Routing.swift
@@ -14,6 +14,7 @@ extension BudgetDetailsView {
         case .lineDetail(let lineId):
             BudgetLineDetailPage(
                 lineId: lineId,
+                tagNamesById: tagStore.namesById,
                 onEditLine: { line in router.present(.editBudgetLine(line)) }
             )
         case .addAllocatedTx(let lineId):

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -157,6 +157,7 @@ struct BudgetDetailsView: View {
                 await coordinator.dispatch(.reloadCurrentBudget)
             }
         }
+        .task(id: screenState.referencedTagIds) { await tagStore.loadIfNeeded(for: screenState.referencedTagIds) }
         .onChange(of: searchText) { _, newValue in
             projector.setSearchText(newValue)
         }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView.swift
@@ -14,6 +14,7 @@ struct BudgetDetailsView: View {
     @Environment(DashboardStore.self) private var dashboardStore
     @Environment(CurrentMonthStore.self) private var currentMonthStore
     @Environment(SavingsGoalStore.self) private var savingsGoalStore
+    @Environment(TagStore.self) var tagStore
     @Environment(\.amountsHidden) private var amountsHidden
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.tabBarClearance) private var tabBarClearance
@@ -149,6 +150,7 @@ struct BudgetDetailsView: View {
             )
             // Resolve "Objectif" names for saving rows / the line detail chip.
             await savingsGoalStore.loadIfNeeded()
+            await tagStore.loadIfNeeded()
             if !screenState.hasAllBudgets {
                 await coordinator.dispatch(.loadDetails(force: false))
             } else {
@@ -267,6 +269,7 @@ struct BudgetDetailsView: View {
                         items: section.items,
                         currency: userSettingsStore.currency,
                         goalNamesById: savingsGoalNamesById,
+                        tagNamesById: tagStore.namesById,
                         savingsWithdrawalOriginMonthName: savingsWithdrawalOriginMonthName,
                         onTap: { line in
                             router.push(.lineDetail(lineId: line.id))
@@ -286,6 +289,7 @@ struct BudgetDetailsView: View {
                     BudgetDetailsFreeTransactionsList(
                         items: free,
                         currency: userSettingsStore.currency,
+                        tagNamesById: tagStore.namesById,
                         onTap: { transaction in
                             router.push(.editTx(transactionId: transaction.id))
                         },

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage+SavingsGoalLink.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage+SavingsGoalLink.swift
@@ -3,6 +3,16 @@ import SwiftUI
 // MARK: - Savings goal link (PUL-12)
 
 extension BudgetLineDetailPage {
+    @ViewBuilder
+    func tagChips(for ids: [String]?) -> some View {
+        let names = TagChips.names(for: ids, namesById: tagNamesById)
+        if !names.isEmpty {
+            TagChips(names: names)
+                .padding(.horizontal, DesignTokens.Spacing.lg)
+                .padding(.bottom, DesignTokens.Spacing.md)
+        }
+    }
+
     /// Tappable "Objectif : <name>" chip shown on a saving prévision that is
     /// linked to a savings goal. Pushes the goal's progression detail through
     /// the router (the budget stack registers `SavingsGoalDestination`).

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailPage.swift
@@ -17,8 +17,8 @@ import SwiftUI
 /// page auto-pops via `dismiss()` from the empty branch — no stale state.
 struct BudgetLineDetailPage: View {
     let lineId: String
+    let tagNamesById: [String: String]
     let onEditLine: (BudgetLine) -> Void
-
     @Environment(BudgetDetailsCoordinator.self) var coordinator
     @Environment(BudgetDetailsProjector.self) var projector
     @Environment(AppState.self) var appState
@@ -74,6 +74,7 @@ struct BudgetLineDetailPage: View {
                 .padding(.bottom, DesignTokens.Spacing.md)
 
             savingsGoalLink(for: line)
+            tagChips(for: line.tagIds)
 
             if let spreadGroupId = line.spreadGroupId {
                 SpreadAffordanceButton {
@@ -147,6 +148,7 @@ struct BudgetLineDetailPage: View {
         BudgetLineDetailTransactionRow(
             transaction: transaction,
             displayCurrency: userSettingsStore.currency,
+            tagNames: TagChips.names(for: transaction.tagIds, namesById: tagNamesById),
             onTap: {
                 router.push(.editTx(transactionId: transaction.id))
             }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailTransactionRow.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailTransactionRow.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct BudgetLineDetailTransactionRow: View {
     let transaction: Transaction
     let displayCurrency: SupportedCurrency
+    let tagNames: [String]
     let onTap: () -> Void
 
     var body: some View {
@@ -17,6 +18,10 @@ struct BudgetLineDetailTransactionRow: View {
                         .foregroundStyle(transaction.isChecked ? .secondary : .primary)
                         .strikethrough(transaction.isChecked, color: .secondary)
                         .lineLimit(1)
+
+                    if !tagNames.isEmpty {
+                        TagChips(names: tagNames, maxVisible: 2)
+                    }
 
                     Text(transaction.transactionDate.relativeFormatted)
                         .font(PulpeTypography.metricMini)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailTransactionRow.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineDetailTransactionRow.swift
@@ -20,7 +20,7 @@ struct BudgetLineDetailTransactionRow: View {
                         .lineLimit(1)
 
                     if !tagNames.isEmpty {
-                        TagChips(names: tagNames, maxVisible: 2)
+                        TagChips(names: tagNames, presentation: .count)
                     }
 
                     Text(transaction.transactionDate.relativeFormatted)

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineMixedRow+Previews.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineMixedRow+Previews.swift
@@ -41,6 +41,7 @@ private struct BudgetLineMixedRowPreviewHost: View {
                         isSyncing: false,
                         currency: .chf,
                         savingsGoalName: nil,
+                        tagNames: [],
                         onTap: {},
                         onTogglePointed: {}
                     )

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineMixedRow.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineMixedRow.swift
@@ -203,7 +203,7 @@ struct BudgetLineMixedRow: View {
                 .truncationMode(.tail)
 
             if !tagNames.isEmpty {
-                TagChips(names: tagNames, maxVisible: 2)
+                TagChips(names: tagNames, presentation: .count)
             }
 
             subtitleView

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineMixedRow.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetLineMixedRow.swift
@@ -29,6 +29,7 @@ struct BudgetLineMixedRow: View {
     /// `nil` when unlinked / not a saving line / the goal cache is still loading.
     /// Passed as a primitive so the row never reads `SavingsGoalStore` directly.
     let savingsGoalName: String?
+    let tagNames: [String]
     /// Origin month name (M) of a savings-withdrawal repayment (PUL-292), shown as
     /// a subtitle complement on the M+1 "Remettre sur ton épargne" saving line.
     /// Passed pre-resolved (budget month − 1) so the row never does date math.
@@ -201,6 +202,10 @@ struct BudgetLineMixedRow: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
 
+            if !tagNames.isEmpty {
+                TagChips(names: tagNames, maxVisible: 2)
+            }
+
             subtitleView
                 .font(PulpeTypography.metricLabelBold)
                 .lineLimit(1)
@@ -334,6 +339,7 @@ struct BudgetLineMixedRow: View {
         let kindWord = line.kind.label
         let pointed = isPointed ? "Pointé" : "À pointer"
         let amount = displayAmount.asCurrency(currency)
-        return "\(kindWord) · \(line.name) · \(amount) · \(pointed)"
+        let tags = tagNames.isEmpty ? "" : " · Tags : \(tagNames.joined(separator: ", "))"
+        return "\(kindWord) · \(line.name) · \(amount) · \(pointed)\(tags)"
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetMixedSection.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetMixedSection.swift
@@ -15,6 +15,7 @@ struct BudgetMixedSection: View {
     /// Savings goal names keyed by goal id (PUL-12). Only the Épargne section
     /// resolves a name; other kinds never carry a `savingsGoalId`.
     let goalNamesById: [String: String]
+    let tagNamesById: [String: String]
     /// Origin month name (M) of a savings-withdrawal repayment (PUL-292), = this
     /// budget's month − 1. Shown only on the M+1 "Remettre sur ton épargne" line.
     let savingsWithdrawalOriginMonthName: String?
@@ -27,6 +28,7 @@ struct BudgetMixedSection: View {
         items: [BudgetDetailsScreenState.LineItem],
         currency: SupportedCurrency,
         goalNamesById: [String: String] = [:],
+        tagNamesById: [String: String] = [:],
         savingsWithdrawalOriginMonthName: String? = nil,
         onTap: @escaping (BudgetLine) -> Void,
         onTogglePointed: @escaping (BudgetLine) -> Void,
@@ -36,6 +38,7 @@ struct BudgetMixedSection: View {
         self.items = items
         self.currency = currency
         self.goalNamesById = goalNamesById
+        self.tagNamesById = tagNamesById
         self.savingsWithdrawalOriginMonthName = savingsWithdrawalOriginMonthName
         self.onTap = onTap
         self.onTogglePointed = onTogglePointed
@@ -88,6 +91,7 @@ struct BudgetMixedSection: View {
                     isSyncing: item.isSyncing,
                     currency: currency,
                     savingsGoalName: goalName(for: item.line),
+                    tagNames: TagChips.names(for: item.line.tagIds, namesById: tagNamesById),
                     savingsWithdrawalOriginMonthName: savingsWithdrawalOriginMonthName,
                     onTap: { onTap(item.line) },
                     onTogglePointed: { onTogglePointed(item.line) }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/EditTransactionLogic.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/EditTransactionLogic.swift
@@ -43,14 +43,16 @@ enum EditTransactionLogic {
         amount: Decimal,
         kind: TransactionKind,
         transactionDate: Date,
-        conversion: CurrencyConversion?
+        conversion: CurrencyConversion?,
+        tagIds: [String]? = nil
     ) -> TransactionUpdate {
         guard let conversion else {
             return TransactionUpdate(
                 name: name,
                 amount: amount,
                 kind: kind,
-                transactionDate: transactionDate
+                transactionDate: transactionDate,
+                tagIds: tagIds
             )
         }
         return TransactionUpdate(
@@ -61,7 +63,8 @@ enum EditTransactionLogic {
             originalAmount: conversion.originalAmount,
             originalCurrency: conversion.originalCurrency,
             targetCurrency: conversion.targetCurrency,
-            exchangeRate: conversion.exchangeRate
+            exchangeRate: conversion.exchangeRate,
+            tagIds: tagIds
         )
     }
 }

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/EditTransactionPage.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/EditTransactionPage.swift
@@ -30,6 +30,8 @@ struct EditTransactionPage: View {
     @State private var didAutofocus = false
     @State private var showDeleteConfirmation = false
     @State private var pendingPostpone: PostponeTarget?
+    @State private var selectedTagIds: Set<String> = []
+    @State private var initialTagIds: Set<String> = []
     @FocusState private var focusedField: AmountDescriptionField?
 
     private let conversionService = CurrencyConversionService.shared
@@ -185,6 +187,7 @@ struct EditTransactionPage: View {
             descriptionField
 
             TransactionDateSelector(date: $transactionDate, currency: userSettingsStore.currency)
+            TagPickerField(selection: $selectedTagIds)
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -281,6 +284,9 @@ struct EditTransactionPage: View {
         name = tx.name
         kind = tx.kind
         transactionDate = tx.transactionDate
+        let tagIds = Set(tx.tagIds ?? [])
+        selectedTagIds = tagIds
+        initialTagIds = tagIds
 
         let editable = EditTransactionLogic.initialAmount(
             for: tx,
@@ -314,7 +320,8 @@ struct EditTransactionPage: View {
                 amount: amount,
                 kind: kind,
                 transactionDate: transactionDate,
-                conversion: conversion
+                conversion: conversion,
+                tagIds: TagPickerField.updatedTagIds(initial: initialTagIds, current: selectedTagIds)
             )
 
             // Routes the server call through the coordinator (Rule 9 — no

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsProjector.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsProjector.swift
@@ -180,6 +180,10 @@ final class BudgetDetailsProjector {
             consumptionByLineId: ctx.consumptionByLineId,
             lineById: ctx.lineById,
             transactionsByLineId: ctx.transactionsByLineId,
+            referencedTagIds: makeReferencedTagIds(
+                budgetLines: ctx.dataStore.budgetLines,
+                transactions: ctx.dataStore.transactions
+            ),
             checkedTickHash: makeCheckedTickHash(
                 budgetLines: ctx.dataStore.budgetLines,
                 transactions: ctx.dataStore.transactions
@@ -252,6 +256,20 @@ final class BudgetDetailsProjector {
         return grouped.mapValues { txs in
             txs.sorted { $0.transactionDate > $1.transactionDate }
         }
+    }
+
+    private static func makeReferencedTagIds(
+        budgetLines: [BudgetLine],
+        transactions: [Transaction]
+    ) -> Set<String> {
+        var ids: Set<String> = []
+        for line in budgetLines {
+            ids.formUnion(line.tagIds ?? [])
+        }
+        for transaction in transactions {
+            ids.formUnion(transaction.tagIds ?? [])
+        }
+        return ids
     }
 
     private static func makePagerMonths(

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsScreenState.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/Projection/BudgetDetailsScreenState.swift
@@ -93,6 +93,10 @@ struct BudgetDetailsScreenState: Equatable {
     /// the view body.
     let transactionsByLineId: [String: [Transaction]]
 
+    /// Tag ids referenced by any line or transaction in the current budget.
+    /// Drives catalog refreshes when a reload introduces an unknown tag.
+    let referencedTagIds: Set<String>
+
     /// Cheap value that changes if-and-only-if any item's `isChecked` flag
     /// flips. Used as the `value:` of the list-level `.animation(_:value:)`
     /// modifier so the animation does not allocate per body re-eval.
@@ -124,6 +128,7 @@ struct BudgetDetailsScreenState: Equatable {
         consumptionByLineId: [:],
         lineById: [:],
         transactionsByLineId: [:],
+        referencedTagIds: [],
         checkedTickHash: 0
     )
 

--- a/ios/Pulpe/Features/CurrentMonth/Components/ActivityCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/ActivityCard.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// the only variateur that maps to real usage.
 struct ActivityCard: View {
     let transactions: [Transaction]
+    var tagNamesById: [String: String] = [:]
     var onViewAll: () -> Void
 
     @Environment(UserSettingsStore.self) private var userSettingsStore
@@ -165,6 +166,11 @@ struct ActivityCard: View {
                     .font(PulpeTypography.labelLarge)
                     .foregroundStyle(Color.textPrimary)
                     .lineLimit(1)
+
+                let tagNames = TagChips.names(for: transaction.tagIds, namesById: tagNamesById)
+                if !tagNames.isEmpty {
+                    TagChips(names: tagNames, maxVisible: 2)
+                }
 
                 Text(transaction.transactionDate.relativeFormatted.lowercased())
                     .font(PulpeTypography.labelMedium)

--- a/ios/Pulpe/Features/CurrentMonth/Components/ActivityCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/ActivityCard.swift
@@ -169,7 +169,7 @@ struct ActivityCard: View {
 
                 let tagNames = TagChips.names(for: transaction.tagIds, namesById: tagNamesById)
                 if !tagNames.isEmpty {
-                    TagChips(names: tagNames, maxVisible: 2)
+                    TagChips(names: tagNames, presentation: .count)
                 }
 
                 Text(transaction.transactionDate.relativeFormatted.lowercased())

--- a/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/AddTransactionSheet.swift
@@ -19,6 +19,7 @@ struct AddTransactionSheet: View {
     @State private var amountText = ""
     @State private var submitSuccessTrigger = false
     @State private var inputCurrency: SupportedCurrency = .chf
+    @State private var selectedTagIds: Set<String> = []
 
     private let dependencies: AddTransactionDependencies
     private let conversionService = CurrencyConversionService.shared
@@ -87,6 +88,7 @@ struct AddTransactionSheet: View {
             descriptionField
             dateSelector
             CheckedToggle(isOn: $isChecked, tintColor: kind.color)
+            TagPickerField(selection: $selectedTagIds)
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -168,7 +170,8 @@ struct AddTransactionSheet: View {
                 originalAmount: conversion?.originalAmount,
                 originalCurrency: conversion?.originalCurrency,
                 targetCurrency: conversion?.targetCurrency,
-                exchangeRate: conversion?.exchangeRate
+                exchangeRate: conversion?.exchangeRate,
+                tagIds: TagPickerField.createdTagIds(from: selectedTagIds)
             )
 
             let transaction = try await dependencies.createTransaction(data)
@@ -198,6 +201,7 @@ struct AddTransactionDependencies: Sendable {
         print("Added: \(transaction)")
     }
     .environment(ToastManager())
+    .environment(TagStore())
 }
 
 // MARK: - Deep Link Wrapper

--- a/ios/Pulpe/Features/CurrentMonth/Components/DriftCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/DriftCard.swift
@@ -148,7 +148,7 @@ struct DriftCard: View {
 
             let tagNames = TagChips.names(for: line.tagIds, namesById: tagNamesById)
             if !tagNames.isEmpty {
-                TagChips(names: tagNames, maxVisible: 2)
+                TagChips(names: tagNames, presentation: .count)
             }
 
             HomeSegmentedBar(

--- a/ios/Pulpe/Features/CurrentMonth/Components/DriftCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/DriftCard.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct DriftCard: View {
     let drifts: [(line: BudgetLine, consumption: BudgetFormulas.Consumption)]
     let totalOver: Decimal
+    var tagNamesById: [String: String] = [:]
     /// Next-month name for the "ajuster {mois}" lever in the footer subtitle.
     let adjustMonthName: String
     var onViewBudget: () -> Void
@@ -38,8 +39,10 @@ struct DriftCard: View {
     }
 
     private func rowAccessibilityLabel(_ line: BudgetLine, overBy: Decimal) -> String {
-        guard !amountsHidden else { return "\(line.name), au-delà du plan" }
-        return "\(line.name), \(overBy.asCompactCurrency(currency)) au-delà du plan"
+        let names = TagChips.names(for: line.tagIds, namesById: tagNamesById)
+        let tags = names.isEmpty ? "" : ", tags : \(names.joined(separator: ", "))"
+        guard !amountsHidden else { return "\(line.name), au-delà du plan\(tags)" }
+        return "\(line.name), \(overBy.asCompactCurrency(currency)) au-delà du plan\(tags)"
     }
 
     var body: some View {
@@ -141,6 +144,11 @@ struct DriftCard: View {
                     .lineLimit(1)
                     .minimumScaleFactor(DesignTokens.TextScale.floor)
                     .sensitiveAmount()
+            }
+
+            let tagNames = TagChips.names(for: line.tagIds, namesById: tagNamesById)
+            if !tagNames.isEmpty {
+                TagChips(names: tagNames, maxVisible: 2)
             }
 
             HomeSegmentedBar(

--- a/ios/Pulpe/Features/CurrentMonth/Components/UncheckedOperationsCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/UncheckedOperationsCard.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct UncheckedOperationsCard: View {
     let items: [CurrentMonthStore.CheckableItem]
     let totalCount: Int
+    var tagNamesById: [String: String] = [:]
     let syncingBudgetLineIds: Set<String>
     let syncingTransactionIds: Set<String>
     var onToggle: (CurrentMonthStore.CheckableItem) -> Void
@@ -204,6 +205,11 @@ struct UncheckedOperationsCard: View {
             }
             .accessibilityElement(children: .combine)
 
+            let tagNames = tagNames(for: item)
+            if !tagNames.isEmpty {
+                TagChips(names: tagNames, maxVisible: 2)
+            }
+
             actionsRow(item)
         }
         .padding(.horizontal, DesignTokens.Spacing.xl)
@@ -307,6 +313,15 @@ struct UncheckedOperationsCard: View {
             transaction.transactionDate.relativeFormatted.lowercased()
         case .budgetLine(let line, _):
             line.recurrence.label.lowercased()
+        }
+    }
+
+    private func tagNames(for item: CurrentMonthStore.CheckableItem) -> [String] {
+        switch item {
+        case .transaction(let transaction, _):
+            TagChips.names(for: transaction.tagIds, namesById: tagNamesById)
+        case .budgetLine(let line, _):
+            TagChips.names(for: line.tagIds, namesById: tagNamesById)
         }
     }
 

--- a/ios/Pulpe/Features/CurrentMonth/Components/UncheckedOperationsCard.swift
+++ b/ios/Pulpe/Features/CurrentMonth/Components/UncheckedOperationsCard.swift
@@ -207,7 +207,7 @@ struct UncheckedOperationsCard: View {
 
             let tagNames = tagNames(for: item)
             if !tagNames.isEmpty {
-                TagChips(names: tagNames, maxVisible: 2)
+                TagChips(names: tagNames, presentation: .count)
             }
 
             actionsRow(item)

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -17,6 +17,7 @@ struct CurrentMonthView: View {
     @Environment(BudgetListStore.self) private var budgetListStore
     @Environment(UserSettingsStore.self) private var userSettingsStore
     @Environment(SavingsGoalStore.self) private var savingsGoalStore
+    @Environment(TagStore.self) private var tagStore
     @Environment(ToastManager.self) private var toastManager
     @State private var activeSheet: SheetDestination?
     @State private var navigateToBudget = false
@@ -140,6 +141,10 @@ struct CurrentMonthView: View {
             if store.budgetLines.contains(where: { $0.savingsGoalId != nil }) {
                 await savingsGoalStore.loadIfNeeded()
             }
+            if store.budgetLines.contains(where: { !($0.tagIds ?? []).isEmpty })
+                || store.transactions.contains(where: { !($0.tagIds ?? []).isEmpty }) {
+                await tagStore.loadIfNeeded()
+            }
             if reduceMotion {
                 hasAppeared = true
             } else {
@@ -206,6 +211,7 @@ struct CurrentMonthView: View {
                     UncheckedOperationsCard(
                         items: store.uncheckedItems,
                         totalCount: store.uncheckedCount,
+                        tagNamesById: tagStore.namesById,
                         syncingBudgetLineIds: store.syncingBudgetLineIds,
                         syncingTransactionIds: store.syncingTransactionIds,
                         onToggle: { item in
@@ -253,6 +259,7 @@ struct CurrentMonthView: View {
                     DriftCard(
                         drifts: store.driftLines,
                         totalOver: store.driftTotal,
+                        tagNamesById: tagStore.namesById,
                         adjustMonthName: nextMonthName,
                         onViewBudget: { navigateToBudget = true },
                         onCatchUp: { navigateToBudget = true }
@@ -273,6 +280,7 @@ struct CurrentMonthView: View {
                 if !store.transactions.isEmpty {
                     ActivityCard(
                         transactions: store.transactions,
+                        tagNamesById: tagStore.namesById,
                         onViewAll: { navigateToBudget = true }
                     )
                     .staggeredEntrance(isVisible: hasAppeared, index: 4)
@@ -479,5 +487,6 @@ private struct CurrentMonthSkeletonView: View {
     .environment(BudgetListStore())
     .environment(UserSettingsStore())
     .environment(SavingsGoalStore())
+    .environment(TagStore())
     .environment(ToastManager())
 }

--- a/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
+++ b/ios/Pulpe/Features/CurrentMonth/CurrentMonthView.swift
@@ -38,6 +38,10 @@ struct CurrentMonthView: View {
         budgetListStore.nextAvailableMonth != nil
     }
 
+    private var referencedTagIds: Set<String> {
+        Set(store.budgetLines.flatMap { $0.tagIds ?? [] } + store.transactions.flatMap { $0.tagIds ?? [] })
+    }
+
     /// One-time post-onboarding handoff (teaches the pointer ritual + Lock Screen
     /// widget). Stateless UserDefaults wrapper — cheap to hold per render.
     private let postOnboardingFlags = PostOnboardingFlagsStore()
@@ -141,10 +145,6 @@ struct CurrentMonthView: View {
             if store.budgetLines.contains(where: { $0.savingsGoalId != nil }) {
                 await savingsGoalStore.loadIfNeeded()
             }
-            if store.budgetLines.contains(where: { !($0.tagIds ?? []).isEmpty })
-                || store.transactions.contains(where: { !($0.tagIds ?? []).isEmpty }) {
-                await tagStore.loadIfNeeded()
-            }
             if reduceMotion {
                 hasAppeared = true
             } else {
@@ -152,6 +152,9 @@ struct CurrentMonthView: View {
                     hasAppeared = true
                 }
             }
+        }
+        .task(id: referencedTagIds) {
+            await tagStore.loadIfNeeded(for: referencedTagIds)
         }
         .onChange(of: navigateToBudget) { _, shouldNavigate in
             if shouldNavigate, let budgetId = store.budget?.id {

--- a/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/EditTemplateLineSheet.swift
@@ -13,6 +13,7 @@ struct EditTemplateLineSheet: View {
     @State private var kind: TransactionKind
     @State private var recurrence: TransactionRecurrence
     @State private var savingsGoalId: String?
+    @State private var selectedTagIds: Set<String>
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var focusedField: AmountDescriptionField?
@@ -24,6 +25,7 @@ struct EditTemplateLineSheet: View {
     @State private var pendingUpdate: TemplateLineUpdate?
     private let inputCurrency: SupportedCurrency
     private let isAlternateCurrency: Bool
+    private let initialTagIds: Set<String>
 
     private let dependencies: EditTemplateLineDependencies
     private let conversionService = CurrencyConversionService.shared
@@ -41,6 +43,9 @@ struct EditTemplateLineSheet: View {
         _kind = State(initialValue: templateLine.kind)
         _recurrence = State(initialValue: templateLine.recurrence)
         _savingsGoalId = State(initialValue: templateLine.savingsGoalId)
+        let tagIds = Set(templateLine.tagIds ?? [])
+        _selectedTagIds = State(initialValue: tagIds)
+        initialTagIds = tagIds
 
         let inputCurrency = templateLine.originalCurrency ?? userCurrency
         let editableAmount = Self.initialAmount(for: templateLine, userCurrency: userCurrency)
@@ -90,6 +95,7 @@ struct EditTemplateLineSheet: View {
             if kind == .saving {
                 SavingsGoalPickerField(selection: $savingsGoalId)
             }
+            TagPickerField(selection: $selectedTagIds)
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -199,7 +205,8 @@ struct EditTemplateLineSheet: View {
                 amount: amount,
                 kind: kind,
                 recurrence: recurrence,
-                conversion: conversion
+                conversion: conversion,
+                tagIds: TagPickerField.updatedTagIds(initial: initialTagIds, current: selectedTagIds)
             )
             // Always emit the link (id or explicit null) so a saving line can be
             // tagged or untagged; the kind-guard clears it for non-saving kinds.
@@ -241,19 +248,7 @@ struct EditTemplateLineSheet: View {
 
         do {
             let operations = TemplateLinesBulkOperations(
-                update: [TemplateLineUpdateWithId(
-                    id: templateLine.id,
-                    name: data.name,
-                    amount: data.amount,
-                    kind: data.kind,
-                    recurrence: data.recurrence,
-                    description: data.description,
-                    savingsGoalId: data.savingsGoalId,
-                    originalAmount: data.originalAmount,
-                    originalCurrency: data.originalCurrency,
-                    targetCurrency: data.targetCurrency,
-                    exchangeRate: data.exchangeRate
-                )],
+                update: [Self.propagationUpdate(id: templateLine.id, data: data)],
                 propagateToBudgets: true
             )
             let response = try await dependencies.bulkUpdateWithPropagation(templateLine.templateId, operations)
@@ -300,14 +295,16 @@ struct EditTemplateLineSheet: View {
         amount: Decimal,
         kind: TransactionKind,
         recurrence: TransactionRecurrence,
-        conversion: CurrencyConversion?
+        conversion: CurrencyConversion?,
+        tagIds: [String]? = nil
     ) -> TemplateLineUpdate {
         guard let conversion else {
             return TemplateLineUpdate(
                 name: name,
                 amount: amount,
                 kind: kind,
-                recurrence: recurrence
+                recurrence: recurrence,
+                tagIds: tagIds
             )
         }
         return TemplateLineUpdate(
@@ -318,7 +315,25 @@ struct EditTemplateLineSheet: View {
             originalAmount: conversion.originalAmount,
             originalCurrency: conversion.originalCurrency,
             targetCurrency: conversion.targetCurrency,
-            exchangeRate: conversion.exchangeRate
+            exchangeRate: conversion.exchangeRate,
+            tagIds: tagIds
+        )
+    }
+
+    static func propagationUpdate(id: String, data: TemplateLineUpdate) -> TemplateLineUpdateWithId {
+        TemplateLineUpdateWithId(
+            id: id,
+            name: data.name,
+            amount: data.amount,
+            kind: data.kind,
+            recurrence: data.recurrence,
+            description: data.description,
+            savingsGoalId: data.savingsGoalId,
+            originalAmount: data.originalAmount,
+            originalCurrency: data.originalCurrency,
+            targetCurrency: data.targetCurrency,
+            exchangeRate: data.exchangeRate,
+            tagIds: data.tagIds
         )
     }
 }
@@ -364,4 +379,5 @@ struct EditTemplateLineDependencies: Sendable {
     .environment(UserSettingsStore())
     .environment(FeatureFlagsStore())
     .environment(SavingsGoalStore())
+    .environment(TagStore())
 }

--- a/ios/Pulpe/Features/Templates/TemplateDetails/TemplateDetailsView.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/TemplateDetailsView.swift
@@ -223,7 +223,7 @@ struct TemplateLineRow: View {
 
                     let tagNames = TagChips.names(for: line.tagIds, namesById: tagNamesById)
                     if !tagNames.isEmpty {
-                        TagChips(names: tagNames, maxVisible: 2)
+                        TagChips(names: tagNames, presentation: .count)
                     }
                 }
 

--- a/ios/Pulpe/Features/Templates/TemplateDetails/TemplateDetailsView.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/TemplateDetailsView.swift
@@ -32,9 +32,9 @@ struct TemplateDetailsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             await viewModel.loadIfNeeded()
-            if viewModel.lines.contains(where: { !($0.tagIds ?? []).isEmpty }) {
-                await tagStore.loadIfNeeded()
-            }
+        }
+        .task(id: referencedTagIds) {
+            await tagStore.loadIfNeeded(for: referencedTagIds)
         }
         .sheet(item: $selectedLineForEdit) { line in
             EditTemplateLineSheet(
@@ -44,6 +44,10 @@ struct TemplateDetailsView: View {
                 Task { await viewModel.updateTemplateLine(updatedLine) }
             }
         }
+    }
+
+    private var referencedTagIds: Set<String> {
+        Set(viewModel.lines.flatMap { $0.tagIds ?? [] })
     }
 
     private func content(template: BudgetTemplate) -> some View {

--- a/ios/Pulpe/Features/Templates/TemplateDetails/TemplateDetailsView.swift
+++ b/ios/Pulpe/Features/Templates/TemplateDetails/TemplateDetailsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TemplateDetailsView: View {
     let templateId: String
     @Environment(UserSettingsStore.self) private var userSettingsStore
+    @Environment(TagStore.self) private var tagStore
     @State private var viewModel: TemplateDetailsViewModel
     @State private var selectedLineForEdit: TemplateLine?
 
@@ -31,6 +32,9 @@ struct TemplateDetailsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             await viewModel.loadIfNeeded()
+            if viewModel.lines.contains(where: { !($0.tagIds ?? []).isEmpty }) {
+                await tagStore.loadIfNeeded()
+            }
         }
         .sheet(item: $selectedLineForEdit) { line in
             EditTemplateLineSheet(
@@ -168,7 +172,7 @@ struct TemplateDetailsView: View {
     private func templateLineSection(title: String, lines: [TemplateLine], kind: TransactionKind) -> some View {
         Section {
             ForEach(lines) { line in
-                TemplateLineRow(line: line) {
+                TemplateLineRow(line: line, tagNamesById: tagStore.namesById) {
                     selectedLineForEdit = line
                 }
             }
@@ -189,6 +193,7 @@ struct TemplateDetailsView: View {
 
 struct TemplateLineRow: View {
     let line: TemplateLine
+    let tagNamesById: [String: String]
     let onEdit: () -> Void
 
     @Environment(UserSettingsStore.self) private var userSettingsStore
@@ -211,6 +216,11 @@ struct TemplateLineRow: View {
                         .lineLimit(1)
 
                     RecurrenceBadge(line.recurrence, style: .compact)
+
+                    let tagNames = TagChips.names(for: line.tagIds, namesById: tagNamesById)
+                    if !tagNames.isEmpty {
+                        TagChips(names: tagNames, maxVisible: 2)
+                    }
                 }
 
                 Spacer()
@@ -379,4 +389,5 @@ private struct TemplateDetailsSkeletonView: View {
         TemplateDetailsView(templateId: "test")
     }
     .environment(UserSettingsStore())
+    .environment(TagStore())
 }

--- a/ios/Pulpe/Shared/Components/EditBudgetLineSheet.swift
+++ b/ios/Pulpe/Shared/Components/EditBudgetLineSheet.swift
@@ -12,6 +12,7 @@ struct EditBudgetLineSheet: View {
     @State private var amount: Decimal?
     @State private var kind: TransactionKind
     @State private var savingsGoalId: String?
+    @State private var selectedTagIds: Set<String>
     @State private var isLoading = false
     @State private var error: Error?
     @FocusState private var focusedField: AmountDescriptionField?
@@ -19,6 +20,7 @@ struct EditBudgetLineSheet: View {
     @State private var submitSuccessTrigger = false
     private let inputCurrency: SupportedCurrency
     private let isAlternateCurrency: Bool
+    private let initialTagIds: Set<String>
 
     private let dependencies: EditBudgetLineDependencies
     private let conversionService = CurrencyConversionService.shared
@@ -35,6 +37,9 @@ struct EditBudgetLineSheet: View {
         _name = State(initialValue: budgetLine.name)
         _kind = State(initialValue: budgetLine.kind)
         _savingsGoalId = State(initialValue: budgetLine.savingsGoalId)
+        let tagIds = Set(budgetLine.tagIds ?? [])
+        _selectedTagIds = State(initialValue: tagIds)
+        initialTagIds = tagIds
 
         let inputCurrency = budgetLine.originalCurrency ?? userCurrency
         let editableAmount = Self.initialAmount(for: budgetLine, userCurrency: userCurrency)
@@ -83,6 +88,7 @@ struct EditBudgetLineSheet: View {
             if kind == .saving {
                 SavingsGoalPickerField(selection: $savingsGoalId)
             }
+            TagPickerField(selection: $selectedTagIds)
 
             if let error {
                 ErrorBanner(message: DomainErrorLocalizer.localize(error)) {
@@ -149,7 +155,8 @@ struct EditBudgetLineSheet: View {
                 name: name.trimmingCharacters(in: .whitespaces),
                 amount: amount,
                 kind: kind,
-                conversion: conversion
+                conversion: conversion,
+                tagIds: TagPickerField.updatedTagIds(initial: initialTagIds, current: selectedTagIds)
             )
             // Always emit the link (id or explicit null) so a saving line can be
             // tagged or untagged; the kind-guard clears it for non-saving kinds.
@@ -193,7 +200,8 @@ struct EditBudgetLineSheet: View {
         name: String,
         amount: Decimal,
         kind: TransactionKind,
-        conversion: CurrencyConversion?
+        conversion: CurrencyConversion?,
+        tagIds: [String]? = nil
     ) -> BudgetLineUpdate {
         guard let conversion else {
             return BudgetLineUpdate(
@@ -201,7 +209,8 @@ struct EditBudgetLineSheet: View {
                 name: name,
                 amount: amount,
                 kind: kind,
-                isManuallyAdjusted: true
+                isManuallyAdjusted: true,
+                tagIds: tagIds
             )
         }
         return BudgetLineUpdate(
@@ -213,7 +222,8 @@ struct EditBudgetLineSheet: View {
             originalAmount: conversion.originalAmount,
             originalCurrency: conversion.originalCurrency,
             targetCurrency: conversion.targetCurrency,
-            exchangeRate: conversion.exchangeRate
+            exchangeRate: conversion.exchangeRate,
+            tagIds: tagIds
         )
     }
 }
@@ -252,4 +262,5 @@ struct EditBudgetLineDependencies: Sendable {
     .environment(UserSettingsStore())
     .environment(FeatureFlagsStore())
     .environment(SavingsGoalStore())
+    .environment(TagStore())
 }

--- a/ios/Pulpe/Shared/Components/TagChips.swift
+++ b/ios/Pulpe/Shared/Components/TagChips.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Horizontal tag rail shared by forms and line details.
+struct TagChips: View {
+    let names: [String]
+    var maxVisible: Int?
+
+    var visibleNames: ArraySlice<String> {
+        names.prefix(maxVisible ?? names.count)
+    }
+
+    var hiddenCount: Int {
+        names.count - visibleNames.count
+    }
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: DesignTokens.ChipMetrics.Standard.interChipGap) {
+                ForEach(Array(visibleNames.enumerated()), id: \.offset) { _, name in
+                    PulpeChip(label: name, style: .muted)
+                }
+                if hiddenCount > 0 {
+                    PulpeChip(label: "+\(hiddenCount)", style: .muted)
+                        .accessibilityLabel("\(hiddenCount) tags supplémentaires")
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+    }
+}

--- a/ios/Pulpe/Shared/Components/TagChips.swift
+++ b/ios/Pulpe/Shared/Components/TagChips.swift
@@ -13,6 +13,10 @@ struct TagChips: View {
         names.count - visibleNames.count
     }
 
+    var accessibilityLabel: String {
+        "Tags : \(names.joined(separator: ", "))"
+    }
+
     var body: some View {
         ScrollView(.horizontal) {
             HStack(spacing: DesignTokens.ChipMetrics.Standard.interChipGap) {
@@ -26,5 +30,11 @@ struct TagChips: View {
             }
         }
         .scrollIndicators(.hidden)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    static func names(for ids: [String]?, namesById: [String: String]) -> [String] {
+        ids?.compactMap { namesById[$0] } ?? []
     }
 }

--- a/ios/Pulpe/Shared/Components/TagChips.swift
+++ b/ios/Pulpe/Shared/Components/TagChips.swift
@@ -1,37 +1,45 @@
 import SwiftUI
 
-/// Horizontal tag rail shared by forms and line details.
+/// Tag metadata rendered as full names in details or as a compact count on dense rows.
 struct TagChips: View {
+    enum Presentation: Equatable {
+        case names
+        case count
+    }
+
     let names: [String]
-    var maxVisible: Int?
-
-    var visibleNames: ArraySlice<String> {
-        names.prefix(maxVisible ?? names.count)
-    }
-
-    var hiddenCount: Int {
-        names.count - visibleNames.count
-    }
+    var presentation: Presentation = .names
 
     var accessibilityLabel: String {
         "Tags : \(names.joined(separator: ", "))"
     }
 
+    var countLabel: String {
+        "\(names.count)"
+    }
+
+    @ViewBuilder
     var body: some View {
-        ScrollView(.horizontal) {
-            HStack(spacing: DesignTokens.ChipMetrics.Standard.interChipGap) {
-                ForEach(Array(visibleNames.enumerated()), id: \.offset) { _, name in
-                    PulpeChip(label: name, style: .muted)
+        if !names.isEmpty {
+            switch presentation {
+            case .names:
+                ScrollView(.horizontal) {
+                    HStack(spacing: DesignTokens.ChipMetrics.Standard.interChipGap) {
+                        ForEach(Array(names.enumerated()), id: \.offset) { _, name in
+                            PulpeChip(label: name, style: .outlined)
+                        }
+                    }
                 }
-                if hiddenCount > 0 {
-                    PulpeChip(label: "+\(hiddenCount)", style: .muted)
-                        .accessibilityLabel("\(hiddenCount) tags supplémentaires")
-                }
+                .scrollIndicators(.hidden)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(accessibilityLabel)
+
+            case .count:
+                PulpeChip(icon: "tag", label: countLabel, style: .outlined)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(accessibilityLabel)
             }
         }
-        .scrollIndicators(.hidden)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
     }
 
     static func names(for ids: [String]?, namesById: [String: String]) -> [String] {

--- a/ios/Pulpe/Shared/Components/TagPickerField.swift
+++ b/ios/Pulpe/Shared/Components/TagPickerField.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+
+/// Shared multi-select field for attaching up to ten tags to a form.
+struct TagPickerField: View {
+    @Binding var selection: Set<String>
+
+    @Environment(TagStore.self) private var store
+    @State private var isPresented = false
+
+    private var selectedNames: [String] {
+        store.tags.filter { selection.contains($0.id) }.map(\.name)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            Text("Tags")
+                .font(PulpeTypography.labelMedium)
+                .foregroundStyle(Color.onSurfaceVariant)
+
+            Button {
+                isPresented = true
+            } label: {
+                HStack(spacing: DesignTokens.Spacing.sm) {
+                    Text(summary)
+                        .foregroundStyle(selection.isEmpty ? Color.onSurfaceVariant : Color.textPrimary)
+                        .lineLimit(1)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(Color.onSurfaceVariant)
+                }
+                .padding(.horizontal, DesignTokens.Spacing.lg)
+                .frame(maxWidth: .infinity, minHeight: DesignTokens.TapTarget.minimum, alignment: .leading)
+                .background(
+                    Color.surfaceContainerLow,
+                    in: RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.button)
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Tags")
+            .accessibilityValue(summary)
+        }
+        .task { await store.loadIfNeeded() }
+        .sheet(isPresented: $isPresented) {
+            TagPickerSheet(selection: $selection)
+        }
+    }
+
+    private var summary: String {
+        if selection.isEmpty { return "Aucun tag" }
+        if selectedNames.isEmpty {
+            return "\(selection.count) \(selection.count == 1 ? "tag" : "tags")"
+        }
+        return selectedNames.joined(separator: ", ")
+    }
+
+    static func normalizedName(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func duplicate(named name: String, in tags: [Tag]) -> Tag? {
+        tags.first { $0.name.caseInsensitiveCompare(normalizedName(name)) == .orderedSame }
+    }
+
+    static func hasValidLength(_ name: String) -> Bool {
+        (1...30).contains(normalizedName(name).count)
+    }
+
+    static func createdTagIds(from selection: Set<String>) -> [String]? {
+        selection.isEmpty ? nil : selection.sorted()
+    }
+
+    static func updatedTagIds(initial: Set<String>, current: Set<String>) -> [String]? {
+        initial == current ? nil : current.sorted()
+    }
+
+    static func toggledTag(_ id: String, in selection: Set<String>) -> Set<String> {
+        var updated = selection
+        if updated.contains(id) {
+            updated.remove(id)
+        } else if updated.count < AppConfiguration.maxTagsPerTransaction {
+            updated.insert(id)
+        }
+        return updated
+    }
+
+    static func selection(afterCreating tag: Tag, current: Set<String>) -> Set<String> {
+        current.union([tag.id])
+    }
+}
+
+private struct TagPickerSheet: View {
+    @Binding var selection: Set<String>
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(TagStore.self) private var store
+    @State private var newTagName = ""
+    @State private var createError: String?
+    @State private var isCreating = false
+
+    private var normalizedName: String {
+        TagPickerField.normalizedName(newTagName)
+    }
+
+    private var selectedNames: [String] {
+        store.tags.filter { selection.contains($0.id) }.map(\.name)
+    }
+
+    private var validationMessage: String? {
+        if normalizedName.count > 30 { return "30 caractères maximum" }
+        if TagPickerField.duplicate(named: normalizedName, in: store.tags) != nil {
+            return "Ce tag existe déjà"
+        }
+        if !normalizedName.isEmpty, selection.count >= AppConfiguration.maxTagsPerTransaction {
+            return "\(AppConfiguration.maxTagsPerTransaction) tags maximum"
+        }
+        return createError
+    }
+
+    private var canCreate: Bool {
+        TagPickerField.hasValidLength(normalizedName)
+            && TagPickerField.duplicate(named: normalizedName, in: store.tags) == nil
+            && selection.count < AppConfiguration.maxTagsPerTransaction
+            && !isCreating
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if !selectedNames.isEmpty {
+                    Section("Sélection") {
+                        TagChips(names: selectedNames)
+                            .listRowInsets(EdgeInsets(
+                                top: DesignTokens.Spacing.sm,
+                                leading: 0,
+                                bottom: DesignTokens.Spacing.sm,
+                                trailing: 0
+                            ))
+                    }
+                }
+
+                tagList
+                createSection
+            }
+            .navigationTitle("Choisir les tags")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Terminé") { dismiss() }
+                }
+            }
+        }
+        .standardSheetPresentation()
+    }
+
+    @ViewBuilder
+    private var tagList: some View {
+        Section("Tags disponibles · \(selection.count)/\(AppConfiguration.maxTagsPerTransaction)") {
+            if store.isLoading, !store.hasLoadedOnce {
+                ProgressView("Chargement…")
+            } else if store.hasError {
+                Button("Réessayer") {
+                    Task { await store.forceRefresh() }
+                }
+            } else if store.tags.isEmpty {
+                Text("Aucun tag")
+                    .foregroundStyle(Color.onSurfaceVariant)
+            } else {
+                ForEach(store.tags) { tag in
+                    let isSelected = selection.contains(tag.id)
+                    Button {
+                        selection = TagPickerField.toggledTag(tag.id, in: selection)
+                    } label: {
+                        HStack {
+                            Text(tag.name)
+                                .foregroundStyle(Color.textPrimary)
+                            Spacer()
+                            if isSelected {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                    .disabled(!isSelected && selection.count >= AppConfiguration.maxTagsPerTransaction)
+                    .accessibilityValue(isSelected ? "Sélectionné" : "Non sélectionné")
+                }
+            }
+        }
+    }
+
+    private var createSection: some View {
+        Section {
+            TextField("Nouveau tag", text: $newTagName)
+                .textInputAutocapitalization(.sentences)
+                .onChange(of: newTagName) { _, _ in createError = nil }
+
+            Button {
+                Task { await createTag() }
+            } label: {
+                if isCreating {
+                    ProgressView()
+                } else {
+                    Label("Créer et sélectionner", systemImage: "plus")
+                }
+            }
+            .disabled(!canCreate)
+        } header: {
+            Text("Créer un tag")
+        } footer: {
+            if let validationMessage {
+                Text(validationMessage)
+                    .foregroundStyle(Color.destructivePrimary)
+            } else {
+                Text("1 à 30 caractères")
+            }
+        }
+    }
+
+    private func createTag() async {
+        guard canCreate else { return }
+        isCreating = true
+        defer { isCreating = false }
+
+        do {
+            let tag = try await store.create(name: normalizedName)
+            selection = TagPickerField.selection(afterCreating: tag, current: selection)
+            newTagName = ""
+        } catch {
+            createError = DomainErrorLocalizer.localize(error)
+        }
+    }
+}

--- a/ios/Pulpe/Shared/Components/TagPickerField.swift
+++ b/ios/Pulpe/Shared/Components/TagPickerField.swift
@@ -85,7 +85,7 @@ struct TagPickerField: View {
     }
 
     static func selection(afterCreating tag: Tag, current: Set<String>) -> Set<String> {
-        current.union([tag.id])
+        current.contains(tag.id) ? current : toggledTag(tag.id, in: current)
     }
 }
 
@@ -147,10 +147,13 @@ private struct TagPickerSheet: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Terminé") { dismiss() }
+                        .disabled(isCreating)
                 }
             }
+            .disabled(isCreating)
         }
         .standardSheetPresentation()
+        .interactiveDismissDisabled(isCreating)
     }
 
     @ViewBuilder

--- a/ios/Pulpe/Shared/Components/TagPickerField.swift
+++ b/ios/Pulpe/Shared/Components/TagPickerField.swift
@@ -108,6 +108,7 @@ private struct TagPickerSheet: View {
     @State private var newTagName = ""
     @State private var createError: String?
     @State private var isCreating = false
+    @FocusState private var isNewTagNameFocused: Bool
 
     private var normalizedName: String {
         TagPickerField.normalizedName(newTagName)
@@ -211,10 +212,12 @@ private struct TagPickerSheet: View {
             HStack(spacing: DesignTokens.Spacing.md) {
                 Image(systemName: "tag")
                     .foregroundStyle(Color.onSurfaceVariant)
+                    .accessibilityHidden(true)
 
                 TextField("Nom du nouveau tag", text: $newTagName)
                     .textInputAutocapitalization(.sentences)
                     .submitLabel(.done)
+                    .focused($isNewTagNameFocused)
                     .onSubmit {
                         guard canCreate else { return }
                         Task { await createTag() }
@@ -238,6 +241,8 @@ private struct TagPickerSheet: View {
                 }
             }
             .frame(minHeight: DesignTokens.TapTarget.minimum)
+            .contentShape(.interaction, Rectangle())
+            .onTapGesture { isNewTagNameFocused = true }
         } header: {
             Text("Nouveau tag")
         } footer: {

--- a/ios/Pulpe/Shared/Components/TagPickerField.swift
+++ b/ios/Pulpe/Shared/Components/TagPickerField.swift
@@ -21,6 +21,8 @@ struct TagPickerField: View {
                 isPresented = true
             } label: {
                 HStack(spacing: DesignTokens.Spacing.sm) {
+                    Image(systemName: "tag")
+                        .foregroundStyle(selection.isEmpty ? Color.onSurfaceVariant : Color.pulpePrimary)
                     Text(summary)
                         .foregroundStyle(selection.isEmpty ? Color.onSurfaceVariant : Color.textPrimary)
                         .lineLimit(1)
@@ -30,13 +32,14 @@ struct TagPickerField: View {
                         .foregroundStyle(Color.onSurfaceVariant)
                 }
                 .padding(.horizontal, DesignTokens.Spacing.lg)
-                .frame(maxWidth: .infinity, minHeight: DesignTokens.TapTarget.minimum, alignment: .leading)
-                .background(
-                    Color.surfaceContainerLow,
-                    in: RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.button)
-                )
             }
-            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, minHeight: DesignTokens.TapTarget.minimum, alignment: .leading)
+            .background(
+                Color.surfaceContainerLow,
+                in: RoundedRectangle(cornerRadius: DesignTokens.CornerRadius.button)
+            )
+            .contentShape(Rectangle())
+            .plainPressedButtonStyle()
             .accessibilityLabel("Tags")
             .accessibilityValue(summary)
         }
@@ -47,11 +50,19 @@ struct TagPickerField: View {
     }
 
     private var summary: String {
-        if selection.isEmpty { return "Aucun tag" }
-        if selectedNames.isEmpty {
-            return "\(selection.count) \(selection.count == 1 ? "tag" : "tags")"
+        Self.summary(selectedNames: selectedNames, selectionCount: selection.count)
+    }
+
+    static func summary(selectedNames: [String], selectionCount: Int) -> String {
+        guard selectionCount > 0 else { return "Aucun tag" }
+        guard !selectedNames.isEmpty else {
+            return "\(selectionCount) \(selectionCount == 1 ? "tag" : "tags")"
         }
-        return selectedNames.joined(separator: ", ")
+
+        let visibleNames = selectedNames.prefix(2)
+        let hiddenCount = max(selectionCount - visibleNames.count, 0)
+        let names = visibleNames.joined(separator: ", ")
+        return hiddenCount > 0 ? "\(names) +\(hiddenCount)" : names
     }
 
     static func normalizedName(_ name: String) -> String {
@@ -102,10 +113,6 @@ private struct TagPickerSheet: View {
         TagPickerField.normalizedName(newTagName)
     }
 
-    private var selectedNames: [String] {
-        store.tags.filter { selection.contains($0.id) }.map(\.name)
-    }
-
     private var validationMessage: String? {
         if normalizedName.count > 30 { return "30 caractères maximum" }
         if TagPickerField.duplicate(named: normalizedName, in: store.tags) != nil {
@@ -127,22 +134,13 @@ private struct TagPickerSheet: View {
     var body: some View {
         NavigationStack {
             List {
-                if !selectedNames.isEmpty {
-                    Section("Sélection") {
-                        TagChips(names: selectedNames)
-                            .listRowInsets(EdgeInsets(
-                                top: DesignTokens.Spacing.sm,
-                                leading: 0,
-                                bottom: DesignTokens.Spacing.sm,
-                                trailing: 0
-                            ))
-                    }
-                }
-
-                tagList
                 createSection
+                tagList
             }
-            .navigationTitle("Choisir les tags")
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(Color.sheetBackground)
+            .navigationTitle("Tags")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
@@ -152,21 +150,23 @@ private struct TagPickerSheet: View {
             }
             .disabled(isCreating)
         }
-        .standardSheetPresentation()
+        .standardSheetPresentation(detents: [.medium, .large])
         .interactiveDismissDisabled(isCreating)
     }
 
     @ViewBuilder
     private var tagList: some View {
-        Section("Tags disponibles · \(selection.count)/\(AppConfiguration.maxTagsPerTransaction)") {
+        Section {
             if store.isLoading, !store.hasLoadedOnce {
                 ProgressView("Chargement…")
             } else if store.hasError {
-                Button("Réessayer") {
+                Button {
                     Task { await store.forceRefresh() }
+                } label: {
+                    Label("Réessayer", systemImage: "arrow.clockwise")
                 }
             } else if store.tags.isEmpty {
-                Text("Aucun tag")
+                Text("Crée ton premier tag ci-dessus.")
                     .foregroundStyle(Color.onSurfaceVariant)
             } else {
                 ForEach(store.tags) { tag in
@@ -174,46 +174,78 @@ private struct TagPickerSheet: View {
                     Button {
                         selection = TagPickerField.toggledTag(tag.id, in: selection)
                     } label: {
-                        HStack {
+                        HStack(spacing: DesignTokens.Spacing.md) {
+                            Image(systemName: "tag")
+                                .foregroundStyle(isSelected ? Color.pulpePrimary : Color.onSurfaceVariant)
+                                .accessibilityHidden(true)
                             Text(tag.name)
                                 .foregroundStyle(Color.textPrimary)
                             Spacer()
-                            if isSelected {
-                                Image(systemName: "checkmark")
-                            }
+                            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                                .font(PulpeTypography.actionIcon)
+                                .foregroundStyle(isSelected ? Color.pulpePrimary : Color.outlineVariant)
+                                .contentTransition(.symbolEffect(.replace))
+                                .accessibilityHidden(true)
                         }
                     }
+                    .frame(minHeight: DesignTokens.TapTarget.minimum)
+                    .contentShape(Rectangle())
+                    .plainPressedButtonStyle()
                     .disabled(!isSelected && selection.count >= AppConfiguration.maxTagsPerTransaction)
+                    .accessibilityLabel(tag.name)
                     .accessibilityValue(isSelected ? "Sélectionné" : "Non sélectionné")
                 }
+            }
+        } header: {
+            HStack {
+                Text("Mes tags")
+                Spacer()
+                Text("\(selection.count) sur \(AppConfiguration.maxTagsPerTransaction)")
+                    .monospacedDigit()
             }
         }
     }
 
     private var createSection: some View {
         Section {
-            TextField("Nouveau tag", text: $newTagName)
-                .textInputAutocapitalization(.sentences)
-                .onChange(of: newTagName) { _, _ in createError = nil }
+            HStack(spacing: DesignTokens.Spacing.md) {
+                Image(systemName: "tag")
+                    .foregroundStyle(Color.onSurfaceVariant)
 
-            Button {
-                Task { await createTag() }
-            } label: {
+                TextField("Nom du nouveau tag", text: $newTagName)
+                    .textInputAutocapitalization(.sentences)
+                    .submitLabel(.done)
+                    .onSubmit {
+                        guard canCreate else { return }
+                        Task { await createTag() }
+                    }
+                    .onChange(of: newTagName) { _, _ in createError = nil }
+
                 if isCreating {
                     ProgressView()
+                        .controlSize(.small)
                 } else {
-                    Label("Créer et sélectionner", systemImage: "plus")
+                    Button {
+                        Task { await createTag() }
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                            .font(PulpeTypography.actionIcon)
+                            .foregroundStyle(canCreate ? Color.pulpePrimary : Color.onSurfaceVariant)
+                    }
+                    .circleIconButtonStyle()
+                    .disabled(!canCreate)
+                    .accessibilityLabel("Créer et sélectionner")
                 }
             }
-            .disabled(!canCreate)
+            .frame(minHeight: DesignTokens.TapTarget.minimum)
         } header: {
-            Text("Créer un tag")
+            Text("Nouveau tag")
         } footer: {
             if let validationMessage {
                 Text(validationMessage)
                     .foregroundStyle(Color.destructivePrimary)
             } else {
-                Text("1 à 30 caractères")
+                Text("1 à 30 caractères · ajouté à la sélection")
             }
         }
     }

--- a/ios/PulpeTests/App/SessionDataResetterTests.swift
+++ b/ios/PulpeTests/App/SessionDataResetterTests.swift
@@ -77,13 +77,15 @@ struct SessionDataResetterTests {
         let dashboardStore = DashboardStore()
         let userSettingsStore = UserSettingsStore()
         let savingsGoalStore = SavingsGoalStore()
+        let tagStore = TagStore()
 
         let sut = LiveSessionDataResetter(
             currentMonthStore: currentMonthStore,
             budgetListStore: budgetListStore,
             dashboardStore: dashboardStore,
             userSettingsStore: userSettingsStore,
-            savingsGoalStore: savingsGoalStore
+            savingsGoalStore: savingsGoalStore,
+            tagStore: tagStore
         )
 
         sut.resetStores()
@@ -97,6 +99,7 @@ struct SessionDataResetterTests {
         #expect(dashboardStore.sparseBudgets.isEmpty)
         #expect(userSettingsStore.payDayOfMonth == nil)
         #expect(savingsGoalStore.goals.isEmpty)
+        #expect(tagStore.tags.isEmpty)
     }
 }
 

--- a/ios/PulpeTests/Architecture/BudgetDetailsArchitectureTests.swift
+++ b/ios/PulpeTests/Architecture/BudgetDetailsArchitectureTests.swift
@@ -268,4 +268,14 @@ struct BudgetDetailsArchitectureTests {
 
         #expect(offenders.isEmpty, "Offenders: \(offenders.joined(separator: ", "))")
     }
+
+    @Test("BudgetDetails reloads tag names when referenced ids change")
+    func budgetDetailsReloadsTagsForReferencedIds() {
+        let source = Self.read(
+            Self.featureDirectory().appendingPathComponent("BudgetDetailsView.swift")
+        )
+
+        #expect(source.contains(".task(id: screenState.referencedTagIds)"))
+        #expect(source.contains("await tagStore.loadIfNeeded(for: screenState.referencedTagIds)"))
+    }
 }

--- a/ios/PulpeTests/Domain/Models/TagCodableTests.swift
+++ b/ios/PulpeTests/Domain/Models/TagCodableTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+struct TagCodableTests {
+    private func decode<T: Decodable>(_ type: T.Type, json: String) throws -> T {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(type, from: Data(json.utf8))
+    }
+
+    private func encodedObject(_ value: some Encodable) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    @Test("BudgetLine decodes tagIds and tolerates their absence")
+    func budgetLine_decodesTagIds() throws {
+        func json(_ tags: String) -> String {
+            """
+            {
+              "id":"line-1","budgetId":"budget-1","templateLineId":null,"savingsGoalId":null,
+              "name":"Courses","amount":80,"kind":"expense","recurrence":"one_off",
+              "isManuallyAdjusted":false,"checkedAt":null,
+              "createdAt":"2026-07-01T00:00:00Z","updatedAt":"2026-07-01T00:00:00Z"\(tags)
+            }
+            """
+        }
+
+        let tagged = try decode(BudgetLine.self, json: json(#", "tagIds":["tag-1","tag-2"]"#))
+        let legacy = try decode(BudgetLine.self, json: json(""))
+
+        #expect(tagged.tagIds == ["tag-1", "tag-2"])
+        #expect(legacy.tagIds == nil)
+        #expect(tagged.toggled().tagIds == tagged.tagIds)
+    }
+
+    @Test("Transaction decodes tagIds and preserves them when toggled")
+    func transaction_decodesTagIds() throws {
+        let transaction = try decode(Transaction.self, json: """
+        {
+          "id":"tx-1","budgetId":"budget-1","budgetLineId":null,"name":"Courses",
+          "amount":80,"kind":"expense","transactionDate":"2026-07-01T00:00:00Z",
+          "category":null,"checkedAt":null,"createdAt":"2026-07-01T00:00:00Z",
+          "updatedAt":"2026-07-01T00:00:00Z","tagIds":["tag-1"]
+        }
+        """)
+
+        #expect(transaction.tagIds == ["tag-1"])
+        #expect(transaction.toggled().tagIds == ["tag-1"])
+    }
+
+    @Test("TemplateLine tolerates a missing tagIds key")
+    func templateLine_decodesLegacyPayload() throws {
+        let line = try decode(TemplateLine.self, json: """
+        {
+          "id":"template-line-1","templateId":"template-1","name":"Loyer","amount":1200,
+          "kind":"expense","recurrence":"fixed","description":"",
+          "createdAt":"2026-07-01T00:00:00Z","updatedAt":"2026-07-01T00:00:00Z"
+        }
+        """)
+
+        #expect(line.tagIds == nil)
+    }
+
+    @Test("PATCH tagIds omit means preserve and empty array means detach")
+    func updateDTOs_encodeTagSemantics() throws {
+        let budgetUntouched = try encodedObject(BudgetLineUpdate(id: "line-1"))
+        var budgetDetached = BudgetLineUpdate(id: "line-1")
+        budgetDetached.tagIds = []
+
+        let transactionUntouched = try encodedObject(TransactionUpdate())
+        var transactionDetached = TransactionUpdate()
+        transactionDetached.tagIds = []
+
+        let templateUntouched = try encodedObject(TemplateLineUpdate())
+        var templateDetached = TemplateLineUpdate()
+        templateDetached.tagIds = []
+
+        #expect(budgetUntouched["tagIds"] == nil)
+        #expect(try encodedObject(budgetDetached)["tagIds"] as? [String] == [])
+        #expect(transactionUntouched["tagIds"] == nil)
+        #expect(try encodedObject(transactionDetached)["tagIds"] as? [String] == [])
+        #expect(templateUntouched["tagIds"] == nil)
+        #expect(try encodedObject(templateDetached)["tagIds"] as? [String] == [])
+    }
+
+    @Test("duplicate tag names use the localized conflict")
+    func duplicateNameError_isLocalized() {
+        let error = APIError.from(code: "ERR_TAG_ALREADY_EXISTS", message: nil)
+
+        #expect(error.errorDescription == "Un tag porte déjà ce nom — choisis-en un autre")
+    }
+}

--- a/ios/PulpeTests/Domain/Services/TagServiceTests.swift
+++ b/ios/PulpeTests/Domain/Services/TagServiceTests.swift
@@ -62,6 +62,41 @@ struct TagServiceTests {
         #expect(tags.isEmpty)
     }
 
+    @Test
+    func create_postsName_andDecodesCreatedTag() async throws {
+        let recorder = TagRequestRecorder()
+        InterceptingURLProtocol.requestHandler = { request in
+            recorder.record(request)
+            return (
+                makeHTTPResponse(for: request, statusCode: 201),
+                Data("""
+                {
+                  "success": true,
+                  "data": {
+                    "id": "tag-2",
+                    "userId": "user-1",
+                    "name": "Courses",
+                    "createdAt": "2026-07-15T18:00:00.000Z",
+                    "updatedAt": "2026-07-15T18:00:00.000Z"
+                  }
+                }
+                """.utf8)
+            )
+        }
+        defer { InterceptingURLProtocol.requestHandler = nil }
+
+        let tag = try await TagService(apiClient: makeAPIClient())
+            .create(TagCreate(name: "Courses"))
+
+        #expect(recorder.method == "POST")
+        #expect(recorder.path == "/tags")
+        let body = try #require(recorder.body)
+        let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: String])
+        #expect(object == ["name": "Courses"])
+        #expect(tag.id == "tag-2")
+        #expect(tag.name == "Courses")
+    }
+
     private func makeAPIClient() -> APIClient {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [InterceptingURLProtocol.self]
@@ -79,6 +114,16 @@ private final class TagRequestRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var storedPath: String?
     private var storedMethod: String?
+    private var storedBody: Data?
+
+    func record(_ request: URLRequest) {
+        let body = Self.bodyData(from: request)
+        lock.withLock {
+            storedPath = request.url?.path
+            storedMethod = request.httpMethod
+            storedBody = body
+        }
+    }
 
     var path: String? {
         get { lock.withLock { storedPath } }
@@ -88,5 +133,25 @@ private final class TagRequestRecorder: @unchecked Sendable {
     var method: String? {
         get { lock.withLock { storedMethod } }
         set { lock.withLock { storedMethod = newValue } }
+    }
+
+    var body: Data? {
+        lock.withLock { storedBody }
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1024)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: 1024)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
     }
 }

--- a/ios/PulpeTests/Domain/Store/TagStoreTests.swift
+++ b/ios/PulpeTests/Domain/Store/TagStoreTests.swift
@@ -71,15 +71,51 @@ struct TagStoreTests {
         #expect(created.name == "Assurance")
         #expect(store.tags.map(\.name) == ["Assurance", "Courses"])
     }
+
+    @Test("a refresh finishing after create cannot overwrite it")
+    func staleRefreshCannotOverwriteCreate() async throws {
+        let service = MockTagService()
+        service.tags = [service.makeTag(id: "existing", name: "Courses")]
+        let store = TagStore(service: service)
+        await store.forceRefresh()
+
+        service.gateGetAll()
+        let refresh = Task {
+            await store.forceRefresh()
+        }
+        await waitForCondition("refresh must reach the service") {
+            service.getAllCallCount == 2
+        }
+
+        _ = try await store.create(name: "Assurance")
+        service.releaseGetAll()
+        await refresh.value
+
+        #expect(store.tags.map(\.name) == ["Assurance", "Courses"])
+        #expect(!store.isLoading)
+    }
 }
 
 @MainActor
 private final class MockTagService: TagServicing {
     var tags: [PulpeTag] = []
+    private(set) var getAllCallCount = 0
     private(set) var lastCreate: TagCreate?
     private(set) var didEnterCreate = false
+    private var getAllContinuation: CheckedContinuation<Void, Never>?
     private var createContinuation: CheckedContinuation<Void, Never>?
+    private var shouldGateGetAll = false
     private var shouldGateCreate = false
+
+    func gateGetAll() {
+        shouldGateGetAll = true
+    }
+
+    func releaseGetAll() {
+        shouldGateGetAll = false
+        getAllContinuation?.resume()
+        getAllContinuation = nil
+    }
 
     func gateCreate() {
         shouldGateCreate = true
@@ -102,7 +138,13 @@ private final class MockTagService: TagServicing {
     }
 
     func getAll() async throws -> [PulpeTag] {
-        tags
+        getAllCallCount += 1
+        if shouldGateGetAll {
+            await withCheckedContinuation { continuation in
+                getAllContinuation = continuation
+            }
+        }
+        return tags
     }
 
     func create(_ data: TagCreate) async throws -> PulpeTag {

--- a/ios/PulpeTests/Domain/Store/TagStoreTests.swift
+++ b/ios/PulpeTests/Domain/Store/TagStoreTests.swift
@@ -64,12 +64,34 @@ struct TagStoreTests {
         let creation = Task { try await store.create(name: "Assurance") }
         await waitForCondition("create must reach the service") { service.didEnterCreate }
 
+        service.tags.append(service.makeTag(id: "created", name: "Assurance"))
         await store.forceRefresh()
         service.releaseCreate()
         let created = try await creation.value
 
         #expect(created.name == "Assurance")
         #expect(store.tags.map(\.name) == ["Assurance", "Courses"])
+        #expect(store.tags.count(where: { $0.id == created.id }) == 1)
+        #expect(store.namesById[created.id] == "Assurance")
+    }
+
+    @Test("referenced tag ids refresh only when a name is missing")
+    func referencedTagIdsRefreshUnknownNames() async {
+        let service = MockTagService()
+        service.tags = [service.makeTag(id: "known", name: "Courses")]
+        let store = TagStore(service: service)
+        await store.forceRefresh()
+
+        await store.loadIfNeeded(for: [])
+        await store.loadIfNeeded(for: ["known"])
+
+        #expect(service.getAllCallCount == 1)
+
+        service.tags.append(service.makeTag(id: "missing", name: "Transport"))
+        await store.loadIfNeeded(for: ["missing"])
+
+        #expect(service.getAllCallCount == 2)
+        #expect(store.namesById["missing"] == "Transport")
     }
 
     @Test("a refresh finishing after create cannot overwrite it")

--- a/ios/PulpeTests/Domain/Store/TagStoreTests.swift
+++ b/ios/PulpeTests/Domain/Store/TagStoreTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+private typealias PulpeTag = Pulpe.Tag
+
+@MainActor
+struct TagStoreTests {
+    @Test("load, create and reset keep one sorted catalog")
+    func catalogLifecycle() async throws {
+        let service = MockTagService()
+        service.tags = [
+            service.makeTag(id: "2", name: "Transport"),
+            service.makeTag(id: "1", name: "Courses"),
+        ]
+        let store = TagStore(service: service)
+
+        await store.forceRefresh()
+
+        #expect(store.tags.map(\.name) == ["Courses", "Transport"])
+        #expect(store.namesById["1"] == "Courses")
+        #expect(store.hasLoadedOnce)
+
+        let created = try await store.create(name: "Assurance")
+
+        #expect(created.name == "Assurance")
+        #expect(store.tags.map(\.name) == ["Assurance", "Courses", "Transport"])
+        #expect(service.lastCreate?.name == "Assurance")
+
+        store.reset()
+
+        #expect(store.tags.isEmpty)
+        #expect(!store.hasLoadedOnce)
+        #expect(store.error == nil)
+    }
+}
+
+@MainActor
+private final class MockTagService: TagServicing {
+    var tags: [PulpeTag] = []
+    private(set) var lastCreate: TagCreate?
+
+    func makeTag(id: String, name: String) -> PulpeTag {
+        PulpeTag(
+            id: id,
+            userId: "user-1",
+            name: name,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    func getAll() async throws -> [PulpeTag] {
+        tags
+    }
+
+    func create(_ data: TagCreate) async throws -> PulpeTag {
+        lastCreate = data
+        return makeTag(id: "created", name: data.name)
+    }
+}

--- a/ios/PulpeTests/Domain/Store/TagStoreTests.swift
+++ b/ios/PulpeTests/Domain/Store/TagStoreTests.swift
@@ -33,12 +33,63 @@ struct TagStoreTests {
         #expect(!store.hasLoadedOnce)
         #expect(store.error == nil)
     }
+
+    @Test("a create finishing after reset cannot mutate the next session")
+    func createAfterResetIsDiscarded() async {
+        let service = MockTagService()
+        let store = TagStore(service: service)
+        service.gateCreate()
+
+        let creation = Task { try await store.create(name: "Privé A") }
+        await waitForCondition("create must reach the service") { service.didEnterCreate }
+
+        store.reset()
+        service.tags = [service.makeTag(id: "session-b", name: "Session B")]
+        await store.forceRefresh()
+        service.releaseCreate()
+
+        await #expect(throws: CancellationError.self) {
+            try await creation.value
+        }
+        #expect(store.tags.map(\.name) == ["Session B"])
+    }
+
+    @Test("a refresh in the same session does not discard a valid create")
+    func createSurvivesSameSessionRefresh() async throws {
+        let service = MockTagService()
+        let store = TagStore(service: service)
+        service.tags = [service.makeTag(id: "existing", name: "Courses")]
+        service.gateCreate()
+
+        let creation = Task { try await store.create(name: "Assurance") }
+        await waitForCondition("create must reach the service") { service.didEnterCreate }
+
+        await store.forceRefresh()
+        service.releaseCreate()
+        let created = try await creation.value
+
+        #expect(created.name == "Assurance")
+        #expect(store.tags.map(\.name) == ["Assurance", "Courses"])
+    }
 }
 
 @MainActor
 private final class MockTagService: TagServicing {
     var tags: [PulpeTag] = []
     private(set) var lastCreate: TagCreate?
+    private(set) var didEnterCreate = false
+    private var createContinuation: CheckedContinuation<Void, Never>?
+    private var shouldGateCreate = false
+
+    func gateCreate() {
+        shouldGateCreate = true
+    }
+
+    func releaseCreate() {
+        shouldGateCreate = false
+        createContinuation?.resume()
+        createContinuation = nil
+    }
 
     func makeTag(id: String, name: String) -> PulpeTag {
         PulpeTag(
@@ -56,6 +107,12 @@ private final class MockTagService: TagServicing {
 
     func create(_ data: TagCreate) async throws -> PulpeTag {
         lastCreate = data
+        didEnterCreate = true
+        if shouldGateCreate {
+            await withCheckedContinuation { continuation in
+                createContinuation = continuation
+            }
+        }
         return makeTag(id: "created", name: data.name)
     }
 }

--- a/ios/PulpeTests/Features/Account/TagsSettingsViewModelTests.swift
+++ b/ios/PulpeTests/Features/Account/TagsSettingsViewModelTests.swift
@@ -76,4 +76,14 @@ private actor StubTagService: TagServicing {
         }
         return tags
     }
+
+    func create(_ data: TagCreate) async throws -> PulpeTag {
+        PulpeTag(
+            id: "created",
+            userId: "user-1",
+            name: data.name,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
 }

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/AddBudgetLineSheetTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/AddBudgetLineSheetTests.swift
@@ -1,0 +1,11 @@
+@testable import Pulpe
+import Testing
+
+struct AddBudgetLineSheetTests {
+    @Test("Tag picker is visible only when the selected flow saves tags")
+    func tagPickerVisibility() {
+        #expect(AddBudgetLineSheet.showsTagPicker(spread: false, withdrawal: false))
+        #expect(!AddBudgetLineSheet.showsTagPicker(spread: true, withdrawal: false))
+        #expect(!AddBudgetLineSheet.showsTagPicker(spread: false, withdrawal: true))
+    }
+}

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/EditTransactionLogicTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/EditTransactionLogicTests.swift
@@ -200,6 +200,20 @@ struct EditTransactionLogicTests {
         #expect(update.exchangeRate == Decimal(0.95))
     }
 
+    @Test("buildUpdate forwards an explicit tag change")
+    func buildUpdate_includesChangedTags() {
+        let update = EditTransactionLogic.buildUpdate(
+            name: "Tagged",
+            amount: 50,
+            kind: .expense,
+            transactionDate: TestDataFactory.fixedDate,
+            conversion: nil,
+            tagIds: []
+        )
+
+        #expect(update.tagIds == [])
+    }
+
     @Test("Case 7: pure helper — repeated calls with stable inputs are deterministic")
     func shouldShowAlternateCurrency_isPure() {
         let tx = Self.makeTransaction(originalCurrency: .eur)

--- a/ios/PulpeTests/Features/Templates/EditTemplateLineSheetTests.swift
+++ b/ios/PulpeTests/Features/Templates/EditTemplateLineSheetTests.swift
@@ -116,6 +116,31 @@ struct EditTemplateLineSheetTests {
         #expect(update.exchangeRate == Decimal(0.95))
     }
 
+    @Test("buildUpdate forwards an explicit tag change")
+    func buildUpdate_includesChangedTags() {
+        let update = EditTemplateLineSheet.buildUpdate(
+            name: "Tagged",
+            amount: 50,
+            kind: .expense,
+            recurrence: .fixed,
+            conversion: nil,
+            tagIds: ["tag-1"]
+        )
+
+        #expect(update.tagIds == ["tag-1"])
+    }
+
+    @Test("Propagation keeps the direct update tag payload")
+    func propagationUpdate_includesChangedTags() {
+        var update = TemplateLineUpdate()
+        update.tagIds = []
+
+        let propagated = EditTemplateLineSheet.propagationUpdate(id: "tl-1", data: update)
+
+        #expect(propagated.id == "tl-1")
+        #expect(propagated.tagIds == [])
+    }
+
     // MARK: - Case 7: pure helper snapshot stability
 
     @Test("Case 7: pure helper — repeated calls with stable inputs are deterministic")

--- a/ios/PulpeTests/Shared/Components/EditBudgetLineSheetTests.swift
+++ b/ios/PulpeTests/Shared/Components/EditBudgetLineSheetTests.swift
@@ -153,6 +153,20 @@ struct EditBudgetLineSheetTests {
         #expect(update.isManuallyAdjusted == true)
     }
 
+    @Test("buildUpdate forwards an explicit tag change")
+    func buildUpdate_includesChangedTags() {
+        let update = EditBudgetLineSheet.buildUpdate(
+            id: "line-1",
+            name: "Tagged",
+            amount: 50,
+            kind: .expense,
+            conversion: nil,
+            tagIds: ["tag-1"]
+        )
+
+        #expect(update.tagIds == ["tag-1"])
+    }
+
     // MARK: - Matrix (cases 1-7)
 
     @Test("Case 4: flag OFF fallback — helper ignores flag; view gates visibility separately")

--- a/ios/PulpeTests/Shared/Components/TagChipsTests.swift
+++ b/ios/PulpeTests/Shared/Components/TagChipsTests.swift
@@ -4,20 +4,20 @@ import Testing
 @Suite("TagChips Tests")
 @MainActor
 struct TagChipsTests {
-    @Test("The rail limits visible chips and exposes the overflow count")
-    func visibleSummary() {
-        let chips = TagChips(names: ["A", "B", "C"], maxVisible: 2)
+    @Test("The compact presentation exposes one icon-and-count indicator")
+    func compactIndicator() {
+        let chips = TagChips(names: ["A", "B", "C"], presentation: .count)
 
-        #expect(Array(chips.visibleNames) == ["A", "B"])
-        #expect(chips.hiddenCount == 1)
+        #expect(chips.presentation == .count)
+        #expect(chips.countLabel == "3")
+        #expect(chips.accessibilityLabel == "Tags : A, B, C")
     }
 
-    @Test("The full rail has no overflow")
+    @Test("The full rail keeps every tag name")
     func fullRail() {
         let chips = TagChips(names: ["A", "B"])
 
-        #expect(Array(chips.visibleNames) == ["A", "B"])
-        #expect(chips.hiddenCount == 0)
+        #expect(chips.presentation == .names)
         #expect(chips.accessibilityLabel == "Tags : A, B")
     }
 

--- a/ios/PulpeTests/Shared/Components/TagChipsTests.swift
+++ b/ios/PulpeTests/Shared/Components/TagChipsTests.swift
@@ -18,5 +18,16 @@ struct TagChipsTests {
 
         #expect(Array(chips.visibleNames) == ["A", "B"])
         #expect(chips.hiddenCount == 0)
+        #expect(chips.accessibilityLabel == "Tags : A, B")
+    }
+
+    @Test("Names resolve in server order and stale ids are ignored")
+    func resolvedNames() {
+        let names = TagChips.names(
+            for: ["tag-2", "missing", "tag-1"],
+            namesById: ["tag-1": "Courses", "tag-2": "Vacances"]
+        )
+
+        #expect(names == ["Vacances", "Courses"])
     }
 }

--- a/ios/PulpeTests/Shared/Components/TagChipsTests.swift
+++ b/ios/PulpeTests/Shared/Components/TagChipsTests.swift
@@ -1,0 +1,22 @@
+@testable import Pulpe
+import Testing
+
+@Suite("TagChips Tests")
+@MainActor
+struct TagChipsTests {
+    @Test("The rail limits visible chips and exposes the overflow count")
+    func visibleSummary() {
+        let chips = TagChips(names: ["A", "B", "C"], maxVisible: 2)
+
+        #expect(Array(chips.visibleNames) == ["A", "B"])
+        #expect(chips.hiddenCount == 1)
+    }
+
+    @Test("The full rail has no overflow")
+    func fullRail() {
+        let chips = TagChips(names: ["A", "B"])
+
+        #expect(Array(chips.visibleNames) == ["A", "B"])
+        #expect(chips.hiddenCount == 0)
+    }
+}

--- a/ios/PulpeTests/Shared/Components/TagPickerFieldTests.swift
+++ b/ios/PulpeTests/Shared/Components/TagPickerFieldTests.swift
@@ -54,5 +54,15 @@ struct TagPickerFieldTests {
         #expect(TagPickerField.createdTagIds(from: []) == nil)
         #expect(TagPickerField.createdTagIds(from: ["tag-2", "tag-1"]) == ["tag-1", "tag-2"])
         #expect(TagPickerField.selection(afterCreating: tag, current: ["tag-1"]) == ["tag-1", "tag-2"])
+
+        let fullSelection = Set((0..<AppConfiguration.maxTagsPerTransaction).map { "tag-\($0)" })
+        let eleventhTag = Tag(
+            id: "tag-10",
+            userId: "user-1",
+            name: "Onzième",
+            createdAt: .distantPast,
+            updatedAt: .distantPast
+        )
+        #expect(TagPickerField.selection(afterCreating: eleventhTag, current: fullSelection) == fullSelection)
     }
 }

--- a/ios/PulpeTests/Shared/Components/TagPickerFieldTests.swift
+++ b/ios/PulpeTests/Shared/Components/TagPickerFieldTests.swift
@@ -32,6 +32,18 @@ struct TagPickerFieldTests {
         #expect(TagPickerField.toggledTag("tag-1", in: ["tag-1"]) == [])
     }
 
+    @Test("The field summary stays compact beyond two tags")
+    func compactSummary() {
+        #expect(TagPickerField.summary(selectedNames: [], selectionCount: 0) == "Aucun tag")
+        #expect(TagPickerField.summary(selectedNames: [], selectionCount: 3) == "3 tags")
+        #expect(
+            TagPickerField.summary(
+                selectedNames: ["Alimentation", "Maison", "Week-end", "Vacances"],
+                selectionCount: 4
+            ) == "Alimentation, Maison +2"
+        )
+    }
+
     @Test("PATCH omits unchanged tags and sends an empty array when detached")
     func patchSemantics() {
         let initial: Set<String> = ["tag-2", "tag-1"]

--- a/ios/PulpeTests/Shared/Components/TagPickerFieldTests.swift
+++ b/ios/PulpeTests/Shared/Components/TagPickerFieldTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+@testable import Pulpe
+import Testing
+
+@Suite("TagPickerField Tests")
+@MainActor
+struct TagPickerFieldTests {
+    @Test("Names are trimmed and exact duplicates ignore case")
+    func nameValidation() {
+        let tag = Tag(
+            id: "tag-1",
+            userId: "user-1",
+            name: "Courses",
+            createdAt: .distantPast,
+            updatedAt: .distantPast
+        )
+
+        #expect(TagPickerField.normalizedName("  Courses \n") == "Courses")
+        #expect(TagPickerField.duplicate(named: "courses", in: [tag])?.id == tag.id)
+        #expect(TagPickerField.duplicate(named: "Course", in: [tag]) == nil)
+        #expect(TagPickerField.hasValidLength(" ") == false)
+        #expect(TagPickerField.hasValidLength(String(repeating: "a", count: 30)))
+        #expect(TagPickerField.hasValidLength(String(repeating: "a", count: 31)) == false)
+    }
+
+    @Test("Selection is unique and capped at ten tags")
+    func selectionLimit() {
+        let tenTags = Set((0..<AppConfiguration.maxTagsPerTransaction).map { "tag-\($0)" })
+
+        #expect(TagPickerField.toggledTag("tag-0", in: tenTags).count == 9)
+        #expect(TagPickerField.toggledTag("tag-10", in: tenTags) == tenTags)
+        #expect(TagPickerField.toggledTag("tag-1", in: ["tag-1"]) == [])
+    }
+
+    @Test("PATCH omits unchanged tags and sends an empty array when detached")
+    func patchSemantics() {
+        let initial: Set<String> = ["tag-2", "tag-1"]
+
+        #expect(TagPickerField.updatedTagIds(initial: initial, current: initial) == nil)
+        #expect(TagPickerField.updatedTagIds(initial: initial, current: []) == [])
+        #expect(TagPickerField.updatedTagIds(initial: initial, current: ["tag-3"]) == ["tag-3"])
+    }
+
+    @Test("Creation payload omits an empty selection and a created tag is selected")
+    func creationSemantics() {
+        let tag = Tag(
+            id: "tag-2",
+            userId: "user-1",
+            name: "Vacances",
+            createdAt: .distantPast,
+            updatedAt: .distantPast
+        )
+
+        #expect(TagPickerField.createdTagIds(from: []) == nil)
+        #expect(TagPickerField.createdTagIds(from: ["tag-2", "tag-1"]) == ["tag-1", "tag-2"])
+        #expect(TagPickerField.selection(afterCreating: tag, current: ["tag-1"]) == ["tag-1", "tag-2"])
+    }
+}


### PR DESCRIPTION
## Summary

- Add tag models, service, store, and session reset handling
- Add tag selection and display across budget lines, templates, and transactions
- Cover tag behavior and affected flows with focused tests

## Testing

- Added and updated iOS unit tests for tag models, service, store, UI components, and budget/template transaction flows
- Not run (not requested)