### PR TITLE
fix(ios): preserve and diagnose authentication sessions

### DIFF
--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -120,6 +120,7 @@ Both events are available to every authenticated user. The selector itself follo
 | `login_failed` | Login fail (any method) | `method`, `error_kind`, `error_message` |
 | `signup_failed` | Signup fail | `method`, `error_kind`, `error_message` |
 | `session_restore_failed` | Session restore at startup fail | `method`, `error_kind`, `error_message` |
+| `auth_session_observed` | Supabase session lifecycle or storage signal | `source`, `outcome`, optional `status`, `request_id`, `endpoint`, `is_retry`, `storage_state`, `access_token_expires_in_seconds`, `is_expected_user_action` |
 | `pin_setup_completed` | PIN created | — |
 | `pin_entered` | PIN entered on return visit | — |
 | `first_budget_created` | Initial budget created at end of onboarding | `signup_method` (`email` \| `apple` \| `google`), `has_pay_day`, `charges_count`, `custom_transactions_count` |
@@ -131,6 +132,13 @@ Both events are available to every authenticated user. The selector itself follo
 | `tab_switched` | User switch tab | `tab` (`currentMonth` \| `budgets` \| `templates`) |
 | `logout_completed` | User log out | — |
 | `ios_whats_new_shown` | Dialog shown after app update with new release notes | `version` |
+
+`auth_session_observed` value spaces:
+
+- `source`: `sdk_event` | `session_validation` | `forced_refresh` | `api_401_refresh` | `supabase_auth_response` | `session_reset`
+- `outcome`: `initial_session` | `token_refreshed` | `signed_out` | `started` | `succeeded` | `failed_retryable` | `storage_unreadable` | `missing_blob` | `undecodable_blob` | `valid_blob` | `session_not_found` | `session_expired` | `refresh_token_not_found` | `refresh_token_already_used`; terminal reset reasons are added in phase 2
+- `storage_state`: `available` | `missing` | `undecodable` | `unreadable`
+- `is_expected_user_action`: reserved for terminal reset classification in phase 2
 
 **iOS funnel idempotency guarantees:**
 - `onboarding_started` fire once per `OnboardingFlow` instance (@State guard). Reset on view re-instantiation via `.id(appState.onboardingSessionID)` after abandon.

--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -130,13 +130,28 @@ Both events are available to every authenticated user. The selector itself follo
 | `budget_created` | Budget created outside onboarding flow | — |
 | `transaction_created` | Transaction added | `type` (`expense` \| `income` \| `saving`) |
 | `tab_switched` | User switch tab | `tab` (`currentMonth` \| `budgets` \| `templates`) |
-| `logout_completed` | User log out | — |
+| `logout_completed` | User log out | `source` (`user_initiated` \| `system`) |
 | `ios_whats_new_shown` | Dialog shown after app update with new release notes | `version` |
 
 `auth_session_observed` value spaces:
 
-- `source`: `sdk_event` | `session_validation` | `forced_refresh` | `api_401_refresh` | `supabase_auth_response` | `session_reset`
-- `outcome`: `initial_session` | `token_refreshed` | `signed_out` | `started` | `succeeded` | `failed_retryable` | `storage_unreadable` | `missing_blob` | `undecodable_blob` | `valid_blob` | `session_not_found` | `session_expired` | `refresh_token_not_found` | `refresh_token_already_used` | `user_logout` | `account_deleted` | `signup_abandoned` | `startup_retry_abandoned` | `password_reset` | `api_session_expired` | `recovery_session_expired` | `background_session_missing` | `session_refresh_failed` | `system_unspecified`
+- `source`: `sdk_event` | `session_validation` | `forced_refresh` | `api_401` |
+  `vault_status_401` | `biometric_resync` | `supabase_auth_response` | `backend_api` |
+  `keychain_write` | `keychain_read` | `keychain_remove` | `startup_result` |
+  `post_auth_destination` | `deep_link` | `session_reset`
+- session outcomes: `initial_session` | `token_refreshed` | `signed_out` | `started` |
+  `succeeded` | `failed_retryable` | `storage_unreadable` | `missing_blob` |
+  `undecodable_blob` | `valid_blob` | `session_not_found` | `session_expired` |
+  `refresh_token_not_found` | `refresh_token_already_used` | `unauthorized`
+- keychain outcomes: `update_failed` | `fallback_delete_failed` | `add_failed` | `failed`
+- startup outcomes: `unauthenticated` | `network_error` | `biometric_session_expired` | `timeout`
+- post-auth outcomes: `needs_pin_setup` | `needs_pin_entry` | `authenticated` |
+  `unauthenticated_session_expired` | `vault_check_failed`
+- deep-link outcomes: `widget_add_expense_received` | `widget_budget_received`
+- terminal reset outcomes: `user_logout` | `account_deleted` | `signup_abandoned` |
+  `startup_retry_abandoned` | `password_reset` | `api_session_expired` |
+  `recovery_session_expired` | `background_session_missing` | `session_refresh_failed` |
+  `system_unspecified`
 - `storage_state`: `available` | `missing` | `undecodable` | `unreadable`
 - `is_expected_user_action`: `true` for logout, account deletion, signup/retry abandon and password reset; `false` for expiry, missing/failed sessions and the `system_unspecified` sentinel
 
@@ -154,9 +169,12 @@ present when the SDK exposes a matching response and are never inferred from an 
 
 ## Properties
 
-**Global properties** (sent with every event):
+**Global properties** (sent with every iOS event):
 ```
-platform: 'web' | 'landing' | 'ios'
+environment: 'local' | 'preview' | 'production'
+app_version: string
+build_number: string
+platform: 'ios'
 ```
 
 ```typescript

--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -136,9 +136,13 @@ Both events are available to every authenticated user. The selector itself follo
 `auth_session_observed` value spaces:
 
 - `source`: `sdk_event` | `session_validation` | `forced_refresh` | `api_401_refresh` | `supabase_auth_response` | `session_reset`
-- `outcome`: `initial_session` | `token_refreshed` | `signed_out` | `started` | `succeeded` | `failed_retryable` | `storage_unreadable` | `missing_blob` | `undecodable_blob` | `valid_blob` | `session_not_found` | `session_expired` | `refresh_token_not_found` | `refresh_token_already_used`; terminal reset reasons are added in phase 2
+- `outcome`: `initial_session` | `token_refreshed` | `signed_out` | `started` | `succeeded` | `failed_retryable` | `storage_unreadable` | `missing_blob` | `undecodable_blob` | `valid_blob` | `session_not_found` | `session_expired` | `refresh_token_not_found` | `refresh_token_already_used` | `user_logout` | `account_deleted` | `signup_abandoned` | `startup_retry_abandoned` | `password_reset` | `api_session_expired` | `recovery_session_expired` | `background_session_missing` | `session_refresh_failed` | `system_unspecified`
 - `storage_state`: `available` | `missing` | `undecodable` | `unreadable`
-- `is_expected_user_action`: reserved for terminal reset classification in phase 2
+- `is_expected_user_action`: `true` for logout, account deletion, signup/retry abandon and password reset; `false` for expiry, missing/failed sessions and the `system_unspecified` sentinel
+
+`session_reset` is captured before PostHog resets its identity. `system_unspecified` is a detectable
+compatibility sentinel; no known production path should emit it. Supabase terminal codes are only
+present when the SDK exposes a matching response and are never inferred from an API 401.
 
 **iOS funnel idempotency guarantees:**
 - `onboarding_started` fire once per `OnboardingFlow` instance (@State guard). Reset on view re-instantiation via `.id(appState.onboardingSessionID)` after abandon.

--- a/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/phase-1.md
@@ -1,0 +1,98 @@
+---
+status: done
+---
+
+# Instruction: Rendre la capture déterministe et durable
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+├── .claude/rules/05-workflows-and-processes/
+│   └── ✏️ posthog-events.md                              # documente l’événement et ses espaces de valeurs
+└── ios/
+    ├── ✏️ project.yml                                    # verrouille supabase-swift 2.54.0
+    ├── Pulpe/Core/
+    │   ├── Analytics/
+    │   │   ├── ✏️ AnalyticsEvent.swift                   # renomme l’événement selon la convention
+    │   │   └── ✏️ AnalyticsService.swift                 # photographie identité et timestamp avant le task
+    │   └── Auth/
+    │       ├── ✏️ AuthTypes.swift                         # accueille le mapping autonome User → UserInfo
+    │       ├── ✏️ AuthService.swift                       # délègue les diagnostics et retire le disable global
+    │       └── ✅ AuthSessionDiagnostics.swift            # isole état persistant et parsing du logger Supabase
+    └── PulpeTests/Core/
+        ├── Analytics/
+        │   └── ✏️ AnalyticsServiceTests.swift             # reproduit la capture différée après reset
+        └── Auth/
+            └── ✏️ AuthServiceBiometricRefactorTests.swift # verrouille le contrat Supabase et l’absence de secrets
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Signal d’authentification observé"] --> B["Photographier identité et timestamp"]
+  B --> C["Construire des propriétés sans secret"]
+  C --> D["Planifier la capture sur le MainActor"]
+  D --> E{"Reset PostHog déjà exécuté ?"}
+  E -- Oui --> F["Capturer avec identité et timestamp photographiés"]
+  E -- Non --> F
+  F --> G["Événement attribuable dans PostHog"]
+```
+
+## Tasks to do
+
+### `1)` Reproduire la perte d’identité
+
+> Le test doit échouer tant que la capture différée relit l’identité après le reset.
+
+1. Ajouter un test qui photographie un distinct ID et un instant, simule leur changement avant l’envoi, puis attend les valeurs initiales dans le snapshot capturé.
+2. Garder la preuve locale et déterministe, sans appel réseau PostHog.
+3. Mettre à jour l’attente de nom vers `auth_session_observed`.
+4. Conserver les tests de sanitization financière.
+
+### `2)` Capturer un événement immuable
+
+> Le task différé transporte l’état de l’incident au lieu de le recalculer.
+
+1. Lire `Date()` et `PostHogSDK.shared.getDistinctId()` avant de créer le task MainActor.
+2. Transporter les champs dans un snapshot typé `Sendable`, y compris le futur indicateur `is_expected_user_action`.
+3. Construire le dictionnaire `[String: Any]` uniquement sur le MainActor.
+4. Dans le task, utiliser l’overload PostHog avec `distinctId` et `timestamp` explicites.
+5. Continuer à passer toutes les propriétés par `sanitizeProperties`.
+6. Ne pas ajouter de flush synchrone ni de nouvelle file d’attente.
+
+### `3)` Stabiliser le diagnostic Supabase
+
+> Le parser ne doit changer que lors d’une mise à jour SDK intentionnelle.
+
+1. Remplacer `from: "2.0.0"` par `exactVersion: "2.54.0"` dans `project.yml`.
+2. Régénérer le projet avec `xcodegen generate --use-cache` et vérifier la résolution 2.54.0.
+3. Déplacer le logger, son parser et les helpers de lecture de session dans `AuthSessionDiagnostics.swift`.
+4. Passer le storage au helper sans élargir le niveau d’accès de la propriété privée d’`AuthService`.
+5. Retirer `swiftlint:disable file_length` et garder `AuthService.swift` sous le seuil configuré.
+6. Préserver la whitelist des quatre codes terminaux et ignorer tout message de requête contenant un refresh token.
+7. Déplacer le mapping autonome `User` → `UserInfo` dans `AuthTypes.swift` pour respecter le seuil sans disable.
+
+### `4)` Aligner le contrat analytics
+
+> Le nom et les propriétés doivent être exploitables sans relire le code.
+
+1. Renommer le case Swift et sa raw value vers `auth_session_observed`.
+2. Ajouter l’événement au catalogue iOS avec `source`, `outcome`, statuts, corrélation, stockage, expiration et classification.
+3. Documenter les valeurs déjà émises et réserver les raisons terminales définies en phase 2.
+4. Vérifier SwiftLint strict et les suites Analytics/Auth ciblées.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Une capture exécutée après un reset conserve le distinct ID et l’horodatage présents au moment exact du signal. |
+| 1 | Le test ne dépend ni du réseau ni d’un projet PostHog actif. |
+| 2 | Tous les diagnostics continuent à passer par le sanitizer et aucune propriété financière ou secrète n’est ajoutée. |
+| 3 | Le projet généré résout exactement `supabase-swift` 2.54.0 et reconnaît les quatre codes terminaux du format livré. |
+| 3 | Un log de requête contenant un refresh token ne produit aucun diagnostic. |
+| 3 | `AuthService.swift` ne contient plus de disable `file_length` et respecte le seuil SwiftLint. |
+| 4 | Le seul nom produit pour ce flux est `auth_session_observed`, documenté avec ses propriétés dans le catalogue. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/phase-2.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Classer chaque fin de session

--- a/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/phase-2.md
@@ -1,0 +1,90 @@
+---
+status: pending
+---
+
+# Instruction: Classer chaque fin de session
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+├── .claude/rules/05-workflows-and-processes/
+│   └── ✏️ posthog-events.md                    # finalise la taxonomie des fins de session
+└── ios/
+    ├── Pulpe/App/
+    │   ├── ✏️ AppState+FlowState.swift         # distingue l’échec de refresh des autres resets
+    │   └── ✏️ AppState+SessionReset.swift      # centralise raison, classification et capture terminale
+    └── PulpeTests/App/
+        ├── ✏️ AppStateLogoutScopeTests.swift   # verrouille actions utilisateur et raisons stables
+        └── ✏️ AppStateBackgroundLockTests.swift # couvre la perte de session au retour du background
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["L’application quitte une session authentifiée"] --> B{"Déclencheur"}
+  B -- "Action volontaire" --> C["Raison précise + is_expected_user_action=true"]
+  B -- "Expiration confirmée" --> D["Raison précise + code serveur corrélé"]
+  B -- "Perte locale ou refresh incohérent" --> E["Raison précise + is_expected_user_action=false"]
+  C --> F["Capturer avant reset analytics"]
+  D --> F
+  E --> F
+  F --> G["Écran de connexion"]
+```
+
+## Tasks to do
+
+### `1)` Reproduire la taxonomie ambiguë
+
+> Deux parcours différents ne doivent plus aboutir au même `system`.
+
+1. Ajouter une table de tests pour toutes les valeurs terminales de `SessionResetScope`.
+2. Attendre une raison non vide et unique pour logout utilisateur, suppression de compte, abandon d’inscription, abandon du retry, password reset, expiration API, expiration recovery, session absente au foreground et échec de refresh.
+3. Attendre `is_expected_user_action=true` uniquement pour les parcours explicitement déclenchés ou confirmés par l’utilisateur.
+4. Garder `system_unspecified` comme sentinelle anormale de compatibilité, jamais comme valeur d’un chemin production connu.
+
+### `2)` Étendre le point central existant
+
+> `resetSession` devient l’unique traduction d’un scope terminal vers le diagnostic.
+
+1. Étendre `SessionResetScope` avec les raisons manquantes et leurs raw values stables.
+2. Ajouter les propriétés calculées `diagnosticOutcome` et `isExpectedUserAction`.
+3. Capturer `auth_session_observed` avec `source=session_reset` au début de `resetSession`.
+4. Déplacer le reset PostHog du début de `logout` après la capture terminale, sans modifier le nettoyage Supabase, biométrique, client key ou navigation.
+5. Conserver `logout_completed` pour la mesure produit existante.
+
+### `3)` Qualifier chaque appel de production
+
+> Aucun appel système connu ne doit retomber sur la sentinelle générique.
+
+1. Marquer la session absente après déverrouillage biométrique comme `background_session_missing`.
+2. Marquer l’abandon du retry de démarrage comme `startup_retry_abandoned`.
+3. Passer une raison distincte à `clearLocalSignupState` pour `account_deleted` et `signup_abandoned`.
+4. Marquer `sessionRefreshFailed` comme `session_refresh_failed`.
+5. Conserver les scopes déjà précis : `user_logout`, `api_session_expired`, `recovery_session_expired` et `password_reset`.
+6. Vérifier qu’aucun chemin production ne produit `system_unspecified`.
+
+### `4)` Vérifier l’investigation de bout en bout
+
+> Une future déconnexion doit fournir une séquence attribuable et interprétable.
+
+1. Exécuter les tests de logout, background, flow state, Analytics et Auth diagnostics.
+2. Vérifier qu’une action volontaire est distinguée d’une session perdue après quelques heures.
+3. Vérifier qu’une expiration API reste corrélable au 401, au request ID et au retry; rattacher le code terminal lorsque Supabase en fournit un et rendre son absence explicite sinon.
+4. Vérifier que reset, PIN et Face ID conservent leur comportement existant.
+5. Relancer SwiftLint strict et le build optimisé `PulpeProd`.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Chaque scope terminal possède une raison stable unique et une classification explicite. |
+| 1 | Suppression de compte, abandon d’inscription et perte de session au foreground ne partagent plus la valeur `system`. |
+| 2 | L’événement terminal est photographié avec l’identité authentifiée avant que PostHog ne la réinitialise. |
+| 2 | Les effets de logout, reset local, biométrie, PIN et navigation restent identiques. |
+| 3 | Aucun chemin de production connu n’émet `system_unspecified`; cette valeur reste uniquement un garde-fou détectable. |
+| 3 | Une expiration API conserve ses 401 backend, retries et request IDs dans la même chronologie utilisateur; un code terminal Supabase y apparaît lorsqu’il existe, sans être inventé sinon. |
+| 4 | Les suites ciblées, SwiftLint strict et le build optimisé `PulpeProd` passent sur le même état de travail. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/plan.md
@@ -1,0 +1,36 @@
+---
+objective: "Toute fin de session iOS en production laisse un diagnostic ordonné, rattaché au bon utilisateur, catégorisé précisément et compatible avec la version Supabase livrée."
+status: in-progress
+---
+
+# Plan: Fiabiliser les diagnostics de déconnexion iOS
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| **Goal** | Fermer les cinq findings de la revue afin qu’une nouvelle déconnexion permette de distinguer une action attendue, une expiration confirmée et une perte locale anormale. |
+| **Source** | Demande utilisateur et `aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md` |
+
+## Phases
+
+| # | Phase | File |
+| --- | --- | --- |
+| 1 | Rendre la capture déterministe et durable | [`phase-1.md`](./phase-1.md) |
+| 2 | Classer chaque fin de session | [`phase-2.md`](./phase-2.md) |
+
+## Resources
+
+| Source | Verified |
+| --- | --- |
+| https://github.com/PostHog/posthog-ios/blob/131859db52a6d65bc77a6f8846239a22bad8dd14/PostHog/PostHogSDK.swift | La version résolue expose une capture avec `distinctId` et `timestamp`; `reset()` remplace ensuite l’identité courante par une identité anonyme. |
+| https://github.com/supabase/supabase-swift/blob/003e58d745f0151c6590bfcb756af8234fdc9ec8/Sources/Helpers/HTTP/LoggerInterceptor.swift | Supabase 2.54.0 produit le format verbose actuellement parsé pour les réponses HTTP. |
+| https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#remote-package | XcodeGen accepte `exactVersion` pour verrouiller une dépendance Swift distante. |
+
+## Decisions
+
+| Decision | Why |
+| --- | --- |
+| Photographier le distinct ID PostHog et l’horodatage avant tout saut vers le MainActor, puis utiliser l’overload de capture explicite. | L’événement garde l’identité et l’instant de l’incident même si `reset()` s’exécute avant le task différé, sans flush réseau bloquant. |
+| Réutiliser `AppState.SessionResetScope` comme source typée de la raison de fin de session. | Ce point central reçoit déjà toutes les transitions vers une session vide; l’étendre évite une deuxième taxonomie susceptible de diverger. |
+| Verrouiller `supabase-swift` sur la version exacte 2.54.0. | Le parser dépend d’un format de log non public; autoriser une autre version 2.x rendrait la collecte silencieusement instable. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Toute fin de session iOS en production laisse un diagnostic ordonné, rattaché au bon utilisateur, catégorisé précisément et compatible avec la version Supabase livrée."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Fiabiliser les diagnostics de déconnexion iOS

--- a/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md
@@ -1,48 +1,44 @@
 # Review: iOS auth session diagnostics
 
 - **Verdict**: changes-requested
-- **Diff**: `origin/preview...86ce7d9e8`
+- **Diff**: `origin/preview...217e5c454`
 - **Axes run**: code, functional, relevancy
 - **Date**: 2026_07_29
-- **Findings**: 0 critical, 4 warning, 1 minor
+- **Findings**: 0 critical, 1 warning, 0 minor
 
 ## Phases
 
 ### Phase 1 — Rendre la capture déterministe et durable
 
-- [x] Une capture différée conserve le distinct ID et l’horodatage présents au signal — `ios/Pulpe/Core/Analytics/AnalyticsService.swift:105`, `ios/Pulpe/Core/Analytics/AnalyticsService.swift:142`
-- [x] Le test du snapshot est local et indépendant du réseau ou d’un projet PostHog — `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift:36`
-- [x] Les diagnostics passent par le sanitizer sans propriété financière ou secrète ajoutée — `ios/Pulpe/Core/Analytics/AnalyticsService.swift:73`, `ios/Pulpe/Core/Analytics/AnalyticsService.swift:142`
-- [x] Le projet résout exactement Supabase 2.54.0 et le parser reconnaît les quatre codes terminaux — `ios/project.yml:19`, `ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift:72`
-- [x] Un log de requête contenant un refresh token ne produit aucun diagnostic terminal — `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift:89`
-- [x] `AuthService.swift` ne contient plus de disable `file_length` et reste au seuil de 500 lignes — `ios/Pulpe/Core/Auth/AuthService.swift:490`
-- [x] Le flux produit uniquement `auth_session_observed`, déclaré avec ses propriétés — `ios/Pulpe/Core/Analytics/AnalyticsEvent.swift:41`, `.claude/rules/05-workflows-and-processes/posthog-events.md:123`
+- [x] Une capture différée conserve le distinct ID et l’horodatage présents au signal — `ios/Pulpe/Core/Analytics/AnalyticsService.swift:159`, `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift:36`
+- [x] Le test du snapshot reste local, sans réseau ni projet PostHog — `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift:36`
+- [x] Tous les diagnostics passent par le sanitizer, sans donnée financière ou secrète — `ios/Pulpe/Core/Analytics/AnalyticsService.swift:70`, `ios/Pulpe/Core/Analytics/AnalyticsService.swift:125`, `ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift:79`
+- [x] Le projet résout exactement Supabase 2.54.0 et le parser reconnaît les quatre codes terminaux — `ios/project.yml:17`, `ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift:68`, `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift:66`
+- [x] Un log de requête contenant un refresh token ne produit aucun diagnostic terminal — `ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift:88`, `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift:89`
+- [x] `AuthService.swift` ne désactive plus `file_length` et reste sous le seuil de 500 lignes — `ios/Pulpe/Core/Auth/AuthService.swift:1`
+- [x] Le flux produit uniquement `auth_session_observed`, déclaré avec ses propriétés et sa taxonomie — `ios/Pulpe/Core/Analytics/AnalyticsEvent.swift:41`, `.claude/rules/05-workflows-and-processes/posthog-events.md:123`
 
 ### Phase 2 — Classer chaque fin de session
 
-- [x] Chaque scope déclaré possède une raison unique et une classification — `ios/Pulpe/App/AppState+SessionReset.swift:303`, `ios/PulpeTests/App/AppStateLogoutScopeTests.swift:17`
-- [x] Suppression de compte, abandon d’inscription et perte au foreground ont des raisons distinctes — `ios/Pulpe/App/AppState+SessionReset.swift:67`, `ios/Pulpe/App/AppState+SessionReset.swift:258`, `ios/Pulpe/App/AppState+SessionReset.swift:266`
-- [ ] Toute expiration terminale passe par la capture typée avant le reset PostHog — `unauthenticatedSessionExpired` contourne `resetSession` dans `ios/Pulpe/App/AppState+Auth.swift:182`
-- [x] Les effets de reset local, biométrie, PIN et navigation restent couverts par la matrice existante — `ios/PulpeTests/App/AppStateResetMatrixTests.swift:53`, `ios/PulpeTests/App/AppStateBiometricColdStartTests.swift:130`
-- [x] Aucun appel système de production connu n’emploie `system_unspecified` — `ios/Pulpe/App/AppState+FlowState.swift:196`, `ios/Pulpe/App/AppState+SessionReset.swift:67`
-- [x] Une expiration API conserve statut 401, retry, request ID, endpoint expurgé et éventuel code Supabase — `ios/Pulpe/Core/Network/APIClient.swift:369`, `ios/Pulpe/Core/Auth/AuthService.swift:244`, `ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift:79`
-- [ ] Les suites ciblées et le build passent, mais SwiftLint strict global reste rouge sur 19 violations — première preuve à `ios/Pulpe/App/AppState.swift:506`
+- [x] Chaque scope terminal possède une raison unique et une classification explicite — `ios/Pulpe/App/AppState+SessionReset.swift:303`, `ios/PulpeTests/App/AppStateLogoutScopeTests.swift:17`
+- [x] Suppression de compte, abandon d’inscription et perte au foreground ont des raisons distinctes — `ios/Pulpe/App/AppState+SessionReset.swift:251`, `ios/Pulpe/App/AppState+SessionReset.swift:266`, `ios/PulpeTests/App/AppStateBackgroundLockTests.swift:390`
+- [x] Le diagnostic terminal est enqueue synchronement avec l’identité courante avant le reset PostHog — `ios/Pulpe/App/AppState+SessionReset.swift:354`, `ios/Pulpe/App/AppState+SessionReset.swift:393`
+- [x] Les effets de logout, reset local, biométrie, PIN et navigation restent couverts — `ios/PulpeTests/App/AppStateResetMatrixTests.swift:53`, `ios/PulpeTests/App/AppStateResetMatrixTests.swift:69`, `ios/PulpeTests/App/AppStateBiometricColdStartTests.swift:130`
+- [x] Aucun chemin de production connu n’émet `system_unspecified`; il reste un sentinel de compatibilité — `ios/Pulpe/App/AppState+FlowState.swift:195`, `ios/Pulpe/App/AppState+SessionReset.swift:190`
+- [x] Une expiration API conserve statut 401, retry, request ID, endpoint expurgé et éventuel code Supabase — `ios/Pulpe/Core/Network/APIClient.swift:233`, `ios/Pulpe/Core/Network/APIClient.swift:368`, `ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift:79`
+- [x] Les suites ciblées, SwiftLint strict ciblé et le build optimisé `PulpeProd` ont passé; les 19 violations globales restent hors diff — `ios/PulpeTests/App/AppStateLogoutScopeTests.swift:17`, `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift:28`, `ios/project.yml:14`
 
 ## Findings
 
 | Sev | Kind | Phase | Location | Issue | Fix |
 | --- | ---- | ----- | -------- | ----- | --- |
-| 🟡 | functional | 2 | `ios/Pulpe/App/AppState+Auth.swift:182` | Le chemin production `vault-status 401 → refresh terminal → unauthenticatedSessionExpired` place directement l’app en `unauthenticated`. Il conserve `currentUser`, n’émet aucun `session_reset` et omet `is_expected_user_action`; cette déconnexion reste hors de la taxonomie terminale annoncée. | Router cette destination par un scope terminal précis et le nettoyage central, ou émettre l’équivalent terminal explicite puis vider l’état utilisateur sans modifier le comportement UI attendu. |
-| 🟡 | functional | 2 | `ios/Pulpe/App/AppState.swift:506` | Le critère « SwiftLint strict passe » n’est pas satisfait: le contrôle global retourne 19 violations préexistantes, dont `AppState.swift` à 506 lignes pour un seuil strict de 500. | Corriger la baseline globale, ou reformuler explicitement le critère vers un lint strict limité aux fichiers modifiés avec une baseline documentée avant de déclarer la phase terminée. |
-| 🟡 | fit | 1 | `ios/Pulpe/Core/Analytics/AnalyticsService.swift:116`, `ios/Pulpe/App/AppState+SessionReset.swift:391` | Le diagnostic terminal est seulement mis en attente, puis `reset()` s’exécute avant son enqueue. PostHog supprime alors les propriétés enregistrées et réinitialise la session: le distinct ID et le timestamp survivent, mais `environment`, `platform`, `build_number` et le contexte de session ne suivent plus l’incident. | Enqueue le snapshot terminal synchronement sur le MainActor avant `reset()`, ou inclure ce contexte immuable dans le snapshot et réenregistrer les propriétés après le reset. |
-| 🟡 | conform | 1 | `.claude/rules/05-workflows-and-processes/posthog-events.md:138` | Le catalogue déclare six sources, dont `api_401_refresh` qui n’est jamais émise, mais omet notamment `api_401`, `backend_api`, `vault_status_401`, `startup_result`, `post_auth_destination`, `deep_link` et les sources keychain; plusieurs outcomes et la propriété `source` de `logout_completed` manquent aussi. | Aligner le catalogue sur toutes les valeurs réellement émises et supprimer ou renommer les valeurs fantômes. |
-| 🟢 | code | 2 | `ios/Pulpe/App/AppState+SessionReset.swift:317`, `ios/PulpeTests/App/AppStateLogoutScopeTests.swift:19` | Le `default: false` et la table manuelle ne forcent pas la classification d’un futur scope; un nouveau cas peut être ajouté sans faire échouer ce contrat supposé exhaustif. | Rendre le switch exhaustif sans `default` et vérifier l’exhaustivité de la table, par exemple avec `CaseIterable`. |
+| 🟡 | fit | 1 | `ios/Pulpe/App/PulpeApp.swift:32` | `AppState()` instancie `AuthService.shared`, qui démarre immédiatement son listener, avant `AnalyticsService.initialize()` à la ligne 92. Les nouveaux événements `initialSession`, `tokenRefreshed`, `signedOut` et les logs Supabase peuvent donc prendre leur snapshot avant le setup PostHog; `getDistinctId()` vaut alors une chaîne vide. Le premier diagnostic d’un cold start peut être capturé sans utilisateur attribuable. | Initialiser `AnalyticsService.shared` avant `AppState()` et donc avant `AuthService.shared`, puis ajouter un test d’ordre d’initialisation ou un garde équivalent. |
 
 ## Verification
 
 | Metric        | Value |
 | ------------- | ----- |
-| Verified      | 86% (12/14) |
-| Files checked | `.claude/rules/05-workflows-and-processes/posthog-events.md`, `aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/{plan,phase-1,phase-2}.md`, `ios/project.yml`, `ios/Pulpe/App/{AppState+Auth,AppState+Bootstrap,AppState+FlowState,AppState+SessionReset,PostAuthResolver,PulpeApp}.swift`, `ios/Pulpe/Core/Analytics/{AnalyticsEvent,AnalyticsService}.swift`, `ios/Pulpe/Core/Auth/{AuthService,AuthSessionDiagnostics,AuthTypes,PulpeAuthStorage}.swift`, `ios/Pulpe/Core/Network/APIClient.swift`, `ios/PulpeTests/App/{AppStateBackgroundLockTests,AppStateLogoutScopeTests,PostAuthResolutionTests}.swift`, `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift`, `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift`, `ios/PulpeTests/Core/Network/APIClientClientKeyHeaderTests.swift`, `ios/Pulpe/App/Auth/StartupCoordinator.swift`, `ios/Pulpe/App/AppState+Recovery.swift`, `ios/Pulpe/App/RootViewModifiers.swift`, `ios/PulpeTests/App/{AppStateResetMatrixTests,AppStateBiometricColdStartTests}.swift` |
-| Unchecked     | Expiration post-auth hors du reset terminal — fix; SwiftLint strict global non passant — fix |
-| Unplanned     | Diagnostics startup, post-auth, widget/deep-link, keychain et backend 401 du commit `5fd06e4e0`: pertinents pour l’objectif, mais hors des projections correctives des phases 1 et 2 |
+| Verified      | 100% (14/14) |
+| Files checked | `.claude/rules/05-workflows-and-processes/posthog-events.md`, `aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/{plan,phase-1,phase-2}.md`, `ios/project.yml`, `ios/Pulpe/App/{AppState+Auth,AppState+Bootstrap,AppState+FlowState,AppState+SessionReset,AppStateDependencies,PostAuthResolver,PulpeApp}.swift`, `ios/Pulpe/Core/Analytics/{AnalyticsEvent,AnalyticsService}.swift`, `ios/Pulpe/Core/Auth/{AuthService,AuthSessionDiagnostics,AuthTypes,PulpeAuthStorage}.swift`, `ios/Pulpe/Core/Network/APIClient.swift`, `ios/PulpeTests/App/{AppStateBackgroundLockTests,AppStateBiometricColdStartTests,AppStateLogoutScopeTests,AppStateResetMatrixTests,PostAuthResolutionTests,ResolvePostAuthOrThrowTests}.swift`, `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift`, `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift`, `ios/PulpeTests/Core/Network/APIClientClientKeyHeaderTests.swift` |
+| Unchecked     | None |
+| Unplanned     | Diagnostics startup, post-auth, widget/deep-link, keychain et backend 401: pertinents à l’objectif et inclus dans la review |

--- a/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md
@@ -1,39 +1,48 @@
 # Review: iOS auth session diagnostics
 
 - **Verdict**: changes-requested
-- **Diff**: `origin/preview...5fd06e4e0`
+- **Diff**: `origin/preview...86ce7d9e8`
 - **Axes run**: code, functional, relevancy
-- **Date**: 2026_07_28
+- **Date**: 2026_07_29
 - **Findings**: 0 critical, 4 warning, 1 minor
 
 ## Phases
 
-### Phase 1 — Diagnostic des déconnexions iOS en production
+### Phase 1 — Rendre la capture déterministe et durable
 
-- [x] La version, le build, l’environnement et la plateforme accompagnent les événements — `ios/Pulpe/Core/Analytics/AnalyticsService.swift:39`
-- [x] L’état du stockage persistant et l’expiration de l’access token sont capturés pendant validation et refresh — `ios/Pulpe/Core/Auth/AuthService.swift:184`
-- [x] Le code terminal Supabase et le statut HTTP sont extraits sans transmettre le body ni les tokens — `ios/Pulpe/Core/Auth/AuthService.swift:461`
-- [x] Chaque 401 backend indique le retry, le request ID et un endpoint sans UUID — `ios/Pulpe/Core/Network/APIClient.swift:368`
-- [x] L’entrée widget et la destination finale du démarrage ou post-auth sont capturées — `ios/Pulpe/App/PulpeApp.swift:194`, `ios/Pulpe/App/AppState+Auth.swift:151`
-- [ ] Chaque fin de session est classée sans ambiguïté comme attendue ou anormale avec une raison stable — fix
-- [ ] Les diagnostics conservent l’identité utilisateur et l’ordre temporel au travers d’un reset analytics — fix
-- [x] Les propriétés excluent tokens, emails, identifiants de budget et données financières — `ios/Pulpe/Core/Auth/AuthService.swift:461`, `ios/Pulpe/Core/Network/APIClient.swift:380`
+- [x] Une capture différée conserve le distinct ID et l’horodatage présents au signal — `ios/Pulpe/Core/Analytics/AnalyticsService.swift:105`, `ios/Pulpe/Core/Analytics/AnalyticsService.swift:142`
+- [x] Le test du snapshot est local et indépendant du réseau ou d’un projet PostHog — `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift:36`
+- [x] Les diagnostics passent par le sanitizer sans propriété financière ou secrète ajoutée — `ios/Pulpe/Core/Analytics/AnalyticsService.swift:73`, `ios/Pulpe/Core/Analytics/AnalyticsService.swift:142`
+- [x] Le projet résout exactement Supabase 2.54.0 et le parser reconnaît les quatre codes terminaux — `ios/project.yml:19`, `ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift:72`
+- [x] Un log de requête contenant un refresh token ne produit aucun diagnostic terminal — `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift:89`
+- [x] `AuthService.swift` ne contient plus de disable `file_length` et reste au seuil de 500 lignes — `ios/Pulpe/Core/Auth/AuthService.swift:490`
+- [x] Le flux produit uniquement `auth_session_observed`, déclaré avec ses propriétés — `ios/Pulpe/Core/Analytics/AnalyticsEvent.swift:41`, `.claude/rules/05-workflows-and-processes/posthog-events.md:123`
+
+### Phase 2 — Classer chaque fin de session
+
+- [x] Chaque scope déclaré possède une raison unique et une classification — `ios/Pulpe/App/AppState+SessionReset.swift:303`, `ios/PulpeTests/App/AppStateLogoutScopeTests.swift:17`
+- [x] Suppression de compte, abandon d’inscription et perte au foreground ont des raisons distinctes — `ios/Pulpe/App/AppState+SessionReset.swift:67`, `ios/Pulpe/App/AppState+SessionReset.swift:258`, `ios/Pulpe/App/AppState+SessionReset.swift:266`
+- [ ] Toute expiration terminale passe par la capture typée avant le reset PostHog — `unauthenticatedSessionExpired` contourne `resetSession` dans `ios/Pulpe/App/AppState+Auth.swift:182`
+- [x] Les effets de reset local, biométrie, PIN et navigation restent couverts par la matrice existante — `ios/PulpeTests/App/AppStateResetMatrixTests.swift:53`, `ios/PulpeTests/App/AppStateBiometricColdStartTests.swift:130`
+- [x] Aucun appel système de production connu n’emploie `system_unspecified` — `ios/Pulpe/App/AppState+FlowState.swift:196`, `ios/Pulpe/App/AppState+SessionReset.swift:67`
+- [x] Une expiration API conserve statut 401, retry, request ID, endpoint expurgé et éventuel code Supabase — `ios/Pulpe/Core/Network/APIClient.swift:369`, `ios/Pulpe/Core/Auth/AuthService.swift:244`, `ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift:79`
+- [ ] Les suites ciblées et le build passent, mais SwiftLint strict global reste rouge sur 19 violations — première preuve à `ios/Pulpe/App/AppState.swift:506`
 
 ## Findings
 
 | Sev | Kind | Phase | Location | Issue | Fix |
 | --- | ---- | ----- | -------- | ----- | --- |
-| 🟡 | functional | 1 | `ios/Pulpe/App/AppState+SessionReset.swift:126` | `source` vaut seulement `user_initiated` ou `system`. Suppression de compte, abandon d’inscription, abandon de retry, session réellement expirée et perte anormale du blob deviennent tous `system`; l’incident ne permet donc pas de conclure « normal » ou « bug ». | Ajouter une raison stable et granulaire au point d’appel, par exemple `user_logout`, `session_expiry`, `account_deletion`, `signup_abandon`, `startup_abandon`, `password_reset`; conserver `source` comme regroupement optionnel. |
-| 🟡 | functional | 1 | `ios/Pulpe/Core/Analytics/AnalyticsService.swift:67`, `ios/Pulpe/App/AppState+SessionReset.swift:130` | Tous les diagnostics passent par un `Task` non structuré, alors qu’un logout appelle immédiatement `reset()`. Le task peut capturer après rotation du distinct ID PostHog, rendant l’événement anonyme ou attribué au mauvais utilisateur et faussant son ordre. | Capturer identité et timestamp à l’appel puis les transmettre explicitement, ou rendre l’envoi attendu/drainé avant `reset()`; couvrir aussi le logger SDK synchrone. |
-| 🟡 | code | 1 | `ios/Pulpe/Core/Auth/AuthService.swift:481`, `ios/project.yml:19` | L’extraction des codes repose sur le texte de log verbose non contractuel de Supabase, tandis que la dépendance accepte toute version `2.x` et que le lockfile n’est pas versionné. Une mise à jour peut supprimer silencieusement ces diagnostics; le test actuel ne vérifie que la chaîne recopiée. | Épingler la version SDK utilisée en production ou utiliser un hook de réponse stable; à défaut, versionner le contrat résolu et tester le format réellement émis par cette version. |
-| 🟡 | conform | 1 | `ios/Pulpe/Core/Analytics/AnalyticsEvent.swift:41`, `.claude/rules/05-workflows-and-processes/posthog-events.md:162` | `auth_session_diagnostic` ne suit pas la convention locale `object_action` au passé, et ses espaces de valeurs `source`/`outcome` ne sont pas documentés dans le catalogue analytics. | Renommer avant diffusion, par exemple `auth_session_observed`, puis documenter les valeurs autorisées de chaque propriété. |
-| 🟢 | rot | 1 | `ios/Pulpe/Core/Auth/AuthService.swift:1` | Le disable `file_length` couvre désormais tout un fichier de 622 lignes et masque sa croissance future. | Déplacer le logger et les diagnostics de session dans un fichier ciblé, puis retirer le disable global. |
+| 🟡 | functional | 2 | `ios/Pulpe/App/AppState+Auth.swift:182` | Le chemin production `vault-status 401 → refresh terminal → unauthenticatedSessionExpired` place directement l’app en `unauthenticated`. Il conserve `currentUser`, n’émet aucun `session_reset` et omet `is_expected_user_action`; cette déconnexion reste hors de la taxonomie terminale annoncée. | Router cette destination par un scope terminal précis et le nettoyage central, ou émettre l’équivalent terminal explicite puis vider l’état utilisateur sans modifier le comportement UI attendu. |
+| 🟡 | functional | 2 | `ios/Pulpe/App/AppState.swift:506` | Le critère « SwiftLint strict passe » n’est pas satisfait: le contrôle global retourne 19 violations préexistantes, dont `AppState.swift` à 506 lignes pour un seuil strict de 500. | Corriger la baseline globale, ou reformuler explicitement le critère vers un lint strict limité aux fichiers modifiés avec une baseline documentée avant de déclarer la phase terminée. |
+| 🟡 | fit | 1 | `ios/Pulpe/Core/Analytics/AnalyticsService.swift:116`, `ios/Pulpe/App/AppState+SessionReset.swift:391` | Le diagnostic terminal est seulement mis en attente, puis `reset()` s’exécute avant son enqueue. PostHog supprime alors les propriétés enregistrées et réinitialise la session: le distinct ID et le timestamp survivent, mais `environment`, `platform`, `build_number` et le contexte de session ne suivent plus l’incident. | Enqueue le snapshot terminal synchronement sur le MainActor avant `reset()`, ou inclure ce contexte immuable dans le snapshot et réenregistrer les propriétés après le reset. |
+| 🟡 | conform | 1 | `.claude/rules/05-workflows-and-processes/posthog-events.md:138` | Le catalogue déclare six sources, dont `api_401_refresh` qui n’est jamais émise, mais omet notamment `api_401`, `backend_api`, `vault_status_401`, `startup_result`, `post_auth_destination`, `deep_link` et les sources keychain; plusieurs outcomes et la propriété `source` de `logout_completed` manquent aussi. | Aligner le catalogue sur toutes les valeurs réellement émises et supprimer ou renommer les valeurs fantômes. |
+| 🟢 | code | 2 | `ios/Pulpe/App/AppState+SessionReset.swift:317`, `ios/PulpeTests/App/AppStateLogoutScopeTests.swift:19` | Le `default: false` et la table manuelle ne forcent pas la classification d’un futur scope; un nouveau cas peut être ajouté sans faire échouer ce contrat supposé exhaustif. | Rendre le switch exhaustif sans `default` et vérifier l’exhaustivité de la table, par exemple avec `CaseIterable`. |
 
 ## Verification
 
-| Metric        | Value                                             |
-| ------------- | ------------------------------------------------- |
-| Verified      | 75% (6/8) |
-| Files checked | `ios/Pulpe/App/AppState+Auth.swift`, `ios/Pulpe/App/AppState+Bootstrap.swift`, `ios/Pulpe/App/AppState+SessionReset.swift`, `ios/Pulpe/App/PostAuthResolver.swift`, `ios/Pulpe/App/PulpeApp.swift`, `ios/Pulpe/Core/Analytics/AnalyticsEvent.swift`, `ios/Pulpe/Core/Analytics/AnalyticsService.swift`, `ios/Pulpe/Core/Auth/AuthService.swift`, `ios/Pulpe/Core/Auth/PulpeAuthStorage.swift`, `ios/Pulpe/Core/Network/APIClient.swift`, `ios/PulpeTests/App/PostAuthResolutionTests.swift`, `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift`, `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift`, `ios/PulpeTests/Core/Network/APIClientClientKeyHeaderTests.swift`, `ios/project.yml`, `ios/Pulpe/App/Runtime/AppRuntimeCoordinator.swift`, `ios/Pulpe/App/RootViewModifiers.swift`, `ios/Pulpe/App/AppState+FlowState.swift`, `ios/Pulpe/App/Auth/StartupCoordinator.swift`, `ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift`, `ios/Pulpe/Core/Network/Endpoints.swift`, `.claude/rules/05-workflows-and-processes/posthog-events.md` |
-| Unchecked     | Classification attendue ou anormale de la fin de session — fix; identité et ordre des diagnostics après reset — fix |
-| Unplanned     | Disable global de la règle `file_length` dans `AuthService.swift` — aucun critère associé |
+| Metric        | Value |
+| ------------- | ----- |
+| Verified      | 86% (12/14) |
+| Files checked | `.claude/rules/05-workflows-and-processes/posthog-events.md`, `aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/{plan,phase-1,phase-2}.md`, `ios/project.yml`, `ios/Pulpe/App/{AppState+Auth,AppState+Bootstrap,AppState+FlowState,AppState+SessionReset,PostAuthResolver,PulpeApp}.swift`, `ios/Pulpe/Core/Analytics/{AnalyticsEvent,AnalyticsService}.swift`, `ios/Pulpe/Core/Auth/{AuthService,AuthSessionDiagnostics,AuthTypes,PulpeAuthStorage}.swift`, `ios/Pulpe/Core/Network/APIClient.swift`, `ios/PulpeTests/App/{AppStateBackgroundLockTests,AppStateLogoutScopeTests,PostAuthResolutionTests}.swift`, `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift`, `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift`, `ios/PulpeTests/Core/Network/APIClientClientKeyHeaderTests.swift`, `ios/Pulpe/App/Auth/StartupCoordinator.swift`, `ios/Pulpe/App/AppState+Recovery.swift`, `ios/Pulpe/App/RootViewModifiers.swift`, `ios/PulpeTests/App/{AppStateResetMatrixTests,AppStateBiometricColdStartTests}.swift` |
+| Unchecked     | Expiration post-auth hors du reset terminal — fix; SwiftLint strict global non passant — fix |
+| Unplanned     | Diagnostics startup, post-auth, widget/deep-link, keychain et backend 401 du commit `5fd06e4e0`: pertinents pour l’objectif, mais hors des projections correctives des phases 1 et 2 |

--- a/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md
@@ -1,0 +1,39 @@
+# Review: iOS auth session diagnostics
+
+- **Verdict**: changes-requested
+- **Diff**: `origin/preview...5fd06e4e0`
+- **Axes run**: code, functional, relevancy
+- **Date**: 2026_07_28
+- **Findings**: 0 critical, 4 warning, 1 minor
+
+## Phases
+
+### Phase 1 — Diagnostic des déconnexions iOS en production
+
+- [x] La version, le build, l’environnement et la plateforme accompagnent les événements — `ios/Pulpe/Core/Analytics/AnalyticsService.swift:39`
+- [x] L’état du stockage persistant et l’expiration de l’access token sont capturés pendant validation et refresh — `ios/Pulpe/Core/Auth/AuthService.swift:184`
+- [x] Le code terminal Supabase et le statut HTTP sont extraits sans transmettre le body ni les tokens — `ios/Pulpe/Core/Auth/AuthService.swift:461`
+- [x] Chaque 401 backend indique le retry, le request ID et un endpoint sans UUID — `ios/Pulpe/Core/Network/APIClient.swift:368`
+- [x] L’entrée widget et la destination finale du démarrage ou post-auth sont capturées — `ios/Pulpe/App/PulpeApp.swift:194`, `ios/Pulpe/App/AppState+Auth.swift:151`
+- [ ] Chaque fin de session est classée sans ambiguïté comme attendue ou anormale avec une raison stable — fix
+- [ ] Les diagnostics conservent l’identité utilisateur et l’ordre temporel au travers d’un reset analytics — fix
+- [x] Les propriétés excluent tokens, emails, identifiants de budget et données financières — `ios/Pulpe/Core/Auth/AuthService.swift:461`, `ios/Pulpe/Core/Network/APIClient.swift:380`
+
+## Findings
+
+| Sev | Kind | Phase | Location | Issue | Fix |
+| --- | ---- | ----- | -------- | ----- | --- |
+| 🟡 | functional | 1 | `ios/Pulpe/App/AppState+SessionReset.swift:126` | `source` vaut seulement `user_initiated` ou `system`. Suppression de compte, abandon d’inscription, abandon de retry, session réellement expirée et perte anormale du blob deviennent tous `system`; l’incident ne permet donc pas de conclure « normal » ou « bug ». | Ajouter une raison stable et granulaire au point d’appel, par exemple `user_logout`, `session_expiry`, `account_deletion`, `signup_abandon`, `startup_abandon`, `password_reset`; conserver `source` comme regroupement optionnel. |
+| 🟡 | functional | 1 | `ios/Pulpe/Core/Analytics/AnalyticsService.swift:67`, `ios/Pulpe/App/AppState+SessionReset.swift:130` | Tous les diagnostics passent par un `Task` non structuré, alors qu’un logout appelle immédiatement `reset()`. Le task peut capturer après rotation du distinct ID PostHog, rendant l’événement anonyme ou attribué au mauvais utilisateur et faussant son ordre. | Capturer identité et timestamp à l’appel puis les transmettre explicitement, ou rendre l’envoi attendu/drainé avant `reset()`; couvrir aussi le logger SDK synchrone. |
+| 🟡 | code | 1 | `ios/Pulpe/Core/Auth/AuthService.swift:481`, `ios/project.yml:19` | L’extraction des codes repose sur le texte de log verbose non contractuel de Supabase, tandis que la dépendance accepte toute version `2.x` et que le lockfile n’est pas versionné. Une mise à jour peut supprimer silencieusement ces diagnostics; le test actuel ne vérifie que la chaîne recopiée. | Épingler la version SDK utilisée en production ou utiliser un hook de réponse stable; à défaut, versionner le contrat résolu et tester le format réellement émis par cette version. |
+| 🟡 | conform | 1 | `ios/Pulpe/Core/Analytics/AnalyticsEvent.swift:41`, `.claude/rules/05-workflows-and-processes/posthog-events.md:162` | `auth_session_diagnostic` ne suit pas la convention locale `object_action` au passé, et ses espaces de valeurs `source`/`outcome` ne sont pas documentés dans le catalogue analytics. | Renommer avant diffusion, par exemple `auth_session_observed`, puis documenter les valeurs autorisées de chaque propriété. |
+| 🟢 | rot | 1 | `ios/Pulpe/Core/Auth/AuthService.swift:1` | Le disable `file_length` couvre désormais tout un fichier de 622 lignes et masque sa croissance future. | Déplacer le logger et les diagnostics de session dans un fichier ciblé, puis retirer le disable global. |
+
+## Verification
+
+| Metric        | Value                                             |
+| ------------- | ------------------------------------------------- |
+| Verified      | 75% (6/8) |
+| Files checked | `ios/Pulpe/App/AppState+Auth.swift`, `ios/Pulpe/App/AppState+Bootstrap.swift`, `ios/Pulpe/App/AppState+SessionReset.swift`, `ios/Pulpe/App/PostAuthResolver.swift`, `ios/Pulpe/App/PulpeApp.swift`, `ios/Pulpe/Core/Analytics/AnalyticsEvent.swift`, `ios/Pulpe/Core/Analytics/AnalyticsService.swift`, `ios/Pulpe/Core/Auth/AuthService.swift`, `ios/Pulpe/Core/Auth/PulpeAuthStorage.swift`, `ios/Pulpe/Core/Network/APIClient.swift`, `ios/PulpeTests/App/PostAuthResolutionTests.swift`, `ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift`, `ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift`, `ios/PulpeTests/Core/Network/APIClientClientKeyHeaderTests.swift`, `ios/project.yml`, `ios/Pulpe/App/Runtime/AppRuntimeCoordinator.swift`, `ios/Pulpe/App/RootViewModifiers.swift`, `ios/Pulpe/App/AppState+FlowState.swift`, `ios/Pulpe/App/Auth/StartupCoordinator.swift`, `ios/Pulpe/App/Auth/SessionLifecycleCoordinator.swift`, `ios/Pulpe/Core/Network/Endpoints.swift`, `.claude/rules/05-workflows-and-processes/posthog-events.md` |
+| Unchecked     | Classification attendue ou anormale de la fin de session — fix; identité et ordre des diagnostics après reset — fix |
+| Unplanned     | Disable global de la règle `file_length` dans `AuthService.swift` — aucun critère associé |

--- a/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_analytics_initialization_order/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_analytics_initialization_order/phase-1.md
@@ -1,0 +1,69 @@
+---
+status: done
+---
+
+# Instruction: Initialiser Analytics avant le listener Auth
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/App/
+│   └── ✏️ PulpeApp.swift                              # initialise PostHog avant les dépendances Auth
+└── PulpeTests/Architecture/
+    └── ✅ AuthDiagnosticsStartupTests.swift           # verrouille l’ordre d’initialisation au cold start
+
+❌ Aucun fichier supprimé
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["L’application démarre"] --> B["Initialiser Analytics et PostHog"]
+  B --> C["Créer AppState et ses dépendances par défaut"]
+  C --> D["AuthService démarre le listener Supabase"]
+  D --> E["Le premier diagnostic photographie un distinct ID PostHog valide"]
+```
+
+## Tasks to do
+
+### `1)` Reproduire la course d’initialisation
+
+> Le test doit échouer tant que `AppState()` est créé avant le setup Analytics.
+
+1. Créer un test Swift Testing dans `PulpeTests/Architecture` en réutilisant le pattern de lecture par `#filePath`.
+2. Lire `PulpeApp.swift` et exiger que l’appel à `AnalyticsService.shared.initialize()` précède la première construction de `AppState()`.
+3. Exiger un seul appel d’initialisation dans `PulpeApp.init`.
+4. Garder le test local, déterministe et sans initialiser le singleton PostHog.
+
+### `2)` Corriger l’ordre de démarrage
+
+> Le setup Analytics doit terminer avant que `AppStateDependencies.default` ne touche `AuthService.shared`.
+
+1. Déplacer l’appel existant à `AnalyticsService.shared.initialize()` au début de `PulpeApp.init`, avant `let appState = AppState()`.
+2. Supprimer l’ancien appel en fin d’initialiseur pour conserver une seule initialisation.
+3. Ne modifier ni `AnalyticsService`, ni `AuthService`, ni leurs files ou gardes internes.
+4. Conserver l’ordre relatif de TipKit, des background tasks, des stores et du câblage applicatif.
+
+### `3)` Vérifier le correctif
+
+> La correction ne doit changer que l’attribution des premiers diagnostics.
+
+1. Exécuter le nouveau test d’architecture puis les suites Analytics et Auth ciblées.
+2. Exécuter SwiftLint strict sur les deux fichiers Swift touchés.
+3. Construire `PulpeProd` en configuration optimisée.
+4. Vérifier qu’aucune nouvelle violation n’est ajoutée au baseline SwiftLint global.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Le test échoue sur l’ordre actuel et ne passe que si Analytics est initialisé avant la construction de `AppState`. |
+| 1 | `PulpeApp.init` contient exactement un appel à `AnalyticsService.shared.initialize()`. |
+| 2 | `AppStateDependencies.default` ne peut plus instancier `AuthService.shared` avant la fin du setup PostHog. |
+| 2 | Quand PostHog est configuré et activé, le premier diagnostic SDK du cold start photographie un distinct ID non vide. |
+| 2 | Aucun mécanisme de queue, garde Analytics ou dépendance supplémentaire n’est ajouté. |
+| 3 | Le test d’architecture, les suites Analytics/Auth ciblées, SwiftLint strict ciblé et le build optimisé `PulpeProd` passent sur le même état. |

--- a/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_analytics_initialization_order/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_analytics_initialization_order/plan.md
@@ -1,0 +1,25 @@
+---
+objective: "Au cold start iOS, PostHog est initialisé avant qu’AuthService puisse démarrer son listener et photographier un diagnostic de session."
+status: in-progress
+---
+
+# Plan: Garantir l’attribution des diagnostics au démarrage iOS
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| **Goal** | Fermer le dernier warning de revue en supprimant la course entre l’initialisation Analytics et le listener Supabase. |
+| **Source** | `aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md` |
+
+## Phases
+
+| # | Phase | File |
+| --- | --- | --- |
+| 1 | Initialiser Analytics avant le listener Auth | [`phase-1.md`](./phase-1.md) |
+
+## Resources
+
+| Source | Verified |
+| --- | --- |
+| https://github.com/PostHog/posthog-ios/blob/131859db52a6d65bc77a6f8846239a22bad8dd14/PostHog/PostHogSDK.swift#L301-L307 | La version PostHog 3.68.2 résolue retourne un distinct ID vide tant que `setup(_:)` n’a pas terminé. |

--- a/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_analytics_initialization_order/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_analytics_initialization_order/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Au cold start iOS, PostHog est initialisé avant qu’AuthService puisse démarrer son listener et photographier un diagnostic de session."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Garantir l’attribution des diagnostics au démarrage iOS

--- a/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/phase-1.md
@@ -1,0 +1,83 @@
+---
+status: done
+---
+
+# Instruction: Fermer le chemin terminal et capturer avant reset
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+ios/
+├── Pulpe/
+│   ├── App/
+│   │   ├── ✏️ AppState+Auth.swift                  # route l’expiration post-auth vers le nettoyage terminal
+│   │   └── ✏️ AppState+SessionReset.swift          # enqueue le diagnostic avant la rotation PostHog
+│   └── Core/Analytics/
+│       └── ✏️ AnalyticsService.swift               # partage l’enqueue synchrone et réarme les propriétés globales
+└── PulpeTests/
+    ├── App/
+    │   └── ✏️ ResolvePostAuthOrThrowTests.swift     # reproduit le chemin terminal actuellement contourné
+    └── Core/Analytics/
+        └── ✏️ AnalyticsServiceTests.swift           # verrouille snapshot et contexte immuable
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Vault-status refuse la session"] --> B["Refresh Supabase confirme la fin de session"]
+  B --> C["Nettoyage terminal central"]
+  C --> D["Enqueue auth_session_observed avec identité et contexte courants"]
+  D --> E["Reset PostHog et réarmement des propriétés globales"]
+  E --> F["Écran de connexion avec message de session expirée"]
+```
+
+## Tasks to do
+
+### `1)` Reproduire l’expiration post-auth hors taxonomie
+
+> Le test doit échouer tant que `unauthenticatedSessionExpired` conserve un utilisateur en mémoire.
+
+1. Étendre `ResolvePostAuthOrThrowTests` avec l’état utilisateur, le message et les effets de reset attendus.
+2. Attendre `currentUser == nil` après l’erreur `sessionExpired`.
+3. Conserver le contrat de throw et l’état UI `unauthenticated`.
+
+### `2)` Réutiliser le nettoyage terminal existant
+
+> Une expiration confirmée ne doit plus écrire directement l’état d’authentification.
+
+1. Déléguer `unauthenticatedSessionExpired` au chemin `handleSessionExpired`.
+2. Réutiliser `.sessionExpiry` au lieu d’ajouter une raison équivalente.
+3. Conserver le diagnostic `post_auth_destination` comme contexte amont.
+4. Garantir un seul diagnostic terminal `session_reset` classé `is_expected_user_action=false`.
+
+### `3)` Enqueue le terminal avant la rotation analytics
+
+> Le snapshot doit être ajouté à la queue PostHog pendant que son contexte authentifié existe encore.
+
+1. Ajouter dans `AnalyticsService` un enqueue MainActor synchrone réutilisé par le wrapper non isolé.
+2. Garder la photographie du distinct ID et du timestamp au point du signal.
+3. Appeler l’enqueue synchrone depuis `resetSession` avant `AnalyticsService.reset()`.
+4. Continuer à passer les propriétés par `sanitizeProperties`.
+5. Ne pas ajouter de flush bloquant, de queue parallèle ou de dépendance.
+
+### `4)` Réarmer le contexte global après reset
+
+> Les événements du prochain écran de connexion et du prochain compte gardent leur contexte de build.
+
+1. Centraliser l’enregistrement de `environment`, `app_version`, `build_number` et `platform`.
+2. L’appeler à l’initialisation et immédiatement après le reset PostHog.
+3. Étendre le test pur existant pour verrouiller les valeurs immuables sans réseau PostHog.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | `unauthenticatedSessionExpired` lance toujours `AuthServiceError.sessionExpired`, affiche le même message et laisse `currentUser == nil`. |
+| 2 | Ce chemin produit exactement un terminal `api_session_expired` avec `is_expected_user_action=false` via le reset central. |
+| 2 | Le nettoyage biométrique, client key, stores, widget et navigation reste celui de `handleSessionExpired`. |
+| 3 | Le terminal est enqueue avant `reset()` avec le distinct ID, le timestamp et la session PostHog présents au signal. |
+| 3 | Tous les diagnostics, synchrones ou différés, restent sanitisés et non bloquants. |
+| 4 | `environment`, `app_version`, `build_number` et `platform` accompagnent le terminal et les événements émis après un reset. |

--- a/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/phase-2.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Rendre le contrat exhaustif et le garde qualité honnête

--- a/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/phase-2.md
@@ -1,0 +1,73 @@
+---
+status: pending
+---
+
+# Instruction: Rendre le contrat exhaustif et le garde qualité honnête
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+├── .claude/rules/05-workflows-and-processes/
+│   └── ✏️ posthog-events.md                         # reflète toutes les valeurs réellement émises
+└── ios/
+    ├── Pulpe/App/
+    │   └── ✏️ AppState+SessionReset.swift           # force la classification de chaque futur scope
+    └── PulpeTests/App/
+        └── ✏️ AppStateLogoutScopeTests.swift        # prouve l’exhaustivité et l’unicité de la taxonomie
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Un diagnostic de session est émis"] --> B["Source et outcome appartiennent au contrat documenté"]
+  B --> C{"Nouveau scope terminal ajouté plus tard ?"}
+  C -- Oui --> D["Compilation ou test échoue sans classification explicite"]
+  C -- Non --> E["Monitoring interprétable"]
+  D --> E
+```
+
+## Tasks to do
+
+### `1)` Rendre la classification exhaustive
+
+> Un futur scope ne doit pas hériter silencieusement de `false`.
+
+1. Rendre `SessionResetScope` itérable.
+2. Retirer le `default` de `isExpectedUserAction`.
+3. Énumérer explicitement les scopes attendus et anormaux.
+4. Faire comparer la table de test à `allCases` avant de vérifier valeurs et unicité.
+
+### `2)` Aligner le catalogue analytics
+
+> Le catalogue devient le contrat exact du code livré.
+
+1. Recenser chaque `source` et `outcome` de `captureAuthSessionDiagnostic`.
+2. Ajouter les sources API, vault, startup, post-auth, deep-link et keychain manquantes.
+3. Supprimer `api_401_refresh` ou aligner l’émetteur sur ce nom unique.
+4. Documenter tous les outcomes manquants.
+5. Documenter `source` sur `logout_completed`.
+
+### `3)` Appliquer un garde qualité proportionné
+
+> Le lot ne doit ni prétendre réparer ni aggraver les 19 violations étrangères déjà recensées.
+
+1. Exécuter SwiftLint strict sur chaque fichier Swift touché.
+2. Relancer le lint global et vérifier qu’aucune nouvelle violation ne provient du diff.
+3. Exécuter les suites Analytics, post-auth, reset, PIN et Face ID concernées.
+4. Construire `PulpeProd` en configuration optimisée.
+5. Rapporter séparément le baseline global préexistant au lieu de le déclarer vert.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Ajouter un nouveau `SessionResetScope` sans classification explicite provoque une erreur de compilation. |
+| 1 | La table couvre exactement `SessionResetScope.allCases`; chaque raison reste unique et stable. |
+| 2 | Le catalogue contient toutes les sources et outcomes émis, aucune valeur fantôme, et la propriété `source` de `logout_completed`. |
+| 3 | Chaque fichier Swift touché passe SwiftLint strict sans violation. |
+| 3 | Le lint global n’ajoute aucune violation au baseline de 19 constaté par la revue. |
+| 3 | Les suites ciblées passent et le build optimisé `PulpeProd` réussit sur le même état de travail. |

--- a/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/plan.md
@@ -1,0 +1,27 @@
+---
+objective: "Toute expiration iOS atteint un reset terminal attribuable avant la rotation PostHog, avec un contrat analytics exact et aucun nouveau défaut de qualité."
+status: in-progress
+---
+
+# Plan: Fermer les écarts de revue des diagnostics de session iOS
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| **Goal** | Fermer les quatre warnings et le mineur de la revue sans élargir le lot aux violations SwiftLint préexistantes. |
+| **Source** | `aidd_docs/tasks/2026_07/2026_07_28_ios_auth_session_diagnostics/review.md` |
+
+## Phases
+
+| # | Phase | File |
+| --- | --- | --- |
+| 1 | Fermer le chemin terminal et capturer avant reset | [`phase-1.md`](./phase-1.md) |
+| 2 | Rendre le contrat exhaustif et le garde qualité honnête | [`phase-2.md`](./phase-2.md) |
+
+## Resources
+
+| Source | Verified |
+| --- | --- |
+| https://github.com/PostHog/posthog-ios/blob/131859db52a6d65bc77a6f8846239a22bad8dd14/PostHog/PostHogSDK.swift#L621-L633 | La version PostHog résolue réinitialise l’identité et la session lors de `reset()`. |
+| https://github.com/PostHog/posthog-ios/blob/131859db52a6d65bc77a6f8846239a22bad8dd14/PostHog/PostHogStorage.swift#L394-L411 | `reset()` supprime les propriétés enregistrées, donc elles doivent être réarmées pour les événements suivants. |

--- a/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_29_ios_auth_session_diagnostics_review_fixes/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Toute expiration iOS atteint un reset terminal attribuable avant la rotation PostHog, avec un contrat analytics exact et aucun nouveau défaut de qualité."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Fermer les écarts de revue des diagnostics de session iOS

--- a/ios/Pulpe/App/AppState+Auth.swift
+++ b/ios/Pulpe/App/AppState+Auth.swift
@@ -148,6 +148,10 @@ extension AppState {
             identifyUserForAnalytics(user, destination: destination)
         }
         authState = .loading
+        AnalyticsService.captureAuthSessionDiagnostic(
+            source: "post_auth_destination",
+            outcome: destination.diagnosticOutcome
+        )
 
         if shouldRedirectToOnboarding(for: destination), let user = currentUser {
             recoveryFlowCoordinator.reset()

--- a/ios/Pulpe/App/AppState+Auth.swift
+++ b/ios/Pulpe/App/AppState+Auth.swift
@@ -181,9 +181,8 @@ extension AppState {
             await enterAuthenticated(context: .directAuthenticated)
         case .unauthenticatedSessionExpired:
             authDebug("AUTH_POST_AUTH_DEST", "unauthenticatedSessionExpired")
-            recoveryFlowCoordinator.reset()
+            await handleSessionExpired()
             biometricError = "Ta session a expiré, connecte-toi avec ton mot de passe"
-            authState = .unauthenticated
         case .vaultCheckFailed:
             recoveryFlowCoordinator.reset()
             authDebug("AUTH_POST_AUTH_DEST", "vaultCheckFailed")

--- a/ios/Pulpe/App/AppState+Bootstrap.swift
+++ b/ios/Pulpe/App/AppState+Bootstrap.swift
@@ -122,6 +122,7 @@ extension AppState {
             currentUser = user
             await applyPostAuthDestination(destination, user: user)
         case .unauthenticated:
+            AnalyticsService.captureAuthSessionDiagnostic(source: "startup_result", outcome: "unauthenticated")
             isNetworkUnavailable = false
             isInMaintenance = false
             await ensureReturningUserFlagLoaded()
@@ -131,11 +132,15 @@ extension AppState {
             isInMaintenance = true
             authState = .loading
         case .networkError(let message):
+            AnalyticsService.captureAuthSessionDiagnostic(source: "startup_result", outcome: "network_error")
             isNetworkUnavailable = true
             isInMaintenance = false
             biometricError = message
             authState = .loading
         case .biometricSessionExpired:
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: "startup_result", outcome: "biometric_session_expired"
+            )
             isNetworkUnavailable = false
             isInMaintenance = false
             biometricError = "Ta session a expiré, connecte-toi avec ton mot de passe"
@@ -145,6 +150,7 @@ extension AppState {
             // No-op: a superseding startup run is in progress.
             break
         case .timeout:
+            AnalyticsService.captureAuthSessionDiagnostic(source: "startup_result", outcome: "timeout")
             isNetworkUnavailable = true
             isInMaintenance = false
             biometricError = "Le chargement a pris trop de temps, réessaie"

--- a/ios/Pulpe/App/AppState+FlowState.swift
+++ b/ios/Pulpe/App/AppState+FlowState.swift
@@ -193,7 +193,7 @@ extension AppState {
             await handleSessionExpired()
             return true
         case .sessionRefreshFailed:
-            await logout(source: .system)
+            await logout(source: .system, resetScope: .sessionRefreshFailed)
             return true
         case .authenticationSucceeded(let user):
             await resolvePostAuth(user: user)

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -62,7 +62,10 @@ extension AppState {
                     Logger.auth.warning(
                         "handleEnterForeground: session refresh returned nil (no active session)"
                     )
-                    await self?.logout(source: .system)
+                    await self?.logout(
+                        source: .system,
+                        resetScope: .backgroundSessionMissing
+                    )
                 }
             } catch let error as URLError {
                 // Keep the session: this URLError is either a transient connectivity blip on a
@@ -116,7 +119,8 @@ extension AppState {
     func logout(
         source: LogoutSource = .userInitiated,
         preserveBiometricSession: Bool? = nil,
-        scope: SignOutScope = .local
+        scope: SignOutScope = .local,
+        resetScope: SessionResetScope? = nil
     ) async {
         guard !isLoggingOut else { return }
         isLoggingOut = true
@@ -127,7 +131,6 @@ extension AppState {
             .logoutCompleted,
             properties: ["source": source == .userInitiated ? "user_initiated" : "system"]
         )
-        AnalyticsService.shared.reset()
 
         backgroundRefreshTask?.cancel()
         backgroundRefreshTask = nil
@@ -174,7 +177,9 @@ extension AppState {
 
         await clientKeyManager.clearSession()
         authDebug("AUTH_LOGOUT", "session cleared, resetting")
-        resetSession(source == .userInitiated ? .userLogout : .systemLogout)
+        resetSession(
+            resetScope ?? (source == .userInitiated ? .userLogout : .systemLogout)
+        )
     }
 
     // MARK: - Startup Retry Escape
@@ -184,7 +189,7 @@ extension AppState {
     /// permanent failure misclassified as retryable traps the user forever.
     func abandonStartupRetry() async {
         authDebug("AUTH_STARTUP_ESCAPE", "user abandoned startup retry")
-        await logout(source: .system)
+        await logout(source: .system, resetScope: .startupRetryAbandoned)
         // `logout` leaves the transitional route flag untouched; clear it so the
         // route derivation stops short-circuiting to the network-error screen.
         isNetworkUnavailable = false
@@ -250,7 +255,7 @@ extension AppState {
             toastManager.show("La suppression du compte a échoué", type: .error)
             return
         }
-        await clearLocalSignupState()
+        await clearLocalSignupState(resetScope: .accountDeleted)
     }
 
     /// Discards an in-progress signup and returns the app to a clean welcome state
@@ -258,7 +263,7 @@ extension AppState {
     func abandonInProgressSignup() async {
         authDebug("AUTH_ABANDON", "begin")
         pendingOnboardingUser = nil
-        await clearLocalSignupState()
+        await clearLocalSignupState(resetScope: .signupAbandoned)
         // Force `OnboardingFlow` to re-instantiate so its `@State` resets to
         // a fresh `OnboardingState` (reads the now-empty UserDefaults → welcome).
         onboardingSessionID = UUID()
@@ -268,7 +273,7 @@ extension AppState {
     /// Shared cleanup for both account deletion and in-progress signup abandon.
     /// Clears the returning-user footprint (keychain email, onboarding draft, flags)
     /// and logs out without preserving biometric session.
-    private func clearLocalSignupState() async {
+    private func clearLocalSignupState(resetScope: SessionResetScope) async {
         await keychainManager.clearLastUsedEmail()
         enrollmentPolicy.clearUserExplicitlyDisabled()
         hasReturningUser = false
@@ -285,36 +290,53 @@ extension AppState {
         clearManualBiometricRetryRequiredFlag()
         // Account deletion / signup abandon → revoke JWT server-side so a
         // snapped access_token cannot be replayed within its ~1h expiry window.
-        await logout(source: .system, preserveBiometricSession: false, scope: .global)
+        await logout(
+            source: .system,
+            preserveBiometricSession: false,
+            scope: .global,
+            resetScope: resetScope
+        )
     }
 
     // MARK: - Session Reset
 
-    enum SessionResetScope {
-        case userLogout
-        case systemLogout
-        case sessionExpiry
-        case recoverySessionExpiry
-        case passwordReset
+    enum SessionResetScope: String {
+        case userLogout = "user_logout"
+        case systemLogout = "system_unspecified"
+        case sessionExpiry = "api_session_expired"
+        case recoverySessionExpiry = "recovery_session_expired"
+        case passwordReset = "password_reset"
+        case backgroundSessionMissing = "background_session_missing"
+        case startupRetryAbandoned = "startup_retry_abandoned"
+        case accountDeleted = "account_deleted"
+        case signupAbandoned = "signup_abandoned"
+        case sessionRefreshFailed = "session_refresh_failed"
 
-        var clearsUIState: Bool {
+        var diagnosticOutcome: String { rawValue }
+
+        var isExpectedUserAction: Bool {
             switch self {
-            case .sessionExpiry: true
-            default: true
+            case .userLogout, .passwordReset, .startupRetryAbandoned,
+                 .accountDeleted, .signupAbandoned:
+                true
+            default:
+                false
             }
         }
 
+        var clearsUIState: Bool { true }
+
         var clearsNavigation: Bool {
             switch self {
-            case .userLogout, .systemLogout, .passwordReset: true
-            default: false
+            case .sessionExpiry, .recoverySessionExpiry: false
+            default: true
             }
         }
 
         var clearsPostAuthError: Bool {
             switch self {
-            case .userLogout, .systemLogout: true
-            default: false
+            case .sessionExpiry, .recoverySessionExpiry, .passwordReset: false
+            default: true
             }
         }
 
@@ -329,6 +351,11 @@ extension AppState {
     }
 
     func resetSession(_ scope: SessionResetScope) {
+        AnalyticsService.captureAuthSessionDiagnostic(
+            source: "session_reset",
+            outcome: scope.diagnosticOutcome,
+            isExpectedUserAction: scope.isExpectedUserAction
+        )
         authDebug(
             "AUTH_RESET_SESSION",
             "scope=\(scope) clearsNav=\(scope.clearsNavigation) clearsUI=\(scope.clearsUIState)"
@@ -361,6 +388,7 @@ extension AppState {
         if scope.setsManualBiometricRetry {
             setManualBiometricRetryRequiredFlag(true)
         }
+        AnalyticsService.shared.reset()
     }
 
     // MARK: - Auth Flags Helpers

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -123,7 +123,10 @@ extension AppState {
         defer { isLoggingOut = false }
         authDebug("AUTH_LOGOUT", "begin source=\(source) biometricEnabled=\(biometric.isEnabled)")
 
-        AnalyticsService.shared.capture(.logoutCompleted)
+        AnalyticsService.shared.capture(
+            .logoutCompleted,
+            properties: ["source": source == .userInitiated ? "user_initiated" : "system"]
+        )
         AnalyticsService.shared.reset()
 
         backgroundRefreshTask?.cancel()

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -300,7 +300,7 @@ extension AppState {
 
     // MARK: - Session Reset
 
-    enum SessionResetScope: String {
+    enum SessionResetScope: String, CaseIterable {
         case userLogout = "user_logout"
         case systemLogout = "system_unspecified"
         case sessionExpiry = "api_session_expired"
@@ -319,7 +319,8 @@ extension AppState {
             case .userLogout, .passwordReset, .startupRetryAbandoned,
                  .accountDeleted, .signupAbandoned:
                 true
-            default:
+            case .systemLogout, .sessionExpiry, .recoverySessionExpiry,
+                 .backgroundSessionMissing, .sessionRefreshFailed:
                 false
             }
         }

--- a/ios/Pulpe/App/AppState+SessionReset.swift
+++ b/ios/Pulpe/App/AppState+SessionReset.swift
@@ -351,11 +351,12 @@ extension AppState {
     }
 
     func resetSession(_ scope: SessionResetScope) {
-        AnalyticsService.captureAuthSessionDiagnostic(
+        let diagnostic = AnalyticsService.makeAuthSessionDiagnosticSnapshot(
             source: "session_reset",
             outcome: scope.diagnosticOutcome,
             isExpectedUserAction: scope.isExpectedUserAction
         )
+        AnalyticsService.shared.captureAuthSessionDiagnostic(diagnostic)
         authDebug(
             "AUTH_RESET_SESSION",
             "scope=\(scope) clearsNav=\(scope.clearsNavigation) clearsUI=\(scope.clearsUIState)"

--- a/ios/Pulpe/App/PostAuthResolver.swift
+++ b/ios/Pulpe/App/PostAuthResolver.swift
@@ -7,6 +7,16 @@ enum PostAuthDestination: Equatable, Sendable {
     case authenticated(needsRecoveryKeyConsent: Bool)
     case unauthenticatedSessionExpired
     case vaultCheckFailed
+
+    var diagnosticOutcome: String {
+        switch self {
+        case .needsPinSetup: "needs_pin_setup"
+        case .needsPinEntry: "needs_pin_entry"
+        case .authenticated: "authenticated"
+        case .unauthenticatedSessionExpired: "unauthenticated_session_expired"
+        case .vaultCheckFailed: "vault_check_failed"
+        }
+    }
 }
 
 protocol PostAuthResolving: Sendable {
@@ -30,7 +40,7 @@ extension ClientKeyManager: ClientKeyResolving {}
 
 extension AuthService: SessionRefreshing {
     func refreshSessionForVaultCheck() async throws -> Bool {
-        try await forceRefreshAccessToken() != nil
+        try await forceRefreshAccessToken(source: "vault_status_401") != nil
     }
 }
 

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -29,6 +29,8 @@ struct PulpeApp: App {
     @State private var whatsNewStore = WhatsNewStore()
 
     init() {
+        AnalyticsService.shared.initialize()
+
         let appState = AppState()
         let currentMonthStore = CurrentMonthStore()
         let budgetListStore = BudgetListStore()
@@ -89,7 +91,6 @@ struct PulpeApp: App {
             .datastoreLocation(.applicationDefault)
         ])
         BackgroundTaskService.shared.registerTasks()
-        AnalyticsService.shared.initialize()
     }
 
     @Environment(\.scenePhase) private var scenePhase

--- a/ios/Pulpe/App/PulpeApp.swift
+++ b/ios/Pulpe/App/PulpeApp.swift
@@ -191,6 +191,10 @@ struct PulpeApp: App {
             case "reset-password":
                 deepLinkDestination = .resetPassword(url: url)
             case "add-expense":
+                AnalyticsService.captureAuthSessionDiagnostic(
+                    source: "deep_link",
+                    outcome: "widget_add_expense_received"
+                )
                 let budgetId = components?.queryItems?.first { $0.name == "budgetId" }?.value
                 if let budgetId, UUID(uuidString: budgetId) == nil {
                     Logger.app.warning("Deep link: invalid UUID for add-expense budgetId=\(budgetId)")
@@ -198,6 +202,10 @@ struct PulpeApp: App {
                 }
                 deepLinkDestination = .addExpense(budgetId: budgetId)
             case "budget":
+                AnalyticsService.captureAuthSessionDiagnostic(
+                    source: "deep_link",
+                    outcome: "widget_budget_received"
+                )
                 if let budgetId = components?.queryItems?.first(where: { $0.name == "id" })?.value,
                    UUID(uuidString: budgetId) != nil {
                     deepLinkDestination = .viewBudget(budgetId: budgetId)

--- a/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
@@ -38,6 +38,7 @@ enum AnalyticsEvent: String, CaseIterable {
     case loginFailed = "login_failed"
     case signupFailed = "signup_failed"
     case sessionRestoreFailed = "session_restore_failed"
+    case authSessionDiagnostic = "auth_session_diagnostic"
     case logoutCompleted = "logout_completed"
     case pinSetupCompleted = "pin_setup_completed"
     case pinEntered = "pin_entered"

--- a/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
@@ -38,7 +38,7 @@ enum AnalyticsEvent: String, CaseIterable {
     case loginFailed = "login_failed"
     case signupFailed = "signup_failed"
     case sessionRestoreFailed = "session_restore_failed"
-    case authSessionDiagnostic = "auth_session_diagnostic"
+    case authSessionObserved = "auth_session_observed"
     case logoutCompleted = "logout_completed"
     case pinSetupCompleted = "pin_setup_completed"
     case pinEntered = "pin_entered"

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -39,6 +39,7 @@ final class AnalyticsService {
         PostHogSDK.shared.register([
             "environment": AppConfiguration.environment.rawValue,
             "app_version": AppConfiguration.appVersion,
+            "build_number": AppConfiguration.buildNumber,
             "platform": "ios"
         ])
 
@@ -61,6 +62,43 @@ final class AnalyticsService {
             "error_kind": String(describing: kind),
             "error_message": AuthErrorLocalizer.localize(error)
         ])
+    }
+
+    nonisolated static func captureAuthSessionDiagnostic(
+        source: String,
+        outcome: String,
+        status: Int? = nil,
+        requestID: String? = nil,
+        endpoint: String? = nil,
+        isRetry: Bool? = nil,
+        storageState: String? = nil,
+        accessTokenExpiresInSeconds: Int? = nil
+    ) {
+        Task { @MainActor in
+            var properties: [String: Any] = [
+                "source": source,
+                "outcome": outcome
+            ]
+            if let status {
+                properties["status"] = status
+            }
+            if let requestID {
+                properties["request_id"] = requestID
+            }
+            if let endpoint {
+                properties["endpoint"] = endpoint
+            }
+            if let isRetry {
+                properties["is_retry"] = isRetry
+            }
+            if let storageState {
+                properties["storage_state"] = storageState
+            }
+            if let accessTokenExpiresInSeconds {
+                properties["access_token_expires_in_seconds"] = accessTokenExpiresInSeconds
+            }
+            shared.capture(.authSessionDiagnostic, properties: properties)
+        }
     }
 
     // MARK: - Screen Tracking

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -31,6 +31,15 @@ final class AnalyticsService {
     nonisolated static let nameProperty = "name"
     nonisolated static let supabaseUserIdProperty = "supabase_user_id"
 
+    static var appContextProperties: [String: Any] {
+        [
+            "environment": AppConfiguration.environment.rawValue,
+            "app_version": AppConfiguration.appVersion,
+            "build_number": AppConfiguration.buildNumber,
+            "platform": "ios"
+        ]
+    }
+
     private(set) var isInitialized = false
     private(set) var isEventCapturingEnabled = false
     /// Tracks whether `identify(userId:)` has fired in this session. Person property
@@ -50,12 +59,7 @@ final class AnalyticsService {
         config.captureApplicationLifecycleEvents = false
         PostHogSDK.shared.setup(config)
 
-        PostHogSDK.shared.register([
-            "environment": AppConfiguration.environment.rawValue,
-            "app_version": AppConfiguration.appVersion,
-            "build_number": AppConfiguration.buildNumber,
-            "platform": "ios"
-        ])
+        registerAppContext()
 
         isInitialized = true
         isEventCapturingEnabled = AppConfiguration.isPostHogEnabled
@@ -114,38 +118,42 @@ final class AnalyticsService {
             isExpectedUserAction: isExpectedUserAction
         )
         Task { @MainActor in
-            var properties: [String: Any] = [
-                "source": snapshot.source,
-                "outcome": snapshot.outcome
-            ]
-            if let status = snapshot.status {
-                properties["status"] = status
-            }
-            if let requestID = snapshot.requestID {
-                properties["request_id"] = requestID
-            }
-            if let endpoint = snapshot.endpoint {
-                properties["endpoint"] = endpoint
-            }
-            if let isRetry = snapshot.isRetry {
-                properties["is_retry"] = isRetry
-            }
-            if let storageState = snapshot.storageState {
-                properties["storage_state"] = storageState
-            }
-            if let accessTokenExpiresInSeconds = snapshot.accessTokenExpiresInSeconds {
-                properties["access_token_expires_in_seconds"] = accessTokenExpiresInSeconds
-            }
-            if let isExpectedUserAction = snapshot.isExpectedUserAction {
-                properties["is_expected_user_action"] = isExpectedUserAction
-            }
-            shared.capture(
-                .authSessionObserved,
-                properties: properties,
-                distinctID: snapshot.distinctID,
-                timestamp: snapshot.timestamp
-            )
+            shared.captureAuthSessionDiagnostic(snapshot)
         }
+    }
+
+    func captureAuthSessionDiagnostic(_ snapshot: AuthSessionDiagnosticSnapshot) {
+        var properties: [String: Any] = [
+            "source": snapshot.source,
+            "outcome": snapshot.outcome
+        ]
+        if let status = snapshot.status {
+            properties["status"] = status
+        }
+        if let requestID = snapshot.requestID {
+            properties["request_id"] = requestID
+        }
+        if let endpoint = snapshot.endpoint {
+            properties["endpoint"] = endpoint
+        }
+        if let isRetry = snapshot.isRetry {
+            properties["is_retry"] = isRetry
+        }
+        if let storageState = snapshot.storageState {
+            properties["storage_state"] = storageState
+        }
+        if let accessTokenExpiresInSeconds = snapshot.accessTokenExpiresInSeconds {
+            properties["access_token_expires_in_seconds"] = accessTokenExpiresInSeconds
+        }
+        if let isExpectedUserAction = snapshot.isExpectedUserAction {
+            properties["is_expected_user_action"] = isExpectedUserAction
+        }
+        capture(
+            .authSessionObserved,
+            properties: properties,
+            distinctID: snapshot.distinctID,
+            timestamp: snapshot.timestamp
+        )
     }
 
     nonisolated static func makeAuthSessionDiagnosticSnapshot(
@@ -211,7 +219,12 @@ final class AnalyticsService {
     func reset() {
         guard isInitialized else { return }
         PostHogSDK.shared.reset()
+        registerAppContext()
         isIdentified = false
+    }
+
+    private func registerAppContext() {
+        PostHogSDK.shared.register(Self.appContextProperties)
     }
 
     // MARK: - Feature Flags

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -1,6 +1,20 @@
 import Foundation
 import PostHog
 
+struct AuthSessionDiagnosticSnapshot: Sendable {
+    let distinctID: String
+    let timestamp: Date
+    let source: String
+    let outcome: String
+    let status: Int?
+    let requestID: String?
+    let endpoint: String?
+    let isRetry: Bool?
+    let storageState: String?
+    let accessTokenExpiresInSeconds: Int?
+    let isExpectedUserAction: Bool?
+}
+
 /// Central analytics service wrapping PostHog iOS SDK.
 /// All callers are @MainActor (SwiftUI views, stores), so MainActor isolation
 /// ensures thread-safe access to `isInitialized` without requiring actor hops.
@@ -49,10 +63,23 @@ final class AnalyticsService {
 
     // MARK: - Event Capture
 
-    func capture(_ event: AnalyticsEvent, properties: [String: Any] = [:]) {
+    func capture(
+        _ event: AnalyticsEvent,
+        properties: [String: Any] = [:],
+        distinctID: String? = nil,
+        timestamp: Date? = nil
+    ) {
         guard isEventCapturingEnabled else { return }
         let sanitized = Self.sanitizeProperties(properties)
-        PostHogSDK.shared.capture(event.rawValue, properties: sanitized)
+        PostHogSDK.shared.capture(
+            event.rawValue,
+            distinctId: distinctID,
+            properties: sanitized,
+            userProperties: nil,
+            userPropertiesSetOnce: nil,
+            groups: nil,
+            timestamp: timestamp
+        )
     }
 
     func captureAuthError(_ event: AnalyticsEvent, error: Error, method: String) {
@@ -72,33 +99,81 @@ final class AnalyticsService {
         endpoint: String? = nil,
         isRetry: Bool? = nil,
         storageState: String? = nil,
-        accessTokenExpiresInSeconds: Int? = nil
+        accessTokenExpiresInSeconds: Int? = nil,
+        isExpectedUserAction: Bool? = nil
     ) {
+        let snapshot = makeAuthSessionDiagnosticSnapshot(
+            source: source,
+            outcome: outcome,
+            status: status,
+            requestID: requestID,
+            endpoint: endpoint,
+            isRetry: isRetry,
+            storageState: storageState,
+            accessTokenExpiresInSeconds: accessTokenExpiresInSeconds,
+            isExpectedUserAction: isExpectedUserAction
+        )
         Task { @MainActor in
             var properties: [String: Any] = [
-                "source": source,
-                "outcome": outcome
+                "source": snapshot.source,
+                "outcome": snapshot.outcome
             ]
-            if let status {
+            if let status = snapshot.status {
                 properties["status"] = status
             }
-            if let requestID {
+            if let requestID = snapshot.requestID {
                 properties["request_id"] = requestID
             }
-            if let endpoint {
+            if let endpoint = snapshot.endpoint {
                 properties["endpoint"] = endpoint
             }
-            if let isRetry {
+            if let isRetry = snapshot.isRetry {
                 properties["is_retry"] = isRetry
             }
-            if let storageState {
+            if let storageState = snapshot.storageState {
                 properties["storage_state"] = storageState
             }
-            if let accessTokenExpiresInSeconds {
+            if let accessTokenExpiresInSeconds = snapshot.accessTokenExpiresInSeconds {
                 properties["access_token_expires_in_seconds"] = accessTokenExpiresInSeconds
             }
-            shared.capture(.authSessionDiagnostic, properties: properties)
+            if let isExpectedUserAction = snapshot.isExpectedUserAction {
+                properties["is_expected_user_action"] = isExpectedUserAction
+            }
+            shared.capture(
+                .authSessionObserved,
+                properties: properties,
+                distinctID: snapshot.distinctID,
+                timestamp: snapshot.timestamp
+            )
         }
+    }
+
+    nonisolated static func makeAuthSessionDiagnosticSnapshot(
+        source: String,
+        outcome: String,
+        status: Int? = nil,
+        requestID: String? = nil,
+        endpoint: String? = nil,
+        isRetry: Bool? = nil,
+        storageState: String? = nil,
+        accessTokenExpiresInSeconds: Int? = nil,
+        isExpectedUserAction: Bool? = nil,
+        distinctIDProvider: () -> String = { PostHogSDK.shared.getDistinctId() },
+        now: () -> Date = { Date() }
+    ) -> AuthSessionDiagnosticSnapshot {
+        AuthSessionDiagnosticSnapshot(
+            distinctID: distinctIDProvider(),
+            timestamp: now(),
+            source: source,
+            outcome: outcome,
+            status: status,
+            requestID: requestID,
+            endpoint: endpoint,
+            isRetry: isRetry,
+            storageState: storageState,
+            accessTokenExpiresInSeconds: accessTokenExpiresInSeconds,
+            isExpectedUserAction: isExpectedUserAction
+        )
     }
 
     // MARK: - Screen Tracking

--- a/ios/Pulpe/Core/Auth/AuthService+UserInfo.swift
+++ b/ios/Pulpe/Core/Auth/AuthService+UserInfo.swift
@@ -1,0 +1,44 @@
+import Supabase
+
+extension AuthService {
+    static func userInfo(from user: User, fallbackEmail: String) -> UserInfo {
+        let metadata = user.userMetadata
+
+        // Priority: firstName (email signup) > given_name (Google) > name (Apple, first sign-in only)
+        var firstName: String?
+        if case .string(let name) = metadata["firstName"] {
+            firstName = name
+        } else if case .string(let name) = metadata["given_name"] {
+            firstName = name
+        } else if case .string(let name) = metadata["name"] {
+            firstName = name
+        }
+
+        // OAuth profile photo — Google exposes both `avatar_url` and `picture`; Apple/email none.
+        var avatarUrl: String?
+        if case .string(let url) = metadata["avatar_url"] {
+            avatarUrl = url
+        } else if case .string(let url) = metadata["picture"] {
+            avatarUrl = url
+        }
+
+        let appMetadata = user.appMetadata
+        var provider: AuthProvider?
+        if case .string(let value) = appMetadata["provider"] {
+            provider = AuthProvider.fromSupabase(value)
+        }
+        var isEarlyAdopter = false
+        if case .bool(let flag) = appMetadata[AnalyticsService.earlyAdopterProperty] {
+            isEarlyAdopter = flag
+        }
+
+        return UserInfo(
+            id: user.id.uuidString,
+            email: user.email ?? fallbackEmail,
+            firstName: firstName,
+            provider: provider,
+            avatarUrl: avatarUrl,
+            isEarlyAdopter: isEarlyAdopter
+        )
+    }
+}

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable file_length
-
 import Foundation
 import LocalAuthentication
 import OSLog
@@ -9,7 +7,6 @@ import Supabase
 /// Mirrors the frontend Angular approach - talks directly to Supabase, not the backend
 actor AuthService {
     static let shared = AuthService()
-    private static let sessionDecoder = JSONDecoder()
 
     private var supabase: SupabaseClient
     private let keychain: KeychainManager
@@ -65,7 +62,7 @@ actor AuthService {
                 switch event {
                 case .initialSession:
                     Logger.auth.debug("[AUTH] session synchronized via PulpeAuthStorage")
-                    Self.captureSessionDiagnostic(
+                    AuthSessionDiagnostics.capture(
                         source: "sdk_event",
                         outcome: "initial_session",
                         session: session
@@ -73,7 +70,7 @@ actor AuthService {
                     await self?.refreshBiometricSnapshotIfPresent(session)
                 case .tokenRefreshed:
                     Logger.auth.debug("[AUTH] session synchronized via PulpeAuthStorage")
-                    Self.captureSessionDiagnostic(
+                    AuthSessionDiagnostics.capture(
                         source: "sdk_event",
                         outcome: "token_refreshed",
                         session: session
@@ -113,19 +110,6 @@ actor AuthService {
 
     // MARK: - Session Validation
 
-    static func isTerminalSessionFailure(_ error: any Error) -> Bool {
-        guard let authError = error as? AuthError else { return false }
-        if case .sessionMissing = authError { return true }
-        return false
-    }
-
-    static func isConfirmedTerminalSessionFailure(
-        _ error: any Error,
-        persistedSessionExists: Bool
-    ) -> Bool {
-        isTerminalSessionFailure(error) && !persistedSessionExists
-    }
-
     /// The SDK removes its persisted blob on sign-out and on confirmed server-side
     /// revocation (reuse-detection, expired session) BEFORE surfacing `sessionMissing`,
     /// so "sessionMissing + no blob" is a reliable terminal verdict. NEVER write that
@@ -159,7 +143,7 @@ actor AuthService {
         // re-reads the slot on the next attempt) or an undecodable blob the SDK can
         // never restore. Purge the latter so the app converges to the login screen
         // instead of an endless retry loop against a corrupt slot.
-        if (try? Self.sessionDecoder.decode(Session.self, from: blob)) == nil {
+        if !AuthSessionDiagnostics.isDecodableSession(blob) {
             Logger.auth.error("session slot undecodable — purging so logout can be confirmed")
             AnalyticsService.captureAuthSessionDiagnostic(
                 source: source,
@@ -182,10 +166,14 @@ actor AuthService {
     }
 
     func validateSession() async throws -> UserInfo? {
-        capturePersistedSessionDiagnostic(source: "session_validation", outcome: "started")
+        AuthSessionDiagnostics.capturePersisted(
+            source: "session_validation",
+            outcome: "started",
+            storage: storage
+        )
         do {
             let session = try await supabase.auth.session
-            Self.captureSessionDiagnostic(
+            AuthSessionDiagnostics.capture(
                 source: "session_validation",
                 outcome: "succeeded",
                 session: session
@@ -254,10 +242,14 @@ actor AuthService {
     /// Forces Supabase to rotate the refresh token even when the access token has not expired.
     /// Used after an API 401 so retrying cannot reuse the token that the backend rejected.
     func forceRefreshAccessToken(source: String = "forced_refresh") async throws -> String? {
-        capturePersistedSessionDiagnostic(source: source, outcome: "started")
+        AuthSessionDiagnostics.capturePersisted(
+            source: source,
+            outcome: "started",
+            storage: storage
+        )
         do {
             let session = try await supabase.auth.refreshSession()
-            Self.captureSessionDiagnostic(source: source, outcome: "succeeded", session: session)
+            AuthSessionDiagnostics.capture(source: source, outcome: "succeeded", session: session)
             return session.accessToken
         } catch {
             if checkAndHandleConfirmedTerminalSessionFailure(error, source: source) {
@@ -393,49 +385,6 @@ actor AuthService {
     }
 }
 
-// MARK: - Session Diagnostics
-
-private extension AuthService {
-    static func captureSessionDiagnostic(source: String, outcome: String, session: Session?) {
-        AnalyticsService.captureAuthSessionDiagnostic(
-            source: source,
-            outcome: outcome,
-            storageState: session == nil ? "missing" : "available",
-            accessTokenExpiresInSeconds: session.map {
-                Int($0.expiresAt - Date().timeIntervalSince1970)
-            }
-        )
-    }
-
-    func capturePersistedSessionDiagnostic(source: String, outcome: String) {
-        do {
-            guard let blob = try storage.retrieve(key: PulpeAuthStorage.sessionStorageKey) else {
-                AnalyticsService.captureAuthSessionDiagnostic(
-                    source: source,
-                    outcome: outcome,
-                    storageState: "missing"
-                )
-                return
-            }
-            guard let session = try? Self.sessionDecoder.decode(Session.self, from: blob) else {
-                AnalyticsService.captureAuthSessionDiagnostic(
-                    source: source,
-                    outcome: outcome,
-                    storageState: "undecodable"
-                )
-                return
-            }
-            Self.captureSessionDiagnostic(source: source, outcome: outcome, session: session)
-        } catch {
-            AnalyticsService.captureAuthSessionDiagnostic(
-                source: source,
-                outcome: outcome,
-                storageState: "unreadable"
-            )
-        }
-    }
-}
-
 // MARK: - OAuth
 
 extension AuthService {
@@ -455,41 +404,6 @@ extension AuthService {
     private func signInWithIdToken(_ credentials: OpenIDConnectCredentials) async throws -> UserInfo {
         let session = try await supabase.auth.signInWithIdToken(credentials: credentials)
         return Self.userInfo(from: session.user, fallbackEmail: "")
-    }
-}
-
-/// Captures only Supabase's terminal session code. The SDK otherwise maps four
-/// different server responses to `sessionMissing` after deleting local storage.
-/// Request bodies and logger context contain refresh tokens and are never forwarded.
-struct PulpeSupabaseLogger: SupabaseLogger {
-    private static let cleanupCodes: Set<String> = [
-        "session_not_found",
-        "session_expired",
-        "refresh_token_not_found",
-        "refresh_token_already_used"
-    ]
-
-    func log(message: SupabaseLogMessage) {
-        guard let (code, status) = Self.cleanupError(from: message.message) else { return }
-        AnalyticsService.captureAuthSessionDiagnostic(
-            source: "supabase_auth_response",
-            outcome: code,
-            status: status
-        )
-    }
-
-    static func cleanupError(from message: String) -> (code: String, status: Int)? {
-        let prefix = "Response: Status code: "
-        guard message.hasPrefix(prefix),
-              let status = Int(message.dropFirst(prefix.count).prefix(while: \.isNumber)),
-              let bodyRange = message.range(of: "\nBody: "),
-              let data = String(message[bodyRange.upperBound...]).data(using: .utf8),
-              let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let code = (body["code"] as? String) ?? (body["error_code"] as? String),
-              cleanupCodes.contains(code) else {
-            return nil
-        }
-        return (code, status)
     }
 }
 
@@ -572,51 +486,5 @@ extension AuthService {
             }
             throw error
         }
-    }
-}
-
-// MARK: - User Info Extraction
-
-extension AuthService {
-    static func userInfo(from user: User, fallbackEmail: String) -> UserInfo {
-        let metadata = user.userMetadata
-
-        // Priority: firstName (email signup) > given_name (Google) > name (Apple, first sign-in only)
-        var firstName: String?
-        if case .string(let name) = metadata["firstName"] {
-            firstName = name
-        } else if case .string(let name) = metadata["given_name"] {
-            firstName = name
-        } else if case .string(let name) = metadata["name"] {
-            firstName = name
-        }
-
-        // OAuth profile photo — Google exposes both `avatar_url` and `picture`; Apple/email none.
-        var avatarUrl: String?
-        if case .string(let url) = metadata["avatar_url"] {
-            avatarUrl = url
-        } else if case .string(let url) = metadata["picture"] {
-            avatarUrl = url
-        }
-
-        // `provider` drives post-auth routing (see `AppState.applyPostAuthDestination`).
-        let appMetadata = user.appMetadata
-        var provider: AuthProvider?
-        if case .string(let value) = appMetadata["provider"] {
-            provider = AuthProvider.fromSupabase(value)
-        }
-        var isEarlyAdopter = false
-        if case .bool(let flag) = appMetadata[AnalyticsService.earlyAdopterProperty] {
-            isEarlyAdopter = flag
-        }
-
-        return UserInfo(
-            id: user.id.uuidString,
-            email: user.email ?? fallbackEmail,
-            firstName: firstName,
-            provider: provider,
-            avatarUrl: avatarUrl,
-            isEarlyAdopter: isEarlyAdopter
-        )
     }
 }

--- a/ios/Pulpe/Core/Auth/AuthService.swift
+++ b/ios/Pulpe/Core/Auth/AuthService.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 import Foundation
 import LocalAuthentication
 import OSLog
@@ -49,7 +51,8 @@ actor AuthService {
                     storage: storage,
                     storageKey: PulpeAuthStorage.sessionStorageKey,
                     emitLocalSessionAsInitialSession: true
-                )
+                ),
+                global: .init(logger: PulpeSupabaseLogger())
             )
         )
     }
@@ -60,11 +63,28 @@ actor AuthService {
         authStateListenerTask = Task(name: "AuthService.authStateListener") { [weak self] in
             for await (event, session) in stream {
                 switch event {
-                case .initialSession, .tokenRefreshed:
+                case .initialSession:
                     Logger.auth.debug("[AUTH] session synchronized via PulpeAuthStorage")
+                    Self.captureSessionDiagnostic(
+                        source: "sdk_event",
+                        outcome: "initial_session",
+                        session: session
+                    )
+                    await self?.refreshBiometricSnapshotIfPresent(session)
+                case .tokenRefreshed:
+                    Logger.auth.debug("[AUTH] session synchronized via PulpeAuthStorage")
+                    Self.captureSessionDiagnostic(
+                        source: "sdk_event",
+                        outcome: "token_refreshed",
+                        session: session
+                    )
                     await self?.refreshBiometricSnapshotIfPresent(session)
                 case .signedOut:
                     Logger.auth.debug("[AUTH] signedOut — SDK cleared storage")
+                    AnalyticsService.captureAuthSessionDiagnostic(
+                        source: "sdk_event",
+                        outcome: "signed_out"
+                    )
                 default:
                     break
                 }
@@ -111,7 +131,10 @@ actor AuthService {
     /// so "sessionMissing + no blob" is a reliable terminal verdict. NEVER write that
     /// blob from the app: the SDK persists every rotation itself, and a second writer
     /// could overwrite a freshly-rotated session with a consumed refresh token.
-    private func checkAndHandleConfirmedTerminalSessionFailure(_ error: any Error) -> Bool {
+    private func checkAndHandleConfirmedTerminalSessionFailure(
+        _ error: any Error,
+        source: String
+    ) -> Bool {
         guard Self.isTerminalSessionFailure(error) else { return false }
         let blob: Data?
         do {
@@ -119,18 +142,36 @@ actor AuthService {
         } catch {
             // Slot unreadable — cannot confirm a logout on a keychain read failure.
             Logger.auth.warning("session slot unreadable - \(error, privacy: .public)")
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: source,
+                outcome: "storage_unreadable"
+            )
             return false
         }
-        guard let blob else { return true }
+        guard let blob else {
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: source,
+                outcome: "missing_blob"
+            )
+            return true
+        }
         // sessionMissing with a persisted blob: either a benign write race (the SDK
         // re-reads the slot on the next attempt) or an undecodable blob the SDK can
         // never restore. Purge the latter so the app converges to the login screen
         // instead of an endless retry loop against a corrupt slot.
         if (try? Self.sessionDecoder.decode(Session.self, from: blob)) == nil {
             Logger.auth.error("session slot undecodable — purging so logout can be confirmed")
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: source,
+                outcome: "undecodable_blob"
+            )
             try? storage.remove(key: PulpeAuthStorage.sessionStorageKey)
             return true
         }
+        AnalyticsService.captureAuthSessionDiagnostic(
+            source: source,
+            outcome: "valid_blob"
+        )
         return false
     }
 
@@ -141,11 +182,17 @@ actor AuthService {
     }
 
     func validateSession() async throws -> UserInfo? {
+        capturePersistedSessionDiagnostic(source: "session_validation", outcome: "started")
         do {
             let session = try await supabase.auth.session
+            Self.captureSessionDiagnostic(
+                source: "session_validation",
+                outcome: "succeeded",
+                session: session
+            )
             return Self.userInfo(from: session.user, fallbackEmail: "")
         } catch {
-            if checkAndHandleConfirmedTerminalSessionFailure(error) {
+            if checkAndHandleConfirmedTerminalSessionFailure(error, source: "session_validation") {
                 Logger.auth.info("validateSession: no active session (logged out)")
                 return nil
             }
@@ -206,15 +253,18 @@ actor AuthService {
 
     /// Forces Supabase to rotate the refresh token even when the access token has not expired.
     /// Used after an API 401 so retrying cannot reuse the token that the backend rejected.
-    func forceRefreshAccessToken() async throws -> String? {
+    func forceRefreshAccessToken(source: String = "forced_refresh") async throws -> String? {
+        capturePersistedSessionDiagnostic(source: source, outcome: "started")
         do {
             let session = try await supabase.auth.refreshSession()
+            Self.captureSessionDiagnostic(source: source, outcome: "succeeded", session: session)
             return session.accessToken
         } catch {
-            if checkAndHandleConfirmedTerminalSessionFailure(error) {
+            if checkAndHandleConfirmedTerminalSessionFailure(error, source: source) {
                 Logger.auth.info("forceRefreshAccessToken: no active session (logged out)")
                 return nil
             }
+            AnalyticsService.captureAuthSessionDiagnostic(source: source, outcome: "failed_retryable")
             Logger.auth.warning(
                 "forceRefreshAccessToken: refresh unavailable - \(error, privacy: .public)"
             )
@@ -270,7 +320,7 @@ actor AuthService {
         } catch {
             // Keep retrying after transport and transient SDK failures. A confirmed
             // terminal logout is the only case where pending work cannot succeed.
-            if checkAndHandleConfirmedTerminalSessionFailure(error) {
+            if checkAndHandleConfirmedTerminalSessionFailure(error, source: "biometric_resync") {
                 pendingBiometricResync = false
             }
         }
@@ -343,6 +393,49 @@ actor AuthService {
     }
 }
 
+// MARK: - Session Diagnostics
+
+private extension AuthService {
+    static func captureSessionDiagnostic(source: String, outcome: String, session: Session?) {
+        AnalyticsService.captureAuthSessionDiagnostic(
+            source: source,
+            outcome: outcome,
+            storageState: session == nil ? "missing" : "available",
+            accessTokenExpiresInSeconds: session.map {
+                Int($0.expiresAt - Date().timeIntervalSince1970)
+            }
+        )
+    }
+
+    func capturePersistedSessionDiagnostic(source: String, outcome: String) {
+        do {
+            guard let blob = try storage.retrieve(key: PulpeAuthStorage.sessionStorageKey) else {
+                AnalyticsService.captureAuthSessionDiagnostic(
+                    source: source,
+                    outcome: outcome,
+                    storageState: "missing"
+                )
+                return
+            }
+            guard let session = try? Self.sessionDecoder.decode(Session.self, from: blob) else {
+                AnalyticsService.captureAuthSessionDiagnostic(
+                    source: source,
+                    outcome: outcome,
+                    storageState: "undecodable"
+                )
+                return
+            }
+            Self.captureSessionDiagnostic(source: source, outcome: outcome, session: session)
+        } catch {
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: source,
+                outcome: outcome,
+                storageState: "unreadable"
+            )
+        }
+    }
+}
+
 // MARK: - OAuth
 
 extension AuthService {
@@ -362,6 +455,41 @@ extension AuthService {
     private func signInWithIdToken(_ credentials: OpenIDConnectCredentials) async throws -> UserInfo {
         let session = try await supabase.auth.signInWithIdToken(credentials: credentials)
         return Self.userInfo(from: session.user, fallbackEmail: "")
+    }
+}
+
+/// Captures only Supabase's terminal session code. The SDK otherwise maps four
+/// different server responses to `sessionMissing` after deleting local storage.
+/// Request bodies and logger context contain refresh tokens and are never forwarded.
+struct PulpeSupabaseLogger: SupabaseLogger {
+    private static let cleanupCodes: Set<String> = [
+        "session_not_found",
+        "session_expired",
+        "refresh_token_not_found",
+        "refresh_token_already_used"
+    ]
+
+    func log(message: SupabaseLogMessage) {
+        guard let (code, status) = Self.cleanupError(from: message.message) else { return }
+        AnalyticsService.captureAuthSessionDiagnostic(
+            source: "supabase_auth_response",
+            outcome: code,
+            status: status
+        )
+    }
+
+    static func cleanupError(from message: String) -> (code: String, status: Int)? {
+        let prefix = "Response: Status code: "
+        guard message.hasPrefix(prefix),
+              let status = Int(message.dropFirst(prefix.count).prefix(while: \.isNumber)),
+              let bodyRange = message.range(of: "\nBody: "),
+              let data = String(message[bodyRange.upperBound...]).data(using: .utf8),
+              let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let code = (body["code"] as? String) ?? (body["error_code"] as? String),
+              cleanupCodes.contains(code) else {
+            return nil
+        }
+        return (code, status)
     }
 }
 

--- a/ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift
+++ b/ios/Pulpe/Core/Auth/AuthSessionDiagnostics.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Supabase
+
+enum AuthSessionDiagnostics {
+    static func isDecodableSession(_ data: Data) -> Bool {
+        (try? JSONDecoder().decode(Session.self, from: data)) != nil
+    }
+
+    static func capture(source: String, outcome: String, session: Session?) {
+        AnalyticsService.captureAuthSessionDiagnostic(
+            source: source,
+            outcome: outcome,
+            storageState: session == nil ? "missing" : "available",
+            accessTokenExpiresInSeconds: session.map {
+                Int($0.expiresAt - Date().timeIntervalSince1970)
+            }
+        )
+    }
+
+    static func capturePersisted(
+        source: String,
+        outcome: String,
+        storage: any AuthLocalStorage
+    ) {
+        do {
+            guard let blob = try storage.retrieve(key: PulpeAuthStorage.sessionStorageKey) else {
+                AnalyticsService.captureAuthSessionDiagnostic(
+                    source: source,
+                    outcome: outcome,
+                    storageState: "missing"
+                )
+                return
+            }
+            guard let session = try? JSONDecoder().decode(Session.self, from: blob) else {
+                AnalyticsService.captureAuthSessionDiagnostic(
+                    source: source,
+                    outcome: outcome,
+                    storageState: "undecodable"
+                )
+                return
+            }
+            capture(source: source, outcome: outcome, session: session)
+        } catch {
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: source,
+                outcome: outcome,
+                storageState: "unreadable"
+            )
+        }
+    }
+}
+
+extension AuthService {
+    static func isTerminalSessionFailure(_ error: any Error) -> Bool {
+        guard let authError = error as? AuthError else { return false }
+        if case .sessionMissing = authError { return true }
+        return false
+    }
+
+    static func isConfirmedTerminalSessionFailure(
+        _ error: any Error,
+        persistedSessionExists: Bool
+    ) -> Bool {
+        isTerminalSessionFailure(error) && !persistedSessionExists
+    }
+}
+
+/// Captures only Supabase's terminal session code. The SDK otherwise maps four
+/// different server responses to `sessionMissing` after deleting local storage.
+/// Request bodies and logger context contain refresh tokens and are never forwarded.
+struct PulpeSupabaseLogger: SupabaseLogger {
+    private static let cleanupCodes: Set<String> = [
+        "session_not_found",
+        "session_expired",
+        "refresh_token_not_found",
+        "refresh_token_already_used"
+    ]
+
+    func log(message: SupabaseLogMessage) {
+        guard let (code, status) = Self.cleanupError(from: message.message) else { return }
+        AnalyticsService.captureAuthSessionDiagnostic(
+            source: "supabase_auth_response",
+            outcome: code,
+            status: status
+        )
+    }
+
+    static func cleanupError(from message: String) -> (code: String, status: Int)? {
+        let prefix = "Response: Status code: "
+        guard message.hasPrefix(prefix),
+              let status = Int(message.dropFirst(prefix.count).prefix(while: \.isNumber)),
+              let bodyRange = message.range(of: "\nBody: "),
+              let data = String(message[bodyRange.upperBound...]).data(using: .utf8),
+              let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let code = (body["code"] as? String) ?? (body["error_code"] as? String),
+              cleanupCodes.contains(code) else {
+            return nil
+        }
+        return (code, status)
+    }
+}

--- a/ios/Pulpe/Core/Auth/AuthTypes.swift
+++ b/ios/Pulpe/Core/Auth/AuthTypes.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Supabase
 
 // MARK: - Auth Errors
 
@@ -88,47 +87,4 @@ struct PasswordRecoveryContext: Equatable, Sendable {
     let email: String
     let firstName: String?
     let hasVaultCodeConfigured: Bool
-}
-
-extension AuthService {
-    static func userInfo(from user: User, fallbackEmail: String) -> UserInfo {
-        let metadata = user.userMetadata
-
-        // Priority: firstName (email signup) > given_name (Google) > name (Apple, first sign-in only)
-        var firstName: String?
-        if case .string(let name) = metadata["firstName"] {
-            firstName = name
-        } else if case .string(let name) = metadata["given_name"] {
-            firstName = name
-        } else if case .string(let name) = metadata["name"] {
-            firstName = name
-        }
-
-        // OAuth profile photo — Google exposes both `avatar_url` and `picture`; Apple/email none.
-        var avatarUrl: String?
-        if case .string(let url) = metadata["avatar_url"] {
-            avatarUrl = url
-        } else if case .string(let url) = metadata["picture"] {
-            avatarUrl = url
-        }
-
-        let appMetadata = user.appMetadata
-        var provider: AuthProvider?
-        if case .string(let value) = appMetadata["provider"] {
-            provider = AuthProvider.fromSupabase(value)
-        }
-        var isEarlyAdopter = false
-        if case .bool(let flag) = appMetadata[AnalyticsService.earlyAdopterProperty] {
-            isEarlyAdopter = flag
-        }
-
-        return UserInfo(
-            id: user.id.uuidString,
-            email: user.email ?? fallbackEmail,
-            firstName: firstName,
-            provider: provider,
-            avatarUrl: avatarUrl,
-            isEarlyAdopter: isEarlyAdopter
-        )
-    }
 }

--- a/ios/Pulpe/Core/Auth/AuthTypes.swift
+++ b/ios/Pulpe/Core/Auth/AuthTypes.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Supabase
 
 // MARK: - Auth Errors
 
@@ -87,4 +88,47 @@ struct PasswordRecoveryContext: Equatable, Sendable {
     let email: String
     let firstName: String?
     let hasVaultCodeConfigured: Bool
+}
+
+extension AuthService {
+    static func userInfo(from user: User, fallbackEmail: String) -> UserInfo {
+        let metadata = user.userMetadata
+
+        // Priority: firstName (email signup) > given_name (Google) > name (Apple, first sign-in only)
+        var firstName: String?
+        if case .string(let name) = metadata["firstName"] {
+            firstName = name
+        } else if case .string(let name) = metadata["given_name"] {
+            firstName = name
+        } else if case .string(let name) = metadata["name"] {
+            firstName = name
+        }
+
+        // OAuth profile photo — Google exposes both `avatar_url` and `picture`; Apple/email none.
+        var avatarUrl: String?
+        if case .string(let url) = metadata["avatar_url"] {
+            avatarUrl = url
+        } else if case .string(let url) = metadata["picture"] {
+            avatarUrl = url
+        }
+
+        let appMetadata = user.appMetadata
+        var provider: AuthProvider?
+        if case .string(let value) = appMetadata["provider"] {
+            provider = AuthProvider.fromSupabase(value)
+        }
+        var isEarlyAdopter = false
+        if case .bool(let flag) = appMetadata[AnalyticsService.earlyAdopterProperty] {
+            isEarlyAdopter = flag
+        }
+
+        return UserInfo(
+            id: user.id.uuidString,
+            email: user.email ?? fallbackEmail,
+            firstName: firstName,
+            provider: provider,
+            avatarUrl: avatarUrl,
+            isEarlyAdopter: isEarlyAdopter
+        )
+    }
 }

--- a/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
+++ b/ios/Pulpe/Core/Auth/PulpeAuthStorage.swift
@@ -53,11 +53,21 @@ public struct PulpeAuthStorage: AuthLocalStorage {
         case errSecItemNotFound:
             break
         default:
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: "keychain_write",
+                outcome: "update_failed",
+                status: Int(updateStatus)
+            )
             let deleteStatus = SecItemDelete(baseQuery as CFDictionary)
             Logger.auth.warning(
                 "PulpeAuthStorage update failed (\(updateStatus)), delete=\(deleteStatus) for key: \(key)"
             )
             guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                AnalyticsService.captureAuthSessionDiagnostic(
+                    source: "keychain_write",
+                    outcome: "fallback_delete_failed",
+                    status: Int(deleteStatus)
+                )
                 // Preserve original failure cause (update) — delete was best-effort cleanup.
                 throw PulpeAuthStorageError.storeFailed(updateStatus)
             }
@@ -75,6 +85,11 @@ public struct PulpeAuthStorage: AuthLocalStorage {
         // re-inserted the item between our SecItemDelete and SecItemAdd. Treat
         // as success — the slot now holds a more recent value than ours would.
         guard addStatus == errSecSuccess || addStatus == errSecDuplicateItem else {
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: "keychain_write",
+                outcome: "add_failed",
+                status: Int(addStatus)
+            )
             throw PulpeAuthStorageError.storeFailed(addStatus)
         }
     }
@@ -97,6 +112,11 @@ public struct PulpeAuthStorage: AuthLocalStorage {
         case errSecItemNotFound:
             return nil
         default:
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: "keychain_read",
+                outcome: "failed",
+                status: Int(status)
+            )
             throw PulpeAuthStorageError.retrieveFailed(status)
         }
     }
@@ -110,6 +130,11 @@ public struct PulpeAuthStorage: AuthLocalStorage {
 
         let status = SecItemDelete(query as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
+            AnalyticsService.captureAuthSessionDiagnostic(
+                source: "keychain_remove",
+                outcome: "failed",
+                status: Int(status)
+            )
             throw PulpeAuthStorageError.removeFailed(status)
         }
     }

--- a/ios/Pulpe/Core/Network/APIClient.swift
+++ b/ios/Pulpe/Core/Network/APIClient.swift
@@ -28,7 +28,7 @@ actor APIClient {
             await ClientKeyManager.shared.resolveClientKey()
         }
         self.forceRefreshAccessToken = {
-            try await AuthService.shared.forceRefreshAccessToken()
+            try await AuthService.shared.forceRefreshAccessToken(source: "api_401")
         }
         self.invalidateSession = {
             try? await AuthService.shared.logout()
@@ -53,7 +53,7 @@ actor APIClient {
         self.authTokenProvider = authTokenProvider
         self.clientKeyProvider = clientKeyProvider
         self.forceRefreshAccessToken = forceRefreshAccessToken ?? {
-            try await AuthService.shared.forceRefreshAccessToken()
+            try await AuthService.shared.forceRefreshAccessToken(source: "api_401")
         }
         self.invalidateSession = invalidateSession ?? {
             try? await AuthService.shared.logout()
@@ -155,6 +155,7 @@ actor APIClient {
 
         // Handle 401 - try token refresh (once only to prevent infinite retry loop)
         if httpResponse.statusCode == 401 {
+            captureUnauthorized(response: httpResponse, endpoint: endpoint, isRetry: isRetry)
             let token = try await handleUnauthorized(isRetry: isRetry)
             try await requestVoid(endpoint, body: body, method: method, isRetry: true, retryAccessToken: token)
             return
@@ -231,6 +232,7 @@ actor APIClient {
 
         // Handle 401 - try token refresh (once only to prevent infinite retry loop)
         if httpResponse.statusCode == 401 {
+            captureUnauthorized(response: httpResponse, endpoint: endpoint, isRetry: isRetry)
             let token = try await handleUnauthorized(isRetry: isRetry)
             var retryRequest = request
             retryRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -360,6 +362,26 @@ actor APIClient {
                 "Request failed: [\(method, privacy: .public)] \(path, privacy: .public) -> \(status, privacy: .public)"
             )
         }
+    }
+}
+
+extension APIClient {
+    private func captureUnauthorized(response: HTTPURLResponse, endpoint: Endpoint, isRetry: Bool) {
+        AnalyticsService.captureAuthSessionDiagnostic(
+            source: "backend_api",
+            outcome: "unauthorized",
+            status: response.statusCode,
+            requestID: response.value(forHTTPHeaderField: "X-Request-Id"),
+            endpoint: Self.diagnosticPath(for: endpoint),
+            isRetry: isRetry
+        )
+    }
+
+    static func diagnosticPath(for endpoint: Endpoint) -> String {
+        "/" + endpoint.path
+            .split(separator: "/")
+            .map { UUID(uuidString: String($0)) == nil ? String($0) : ":id" }
+            .joined(separator: "/")
     }
 }
 

--- a/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
+++ b/ios/PulpeTests/App/AppStateBackgroundLockTests.swift
@@ -389,6 +389,12 @@ struct AppStateBackgroundLockTests {
     }
 
     @Test func foregroundBiometricUnlock_sessionRefreshReturnsNil_logsOut() async {
+        #expect(
+            AppState.SessionResetScope.backgroundSessionMissing.diagnosticOutcome
+                == "background_session_missing"
+        )
+        #expect(!AppState.SessionResetScope.backgroundSessionMissing.isExpectedUserAction)
+
         let sessionRefreshAttempted = AtomicFlag()
         let now = AtomicProperty(Date(timeIntervalSince1970: 0))
 

--- a/ios/PulpeTests/App/AppStateLogoutScopeTests.swift
+++ b/ios/PulpeTests/App/AppStateLogoutScopeTests.swift
@@ -28,6 +28,7 @@ struct AppStateLogoutScopeTests {
             (.sessionRefreshFailed, ("session_refresh_failed", false)),
             (.systemLogout, ("system_unspecified", false))
         ]
+        #expect(Set(cases.map(\.0)) == Set(AppState.SessionResetScope.allCases))
         var outcomes = Set<String>()
 
         for (scope, expected) in cases {

--- a/ios/PulpeTests/App/AppStateLogoutScopeTests.swift
+++ b/ios/PulpeTests/App/AppStateLogoutScopeTests.swift
@@ -14,6 +14,29 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct AppStateLogoutScopeTests {
+    @Test("Every terminal reset has a unique reason and explicit classification")
+    func terminalResetScopes_haveStableDiagnosticTaxonomy() {
+        let cases: [(AppState.SessionResetScope, (String, Bool))] = [
+            (.userLogout, ("user_logout", true)),
+            (.accountDeleted, ("account_deleted", true)),
+            (.signupAbandoned, ("signup_abandoned", true)),
+            (.startupRetryAbandoned, ("startup_retry_abandoned", true)),
+            (.passwordReset, ("password_reset", true)),
+            (.sessionExpiry, ("api_session_expired", false)),
+            (.recoverySessionExpiry, ("recovery_session_expired", false)),
+            (.backgroundSessionMissing, ("background_session_missing", false)),
+            (.sessionRefreshFailed, ("session_refresh_failed", false)),
+            (.systemLogout, ("system_unspecified", false))
+        ]
+        var outcomes = Set<String>()
+
+        for (scope, expected) in cases {
+            #expect(scope.diagnosticOutcome == expected.0)
+            #expect(scope.isExpectedUserAction == expected.1)
+            #expect(outcomes.insert(scope.diagnosticOutcome).inserted)
+        }
+    }
+
     @Test("deleteAccount() triggers performSignOut with .global scope")
     func deleteAccount_triggersGlobalSignOutScope() async {
         let receivedScope = AtomicProperty<SignOutScope?>(nil)

--- a/ios/PulpeTests/App/PostAuthResolutionTests.swift
+++ b/ios/PulpeTests/App/PostAuthResolutionTests.swift
@@ -9,6 +9,18 @@ import Testing
 struct PostAuthResolutionRouterTests {
     private let user = UserInfo(id: "user-1", email: "test@pulpe.app", firstName: "Max")
 
+    @Test("post-auth diagnostics never serialize associated user state")
+    func postAuthDiagnosticOutcomes_areStableLabels() {
+        #expect(PostAuthDestination.needsPinSetup.diagnosticOutcome == "needs_pin_setup")
+        #expect(PostAuthDestination.needsPinEntry(needsRecoveryKeyConsent: true).diagnosticOutcome == "needs_pin_entry")
+        #expect(PostAuthDestination.authenticated(needsRecoveryKeyConsent: true).diagnosticOutcome == "authenticated")
+        #expect(
+            PostAuthDestination.unauthenticatedSessionExpired.diagnosticOutcome
+                == "unauthenticated_session_expired"
+        )
+        #expect(PostAuthDestination.vaultCheckFailed.diagnosticOutcome == "vault_check_failed")
+    }
+
     private func makeBiometricPreferenceStore(initial: Bool) -> BiometricPreferenceStore {
         BiometricPreferenceStore(
             keychain: StubBiometricPreferenceKeychain(initial: initial),

--- a/ios/PulpeTests/App/ResolvePostAuthOrThrowTests.swift
+++ b/ios/PulpeTests/App/ResolvePostAuthOrThrowTests.swift
@@ -26,6 +26,7 @@ struct ResolvePostAuthOrThrowTests {
         }
 
         #expect(sut.authState == .unauthenticated)
+        #expect(sut.currentUser == nil)
         #expect(sut.biometricError == "Ta session a expiré, connecte-toi avec ton mot de passe")
     }
 

--- a/ios/PulpeTests/Architecture/AuthDiagnosticsStartupTests.swift
+++ b/ios/PulpeTests/Architecture/AuthDiagnosticsStartupTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+
+@Suite("Auth diagnostics startup invariants")
+struct AuthDiagnosticsStartupTests {
+    private static func pulpeAppSource() throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Architecture/
+            .deletingLastPathComponent() // PulpeTests/
+            .deletingLastPathComponent() // ios/
+            .appendingPathComponent("Pulpe")
+            .appendingPathComponent("App")
+            .appendingPathComponent("PulpeApp.swift")
+
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("Analytics initializes once before AppState")
+    func analyticsInitializesOnceBeforeAppState() throws {
+        let source = try Self.pulpeAppSource()
+        let analyticsCall = "AnalyticsService.shared.initialize()"
+        let analyticsRange = try #require(source.range(of: analyticsCall))
+        let appStateRange = try #require(source.range(of: "let appState = AppState()"))
+
+        #expect(analyticsRange.lowerBound < appStateRange.lowerBound)
+        #expect(source[analyticsRange.upperBound...].range(of: analyticsCall) == nil)
+    }
+}

--- a/ios/PulpeTests/Architecture/AuthDiagnosticsStartupTests.swift
+++ b/ios/PulpeTests/Architecture/AuthDiagnosticsStartupTests.swift
@@ -16,7 +16,7 @@ struct AuthDiagnosticsStartupTests {
     }
 
     @Test("Analytics initializes once before AppState")
-    func analyticsInitializesOnceBeforeAppState() throws {
+    func analyticsInitialization_beforeAppState_occursExactlyOnce() throws {
         let source = try Self.pulpeAppSource()
         let analyticsCall = "AnalyticsService.shared.initialize()"
         let analyticsRange = try #require(source.range(of: analyticsCall))

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -25,12 +25,31 @@ struct AnalyticsServiceTests {
         #expect(AnalyticsEvent.signupCompleted.rawValue == "signup_completed")
         #expect(AnalyticsEvent.onboardingStepCompleted.rawValue == "onboarding_step_completed")
         #expect(AnalyticsEvent.loginCompleted.rawValue == "login_completed")
-        #expect(AnalyticsEvent.authSessionDiagnostic.rawValue == "auth_session_diagnostic")
+        #expect(AnalyticsEvent.authSessionObserved.rawValue == "auth_session_observed")
         #expect(AnalyticsEvent.pinSetupCompleted.rawValue == "pin_setup_completed")
         #expect(AnalyticsEvent.budgetCreated.rawValue == "budget_created")
         #expect(AnalyticsEvent.transactionCreated.rawValue == "transaction_created")
         #expect(AnalyticsEvent.tabSwitched.rawValue == "tab_switched")
         #expect(AnalyticsEvent.currencyPersistFailed.rawValue == "currency_persist_failed")
+    }
+
+    @Test func authSessionSnapshot_identityChangesBeforeCapture_keepsSignalValues() {
+        let signalTimestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        var currentDistinctID = "identified-user"
+        var currentTimestamp = signalTimestamp
+
+        let snapshot = AnalyticsService.makeAuthSessionDiagnosticSnapshot(
+            source: "session_validation",
+            outcome: "missing_blob",
+            distinctIDProvider: { currentDistinctID },
+            now: { currentTimestamp }
+        )
+
+        currentDistinctID = "anonymous-after-reset"
+        currentTimestamp = signalTimestamp.addingTimeInterval(60)
+
+        #expect(snapshot.distinctID == "identified-user")
+        #expect(snapshot.timestamp == signalTimestamp)
     }
 
     // MARK: - Sanitization

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -25,6 +25,7 @@ struct AnalyticsServiceTests {
         #expect(AnalyticsEvent.signupCompleted.rawValue == "signup_completed")
         #expect(AnalyticsEvent.onboardingStepCompleted.rawValue == "onboarding_step_completed")
         #expect(AnalyticsEvent.loginCompleted.rawValue == "login_completed")
+        #expect(AnalyticsEvent.authSessionDiagnostic.rawValue == "auth_session_diagnostic")
         #expect(AnalyticsEvent.pinSetupCompleted.rawValue == "pin_setup_completed")
         #expect(AnalyticsEvent.budgetCreated.rawValue == "budget_created")
         #expect(AnalyticsEvent.transactionCreated.rawValue == "transaction_created")

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -52,6 +52,15 @@ struct AnalyticsServiceTests {
         #expect(snapshot.timestamp == signalTimestamp)
     }
 
+    @Test func appContextProperties_matchRuntimeConfiguration() {
+        let properties = AnalyticsService.appContextProperties
+
+        #expect(properties["environment"] as? String == AppConfiguration.environment.rawValue)
+        #expect(properties["app_version"] as? String == AppConfiguration.appVersion)
+        #expect(properties["build_number"] as? String == AppConfiguration.buildNumber)
+        #expect(properties["platform"] as? String == "ios")
+    }
+
     // MARK: - Sanitization
 
     @Test func sanitizeProperties_removesFinancialData() {

--- a/ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift
+++ b/ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift
@@ -63,18 +63,26 @@ struct AuthServiceBiometricRefactorTests {
         #expect(!AuthService.isTerminalSessionFailure(serverError))
     }
 
-    @Test("Supabase cleanup response preserves the exact server error code for diagnostics")
-    func supabaseLogger_extractsExactCleanupCode() throws {
+    @Test(
+        "Supabase cleanup response preserves every terminal server error code",
+        arguments: [
+            "session_not_found",
+            "session_expired",
+            "refresh_token_not_found",
+            "refresh_token_already_used"
+        ]
+    )
+    func supabaseLogger_extractsExactCleanupCode(code: String) throws {
         let message = """
         Response: Status code: 400 Content-Length: 91
         Body: {
-          "error_code" : "refresh_token_already_used",
+          "error_code" : "\(code)",
           "msg" : "Invalid Refresh Token"
         }
         """
 
         let result = try #require(PulpeSupabaseLogger.cleanupError(from: message))
-        #expect(result.code == "refresh_token_already_used")
+        #expect(result.code == code)
         #expect(result.status == 400)
     }
 

--- a/ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift
+++ b/ios/PulpeTests/Core/Auth/AuthServiceBiometricRefactorTests.swift
@@ -63,6 +63,33 @@ struct AuthServiceBiometricRefactorTests {
         #expect(!AuthService.isTerminalSessionFailure(serverError))
     }
 
+    @Test("Supabase cleanup response preserves the exact server error code for diagnostics")
+    func supabaseLogger_extractsExactCleanupCode() throws {
+        let message = """
+        Response: Status code: 400 Content-Length: 91
+        Body: {
+          "error_code" : "refresh_token_already_used",
+          "msg" : "Invalid Refresh Token"
+        }
+        """
+
+        let result = try #require(PulpeSupabaseLogger.cleanupError(from: message))
+        #expect(result.code == "refresh_token_already_used")
+        #expect(result.status == 400)
+    }
+
+    @Test("Supabase logger ignores request bodies containing refresh tokens")
+    func supabaseLogger_doesNotParseSensitiveRequestBody() {
+        let message = """
+        Request: POST https://example.supabase.co/auth/v1/token?grant_type=refresh_token
+        Body: {
+          "refresh_token" : "secret-token"
+        }
+        """
+
+        #expect(PulpeSupabaseLogger.cleanupError(from: message) == nil)
+    }
+
     // MARK: - Token rotation slot consistency
 
     @Test("Token rotation via PulpeAuthStorage does not touch biometric slot bytes",

--- a/ios/PulpeTests/Core/Network/APIClientClientKeyHeaderTests.swift
+++ b/ios/PulpeTests/Core/Network/APIClientClientKeyHeaderTests.swift
@@ -151,6 +151,12 @@ struct APIClientClientKeyHeaderTests {
         #expect(invalidationCalled.value == false)
     }
 
+    @Test func diagnosticPath_redactsResourceIdentifiers() {
+        let id = "52d65f63-c7c9-4fcb-bf20-b8080fed6288"
+
+        #expect(APIClient.diagnosticPath(for: .budgetDetails(id: id)) == "/budgets/:id/details")
+    }
+
     private func makeSUT(
         token: String?,
         clientKey: String?,

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -16,7 +16,7 @@ configs:
 packages:
   supabase-swift:
     url: https://github.com/supabase/supabase-swift
-    from: "2.0.0"
+    exactVersion: "2.54.0"
   lottie-spm:
     url: https://github.com/airbnb/lottie-spm
     from: "4.0.0"


### PR DESCRIPTION
## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Ajoute une chronologie PostHog sanitisée pour expliquer chaque restauration, refresh et fin de session iOS. Corrige les chemins qui pouvaient déconnecter l’utilisateur après une erreur transitoire et garantit que le diagnostic terminal conserve l’identité présente au signal avant le reset.

## 🚶‍➡️ Behavior

- Les erreurs réseau transitoires au retour foreground conservent la session et reportent le refresh.
- Une session réellement absente ou révoquée déclenche le nettoyage terminal existant avec une raison unique.
- Les ouvertures directes et via widget sont traçables sans envoyer de token, donnée financière ou identifiant de ressource.
- Analytics est initialisé avant le listener Supabase afin d’attribuer le premier signal du cold start.

## 🧪 Steps to test

- [x] `pnpm quality` : 11/11 tâches réussies.
- [x] Suite iOS `PulpeLocal` : 1 928 réussis, 0 échec, 11 ignorés conditionnels.
- [x] Build iOS `PulpeProd` en configuration `Prod`.
- [ ] Sur un appareil réel, ouvrir l’app directement puis via le widget après plusieurs heures et vérifier Face ID/PIN sans reconnexion.
- [ ] Dans PostHog, vérifier la chronologie `auth_session_observed` si une session terminale survient.