### PR TITLE
fix: stabilize webapp first-run guidance

### DIFF
--- a/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/phase-1.md
@@ -1,0 +1,60 @@
+---
+status: done
+---
+
+# Instruction: Mettre à niveau la dépendance sans refonte
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+├── package.json ✏️
+├── frontend
+│   ├── package.json ✏️
+│   └── projects
+│       └── webapp
+│           └── src
+│               └── app
+│                   └── core
+│                       └── product-tour
+│                           └── product-tour.service.spec.ts ✏️
+└── pnpm-lock.yaml ✏️
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["Le frontend charge Driver.js 1.8"] --> B["Le service réutilise sa configuration actuelle"]
+  B --> C["Les mêmes étapes et styles sont affichés"]
+  C --> D["Terminer et fermer conservent leurs états actuels"]
+```
+
+## Tasks to do
+
+### `1)` Aligner Driver.js sur la version 1.8
+
+> Mettre à niveau les deux déclarations existantes sans modifier l’architecture du workspace.
+
+1. Passer `driver.js` de `^1.4.0` à `^1.8.0` dans le manifeste racine et celui du frontend.
+2. Régénérer le lockfile avec pnpm sans mettre à jour les autres dépendances.
+3. Vérifier que le lockfile ne résout plus Driver.js 1.4.
+
+### `2)` Prouver la compatibilité avant toute adaptation
+
+> Garder le service, les étapes et le thème inchangés tant qu’aucune régression n’est démontrée.
+
+1. Fournir `index: undefined` au mock de hook conformément au type Driver.js 1.8.
+2. Exécuter le test unitaire ciblé de `ProductTourService`.
+3. Exécuter les contrôles de types du frontend et des tests E2E.
+4. Exécuter le build frontend afin de valider l’import CSS et le bundle Driver.js.
+5. Si une autre incompatibilité apparaît, arrêter cette phase et réviser la projection avant de toucher au service ou au thème.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Les deux manifestes demandent Driver.js `^1.8.0`, le lockfile résout `1.8.0` et aucune autre dépendance ne change de version. |
+| 2 | Le mock respecte `HookOpts` 1.8 ; la suite ciblée du product tour, les contrôles de types E2E et frontend, puis le build frontend passent sans modification des textes, étapes, états ou styles du tour. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/phase-2.md
@@ -1,0 +1,58 @@
+---
+status: pending
+---
+
+# Instruction: Verrouiller l’accessibilité réelle
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── frontend
+    └── e2e
+        └── tests
+            └── features
+                └── product-tour-accessibility.spec.ts ✅
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["L’utilisateur ouvre Découvrir cet écran au clavier"] --> B["Le lecteur d’écran annonce le dialogue, son titre et sa description"]
+  B --> C["Tab et Maj+Tab restent dans le tour et sa cible active"]
+  C --> D["Action clavier"]
+  D -->|"Suivant ou Précédent"| B
+  D -->|"Terminer ou Échap"| E["Le tour se ferme et le focus revient au déclencheur"]
+```
+
+## Tasks to do
+
+### `1)` Ajouter la régression Playwright ciblée
+
+> Tester le vrai DOM de Driver.js avec les fixtures existantes, sans nouvelle librairie ni nouveau helper.
+
+1. Ouvrir le tour rejouable du dashboard depuis le menu utilisateur avec le clavier.
+2. Vérifier le rôle dialogue, le nom et la description accessibles, les libellés des contrôles et le focus visible.
+3. Vérifier Tab, Maj+Tab, Entrée, les flèches gauche et droite, puis Échap.
+4. Vérifier un parcours terminé et la restauration du focus vers le déclencheur logique.
+5. Garder le test limité à la régression clavier et sémantique commune à tous les tours.
+
+### `2)` Valider le lecteur d’écran et le rendu local
+
+> Compléter l’automatisation par une écoute réelle, car Playwright ne remplace pas VoiceOver.
+
+1. Démarrer le frontend et le backend locaux, puis confirmer leurs ports depuis les logs avant d’ouvrir l’application.
+2. Avec VoiceOver sur macOS, rejouer le tour du dashboard et confirmer l’annonce du titre, de la description, de la progression et des boutons à chaque étape.
+3. Confirmer que Suivant, Précédent, Terminer et Échap produisent l’action annoncée et que le focus revient au menu utilisateur.
+4. Avec `@Browser`, capturer un écran du tour sur dashboard, budgets, détail d’un budget, modèles et objectifs afin d’écarter tout recadrage ou débordement lié à la mise à niveau.
+5. Exécuter le contrôle qualité du monorepo et le test Playwright ciblé.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | Le tour est entièrement opérable sans souris ; le dialogue et ses contrôles ont des noms accessibles ; le focus ne s’échappe pas vers le contenu masqué ; Échap ferme le tour ; Terminer le clôture ; le focus revient au déclencheur logique. |
+| 2 | VoiceOver annonce chaque étape et ses contrôles sans silence ni contenu ambigu ; les cinq captures ne montrent ni popover rogné, ni cible incorrecte, ni débordement ; le contrôle qualité et le test Playwright ciblé passent. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/phase-2.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Verrouiller l’accessibilité réelle
@@ -11,6 +11,17 @@ status: pending
 ```txt
 .
 └── frontend
+    ├── projects
+    │   └── webapp
+    │       └── src
+    │           └── app
+    │               ├── core
+    │               │   └── product-tour
+    │               │       ├── product-tour.css ✏️
+    │               │       └── product-tour.service.ts ✏️
+    │               └── layout
+    │                   ├── main-layout.spec.ts ✏️
+    │                   └── main-layout.ts ✏️
     └── e2e
         └── tests
             └── features
@@ -21,7 +32,7 @@ status: pending
 
 ```mermaid
 flowchart TD
-  A["L’utilisateur ouvre Découvrir cet écran au clavier"] --> B["Le lecteur d’écran annonce le dialogue, son titre et sa description"]
+  A["L’utilisateur ouvre Découvrir cet écran au clavier"] --> B["Le dialogue expose son titre et sa description accessibles"]
   B --> C["Tab et Maj+Tab restent dans le tour et sa cible active"]
   C --> D["Action clavier"]
   D -->|"Suivant ou Précédent"| B
@@ -39,20 +50,19 @@ flowchart TD
 3. Vérifier Tab, Maj+Tab, Entrée, les flèches gauche et droite, puis Échap.
 4. Vérifier un parcours terminé et la restauration du focus vers le déclencheur logique.
 5. Garder le test limité à la régression clavier et sémantique commune à tous les tours.
+6. Démarrer le tour après la restauration du focus par le menu Material, puis conserver ce déclencheur stable pendant toutes les étapes afin de le refocaliser à la fermeture.
 
-### `2)` Valider le lecteur d’écran et le rendu local
+### `2)` Valider le rendu local
 
-> Compléter l’automatisation par une écoute réelle, car Playwright ne remplace pas VoiceOver.
+> Compléter l’automatisation par une vérification visuelle dans le navigateur intégré.
 
 1. Démarrer le frontend et le backend locaux, puis confirmer leurs ports depuis les logs avant d’ouvrir l’application.
-2. Avec VoiceOver sur macOS, rejouer le tour du dashboard et confirmer l’annonce du titre, de la description, de la progression et des boutons à chaque étape.
-3. Confirmer que Suivant, Précédent, Terminer et Échap produisent l’action annoncée et que le focus revient au menu utilisateur.
-4. Avec `@Browser`, capturer un écran du tour sur dashboard, budgets, détail d’un budget, modèles et objectifs afin d’écarter tout recadrage ou débordement lié à la mise à niveau.
-5. Exécuter le contrôle qualité du monorepo et le test Playwright ciblé.
+2. Avec `@Browser`, capturer un écran du tour sur dashboard, budgets, détail d’un budget, modèles et objectifs afin d’écarter tout recadrage ou débordement lié à la mise à niveau.
+3. Exécuter le contrôle qualité du monorepo et le test Playwright ciblé.
 
 ## Test acceptance criteria
 
 | Task | Acceptance criteria |
 | ---- | ------------------- |
 | 1 | Le tour est entièrement opérable sans souris ; le dialogue et ses contrôles ont des noms accessibles ; le focus ne s’échappe pas vers le contenu masqué ; Échap ferme le tour ; Terminer le clôture ; le focus revient au déclencheur logique. |
-| 2 | VoiceOver annonce chaque étape et ses contrôles sans silence ni contenu ambigu ; les cinq captures ne montrent ni popover rogné, ni cible incorrecte, ni débordement ; le contrôle qualité et le test Playwright ciblé passent. |
+| 2 | Les cinq captures ne montrent ni popover rogné, ni cible incorrecte, ni débordement ; le contrôle qualité et le test Playwright ciblé passent. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "Driver.js 1.8 remplace la version 1.4 sans refonte du product tour, avec une régression clavier automatisée et une validation visuelle locale reproductible."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Mise à niveau Driver.js 1.8 et validation d’accessibilité

--- a/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/plan.md
@@ -1,5 +1,5 @@
 ---
-objective: "Driver.js 1.8 remplace la version 1.4 sans refonte du product tour, avec une régression clavier automatisée et une validation VoiceOver reproductible."
+objective: "Driver.js 1.8 remplace la version 1.4 sans refonte du product tour, avec une régression clavier automatisée et une validation visuelle locale reproductible."
 status: in-progress
 ---
 

--- a/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_driver-js-1-8-accessibility/plan.md
@@ -1,0 +1,35 @@
+---
+objective: "Driver.js 1.8 remplace la version 1.4 sans refonte du product tour, avec une régression clavier automatisée et une validation VoiceOver reproductible."
+status: in-progress
+---
+
+# Plan: Mise à niveau Driver.js 1.8 et validation d’accessibilité
+
+## Overview
+
+| Field      | Value                                      |
+| ---------- | ------------------------------------------ |
+| **Goal**   | Mettre à niveau Driver.js sans changer l’expérience actuelle et verrouiller son accessibilité. |
+| **Source** | Texte utilisateur du 28 juillet 2026      |
+
+## Phases
+
+| #   | Phase                                      | File                         |
+| --- | ------------------------------------------ | ---------------------------- |
+| 1   | Mettre à niveau la dépendance sans refonte | [`phase-1.md`](./phase-1.md) |
+| 2   | Verrouiller l’accessibilité réelle         | [`phase-2.md`](./phase-2.md) |
+
+## Resources
+
+| Source | Verified |
+| ------ | -------- |
+| https://driverjs.com/docs/changelog | Driver.js 1.8.0 conserve les exports existants, ajoute des options sans migration obligatoire et documente les changements de style introduits depuis 1.5. |
+| https://driverjs.com/docs/configuration | Le contrôle clavier reste activé par défaut et les hooks actuels `onNextClick` et `onDestroyed` restent supportés. |
+| https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/ | Le dialogue doit avoir un nom accessible, contenir le parcours de tabulation, se fermer avec Échap et restaurer le focus. |
+| https://www.w3.org/TR/WCAG22/ | Les critères clavier, ordre du focus, focus visible et focus non masqué structurent la validation. |
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Conserver Driver.js, les textes, les étapes et le thème actuels. | Le besoin porte sur une maintenance de dépendance et une preuve d’accessibilité, pas sur une nouvelle conception ni un changement de librairie. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/phase-1.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/phase-1.md
@@ -1,0 +1,74 @@
+---
+status: done
+---
+
+# Instruction: Restore the checklist host layout contract
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+frontend/
+├── e2e/tests/features/
+│   └── authentication.spec.ts                           ✏️ visual regression coverage
+└── projects/webapp/src/app/ui/password-criteria/
+    └── password-criteria.ts                             ✏️ block-level host contract
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["User enters a password"] --> B["Password criteria update"]
+  B --> C["User focuses confirmation"]
+  C --> D["Criteria and confirmation label remain distinct"]
+```
+
+## Wireframe
+
+```txt
+┌─────────────────────────────────────┐
+│ (1) Password field                  │
+├─────────────────────────────────────┤
+│ (2) Password criteria               │
+│     ○ criterion                     │
+│     ○ criterion                     │
+│     ○ criterion                     │
+├─────────────────────────────────────┤
+│ (3) Confirmation field              │
+└─────────────────────────────────────┘
+```
+
+1. Password field: the password entry control.
+2. Password criteria: a compact group owned by the password field.
+3. Confirmation field: a separate form control below the complete criteria box.
+
+## Tasks to do
+
+### `1)` Reproduce the overlap
+
+> Lock the reported geometry before changing the component.
+
+1. Add a narrow-viewport signup scenario to the existing authentication E2E suite.
+2. Focus the confirmation field while criteria are unmet and assert that its floating label does not intersect the final criterion.
+3. Enter a valid password and confirmation, then repeat the non-intersection assertion for the met state.
+
+### `2)` Restore block layout
+
+> Make the reusable component host participate in the parent form's vertical flow.
+
+1. Add the existing project pattern `host: { class: 'block' }` to `PasswordCriteria`.
+2. Keep the current `4px / 8px / 16px` spacing utilities unchanged.
+3. Run the focused E2E regression and the existing password-criteria unit test.
+4. Re-run the Impeccable layout scan; accept no unresolved layout finding.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | The regression fails on the current layout because the confirmation label intersects the last criterion in the reported narrow viewport. |
+| 1 | The scenario covers both unmet and met password criteria with the confirmation label floating. |
+| 2 | The checklist host occupies its complete vertical box and the existing form spacing separates it from the confirmation field. |
+| 2 | No compensating margin is added to the confirmation field and no global Material or form spacing is changed. |
+| 2 | Password criteria logic, validation feedback, focus controls, and the signup form remain functional. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/phase-2.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/phase-2.md
@@ -1,0 +1,152 @@
+---
+status: done
+---
+
+# Instruction: Repair and refresh every product tour
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+frontend/projects/webapp/src/app/
+├── core/product-tour/
+│   ├── product-tour.service.spec.ts                    ✏️ target-readiness and step-contract coverage
+│   └── product-tour.service.ts                         ✏️ shared target guard and factual copy
+└── layout/
+    ├── main-layout.spec.ts                             ✏️ route and responsive navigation coverage
+    └── main-layout.ts                                  ✏️ exact route classification and mobile tour target
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["User opens a supported page"] --> B{"Automatic start or Discover this page"}
+  B --> C["Layout resolves the exact page tour"]
+  C --> D{"First page target is ready"}
+  D -- "Not yet" --> E["Wait for the target without starting Driver.js"]
+  E --> D
+  D -- "Ready" --> F["Keep only targets present in the DOM"]
+  F --> G["Show concise, factual steps anchored to the current UI"]
+  E -- "Timeout" --> H["Stop without marking the tour as completed"]
+```
+
+## Wireframe
+
+```txt
+┌───────────────────────────────────────────────────────┐
+│ Mes modèles de budget                 (2) Ajouter     │
+├───────────────────────────────────────────────────────┤
+│ (1) Modèles                                           │
+│     ┌───────────────────────────────────────────┐     │
+│     │ Template                                  │     │
+│     └───────────────────────────────────────────┘     │
+└───────────────────────────────────────────────────────┘
+```
+
+1. Template list: explains what a model contains and how it is reused.
+2. Add action: explains how to create another model without assuming this is the user's first one.
+
+## Tasks to do
+
+The audit found four independent faults in the same flow: `/budget-templates` is captured by the generic `/budget` match; tours can start before async page targets exist; the intro has no visible navigation target on handset; and several descriptions no longer match the product or use the project's vocabulary.
+
+### `1)` Reproduce and fix the route collision
+
+> Prove that the manual action selects the budget-list tour on the templates route.
+
+1. In the existing main-layout unit suite, navigate the mocked router to `/budget-templates`.
+2. Trigger the existing page-tour action and expect `templates-list`.
+3. Keep happy-path assertions for `/budget` and `/budget/:id`.
+4. Match the specific budget templates route before the generic budget route. Do not add a new router abstraction for one ordering bug.
+
+### `2)` Make target resolution safe in the shared service
+
+> Never give Driver.js a missing selector, which is what produces the detached centered popovers.
+
+1. Add a failing service test where the first page target is absent at `startPageTour()` time and appears after a DOM update.
+2. Use the already injected `DOCUMENT` and the native `MutationObserver` to wait for the first targeted page step, bounded by a 10-second timeout. Keep one pending request; a request for another page replaces it.
+3. On timeout or cancellation, disconnect the observer, clear the timer, do not create Driver.js, and do not mark the intro or page tour as completed.
+4. Once the first page target exists, remove any remaining selector-based step whose element is not present before calling `setSteps()`. Elementless introduction steps remain intentional.
+5. Cancel the pending wait from the existing `cancelActiveTour()` path so route changes cannot launch a stale tour later.
+6. Target the always-present budget-details FAB with its existing `data-testid="add-budget-line-fab"` instead of the conditional footer action.
+7. Remove the template-counter step. The counter stays in the page, but a conditional limit reminder is not needed to understand the feature and is absent when the list is empty.
+8. Set Driver.js `animate` from `DOCUMENT.defaultView.matchMedia('(prefers-reduced-motion: reduce)')` so the tour follows the product motion contract without adding another dependency.
+
+### `3)` Keep the introduction anchored on desktop and handset
+
+> The desktop rail has the navigation target; the closed mobile drawer does not.
+
+1. Reuse `data-tour="navigation"` on the handset menu button. Only one matching target is rendered at a time.
+2. Keep the existing desktop navigation target and let the shared missing-target guard handle any future layout state safely.
+3. Add a responsive layout assertion that desktop targets the rail and handset targets the visible menu button.
+
+### `4)` Replace stale and promotional copy
+
+> Keep the tutoiement, remove unverifiable timing claims, avoid "premier" on replayable tours, and use the product vocabulary: Prévision, Pointé, À pointer, Disponible à dépenser, Revenu, Dépense, Épargne, Récurrent, Prévu.
+
+#### Introduction
+
+1. **Bienvenue dans Pulpe**: "Pulpe t'aide à préparer tes mois et à suivre tes revenus, dépenses et épargnes. Voici les repères utiles pour commencer."
+2. **Les espaces de Pulpe**:
+   - "Tableau de bord : suis le mois en cours et pointe tes prévisions."
+   - "Budgets : consulte, crée et ajuste chaque mois."
+   - "Modèles : prépare des revenus, dépenses et épargnes à réutiliser."
+   - "Objectifs : suis tes projets d'épargne et les prévisions qui leur sont liées."
+
+#### Tableau de bord
+
+1. **Disponible à dépenser**: "Ce montant résume ce qu'il reste pour le mois en tenant compte des revenus, dépenses et épargnes. Ouvre ce bloc pour accéder au budget détaillé."
+2. **Prévisions à pointer et transactions**: "Retrouve ici les prévisions encore à pointer et les dernières transactions du mois. Ouvre le budget pour voir la liste complète."
+3. **Ajouter une transaction**: "Ajoute un revenu, une dépense ou une épargne depuis ce bouton."
+
+#### Budgets
+
+1. **Parcourir les années**: "Passe d'une année à l'autre avec ces onglets."
+2. **Ouvrir ou créer un mois**: "Sélectionne un mois existant pour ouvrir son budget, ou un mois vide pour le créer."
+3. **Ajouter un budget**: "Choisis un mois et un modèle. Les prévisions du modèle sont copiées dans le nouveau budget."
+
+#### Détail d'un budget
+
+1. **Disponible du mois**: "Ce bloc résume les revenus, les dépenses, l'épargne et le report éventuel du mois précédent."
+2. **Prévisions du mois**: "Pointe une prévision quand elle est réalisée. Ouvre une ligne pour la modifier ou consulter ses transactions."
+3. **Ajouter une prévision**: "Ajoute un Revenu, une Dépense ou une Épargne, puis choisis sa fréquence : Récurrent ou Prévu."
+
+#### Modèles
+
+1. **Tes modèles de budget**: "Un modèle regroupe les revenus, dépenses et épargnes que tu veux réutiliser. Ouvre un modèle pour modifier ses prévisions."
+2. **Ajouter un modèle**: "Crée un modèle, puis ajoute les prévisions à reprendre dans tes futurs budgets."
+
+#### Objectifs
+
+1. **Des objectifs à ton rythme**: "Seul le nom est obligatoire. Tu peux ajouter un montant cible, une date de début ou une échéance selon ton besoin. L'option d'épargne mensuelle peut préparer les prévisions associées sans créer de nouveaux budgets."
+2. **Tes objectifs**: "Chaque carte affiche les informations renseignées. Ouvre un objectif pour suivre les prévisions liées et ajuster son plan."
+3. **Nouvel objectif**: "Commence par le nom. Tu pourras compléter le montant, les dates et l'épargne mensuelle maintenant ou plus tard."
+
+### `5)` Verify the complete tour contract
+
+> Cover the reported bug and the shared failure mode without snapshotting every sentence.
+
+1. In `product-tour.service.spec.ts`, mock the Driver.js factory and assert that `drive()` waits for the first page target, receives no missing selector, and is not called after timeout or cancellation.
+2. Assert that the templates tour now contains only the list and add action, that the budget-details add step uses the always-present FAB, and that reduced-motion preference disables Driver.js animation.
+3. In `main-layout.spec.ts`, assert the three budget route mappings and the responsive navigation target.
+4. Run the focused Vitest files, then exercise each page tour manually at desktop and handset widths with loaded, empty, and slow-loading data.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | The regression fails on the current code because `/budget-templates` resolves to `budget-list`; `/budget` and `/budget/:id` remain correct. |
+| 1 | Starting "Découvrir cette page" from `/budget-templates` calls `startPageTour('templates-list')`. |
+| 2 | Driver.js is not created until the first page target exists, and a timeout never marks a tour as seen. |
+| 2 | No selector-based step reaches Driver.js without a matching DOM element. Centered popovers remain only for explicitly elementless introduction steps. |
+| 2 | The template tour has two useful steps; an empty template list cannot fall back on the absent counter. |
+| 2 | The budget-details add step remains anchored even when the budget has no existing prévision. |
+| 2 | `prefers-reduced-motion: reduce` sets Driver.js `animate` to `false`; the default remains animated. |
+| 3 | The navigation step anchors to the desktop rail or the visible handset menu button. |
+| 4 | No tour promises "2 clics", "5 secondes", "30 secondes", "1 clic", or "2 minutes". |
+| 4 | Replayable tours do not tell an existing user to create a "premier" model or goal. |
+| 4 | The goals tour states that only the name is required and does not imply that Pulpe always creates budgets or a monthly plan. |
+| 4 | Budget terminology matches the project vocabulary, including "Pointé", "À pointer", "Récurrent", and "Prévu". |
+| 5 | Focused Vitest suites pass and every supported page tour stays attached at desktop and handset widths. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/phase-3.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/phase-3.md
@@ -1,0 +1,54 @@
+---
+status: done
+---
+
+# Instruction: Generate a complete onboarding horizon
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+frontend/projects/webapp/src/app/core/complete-profile/
+├── profile-setup.service.spec.ts                       ✏️ onboarding horizon regression coverage
+└── profile-setup.service.ts                            ✏️ current period plus twelve future periods
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A["User completes onboarding"] --> B["Current budget is created"]
+  B --> C["Twelve following monthly budgets are created"]
+  C --> D["Dashboard projection opens with no onboarding-created gap"]
+```
+
+## Tasks to do
+
+### `1)` Reproduce the horizon mismatch
+
+> Lock the contract between onboarding generation and the dashboard's future projection.
+
+1. Freeze the profile-setup test clock on a known calendar period.
+2. Assert that onboarding requests the current period plus twelve following periods.
+3. Cover a year boundary so the thirteenth period rolls into the correct year.
+
+### `2)` Include the full future horizon
+
+> Keep the current budget and provide every month consumed by the twelve-month projection.
+
+1. Change the initial generation count from twelve total periods to thirteen total periods.
+2. Document the count locally as one current period plus twelve future periods.
+3. Keep the backend generation formula, dashboard projection range, and missing-month warning unchanged.
+4. Run the focused profile-setup and dashboard upcoming-budget tests.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | The new regression fails on the current code because a count of 12 covers the current period and only eleven future periods. |
+| 1 | A year-boundary case proves that all twelve following periods are requested in order. |
+| 2 | A newly onboarded user receives thirteen consecutive budgets: the active period and the next twelve periods. |
+| 2 | The dashboard still displays exactly twelve future months. |
+| 2 | With untouched onboarding data, none of those twelve future months is reported missing. |
+| 2 | The warning remains available for genuine gaps created later by deletion or incomplete user data. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/plan.md
@@ -1,0 +1,30 @@
+---
+objective: "The signup form preserves its layout, product tours stay anchored and accurate, and onboarding creates a complete twelve-month future projection."
+status: in-progress
+---
+
+# Plan: Fix webapp first-run regressions
+
+## Overview
+
+| Field      | Value |
+| ---------- | ----- |
+| **Goal**   | Fix three independent webapp regressions, including a complete product-tour consistency pass, without hiding valid validation or projection feedback. |
+| **Source** | User reports and screenshots from 2026-07-28 showing the signup overlap, the wrong tour on budget templates, and one missing future budget immediately after onboarding. |
+
+## Phases
+
+| #   | Phase | File |
+| --- | ----- | ---- |
+| 1   | Restore the checklist host layout contract | [`phase-1.md`](./phase-1.md) |
+| 2   | Repair and refresh every product tour | [`phase-2.md`](./phase-2.md) |
+| 3   | Generate a complete onboarding horizon | [`phase-3.md`](./phase-3.md) |
+
+## Resources
+
+| Source | Verified |
+| ------ | -------- |
+| https://angular.dev/guide/components/host-elements | An Angular component renders inside its selector's host element, and the component metadata can bind classes or styles to that host. |
+| https://tailwindcss.com/docs/display | Tailwind's `block` utility gives the host a block-level box that fills the available inline space. |
+| https://tailwindcss.com/docs/margin#adding-space-between-children | `space-y-*` is implemented with child margins; its documented limitations support fixing the child host contract instead of compensating on the following field. |
+| https://driverjs.com/docs/configuration | A tour step whose selector is missing falls back to a centered popover, matching the reported screenshots. |

--- a/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_28_fix_signup_password_criteria_overlap/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "The signup form preserves its layout, product tours stay anchored and accurate, and onboarding creates a complete twelve-month future projection."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Fix webapp first-run regressions

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -57,6 +57,7 @@ All Material components are themed via `mat.<component>-overrides()` mixins in g
 - **Form fields:** `matInput` with floating labels. Custom `--pulpe-input-*` overrides for brand consistency.
 - **Cards:** Plain `<div>` with Tailwind utilities; `mat-card` is used only when its accessibility behaviors are required.
 - **Chips:** TODO — chip vocabulary not yet extracted. The `PulpeChip` atom on iOS does not have a webapp counterpart yet. **Open question:** should we ship a shared web `<pulpe-chip>` Angular component, or rely on `mat-chip` with `--pulpe-*` overrides? Decide during the next extraction pass.
+- **Inline icons:** Use Angular Material's native `<mat-icon inline>` whenever an icon follows surrounding text sizing or is smaller than the default 24 px. Size the glyph with typography utilities; never force matching `width` and `height`, which clips the 24 px Material line box.
 
 ### Webapp-Specific Named Rules
 

--- a/frontend/e2e/tests/features/authentication.spec.ts
+++ b/frontend/e2e/tests/features/authentication.spec.ts
@@ -67,6 +67,44 @@ test.describe('Authentication', () => {
     await expect(submitButton).toBeVisible();
   });
 
+  test('should keep password criteria clear of the confirmation label', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/signup');
+
+    const passwordInput = page.getByTestId('password-input');
+    const confirmPasswordInput = page.getByTestId('confirm-password-input');
+    const lastCriterion = page
+      .getByTestId('password-criteria')
+      .locator('li')
+      .last();
+    const confirmPasswordLabel = confirmPasswordInput
+      .locator('xpath=ancestor::mat-form-field')
+      .locator('.mat-mdc-floating-label');
+
+    const expectNoOverlap = async () => {
+      const [criterionBox, labelBox] = await Promise.all([
+        lastCriterion.boundingBox(),
+        confirmPasswordLabel.boundingBox(),
+      ]);
+
+      expect(criterionBox).not.toBeNull();
+      expect(labelBox).not.toBeNull();
+      expect(criterionBox!.y + criterionBox!.height).toBeLessThanOrEqual(
+        labelBox!.y,
+      );
+    };
+
+    await passwordInput.fill('abc');
+    await confirmPasswordInput.focus();
+    await expectNoOverlap();
+
+    await passwordInput.fill('Password1');
+    await confirmPasswordInput.fill('Password1');
+    await expectNoOverlap();
+  });
+
   test('should maintain session after refresh', async ({
     authenticatedPage,
   }) => {

--- a/frontend/e2e/tests/features/authentication.spec.ts
+++ b/frontend/e2e/tests/features/authentication.spec.ts
@@ -105,6 +105,31 @@ test.describe('Authentication', () => {
     await expectNoOverlap();
   });
 
+  test('should keep compact password criterion icons unclipped', async ({
+    page,
+  }) => {
+    await page.goto('/signup');
+
+    const icons = page.getByTestId('password-criteria').locator('mat-icon');
+    await expect(icons).toHaveCount(3);
+
+    const layouts = await icons.evaluateAll((elements) =>
+      elements.map((element) => {
+        const style = getComputedStyle(element);
+        return {
+          height: style.height,
+          isInline: element.classList.contains('mat-icon-inline'),
+          lineHeight: style.lineHeight,
+        };
+      }),
+    );
+
+    for (const layout of layouts) {
+      expect(layout.isInline).toBe(true);
+      expect(layout.lineHeight).toBe(layout.height);
+    }
+  });
+
   test('should maintain session after refresh', async ({
     authenticatedPage,
   }) => {

--- a/frontend/e2e/tests/features/product-tour-accessibility.spec.ts
+++ b/frontend/e2e/tests/features/product-tour-accessibility.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '../../fixtures/test-fixtures';
+
+test.describe('Product tour accessibility', () => {
+  test.beforeEach(async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/dashboard');
+    await expect(
+      authenticatedPage.getByTestId('dashboard-page'),
+    ).toBeVisible();
+  });
+
+  test('should expose dialog semantics and contain keyboard focus', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.emulateMedia({ reducedMotion: 'reduce' });
+    const menuTrigger = authenticatedPage.getByTestId('user-menu-trigger');
+    await menuTrigger.focus();
+    await authenticatedPage.keyboard.press('Enter');
+    await authenticatedPage.keyboard.press('ArrowDown');
+    await authenticatedPage.keyboard.press('ArrowDown');
+    await expect(
+      authenticatedPage.getByTestId('page-tour-button'),
+    ).toBeFocused();
+    await authenticatedPage.keyboard.press('Enter');
+
+    const dialog = authenticatedPage.getByRole('dialog');
+    const closeButton = dialog.getByRole('button', { name: 'Fermer' });
+    await expect(dialog).toHaveAccessibleName("Ton mois en un coup d'œil");
+    await expect(dialog).toHaveAccessibleDescription(/Commence ici/);
+    await expect(dialog).toContainText('Étape 1 sur 3');
+    await expect(closeButton).toBeFocused();
+    await expect
+      .poll(() =>
+        closeButton.evaluate(
+          (button) => getComputedStyle(button).outlineStyle,
+        ),
+      )
+      .not.toBe('none');
+
+    for (const key of ['Shift+Tab', 'Tab']) {
+      await authenticatedPage.keyboard.press(key);
+      expect(
+        await authenticatedPage.evaluate(() => {
+          const focused = document.activeElement;
+          const activeTarget = document.querySelector(
+            '.driver-active-element',
+          );
+          const popover = document.querySelector('[role="dialog"]');
+          return (
+            !!focused &&
+            (!!popover?.contains(focused) || !!activeTarget?.contains(focused))
+          );
+        }),
+      ).toBe(true);
+    }
+
+    await authenticatedPage.keyboard.press('ArrowRight');
+    await expect(dialog).toHaveAccessibleName('Commence par ce qui bouge');
+    await authenticatedPage.keyboard.press('ArrowLeft');
+    await expect(dialog).toHaveAccessibleName("Ton mois en un coup d'œil");
+    await authenticatedPage.keyboard.press('Escape');
+
+    await expect(dialog).not.toBeVisible();
+    await expect(menuTrigger).toBeFocused();
+  });
+
+  test('should complete the tour with the keyboard and restore focus', async ({
+    authenticatedPage,
+  }) => {
+    const menuTrigger = authenticatedPage.getByTestId('user-menu-trigger');
+    await menuTrigger.focus();
+    await authenticatedPage.keyboard.press('Enter');
+    await authenticatedPage.keyboard.press('ArrowDown');
+    await authenticatedPage.keyboard.press('ArrowDown');
+    await authenticatedPage.keyboard.press('Enter');
+
+    const dialog = authenticatedPage.getByRole('dialog');
+    for (const [progress, buttonName] of [
+      ['Étape 1 sur 3', 'Suivant'],
+      ['Étape 2 sur 3', 'Suivant'],
+      ['Étape 3 sur 3', 'Terminer'],
+    ] as const) {
+      await expect(dialog).toContainText(progress);
+      await dialog.evaluate(async (element) => {
+        await Promise.all(
+          element
+            .getAnimations({ subtree: true })
+            .map((animation) => animation.finished),
+        );
+      });
+      const button = dialog.getByRole('button', { name: buttonName });
+      await button.focus();
+      await expect(button).toBeFocused();
+      await authenticatedPage.keyboard.press('Enter');
+    }
+
+    await expect(dialog).not.toBeVisible();
+    await expect(menuTrigger).toBeFocused();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "@tailwindcss/postcss": "^4.1.17",
     "chart.js": "^4.5.1",
     "date-fns": "^4.1.0",
-    "driver.js": "^1.4.0",
+    "driver.js": "^1.8.0",
     "lottie-web": "^5.13.0",
     "ng2-charts": "^8.0.0",
     "ngx-lottie": "^22.0.0",

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -48,7 +48,7 @@
     "settings": "Paramètres",
     "about": "À propos",
     "newFeatures": "Nouveautés",
-    "discoverPage": "Découvrir cette page",
+    "discoverPage": "Aide sur cette page",
     "dashboardTooltip": "Ta vue d'ensemble du mois",
     "budgetsTooltip": "Planifie tous tes mois",
     "templatesTooltip": "Prépare tes bases mensuelles",

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -55,6 +55,73 @@
     "savingsGoalsTooltip": "Suis tes objectifs d'épargne",
     "designSystem": "Design System"
   },
+  "productTour": {
+    "controls": {
+      "progress": "Étape {{current}} sur {{total}}",
+      "next": "Suivant",
+      "previous": "Précédent",
+      "done": "Terminer",
+      "close": "Fermer"
+    },
+    "intro": {
+      "hero": {
+        "title": "Ton mois en un coup d'œil",
+        "description": "<p>Commence ici : <strong>Disponible à dépenser</strong> tient compte de tes revenus, dépenses et épargnes. Ouvre ce bloc pour ajuster le budget du mois.</p>"
+      },
+      "tracking": {
+        "title": "Commence par ce qui bouge",
+        "description": "<p><strong>À pointer</strong> signifie que le mouvement est encore prévu. Passe-le à <strong>Pointé</strong> dès qu'il se réalise.</p>"
+      },
+      "navigation": {
+        "title": "Retrouve chaque besoin",
+        "description": "<p><strong>Budgets</strong> pour tes mois, <strong>Modèles</strong> pour préparer ce qui revient, <strong>Objectifs</strong> pour tes projets d'épargne. Tu peux revoir l'aide de chaque écran depuis ton menu.</p>"
+      }
+    },
+    "budgetList": {
+      "calendar": {
+        "title": "Choisis le mois à gérer",
+        "description": "<p>Ouvre un budget existant pour le suivre. Sélectionne un mois vide pour le préparer.</p>"
+      },
+      "create": {
+        "title": "Prépare un nouveau mois",
+        "description": "<p>Choisis un mois et, si tu veux, un modèle. Ses prévisions seront copiées dans le nouveau budget.</p>"
+      }
+    },
+    "budgetDetails": {
+      "overview": {
+        "title": "Vérifie le cap du mois",
+        "description": "<p>Ce bloc résume les revenus, les dépenses, l'épargne et le report éventuel du mois précédent.</p>"
+      },
+      "tracking": {
+        "title": "Suis ce qui se réalise",
+        "description": "<p><strong>À pointer</strong> signifie que le mouvement est encore prévu. Passe-le à <strong>Pointé</strong> quand il se réalise, puis ouvre la ligne pour voir ses transactions.</p>"
+      },
+      "create": {
+        "title": "Ajoute une prévision",
+        "description": "<p>Choisis <strong>Récurrent</strong> pour ce qui revient ou <strong>Prévu</strong> pour un mouvement ponctuel.</p>"
+      }
+    },
+    "templatesList": {
+      "list": {
+        "title": "Prépare ce qui revient",
+        "description": "<p>Un modèle regroupe les revenus, dépenses et épargnes que tu veux réutiliser. Ouvre un modèle pour modifier ses prévisions.</p>"
+      },
+      "create": {
+        "title": "Crée ton prochain modèle",
+        "description": "<p>Crée un modèle, puis ajoute les prévisions à reprendre dans tes futurs budgets.</p>"
+      }
+    },
+    "savingsGoals": {
+      "list": {
+        "title": "Suis un projet d'épargne",
+        "description": "<p>Ouvre un objectif pour voir sa progression, les prévisions liées et ajuster ton plan.</p>"
+      },
+      "create": {
+        "title": "Commence simplement",
+        "description": "<p>Seul le nom est obligatoire. Ajoute le montant, les dates et l'épargne mensuelle maintenant ou plus tard.</p>"
+      }
+    }
+  },
   "auth": {
     "oauthLoading": "Connexion en cours...",
     "continueWithGoogle": "Continuer avec Google",
@@ -802,6 +869,7 @@
     "lineDeleteSuccess": "Prévision supprimée",
     "selectAriaLabel": "Sélectionner {{ name }}",
     "defaultTag": "Par défaut",
+    "details": "Détails",
     "calculating": "Calcul en cours...",
     "analyzingData": "Analyse de vos données financières",
     "monthlyIncomes": "Revenus mensuels",

--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.spec.ts
@@ -185,7 +185,7 @@ describe('ProfileSetupService', () => {
         expect.objectContaining({
           startMonth: 1,
           startYear: 2026,
-          count: 12,
+          count: 13,
         }),
       );
     });
@@ -204,7 +204,7 @@ describe('ProfileSetupService', () => {
         expect.objectContaining({
           startMonth: 2,
           startYear: 2026,
-          count: 12,
+          count: 13,
         }),
       );
     });
@@ -227,7 +227,7 @@ describe('ProfileSetupService', () => {
       ).toHaveBeenCalledWith(['budget', 'list'], expect.any(Function));
     });
 
-    it('should handle year boundary correctly', async () => {
+    it('should request the current period and twelve future periods across a year boundary', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-01-02'));
 
@@ -238,13 +238,26 @@ describe('ProfileSetupService', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockBudgetApi.generateBudgets$).toHaveBeenCalledWith(
-        expect.objectContaining({
-          startMonth: 12,
-          startYear: 2025,
-          count: 12,
-        }),
-      );
+      const request = mockBudgetApi.generateBudgets$.mock.calls[0]![0] as {
+        startMonth: number;
+        startYear: number;
+        count: number;
+      };
+      const periods = Array.from({ length: request.count }, (_, offset) => {
+        const monthIndex = request.startMonth - 1 + offset;
+        return {
+          month: (monthIndex % 12) + 1,
+          year: request.startYear + Math.floor(monthIndex / 12),
+        };
+      });
+
+      expect(periods).toEqual([
+        { month: 12, year: 2025 },
+        ...Array.from({ length: 12 }, (_, index) => ({
+          month: index + 1,
+          year: 2026,
+        })),
+      ]);
     });
 
     it('should pass templateId from template creation response', async () => {

--- a/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.ts
+++ b/frontend/projects/webapp/src/app/core/complete-profile/profile-setup.service.ts
@@ -17,7 +17,8 @@ import {
   type ProfileSetupResult,
 } from './profile-setup.types';
 
-const INITIAL_BUDGET_MONTHS = 12;
+// Current budget period plus the twelve periods shown by the projection.
+const INITIAL_BUDGET_MONTHS = 13;
 
 @Service()
 export class ProfileSetupService {

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.css
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.css
@@ -245,6 +245,12 @@ body.driver-active {
   box-shadow: none !important;
 }
 
+.driver-popover button:focus-visible,
+.driver-active-element:focus-visible {
+  outline: 2px solid var(--mat-sys-primary) !important;
+  outline-offset: 2px !important;
+}
+
 /* Override Driver.js overflow:hidden only for flex containers with buttons
    The original rule breaks button layouts in flex containers */
 .flex:has(> button.driver-active-element) {

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.css
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.css
@@ -22,9 +22,11 @@ body.driver-active {
 .driver-popover {
   background-color: var(--mat-sys-surface-container-high) !important;
   color: var(--mat-sys-on-surface) !important;
-  border-radius: 28px !important;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3) !important;
+  border-radius: 16px !important;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.24) !important;
   max-width: 400px !important;
+  max-height: calc(100vh - 32px) !important;
+  overflow-y: auto !important;
   padding: 24px !important;
 }
 
@@ -104,7 +106,7 @@ body.driver-active {
   border: none !important;
   border-radius: var(--mat-sys-corner-full) !important;
   padding: 10px 24px !important;
-  min-height: 40px !important;
+  min-height: 44px !important;
   font-family: var(--mat-sys-label-large-font) !important;
   font-size: var(--mat-sys-label-large-size) !important;
   font-weight: 500 !important;
@@ -155,7 +157,7 @@ body.driver-active {
   border: none !important;
   border-radius: var(--mat-sys-corner-full) !important;
   padding: 10px 16px !important;
-  min-height: 40px !important;
+  min-height: 44px !important;
   font-family: var(--mat-sys-label-large-font) !important;
   font-size: var(--mat-sys-label-large-size) !important;
   font-weight: 500 !important;
@@ -194,7 +196,7 @@ body.driver-active {
   border: none !important;
   border-radius: var(--mat-sys-corner-full) !important;
   padding: 10px 16px !important;
-  min-height: 40px !important;
+  min-height: 44px !important;
   font-family: var(--mat-sys-label-large-font) !important;
   font-size: var(--mat-sys-label-large-size) !important;
   font-weight: 500 !important;
@@ -216,10 +218,10 @@ body.driver-active {
 /* Close button - positioned in top right corner */
 .driver-popover-close-btn {
   position: absolute !important;
-  top: 16px !important;
-  right: 16px !important;
-  width: 32px !important;
-  height: 32px !important;
+  top: 10px !important;
+  right: 10px !important;
+  width: 44px !important;
+  height: 44px !important;
   border-radius: 50% !important;
   display: flex !important;
   align-items: center !important;

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
@@ -4,6 +4,24 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { ProductTourService, type TourPageId } from './product-tour.service';
 import { AuthStore } from '@core/auth';
 
+const driverMocks = vi.hoisted(() => {
+  const instance = {
+    setConfig: vi.fn(),
+    setSteps: vi.fn(),
+    drive: vi.fn(),
+    destroy: vi.fn(),
+  };
+
+  return {
+    factory: vi.fn(() => instance),
+    instance,
+  };
+});
+
+vi.mock('driver.js', () => ({
+  driver: driverMocks.factory,
+}));
+
 /**
  * Generate a tour storage key for testing.
  * Mirrors the internal logic of ProductTourService.
@@ -30,6 +48,8 @@ describe('ProductTourService', () => {
 
   beforeEach(() => {
     localStorage.clear();
+    document.body.replaceChildren();
+    vi.clearAllMocks();
     mockCurrentUser = { id: 'test-user-123' };
 
     const mockAuthStore = {
@@ -48,7 +68,11 @@ describe('ProductTourService', () => {
   });
 
   afterEach(() => {
+    service.cancelActiveTour();
     localStorage.clear();
+    document.body.replaceChildren();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -181,12 +205,134 @@ describe('ProductTourService', () => {
     });
 
     it('should prevent concurrent tours (second call is ignored)', () => {
-      // GIVEN: A tour is already running
+      setVersionedValue(getTourKey('intro'), 'true');
+      const hero = document.createElement('div');
+      hero.dataset['tour'] = 'dashboard-hero';
+      document.body.append(hero);
+
+      service.startPageTour('dashboard');
+      service.startPageTour('budget-list');
+
+      expect(driverMocks.factory).toHaveBeenCalledOnce();
+    });
+
+    it('waits for the first page target and removes missing later targets', async () => {
+      setVersionedValue(getTourKey('intro'), 'true');
+
       service.startPageTour('dashboard');
 
-      // WHEN: Another tour is started
-      // THEN: No error occurs (call is silently ignored)
-      expect(() => service.startPageTour('budget-list')).not.toThrow();
+      expect(driverMocks.factory).not.toHaveBeenCalled();
+
+      const hero = document.createElement('div');
+      hero.dataset['tour'] = 'dashboard-hero';
+      document.body.append(hero);
+      await vi.waitFor(() =>
+        expect(driverMocks.instance.drive).toHaveBeenCalledOnce(),
+      );
+
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+      expect(steps).toHaveLength(1);
+      expect(
+        steps.every(
+          (step: { element?: string }) =>
+            typeof step.element !== 'string' ||
+            document.querySelector(step.element),
+        ),
+      ).toBe(true);
+    });
+
+    it('does not start or mark a tour after the target timeout', () => {
+      vi.useFakeTimers();
+
+      service.startPageTour('dashboard');
+      vi.advanceTimersByTime(10_000);
+
+      expect(driverMocks.factory).not.toHaveBeenCalled();
+      expect(service.hasSeenIntro()).toBe(false);
+      expect(service.hasSeenPageTour('dashboard')).toBe(false);
+    });
+
+    it('replaces a pending tour with the latest page request', async () => {
+      setVersionedValue(getTourKey('intro'), 'true');
+
+      service.startPageTour('dashboard');
+      service.startPageTour('budget-list');
+
+      const dashboardHero = document.createElement('div');
+      dashboardHero.dataset['tour'] = 'dashboard-hero';
+      document.body.append(dashboardHero);
+      await Promise.resolve();
+      expect(driverMocks.factory).not.toHaveBeenCalled();
+
+      const yearTabs = document.createElement('div');
+      yearTabs.dataset['tour'] = 'year-tabs';
+      yearTabs.append(document.createElement('mat-tab-header'));
+      document.body.append(yearTabs);
+      await vi.waitFor(() =>
+        expect(driverMocks.instance.drive).toHaveBeenCalledOnce(),
+      );
+    });
+
+    it('does not start a pending tour after cancellation', async () => {
+      setVersionedValue(getTourKey('intro'), 'true');
+
+      service.startPageTour('dashboard');
+      service.cancelActiveTour();
+
+      const hero = document.createElement('div');
+      hero.dataset['tour'] = 'dashboard-hero';
+      document.body.append(hero);
+      await Promise.resolve();
+
+      expect(driverMocks.factory).not.toHaveBeenCalled();
+      expect(service.hasSeenPageTour('dashboard')).toBe(false);
+    });
+
+    it('keeps only the template list and add action', () => {
+      setVersionedValue(getTourKey('intro'), 'true');
+      document.body.innerHTML = `
+        <div data-tour="templates-list"></div>
+        <button data-tour="template-counter"></button>
+        <button data-tour="create-template"></button>
+      `;
+
+      service.startPageTour('templates-list');
+
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+      expect(steps.map((step: { element?: string }) => step.element)).toEqual([
+        '[data-tour="templates-list"]',
+        '[data-tour="create-template"]',
+      ]);
+    });
+
+    it('targets the always-present add budget line FAB', () => {
+      setVersionedValue(getTourKey('intro'), 'true');
+      document.body.innerHTML = `
+        <div data-tour="financial-overview"></div>
+        <div data-tour="budget-table"></div>
+        <button data-testid="add-budget-line-fab"></button>
+      `;
+
+      service.startPageTour('budget-details');
+
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+      expect(steps.at(-1)?.element).toBe('[data-testid="add-budget-line-fab"]');
+    });
+
+    it('disables animation when reduced motion is preferred', () => {
+      vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+      setVersionedValue(getTourKey('intro'), 'true');
+      document.body.innerHTML = `
+        <div data-tour="dashboard-hero"></div>
+        <div data-tour="dashboard-lists"></div>
+        <button data-tour="add-transaction-fab"></button>
+      `;
+
+      service.startPageTour('dashboard');
+
+      expect(driverMocks.instance.setConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ animate: false }),
+      );
     });
   });
 

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
@@ -65,6 +65,7 @@ function callDriverHook(
     config,
     state: {},
     driver: driverMocks.instance as unknown as Driver,
+    index: undefined,
   });
 }
 

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ProductTourService, type TourPageId } from './product-tour.service';
 import { AuthStore } from '@core/auth';
+import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import type { Config, DriveStep, Driver } from 'driver.js';
 
 const driverMocks = vi.hoisted(() => {
@@ -86,6 +87,7 @@ describe('ProductTourService', () => {
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
+        ...provideTranslocoForTest(),
         ProductTourService,
         { provide: AuthStore, useValue: mockAuthStore },
       ],
@@ -379,6 +381,45 @@ describe('ProductTourService', () => {
       const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
       expect(steps).toHaveLength(2);
       expect(steps.every((step: DriveStep) => !!step.element)).toBe(true);
+    });
+
+    it('uses translated controls and explains pointing statuses', () => {
+      document.body.innerHTML = `
+        <div data-tour="dashboard-hero"></div>
+        <div data-tour="dashboard-lists"></div>
+        <nav data-tour="navigation"></nav>
+      `;
+
+      service.startPageTour('dashboard');
+
+      const config = getDriverConfig();
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+      const renderedTour = JSON.stringify({ config, steps });
+      expect(config).toMatchObject({
+        progressText: 'Étape {{current}} sur {{total}}',
+        nextBtnText: 'Suivant',
+        prevBtnText: 'Précédent',
+        doneBtnText: 'Terminer',
+      });
+      expect(renderedTour).toContain('Pointé');
+      expect(renderedTour).toContain('À pointer');
+      expect(renderedTour).not.toMatch(/productTour\./);
+    });
+
+    it('explains the recurrent and planned budget line vocabulary', () => {
+      document.body.innerHTML = `
+        <div data-tour="financial-overview"></div>
+        <div data-tour="budget-table"></div>
+        <button data-testid="add-budget-line-fab"></button>
+      `;
+
+      service.startPageTour('budget-details');
+
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+      const renderedSteps = JSON.stringify(steps);
+      expect(renderedSteps).toContain('Récurrent');
+      expect(renderedSteps).toContain('Prévu');
+      expect(renderedSteps).not.toMatch(/productTour\./);
     });
   });
 

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ProductTourService, type TourPageId } from './product-tour.service';
 import { AuthStore } from '@core/auth';
+import type { Config, DriveStep, Driver } from 'driver.js';
 
 const driverMocks = vi.hoisted(() => {
   const instance = {
@@ -10,6 +11,8 @@ const driverMocks = vi.hoisted(() => {
     setSteps: vi.fn(),
     drive: vi.fn(),
     destroy: vi.fn(),
+    isLastStep: vi.fn(),
+    moveNext: vi.fn(),
   };
 
   return {
@@ -40,6 +43,29 @@ function setVersionedValue(key: string, value: string): void {
     updatedAt: new Date().toISOString(),
   };
   localStorage.setItem(key, JSON.stringify(entry));
+}
+
+function getStoredTourState(tourId: string): string | null {
+  const raw = localStorage.getItem(getTourKey(tourId));
+  if (!raw) return null;
+
+  return JSON.parse(raw).data as string;
+}
+
+function getDriverConfig(): Config {
+  return driverMocks.instance.setConfig.mock.calls.at(-1)![0] as Config;
+}
+
+function callDriverHook(
+  hook: Config['onNextClick'] | Config['onDestroyed'],
+  step: DriveStep,
+): void {
+  const config = getDriverConfig();
+  hook?.(undefined, step, {
+    config,
+    state: {},
+    driver: driverMocks.instance as unknown as Driver,
+  });
 }
 
 describe('ProductTourService', () => {
@@ -87,7 +113,16 @@ describe('ProductTourService', () => {
       expect(service.hasSeenIntro()).toBe(true);
     });
 
-    it('should return false for non-true values', () => {
+    it.each(['completed', 'dismissed'])(
+      'should treat %s as a seen intro',
+      (state) => {
+        setVersionedValue(getTourKey('intro'), state);
+
+        expect(service.hasSeenIntro()).toBe(true);
+      },
+    );
+
+    it('should return false for unknown values', () => {
       setVersionedValue(getTourKey('intro'), 'false');
 
       expect(service.hasSeenIntro()).toBe(false);
@@ -264,10 +299,9 @@ describe('ProductTourService', () => {
       await Promise.resolve();
       expect(driverMocks.factory).not.toHaveBeenCalled();
 
-      const yearTabs = document.createElement('div');
-      yearTabs.dataset['tour'] = 'year-tabs';
-      yearTabs.append(document.createElement('mat-tab-header'));
-      document.body.append(yearTabs);
+      const calendar = document.createElement('div');
+      calendar.dataset['tour'] = 'calendar-grid';
+      document.body.append(calendar);
       await vi.waitFor(() =>
         expect(driverMocks.instance.drive).toHaveBeenCalledOnce(),
       );
@@ -289,7 +323,6 @@ describe('ProductTourService', () => {
     });
 
     it('keeps only the template list and add action', () => {
-      setVersionedValue(getTourKey('intro'), 'true');
       document.body.innerHTML = `
         <div data-tour="templates-list"></div>
         <button data-tour="template-counter"></button>
@@ -306,7 +339,6 @@ describe('ProductTourService', () => {
     });
 
     it('targets the always-present add budget line FAB', () => {
-      setVersionedValue(getTourKey('intro'), 'true');
       document.body.innerHTML = `
         <div data-tour="financial-overview"></div>
         <div data-tour="budget-table"></div>
@@ -333,6 +365,78 @@ describe('ProductTourService', () => {
       expect(driverMocks.instance.setConfig).toHaveBeenCalledWith(
         expect.objectContaining({ animate: false }),
       );
+    });
+
+    it('does not prepend global onboarding to contextual page help', () => {
+      document.body.innerHTML = `
+        <div data-tour="templates-list"></div>
+        <button data-tour="create-template"></button>
+      `;
+
+      service.startPageTour('templates-list');
+
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+      expect(steps).toHaveLength(2);
+      expect(steps.every((step: DriveStep) => !!step.element)).toBe(true);
+    });
+  });
+
+  describe('startFirstRunTour', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div data-tour="dashboard-hero"></div>
+        <div data-tour="dashboard-lists"></div>
+        <nav data-tour="navigation"></nav>
+      `;
+    });
+
+    it('starts one short orientation from the dashboard', () => {
+      service.startFirstRunTour();
+
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+      expect(steps.map((step: DriveStep) => step.element)).toEqual([
+        '[data-tour="dashboard-hero"]',
+        '[data-tour="dashboard-lists"]',
+        '[data-tour="navigation"]',
+      ]);
+    });
+
+    it('does not relaunch after the user dismissed it', () => {
+      setVersionedValue(getTourKey('intro'), 'dismissed');
+
+      service.startFirstRunTour();
+
+      expect(driverMocks.factory).not.toHaveBeenCalled();
+    });
+
+    it('stores dismissal separately from completion', () => {
+      service.startFirstRunTour();
+
+      const config = getDriverConfig();
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+      callDriverHook(config.onDestroyed, steps[0]);
+
+      expect(getStoredTourState('intro')).toBe('dismissed');
+      expect(service.hasSeenIntro()).toBe(true);
+    });
+
+    it('marks completion only after advancing from the last step', () => {
+      service.startFirstRunTour();
+
+      const config = getDriverConfig();
+      const steps = driverMocks.instance.setSteps.mock.calls[0]![0];
+
+      driverMocks.instance.isLastStep.mockReturnValue(false);
+      callDriverHook(config.onNextClick, steps[0]);
+      expect(driverMocks.instance.moveNext).toHaveBeenCalledOnce();
+      expect(getStoredTourState('intro')).toBeNull();
+
+      driverMocks.instance.isLastStep.mockReturnValue(true);
+      callDriverHook(config.onNextClick, steps.at(-1));
+      callDriverHook(config.onDestroyed, steps.at(-1));
+
+      expect(driverMocks.instance.destroy).toHaveBeenCalledOnce();
+      expect(getStoredTourState('intro')).toBe('completed');
     });
   });
 

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -11,11 +11,8 @@ import { AuthStore } from '@core/auth/auth-store';
 import { StorageService, type StorageKey } from '@core/storage';
 import { driver, type Config, type Driver, type DriveStep } from 'driver.js';
 
-/**
- * Selectors for layout containers that need scroll reset after tour.
- * Driver.js scrollIntoView() affects all scrollable ancestors.
- */
-const SCROLL_RESET_SELECTORS = [
+/** Scrollable layout containers affected by Driver.js scrollIntoView(). */
+const SCROLL_CONTAINER_SELECTORS = [
   '[data-testid="page-content"]',
   '[data-testid="main-content"] > div',
 ] as const;
@@ -38,6 +35,7 @@ export type TourPageId =
   | 'savings-goals';
 
 export type TourId = 'intro' | TourPageId;
+type TourState = 'completed' | 'dismissed';
 
 /**
  * Delay before starting tour to ensure DOM is fully rendered
@@ -73,6 +71,8 @@ export class ProductTourService {
     timeoutId: number;
   } | null = null;
 
+  readonly #scrollPositions = new Map<HTMLElement, number>();
+
   /**
    * Check if user is authenticated.
    * Tours require authentication to start because they reference app content
@@ -95,34 +95,23 @@ export class ProductTourService {
    * Check if user has seen the intro (welcome + navigation)
    */
   hasSeenIntro(): boolean {
-    return (
-      this.#storageService.getString(this.#getTourKey(TOUR_IDS.intro)) ===
-      'true'
-    );
+    return this.#hasSeenTour(TOUR_IDS.intro);
   }
 
   /**
    * Check if user has seen a specific page tour
    */
   hasSeenPageTour(pageId: TourPageId): boolean {
-    return (
-      this.#storageService.getString(this.#getTourKey(TOUR_IDS[pageId])) ===
-      'true'
-    );
+    return this.#hasSeenTour(TOUR_IDS[pageId]);
   }
 
-  /**
-   * Mark intro as completed
-   */
-  #markIntroCompleted(): void {
-    this.#storageService.setString(this.#getTourKey(TOUR_IDS.intro), 'true');
+  #hasSeenTour(tourId: TourId): boolean {
+    const state = this.#storageService.getString(this.#getTourKey(tourId));
+    return state === 'true' || state === 'completed' || state === 'dismissed';
   }
 
-  /**
-   * Mark a page tour as completed
-   */
-  #markPageTourCompleted(pageId: TourPageId): void {
-    this.#storageService.setString(this.#getTourKey(TOUR_IDS[pageId]), 'true');
+  #markTour(tourId: TourId, state: TourState): void {
+    this.#storageService.setString(this.#getTourKey(tourId), state);
   }
 
   /**
@@ -163,7 +152,7 @@ export class ProductTourService {
   #cleanupDriverArtifacts(): void {
     setTimeout(() => {
       this.#removeDriverClasses();
-      this.#resetScrollPositions();
+      this.#restoreScrollPositions();
     }, 0);
   }
 
@@ -176,30 +165,45 @@ export class ProductTourService {
     this.#document.body.classList.remove(...DRIVER_BODY_CLASSES);
   }
 
-  #resetScrollPositions(): void {
-    for (const selector of SCROLL_RESET_SELECTORS) {
+  #rememberScrollPositions(): void {
+    this.#scrollPositions.clear();
+    for (const selector of SCROLL_CONTAINER_SELECTORS) {
       const element = this.#document.querySelector<HTMLElement>(selector);
       if (element) {
-        element.scrollTop = 0;
+        this.#scrollPositions.set(element, element.scrollTop);
       }
     }
   }
 
-  /**
-   * Start a page-specific tour
-   * Includes intro steps if user hasn't seen them yet
-   * Does nothing if user is not authenticated or a tour is already active
-   */
+  #restoreScrollPositions(): void {
+    this.#scrollPositions.forEach((scrollTop, element) => {
+      element.scrollTop = scrollTop;
+    });
+    this.#scrollPositions.clear();
+  }
+
+  /** Start the one-time orientation from the first dashboard visit. */
+  startFirstRunTour(): void {
+    if (!this.isAuthenticated() || this.hasSeenIntro() || this.#activeDriver) {
+      return;
+    }
+
+    this.#prepareTour(TOUR_IDS.intro, this.#firstRunSteps);
+  }
+
+  /** Start contextual, replayable help for the current page. */
   startPageTour(pageId: TourPageId): void {
     if (!this.isAuthenticated() || this.#activeDriver) {
       return;
     }
 
+    this.#prepareTour(TOUR_IDS[pageId], this.#getPageSteps(pageId));
+  }
+
+  #prepareTour(tourId: TourId, steps: DriveStep[]): void {
     this.#cancelPendingTour();
 
-    const includeIntro = !this.hasSeenIntro();
-    const steps = this.#getStepsForPage(pageId, includeIntro);
-    const firstPageTarget = this.#getPageSteps(pageId).find(
+    const firstPageTarget = steps.find(
       (step) => typeof step.element === 'string',
     )?.element;
 
@@ -214,7 +218,7 @@ export class ProductTourService {
         if (!this.#document.querySelector(firstPageTarget)) return;
 
         this.#cancelPendingTour();
-        this.#startTour(pageId, includeIntro, steps);
+        this.#startTour(tourId, steps);
       });
       const timeoutId = view.setTimeout(
         () => this.#cancelPendingTour(),
@@ -226,14 +230,10 @@ export class ProductTourService {
       return;
     }
 
-    this.#startTour(pageId, includeIntro, steps);
+    this.#startTour(tourId, steps);
   }
 
-  #startTour(
-    pageId: TourPageId,
-    includeIntro: boolean,
-    steps: DriveStep[],
-  ): void {
+  #startTour(tourId: TourId, steps: DriveStep[]): void {
     const availableSteps = steps.filter(
       (step) =>
         typeof step.element !== 'string' ||
@@ -243,6 +243,8 @@ export class ProductTourService {
 
     const tourDriver = driver();
     this.#activeDriver = tourDriver;
+    this.#rememberScrollPositions();
+    let completed = false;
 
     const driverConfig: Config = {
       showProgress: true,
@@ -253,7 +255,7 @@ export class ProductTourService {
       doneBtnText: 'Terminer',
       allowClose: true,
       overlayColor: '#000',
-      overlayOpacity: 0.75,
+      overlayOpacity: 0.55,
       smoothScroll: true,
       animate: !this.#document.defaultView?.matchMedia?.(
         '(prefers-reduced-motion: reduce)',
@@ -262,28 +264,28 @@ export class ProductTourService {
       stagePadding: 10,
       stageRadius: 8,
       popoverOffset: 16,
+      onPopoverRender: (popover) => {
+        popover.closeButton.setAttribute('aria-label', 'Fermer');
+      },
+      onNextClick: (_element, _step, { driver: currentDriver }) => {
+        if (currentDriver.isLastStep()) {
+          completed = true;
+          currentDriver.destroy();
+          return;
+        }
+
+        currentDriver.moveNext();
+      },
       onDestroyed: () => {
         this.#activeDriver = null;
         this.#cleanupDriverArtifacts();
-        if (includeIntro) {
-          this.#markIntroCompleted();
-        }
-        this.#markPageTourCompleted(pageId);
+        this.#markTour(tourId, completed ? 'completed' : 'dismissed');
       },
     };
 
     tourDriver.setConfig(driverConfig);
     tourDriver.setSteps(availableSteps);
     tourDriver.drive();
-  }
-
-  /**
-   * Get steps for a specific page, optionally including intro
-   */
-  #getStepsForPage(pageId: TourPageId, includeIntro: boolean): DriveStep[] {
-    const introSteps = includeIntro ? this.#introSteps : [];
-    const pageSteps = this.#getPageSteps(pageId);
-    return [...introSteps, ...pageSteps];
   }
 
   /**
@@ -312,40 +314,13 @@ export class ProductTourService {
   // Step Definitions
   // ============================================
 
-  readonly #introSteps: DriveStep[] = [
-    {
-      popover: {
-        title: 'Bienvenue dans Pulpe',
-        description: `
-          <p>Pulpe t'aide à préparer tes mois et à suivre tes revenus, dépenses et épargnes. Voici les repères utiles pour commencer.</p>
-        `,
-      },
-    },
-    {
-      element: '[data-tour="navigation"]',
-      popover: {
-        title: 'Les espaces de Pulpe',
-        description: `
-          <ul>
-            <li><strong>Tableau de bord</strong> : suis le mois en cours et pointe tes prévisions.</li>
-            <li><strong>Budgets</strong> : consulte, crée et ajuste chaque mois.</li>
-            <li><strong>Modèles</strong> : prépare des revenus, dépenses et épargnes à réutiliser.</li>
-            <li><strong>Objectifs</strong> : suis tes projets d'épargne et les prévisions qui leur sont liées.</li>
-          </ul>
-        `,
-        side: 'right',
-        align: 'start',
-      },
-    },
-  ];
-
-  readonly #dashboardSteps: DriveStep[] = [
+  readonly #firstRunSteps: DriveStep[] = [
     {
       element: '[data-tour="dashboard-hero"]',
       popover: {
-        title: 'Disponible à dépenser',
+        title: "Ton mois en un coup d'œil",
         description: `
-          <p>Ce montant résume ce qu'il reste pour le mois en tenant compte des revenus, dépenses et épargnes. Ouvre ce bloc pour accéder au budget détaillé.</p>
+          <p>Commence ici : <strong>Disponible à dépenser</strong> tient compte de tes revenus, dépenses et épargnes. Ouvre ce bloc pour ajuster le budget du mois.</p>
         `,
         side: 'bottom',
         align: 'center',
@@ -354,45 +329,36 @@ export class ProductTourService {
     {
       element: '[data-tour="dashboard-lists"]',
       popover: {
-        title: 'Prévisions à pointer et transactions',
+        title: 'Commence par ce qui bouge',
         description: `
-          <p>Retrouve ici les prévisions encore à pointer et les dernières transactions du mois. Ouvre le budget pour voir la liste complète.</p>
+          <p>Quand une prévision se réalise, pointe-la. Tes dernières transactions restent visibles juste à côté.</p>
         `,
         side: 'top',
         align: 'start',
       },
     },
     {
-      element: '[data-tour="add-transaction-fab"]',
+      element: '[data-tour="navigation"]',
       popover: {
-        title: 'Ajouter une transaction',
+        title: 'Retrouve chaque besoin',
         description: `
-          <p>Ajoute un revenu, une dépense ou une épargne depuis ce bouton.</p>
+          <p><strong>Budgets</strong> pour tes mois, <strong>Modèles</strong> pour préparer ce qui revient, <strong>Objectifs</strong> pour tes projets d'épargne. Tu peux revoir l'aide de chaque écran depuis ton menu.</p>
         `,
-        side: 'top',
-        align: 'end',
+        side: 'right',
+        align: 'start',
       },
     },
   ];
 
+  readonly #dashboardSteps = this.#firstRunSteps;
+
   readonly #budgetListSteps: DriveStep[] = [
-    {
-      element: '[data-tour="year-tabs"] > mat-tab-header',
-      popover: {
-        title: 'Parcourir les années',
-        description: `
-          <p>Passe d'une année à l'autre avec ces onglets.</p>
-        `,
-        side: 'bottom',
-        align: 'start',
-      },
-    },
     {
       element: '[data-tour="calendar-grid"]',
       popover: {
-        title: 'Ouvrir ou créer un mois',
+        title: 'Choisis le mois à gérer',
         description: `
-          <p>Sélectionne un mois existant pour ouvrir son budget, ou un mois vide pour le créer.</p>
+          <p>Ouvre un budget existant pour le suivre. Sélectionne un mois vide pour le préparer.</p>
         `,
         side: 'top',
         align: 'center',
@@ -401,9 +367,9 @@ export class ProductTourService {
     {
       element: '[data-tour="create-budget"]',
       popover: {
-        title: 'Ajouter un budget',
+        title: 'Prépare un nouveau mois',
         description: `
-          <p>Choisis un mois et un modèle. Les prévisions du modèle sont copiées dans le nouveau budget.</p>
+          <p>Choisis un mois et, si tu veux, un modèle. Ses prévisions seront copiées dans le nouveau budget.</p>
         `,
         side: 'left',
         align: 'start',
@@ -415,7 +381,7 @@ export class ProductTourService {
     {
       element: '[data-tour="financial-overview"]',
       popover: {
-        title: 'Disponible du mois',
+        title: 'Vérifie le cap du mois',
         description: `
           <p>Ce bloc résume les revenus, les dépenses, l'épargne et le report éventuel du mois précédent.</p>
         `,
@@ -426,7 +392,7 @@ export class ProductTourService {
     {
       element: '[data-tour="budget-table"]',
       popover: {
-        title: 'Prévisions du mois',
+        title: 'Suis ce qui se réalise',
         description: `
           <p>Pointe une prévision quand elle est réalisée. Ouvre une ligne pour la modifier ou consulter ses transactions.</p>
         `,
@@ -437,9 +403,9 @@ export class ProductTourService {
     {
       element: '[data-testid="add-budget-line-fab"]',
       popover: {
-        title: 'Ajouter une prévision',
+        title: 'Prévois un mouvement ponctuel',
         description: `
-          <p>Ajoute un Revenu, une Dépense ou une Épargne, puis choisis sa fréquence : Récurrent ou Prévu.</p>
+          <p>Ajoute ici une prévision ponctuelle. Pour ce qui revient, ajoute d'abord la prévision à un modèle.</p>
         `,
         side: 'left',
         align: 'start',
@@ -451,7 +417,7 @@ export class ProductTourService {
     {
       element: '[data-tour="templates-list"]',
       popover: {
-        title: 'Tes modèles de budget',
+        title: 'Prépare ce qui revient',
         description: `
           <p>Un modèle regroupe les revenus, dépenses et épargnes que tu veux réutiliser. Ouvre un modèle pour modifier ses prévisions.</p>
         `,
@@ -462,7 +428,7 @@ export class ProductTourService {
     {
       element: '[data-tour="create-template"]',
       popover: {
-        title: 'Ajouter un modèle',
+        title: 'Crée ton prochain modèle',
         description: `
           <p>Crée un modèle, puis ajoute les prévisions à reprendre dans tes futurs budgets.</p>
         `,
@@ -474,19 +440,11 @@ export class ProductTourService {
 
   readonly #savingsGoalsSteps: DriveStep[] = [
     {
-      popover: {
-        title: 'Des objectifs à ton rythme',
-        description: `
-          <p>Seul le nom est obligatoire. Tu peux ajouter un montant cible, une date de début ou une échéance selon ton besoin. L'option d'épargne mensuelle peut préparer les prévisions associées sans créer de nouveaux budgets.</p>
-        `,
-      },
-    },
-    {
       element: '[data-tour="savings-goals-list"]',
       popover: {
-        title: 'Tes objectifs',
+        title: 'Suis un projet d’épargne',
         description: `
-          <p>Chaque carte affiche les informations renseignées. Ouvre un objectif pour suivre les prévisions liées et ajuster son plan.</p>
+          <p>Ouvre un objectif pour voir sa progression, les prévisions liées et ajuster ton plan.</p>
         `,
         // 'bottom' anchors the popover in the empty space below the goals grid
         // (or the empty-state card on first run). A large, full-width target
@@ -499,9 +457,9 @@ export class ProductTourService {
     {
       element: '[data-tour="create-goal"]',
       popover: {
-        title: 'Nouvel objectif',
+        title: 'Commence simplement',
         description: `
-          <p>Commence par le nom. Tu pourras compléter le montant, les dates et l'épargne mensuelle maintenant ou plus tard.</p>
+          <p>Seul le nom est obligatoire. Ajoute le montant, les dates et l’épargne mensuelle maintenant ou plus tard.</p>
         `,
         side: 'bottom',
         align: 'end',

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -1,53 +1,33 @@
-/**
- * Product Tour Service using Driver.js
- *
- * Page-specific product tours with spotlight highlighting.
- * Uses Driver.js library with Material Design 3 theming.
- */
-
 import { DOCUMENT } from '@angular/common';
 import { inject, Service } from '@angular/core';
 import { AuthStore } from '@core/auth/auth-store';
 import { StorageService, type StorageKey } from '@core/storage';
+import { TranslocoService } from '@jsverse/transloco';
 import { driver, type Config, type Driver, type DriveStep } from 'driver.js';
+import {
+  createProductTourSteps,
+  type TourId,
+  type TourPageId,
+} from './product-tour.steps';
 
-/** Scrollable layout containers affected by Driver.js scrollIntoView(). */
 const SCROLL_CONTAINER_SELECTORS = [
   '[data-testid="page-content"]',
   '[data-testid="main-content"] > div',
 ] as const;
 
-/** Driver.js CSS class applied to highlighted elements (driver.js v1.x) */
 const DRIVER_ACTIVE_ELEMENT_CLASS = 'driver-active-element';
-
-/** Driver.js CSS classes applied to document body (driver.js v1.x) */
 const DRIVER_BODY_CLASSES = [
   'driver-active',
   'driver-fade',
   'driver-simple',
 ] as const;
 
-export type TourPageId =
-  | 'dashboard'
-  | 'budget-list'
-  | 'budget-details'
-  | 'templates-list'
-  | 'savings-goals';
-
-export type TourId = 'intro' | TourPageId;
+export type { TourPageId } from './product-tour.steps';
 type TourState = 'completed' | 'dismissed';
 
-/**
- * Delay before starting tour to ensure DOM is fully rendered
- * and Angular animations have completed
- */
 export const TOUR_START_DELAY = 500;
 const TOUR_TARGET_TIMEOUT = 10_000;
 
-/**
- * Tour identifiers used to generate storage keys.
- * Keys are stored as `pulpe-tour-{tourId}` (device-scoped, not user-scoped).
- */
 const TOUR_IDS = {
   intro: 'intro',
   dashboard: 'dashboard',
@@ -62,8 +42,9 @@ export class ProductTourService {
   readonly #document = inject(DOCUMENT);
   readonly #storageService = inject(StorageService);
   readonly #authStore = inject(AuthStore);
+  readonly #transloco = inject(TranslocoService);
+  readonly #steps = createProductTourSteps(this.#transloco);
 
-  /** Active Driver.js instance to prevent concurrent tours */
   #activeDriver: Driver | null = null;
 
   #pendingTour: {
@@ -73,34 +54,18 @@ export class ProductTourService {
 
   readonly #scrollPositions = new Map<HTMLElement, number>();
 
-  /**
-   * Check if user is authenticated.
-   * Tours require authentication to start because they reference app content
-   * that only exists for logged-in users, even though tour completion state
-   * is stored device-scoped (persists across account changes on same device).
-   */
   isAuthenticated(): boolean {
     return !!this.#authStore.user()?.id;
   }
 
-  /**
-   * Generate a storage key for a tour.
-   * Keys are device-scoped (no userId) to persist across account changes.
-   */
   #getTourKey(tourId: TourId): StorageKey {
     return `pulpe-tour-${tourId}`;
   }
 
-  /**
-   * Check if user has seen the intro (welcome + navigation)
-   */
   hasSeenIntro(): boolean {
     return this.#hasSeenTour(TOUR_IDS.intro);
   }
 
-  /**
-   * Check if user has seen a specific page tour
-   */
   hasSeenPageTour(pageId: TourPageId): boolean {
     return this.#hasSeenTour(TOUR_IDS[pageId]);
   }
@@ -114,9 +79,6 @@ export class ProductTourService {
     this.#storageService.setString(this.#getTourKey(tourId), state);
   }
 
-  /**
-   * Reset all tours (device-scoped)
-   */
   resetAllTours(): void {
     this.#storageService.remove(this.#getTourKey(TOUR_IDS.intro));
     this.#storageService.remove(this.#getTourKey(TOUR_IDS.dashboard));
@@ -126,9 +88,6 @@ export class ProductTourService {
     this.#storageService.remove(this.#getTourKey(TOUR_IDS['savings-goals']));
   }
 
-  /**
-   * Cancel active tour if running
-   */
   cancelActiveTour(): void {
     this.#cancelPendingTour();
     if (this.#activeDriver) {
@@ -145,10 +104,6 @@ export class ProductTourService {
     this.#pendingTour = null;
   }
 
-  /**
-   * Clean up Driver.js artifacts that may persist after tour ends.
-   * Delayed execution ensures cleanup runs after Driver.js completes its own teardown.
-   */
   #cleanupDriverArtifacts(): void {
     setTimeout(() => {
       this.#removeDriverClasses();
@@ -182,26 +137,20 @@ export class ProductTourService {
     this.#scrollPositions.clear();
   }
 
-  /** Start the one-time orientation from the first dashboard visit. */
   startFirstRunTour(): void {
     if (!this.isAuthenticated() || this.hasSeenIntro() || this.#activeDriver) {
       return;
     }
 
-    this.#prepareTour(TOUR_IDS.intro, this.#firstRunSteps);
+    this.#prepareTour(TOUR_IDS.intro, this.#steps.intro);
   }
 
-  /** Start contextual, replayable help for the current page. */
   startPageTour(pageId: TourPageId, focusTarget?: HTMLElement): void {
     if (!this.isAuthenticated() || this.#activeDriver) {
       return;
     }
 
-    this.#prepareTour(
-      TOUR_IDS[pageId],
-      this.#getPageSteps(pageId),
-      focusTarget,
-    );
+    this.#prepareTour(TOUR_IDS[pageId], this.#steps[pageId], focusTarget);
   }
 
   #prepareTour(
@@ -261,10 +210,16 @@ export class ProductTourService {
     const driverConfig: Config = {
       showProgress: true,
       showButtons: ['next', 'previous', 'close'],
-      progressText: 'Étape {{current}} sur {{total}}',
-      nextBtnText: 'Suivant',
-      prevBtnText: 'Précédent',
-      doneBtnText: 'Terminer',
+      progressText: this.#transloco
+        .translate('productTour.controls.progress', {
+          current: '__driver_current__',
+          total: '__driver_total__',
+        })
+        .replace('__driver_current__', '{{current}}')
+        .replace('__driver_total__', '{{total}}'),
+      nextBtnText: this.#transloco.translate('productTour.controls.next'),
+      prevBtnText: this.#transloco.translate('productTour.controls.previous'),
+      doneBtnText: this.#transloco.translate('productTour.controls.done'),
       allowClose: true,
       overlayColor: '#000',
       overlayOpacity: 0.55,
@@ -277,7 +232,10 @@ export class ProductTourService {
       stageRadius: 8,
       popoverOffset: 16,
       onPopoverRender: (popover) => {
-        popover.closeButton.setAttribute('aria-label', 'Fermer');
+        popover.closeButton.setAttribute(
+          'aria-label',
+          this.#transloco.translate('productTour.controls.close'),
+        );
       },
       onNextClick: (_element, _step, { driver: currentDriver }) => {
         if (currentDriver.isLastStep()) {
@@ -302,183 +260,4 @@ export class ProductTourService {
     tourDriver.setSteps(availableSteps);
     tourDriver.drive();
   }
-
-  /**
-   * Get page-specific steps
-   */
-  #getPageSteps(pageId: TourPageId): DriveStep[] {
-    switch (pageId) {
-      case 'dashboard':
-        return this.#dashboardSteps;
-      case 'budget-list':
-        return this.#budgetListSteps;
-      case 'budget-details':
-        return this.#budgetDetailsSteps;
-      case 'templates-list':
-        return this.#templatesListSteps;
-      case 'savings-goals':
-        return this.#savingsGoalsSteps;
-      default: {
-        const _exhaustive: never = pageId;
-        throw new Error(`Unknown page ID: ${_exhaustive}`);
-      }
-    }
-  }
-
-  // ============================================
-  // Step Definitions
-  // ============================================
-
-  readonly #firstRunSteps: DriveStep[] = [
-    {
-      element: '[data-tour="dashboard-hero"]',
-      popover: {
-        title: "Ton mois en un coup d'œil",
-        description: `
-          <p>Commence ici : <strong>Disponible à dépenser</strong> tient compte de tes revenus, dépenses et épargnes. Ouvre ce bloc pour ajuster le budget du mois.</p>
-        `,
-        side: 'bottom',
-        align: 'center',
-      },
-    },
-    {
-      element: '[data-tour="dashboard-lists"]',
-      popover: {
-        title: 'Commence par ce qui bouge',
-        description: `
-          <p>Quand une prévision se réalise, pointe-la. Tes dernières transactions restent visibles juste à côté.</p>
-        `,
-        side: 'top',
-        align: 'start',
-      },
-    },
-    {
-      element: '[data-tour="navigation"]',
-      popover: {
-        title: 'Retrouve chaque besoin',
-        description: `
-          <p><strong>Budgets</strong> pour tes mois, <strong>Modèles</strong> pour préparer ce qui revient, <strong>Objectifs</strong> pour tes projets d'épargne. Tu peux revoir l'aide de chaque écran depuis ton menu.</p>
-        `,
-        side: 'right',
-        align: 'start',
-      },
-    },
-  ];
-
-  readonly #dashboardSteps = this.#firstRunSteps;
-
-  readonly #budgetListSteps: DriveStep[] = [
-    {
-      element: '[data-tour="calendar-grid"]',
-      popover: {
-        title: 'Choisis le mois à gérer',
-        description: `
-          <p>Ouvre un budget existant pour le suivre. Sélectionne un mois vide pour le préparer.</p>
-        `,
-        side: 'top',
-        align: 'center',
-      },
-    },
-    {
-      element: '[data-tour="create-budget"]',
-      popover: {
-        title: 'Prépare un nouveau mois',
-        description: `
-          <p>Choisis un mois et, si tu veux, un modèle. Ses prévisions seront copiées dans le nouveau budget.</p>
-        `,
-        side: 'left',
-        align: 'start',
-      },
-    },
-  ];
-
-  readonly #budgetDetailsSteps: DriveStep[] = [
-    {
-      element: '[data-tour="financial-overview"]',
-      popover: {
-        title: 'Vérifie le cap du mois',
-        description: `
-          <p>Ce bloc résume les revenus, les dépenses, l'épargne et le report éventuel du mois précédent.</p>
-        `,
-        side: 'bottom',
-        align: 'center',
-      },
-    },
-    {
-      element: '[data-tour="budget-table"]',
-      popover: {
-        title: 'Suis ce qui se réalise',
-        description: `
-          <p>Pointe une prévision quand elle est réalisée. Ouvre une ligne pour la modifier ou consulter ses transactions.</p>
-        `,
-        side: 'top',
-        align: 'center',
-      },
-    },
-    {
-      element: '[data-testid="add-budget-line-fab"]',
-      popover: {
-        title: 'Prévois un mouvement ponctuel',
-        description: `
-          <p>Ajoute ici une prévision ponctuelle. Pour ce qui revient, ajoute d'abord la prévision à un modèle.</p>
-        `,
-        side: 'left',
-        align: 'start',
-      },
-    },
-  ];
-
-  readonly #templatesListSteps: DriveStep[] = [
-    {
-      element: '[data-tour="templates-list"]',
-      popover: {
-        title: 'Prépare ce qui revient',
-        description: `
-          <p>Un modèle regroupe les revenus, dépenses et épargnes que tu veux réutiliser. Ouvre un modèle pour modifier ses prévisions.</p>
-        `,
-        side: 'top',
-        align: 'start',
-      },
-    },
-    {
-      element: '[data-tour="create-template"]',
-      popover: {
-        title: 'Crée ton prochain modèle',
-        description: `
-          <p>Crée un modèle, puis ajoute les prévisions à reprendre dans tes futurs budgets.</p>
-        `,
-        side: 'left',
-        align: 'start',
-      },
-    },
-  ];
-
-  readonly #savingsGoalsSteps: DriveStep[] = [
-    {
-      element: '[data-tour="savings-goals-list"]',
-      popover: {
-        title: 'Suis un projet d’épargne',
-        description: `
-          <p>Ouvre un objectif pour voir sa progression, les prévisions liées et ajuster ton plan.</p>
-        `,
-        // 'bottom' anchors the popover in the empty space below the goals grid
-        // (or the empty-state card on first run). A large, full-width target
-        // leaves no room above, so 'top' forces driver.js to flip, and its
-        // reposition pass leaves the popover stuck at opacity 0.
-        side: 'bottom',
-        align: 'center',
-      },
-    },
-    {
-      element: '[data-tour="create-goal"]',
-      popover: {
-        title: 'Commence simplement',
-        description: `
-          <p>Seul le nom est obligatoire. Ajoute le montant, les dates et l’épargne mensuelle maintenant ou plus tard.</p>
-        `,
-        side: 'bottom',
-        align: 'end',
-      },
-    },
-  ];
 }

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -44,6 +44,7 @@ export type TourId = 'intro' | TourPageId;
  * and Angular animations have completed
  */
 export const TOUR_START_DELAY = 500;
+const TOUR_TARGET_TIMEOUT = 10_000;
 
 /**
  * Tour identifiers used to generate storage keys.
@@ -66,6 +67,11 @@ export class ProductTourService {
 
   /** Active Driver.js instance to prevent concurrent tours */
   #activeDriver: Driver | null = null;
+
+  #pendingTour: {
+    observer: MutationObserver;
+    timeoutId: number;
+  } | null = null;
 
   /**
    * Check if user is authenticated.
@@ -135,10 +141,19 @@ export class ProductTourService {
    * Cancel active tour if running
    */
   cancelActiveTour(): void {
+    this.#cancelPendingTour();
     if (this.#activeDriver) {
       this.#activeDriver.destroy();
       this.#activeDriver = null;
     }
+  }
+
+  #cancelPendingTour(): void {
+    if (!this.#pendingTour) return;
+
+    this.#pendingTour.observer.disconnect();
+    this.#document.defaultView?.clearTimeout(this.#pendingTour.timeoutId);
+    this.#pendingTour = null;
   }
 
   /**
@@ -180,10 +195,52 @@ export class ProductTourService {
       return;
     }
 
+    this.#cancelPendingTour();
+
     const includeIntro = !this.hasSeenIntro();
     const steps = this.#getStepsForPage(pageId, includeIntro);
+    const firstPageTarget = this.#getPageSteps(pageId).find(
+      (step) => typeof step.element === 'string',
+    )?.element;
 
-    // Create driver instance first to avoid closure timing issues
+    if (
+      typeof firstPageTarget === 'string' &&
+      !this.#document.querySelector(firstPageTarget)
+    ) {
+      const view = this.#document.defaultView;
+      if (!view) return;
+
+      const observer = new view.MutationObserver(() => {
+        if (!this.#document.querySelector(firstPageTarget)) return;
+
+        this.#cancelPendingTour();
+        this.#startTour(pageId, includeIntro, steps);
+      });
+      const timeoutId = view.setTimeout(
+        () => this.#cancelPendingTour(),
+        TOUR_TARGET_TIMEOUT,
+      );
+
+      this.#pendingTour = { observer, timeoutId };
+      observer.observe(this.#document.body, { childList: true, subtree: true });
+      return;
+    }
+
+    this.#startTour(pageId, includeIntro, steps);
+  }
+
+  #startTour(
+    pageId: TourPageId,
+    includeIntro: boolean,
+    steps: DriveStep[],
+  ): void {
+    const availableSteps = steps.filter(
+      (step) =>
+        typeof step.element !== 'string' ||
+        !!this.#document.querySelector(step.element),
+    );
+    if (availableSteps.length === 0) return;
+
     const tourDriver = driver();
     this.#activeDriver = tourDriver;
 
@@ -198,7 +255,9 @@ export class ProductTourService {
       overlayColor: '#000',
       overlayOpacity: 0.75,
       smoothScroll: true,
-      animate: true,
+      animate: !this.#document.defaultView?.matchMedia?.(
+        '(prefers-reduced-motion: reduce)',
+      ).matches,
       disableActiveInteraction: false,
       stagePadding: 10,
       stageRadius: 8,
@@ -214,7 +273,7 @@ export class ProductTourService {
     };
 
     tourDriver.setConfig(driverConfig);
-    tourDriver.setSteps(steps);
+    tourDriver.setSteps(availableSteps);
     tourDriver.drive();
   }
 
@@ -258,21 +317,20 @@ export class ProductTourService {
       popover: {
         title: 'Bienvenue dans Pulpe',
         description: `
-          <p>Avec Pulpe, fini le stress de la fin de mois. Tu anticipes tes dépenses, et tu vis sereinement.</p>
-          <p>On y va ? C'est parti pour 2 minutes de découverte.</p>
+          <p>Pulpe t'aide à préparer tes mois et à suivre tes revenus, dépenses et épargnes. Voici les repères utiles pour commencer.</p>
         `,
       },
     },
     {
       element: '[data-tour="navigation"]',
       popover: {
-        title: 'Quatre espaces, un cap',
+        title: 'Les espaces de Pulpe',
         description: `
           <ul>
-            <li><strong>Tableau de bord</strong> : ici, tu suis tes dépenses en temps réel, sans surprise.</li>
-            <li><strong>Budgets</strong> : prépare tes prochains mois en 2 clics, et vois loin.</li>
-            <li><strong>Modèles</strong> : ta recette mensuelle, à réutiliser sans effort.</li>
-            <li><strong>Objectifs</strong> : mets de l'argent de côté pour tes projets, mois après mois.</li>
+            <li><strong>Tableau de bord</strong> : suis le mois en cours et pointe tes prévisions.</li>
+            <li><strong>Budgets</strong> : consulte, crée et ajuste chaque mois.</li>
+            <li><strong>Modèles</strong> : prépare des revenus, dépenses et épargnes à réutiliser.</li>
+            <li><strong>Objectifs</strong> : suis tes projets d'épargne et les prévisions qui leur sont liées.</li>
           </ul>
         `,
         side: 'right',
@@ -285,10 +343,9 @@ export class ProductTourService {
     {
       element: '[data-tour="dashboard-hero"]',
       popover: {
-        title: 'Ton reste à dépenser',
+        title: 'Disponible à dépenser',
         description: `
-          <p>Ici, tu vois en un clin d'œil ce qu'il te reste à dépenser ce mois-ci.</p>
-          <p>Plus de mauvaises surprises, juste de la clarté.</p>
+          <p>Ce montant résume ce qu'il reste pour le mois en tenant compte des revenus, dépenses et épargnes. Ouvre ce bloc pour accéder au budget détaillé.</p>
         `,
         side: 'bottom',
         align: 'center',
@@ -297,10 +354,9 @@ export class ProductTourService {
     {
       element: '[data-tour="dashboard-lists"]',
       popover: {
-        title: 'Tes prévisions et transactions',
+        title: 'Prévisions à pointer et transactions',
         description: `
-          <p>Tes frais fixes sont déjà pris en compte. Le reste, c'est toi qui décides.</p>
-          <p>Un coup d'œil, et tu sais où tu en es.</p>
+          <p>Retrouve ici les prévisions encore à pointer et les dernières transactions du mois. Ouvre le budget pour voir la liste complète.</p>
         `,
         side: 'top',
         align: 'start',
@@ -309,10 +365,9 @@ export class ProductTourService {
     {
       element: '[data-tour="add-transaction-fab"]',
       popover: {
-        title: 'Note une dépense',
+        title: 'Ajouter une transaction',
         description: `
-          <p>Note tes dépenses en 5 secondes. C'est rapide, et ça te libère l'esprit.</p>
-          <p>Une petite habitude pour un grand soulagement.</p>
+          <p>Ajoute un revenu, une dépense ou une épargne depuis ce bouton.</p>
         `,
         side: 'top',
         align: 'end',
@@ -324,10 +379,9 @@ export class ProductTourService {
     {
       element: '[data-tour="year-tabs"] > mat-tab-header',
       popover: {
-        title: 'Vois loin',
+        title: 'Parcourir les années',
         description: `
-          <p>Passe d'une année à l'autre pour anticiper tes gros mois (vacances, impôts, fêtes…).</p>
-          <p>Préparé à l'avance = plus de sérénité après.</p>
+          <p>Passe d'une année à l'autre avec ces onglets.</p>
         `,
         side: 'bottom',
         align: 'start',
@@ -336,10 +390,9 @@ export class ProductTourService {
     {
       element: '[data-tour="calendar-grid"]',
       popover: {
-        title: "Ton année en un coup d'œil",
+        title: 'Ouvrir ou créer un mois',
         description: `
-          <p>Chaque mois a son propre budget. Ceux en gris sont prêts à être créés.</p>
-          <p>Clique sur un mois pour le personnaliser en 30 secondes.</p>
+          <p>Sélectionne un mois existant pour ouvrir son budget, ou un mois vide pour le créer.</p>
         `,
         side: 'top',
         align: 'center',
@@ -348,10 +401,9 @@ export class ProductTourService {
     {
       element: '[data-tour="create-budget"]',
       popover: {
-        title: 'Crée ton budget',
+        title: 'Ajouter un budget',
         description: `
-          <p>Sélectionne un modèle, et ton budget est prêt en un instant.</p>
-          <p>Plus de saisie fastidieuse : tout est déjà là.</p>
+          <p>Choisis un mois et un modèle. Les prévisions du modèle sont copiées dans le nouveau budget.</p>
         `,
         side: 'left',
         align: 'start',
@@ -363,10 +415,9 @@ export class ProductTourService {
     {
       element: '[data-tour="financial-overview"]',
       popover: {
-        title: 'Ton solde réel',
+        title: 'Disponible du mois',
         description: `
-          <p>Ton solde se met à jour automatiquement quand tu coches tes dépenses.</p>
-          <p>Tu sais toujours où tu en es, sans avoir à faire de calculs.</p>
+          <p>Ce bloc résume les revenus, les dépenses, l'épargne et le report éventuel du mois précédent.</p>
         `,
         side: 'bottom',
         align: 'center',
@@ -375,22 +426,20 @@ export class ProductTourService {
     {
       element: '[data-tour="budget-table"]',
       popover: {
-        title: 'Tes prévisions',
+        title: 'Prévisions du mois',
         description: `
-          <p>Coche tes dépenses au fur et à mesure pour suivre ton budget en temps réel.</p>
-          <p>Un clic sur une ligne pour tout modifier si besoin.</p>
+          <p>Pointe une prévision quand elle est réalisée. Ouvre une ligne pour la modifier ou consulter ses transactions.</p>
         `,
         side: 'top',
         align: 'center',
       },
     },
     {
-      element: '[data-tour="add-budget-line"]',
+      element: '[data-testid="add-budget-line-fab"]',
       popover: {
-        title: 'Ajuste ton mois',
+        title: 'Ajouter une prévision',
         description: `
-          <p>Besoin d'ajouter un revenu, une dépense ou une épargne ? C'est ici.</p>
-          <p>Choisis si c'est tous les mois ("récurrent") ou juste pour ce mois-ci.</p>
+          <p>Ajoute un Revenu, une Dépense ou une Épargne, puis choisis sa fréquence : Récurrent ou Prévu.</p>
         `,
         side: 'left',
         align: 'start',
@@ -402,34 +451,20 @@ export class ProductTourService {
     {
       element: '[data-tour="templates-list"]',
       popover: {
-        title: 'Ta base mensuelle',
+        title: 'Tes modèles de budget',
         description: `
-          <p>Ici, tu notes tes revenus et tes frais fixes (loyer, abonnements…).</p>
-          <p>C'est ta base pour créer tous tes budgets en un clic.</p>
+          <p>Un modèle regroupe les revenus, dépenses et épargnes que tu veux réutiliser. Ouvre un modèle pour modifier ses prévisions.</p>
         `,
         side: 'top',
         align: 'start',
       },
     },
     {
-      element: '[data-tour="template-counter"]',
-      popover: {
-        title: "Garde l'esprit léger",
-        description: `
-          <p>5 modèles max, c'est largement assez pour couvrir tous tes besoins.</p>
-          <p>Un pour les mois classiques, un pour les vacances… et hop, c'est prêt !</p>
-        `,
-        side: 'bottom',
-        align: 'start',
-      },
-    },
-    {
       element: '[data-tour="create-template"]',
       popover: {
-        title: 'Lance-toi',
+        title: 'Ajouter un modèle',
         description: `
-          <p>Crée ton premier modèle, et tes budgets futurs seront prêts en 1 clic.</p>
-          <p>C'est parti pour 2 minutes de configuration !</p>
+          <p>Crée un modèle, puis ajoute les prévisions à reprendre dans tes futurs budgets.</p>
         `,
         side: 'left',
         align: 'start',
@@ -440,24 +475,22 @@ export class ProductTourService {
   readonly #savingsGoalsSteps: DriveStep[] = [
     {
       popover: {
-        title: 'Épargne pour tes projets',
+        title: 'Des objectifs à ton rythme',
         description: `
-          <p>Un voyage, un imprévu, un gros achat… Fixe un montant à atteindre et une date, Pulpe s'occupe du calcul.</p>
-          <p>Ton objectif est réparti sur les mois qui restent : tu épargnes un peu chaque mois, sans y penser.</p>
+          <p>Seul le nom est obligatoire. Tu peux ajouter un montant cible, une date de début ou une échéance selon ton besoin. L'option d'épargne mensuelle peut préparer les prévisions associées sans créer de nouveaux budgets.</p>
         `,
       },
     },
     {
       element: '[data-tour="savings-goals-list"]',
       popover: {
-        title: 'Tout au même endroit',
+        title: 'Tes objectifs',
         description: `
-          <p>Chaque objectif affiche son montant visé et son échéance, en un coup d'œil.</p>
-          <p>En l'ouvrant, tu retrouves ton plan mois par mois et tu suis ta progression.</p>
+          <p>Chaque carte affiche les informations renseignées. Ouvre un objectif pour suivre les prévisions liées et ajuster son plan.</p>
         `,
         // 'bottom' anchors the popover in the empty space below the goals grid
         // (or the empty-state card on first run). A large, full-width target
-        // leaves no room above, so 'top' forces driver.js to flip — and its
+        // leaves no room above, so 'top' forces driver.js to flip, and its
         // reposition pass leaves the popover stuck at opacity 0.
         side: 'bottom',
         align: 'center',
@@ -466,10 +499,9 @@ export class ProductTourService {
     {
       element: '[data-tour="create-goal"]',
       popover: {
-        title: 'Lance-toi',
+        title: 'Nouvel objectif',
         description: `
-          <p>Crée ton premier objectif : donne-lui un nom, un montant et une date.</p>
-          <p>Pulpe prépare le reste. À toi de jouer !</p>
+          <p>Commence par le nom. Tu pourras compléter le montant, les dates et l'épargne mensuelle maintenant ou plus tard.</p>
         `,
         side: 'bottom',
         align: 'end',

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.service.ts
@@ -192,15 +192,23 @@ export class ProductTourService {
   }
 
   /** Start contextual, replayable help for the current page. */
-  startPageTour(pageId: TourPageId): void {
+  startPageTour(pageId: TourPageId, focusTarget?: HTMLElement): void {
     if (!this.isAuthenticated() || this.#activeDriver) {
       return;
     }
 
-    this.#prepareTour(TOUR_IDS[pageId], this.#getPageSteps(pageId));
+    this.#prepareTour(
+      TOUR_IDS[pageId],
+      this.#getPageSteps(pageId),
+      focusTarget,
+    );
   }
 
-  #prepareTour(tourId: TourId, steps: DriveStep[]): void {
+  #prepareTour(
+    tourId: TourId,
+    steps: DriveStep[],
+    focusTarget: Element | null = this.#document.activeElement,
+  ): void {
     this.#cancelPendingTour();
 
     const firstPageTarget = steps.find(
@@ -218,7 +226,7 @@ export class ProductTourService {
         if (!this.#document.querySelector(firstPageTarget)) return;
 
         this.#cancelPendingTour();
-        this.#startTour(tourId, steps);
+        this.#startTour(tourId, steps, focusTarget);
       });
       const timeoutId = view.setTimeout(
         () => this.#cancelPendingTour(),
@@ -230,10 +238,14 @@ export class ProductTourService {
       return;
     }
 
-    this.#startTour(tourId, steps);
+    this.#startTour(tourId, steps, focusTarget);
   }
 
-  #startTour(tourId: TourId, steps: DriveStep[]): void {
+  #startTour(
+    tourId: TourId,
+    steps: DriveStep[],
+    focusTarget: Element | null,
+  ): void {
     const availableSteps = steps.filter(
       (step) =>
         typeof step.element !== 'string' ||
@@ -280,6 +292,9 @@ export class ProductTourService {
         this.#activeDriver = null;
         this.#cleanupDriverArtifacts();
         this.#markTour(tourId, completed ? 'completed' : 'dismissed');
+        if (focusTarget instanceof HTMLElement && focusTarget.isConnected) {
+          focusTarget.focus();
+        }
       },
     };
 

--- a/frontend/projects/webapp/src/app/core/product-tour/product-tour.steps.ts
+++ b/frontend/projects/webapp/src/app/core/product-tour/product-tour.steps.ts
@@ -1,0 +1,140 @@
+import { type TranslocoService } from '@jsverse/transloco';
+import { type DriveStep } from 'driver.js';
+
+export type TourPageId =
+  | 'dashboard'
+  | 'budget-list'
+  | 'budget-details'
+  | 'templates-list'
+  | 'savings-goals';
+
+export type TourId = 'intro' | TourPageId;
+
+export function createProductTourSteps(
+  transloco: TranslocoService,
+): Record<TourId, DriveStep[]> {
+  const text = (key: string) => transloco.translate(key);
+  const intro: DriveStep[] = [
+    {
+      element: '[data-tour="dashboard-hero"]',
+      popover: {
+        title: text('productTour.intro.hero.title'),
+        description: text('productTour.intro.hero.description'),
+        side: 'bottom',
+        align: 'center',
+      },
+    },
+    {
+      element: '[data-tour="dashboard-lists"]',
+      popover: {
+        title: text('productTour.intro.tracking.title'),
+        description: text('productTour.intro.tracking.description'),
+        side: 'top',
+        align: 'start',
+      },
+    },
+    {
+      element: '[data-tour="navigation"]',
+      popover: {
+        title: text('productTour.intro.navigation.title'),
+        description: text('productTour.intro.navigation.description'),
+        side: 'right',
+        align: 'start',
+      },
+    },
+  ];
+
+  return {
+    intro,
+    dashboard: intro,
+    'budget-list': [
+      {
+        element: '[data-tour="calendar-grid"]',
+        popover: {
+          title: text('productTour.budgetList.calendar.title'),
+          description: text('productTour.budgetList.calendar.description'),
+          side: 'top',
+          align: 'center',
+        },
+      },
+      {
+        element: '[data-tour="create-budget"]',
+        popover: {
+          title: text('productTour.budgetList.create.title'),
+          description: text('productTour.budgetList.create.description'),
+          side: 'left',
+          align: 'start',
+        },
+      },
+    ],
+    'budget-details': [
+      {
+        element: '[data-tour="financial-overview"]',
+        popover: {
+          title: text('productTour.budgetDetails.overview.title'),
+          description: text('productTour.budgetDetails.overview.description'),
+          side: 'bottom',
+          align: 'center',
+        },
+      },
+      {
+        element: '[data-tour="budget-table"]',
+        popover: {
+          title: text('productTour.budgetDetails.tracking.title'),
+          description: text('productTour.budgetDetails.tracking.description'),
+          side: 'top',
+          align: 'center',
+        },
+      },
+      {
+        element: '[data-testid="add-budget-line-fab"]',
+        popover: {
+          title: text('productTour.budgetDetails.create.title'),
+          description: text('productTour.budgetDetails.create.description'),
+          side: 'left',
+          align: 'start',
+        },
+      },
+    ],
+    'templates-list': [
+      {
+        element: '[data-tour="templates-list"]',
+        popover: {
+          title: text('productTour.templatesList.list.title'),
+          description: text('productTour.templatesList.list.description'),
+          side: 'top',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="create-template"]',
+        popover: {
+          title: text('productTour.templatesList.create.title'),
+          description: text('productTour.templatesList.create.description'),
+          side: 'left',
+          align: 'start',
+        },
+      },
+    ],
+    'savings-goals': [
+      {
+        element: '[data-tour="savings-goals-list"]',
+        popover: {
+          title: text('productTour.savingsGoals.list.title'),
+          description: text('productTour.savingsGoals.list.description'),
+          side: 'bottom',
+          align: 'center',
+        },
+      },
+      {
+        element: '[data-tour="create-goal"]',
+        popover: {
+          title: text('productTour.savingsGoals.create.title'),
+          description: text('productTour.savingsGoals.create.description'),
+          side: 'bottom',
+          align: 'end',
+        },
+      },
+    ],
+  };
+}

--- a/frontend/projects/webapp/src/app/feature/budget-templates/list/template-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget-templates/list/template-list-page.ts
@@ -1,5 +1,4 @@
 import {
-  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
@@ -17,10 +16,6 @@ import { BaseLoading } from '@ui/loading';
 import { TemplatesError } from '../components/templates-error';
 import { TitleDisplay } from '@core/routing';
 import { LoadingIndicator } from '@core/loading/loading-indicator';
-import {
-  ProductTourService,
-  TOUR_START_DELAY,
-} from '@core/product-tour/product-tour.service';
 
 @Component({
   selector: 'pulpe-template-list-page',
@@ -133,7 +128,6 @@ import {
 export default class TemplateListPage {
   protected readonly store = inject(BudgetTemplatesStore);
   protected readonly title = inject(TitleDisplay);
-  readonly #productTourService = inject(ProductTourService);
   readonly #destroyRef = inject(DestroyRef);
   readonly #loadingIndicator = inject(LoadingIndicator);
 
@@ -147,15 +141,6 @@ export default class TemplateListPage {
 
     this.#destroyRef.onDestroy(() => {
       this.#loadingIndicator.setLoading(false);
-    });
-
-    afterNextRender(() => {
-      if (!this.#productTourService.hasSeenPageTour('templates-list')) {
-        setTimeout(
-          () => this.#productTourService.startPageTour('templates-list'),
-          TOUR_START_DELAY,
-        );
-      }
     });
   }
 }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -1,5 +1,4 @@
 import {
-  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
@@ -18,10 +17,6 @@ import { DatePipe } from '@angular/common';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { LoadingIndicator } from '@core/loading/loading-indicator';
 import { BreadcrumbState } from '@core/shell/breadcrumb-state';
-import {
-  ProductTourService,
-  TOUR_START_DELAY,
-} from '@core/product-tour/product-tour.service';
 import { formatDate } from 'date-fns';
 import { dateFnsLocaleFor } from '@core/locale';
 import { BaseLoading } from '@ui/loading';
@@ -144,7 +139,6 @@ export default class BudgetDetailsPage {
   protected readonly userSettingsStore = inject(UserSettingsStore);
   readonly #router = inject(Router);
   readonly #breadcrumbState = inject(BreadcrumbState);
-  readonly #productTourService = inject(ProductTourService);
   readonly #loadingIndicator = inject(LoadingIndicator);
   readonly #destroyRef = inject(DestroyRef);
   readonly #dialogService = inject(BudgetDetailsDialogService);
@@ -205,15 +199,6 @@ export default class BudgetDetailsPage {
         onCleanup(() => {
           this.#breadcrumbState.clearDynamicBreadcrumb();
         });
-      }
-    });
-
-    afterNextRender(() => {
-      if (!this.#productTourService.hasSeenPageTour('budget-details')) {
-        setTimeout(
-          () => this.#productTourService.startPageTour('budget-details'),
-          TOUR_START_DELAY,
-        );
       }
     });
   }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.spec.ts
@@ -12,7 +12,6 @@ import { ExcelExportService } from '@core/budget/excel-export.service';
 import { downloadAsExcelFile, downloadAsJsonFile } from '@core/file-download';
 import { Logger } from '@core/logging/logger';
 import { LoadingIndicator } from '@core/loading/loading-indicator';
-import { ProductTourService } from '@core/product-tour/product-tour.service';
 import { TitleDisplay } from '@core/routing';
 import { UserSettingsStore } from '@core/user-settings';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
@@ -54,13 +53,6 @@ describe('BudgetListPage', () => {
         ...provideTranslocoForTest(),
         { provide: BudgetListStore, useValue: mockStore },
         { provide: TitleDisplay, useValue: { currentTitle: signal('') } },
-        {
-          provide: ProductTourService,
-          useValue: {
-            hasSeenPageTour: vi.fn().mockReturnValue(true),
-            startPageTour: vi.fn(),
-          },
-        },
         { provide: MatDialog, useValue: { open: vi.fn() } },
         {
           provide: BreakpointObserver,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/budget-list-page.ts
@@ -1,6 +1,5 @@
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import {
-  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -37,10 +36,6 @@ import {
   type BudgetExportResponse,
   type TransactionSearchResult,
 } from 'pulpe-shared';
-import {
-  ProductTourService,
-  TOUR_START_DELAY,
-} from '@core/product-tour/product-tour.service';
 import { LoadingIndicator } from '@core/loading/loading-indicator';
 import { TranslocoService, TranslocoPipe } from '@jsverse/transloco';
 import { CURRENCY_CONFIG } from '@core/currency';
@@ -168,7 +163,6 @@ import { UserSettingsStore } from '@core/user-settings';
 export default class BudgetListPage {
   protected readonly state = inject(BudgetListStore);
   protected readonly titleDisplay = inject(TitleDisplay);
-  readonly #productTourService = inject(ProductTourService);
   readonly #dialog = inject(MatDialog);
   readonly #router = inject(Router);
   readonly #breakpointObserver = inject(BreakpointObserver);
@@ -211,15 +205,6 @@ export default class BudgetListPage {
 
     this.#destroyRef.onDestroy(() => {
       this.#loadingIndicator.setLoading(false);
-    });
-
-    afterNextRender(() => {
-      if (!this.#productTourService.hasSeenPageTour('budget-list')) {
-        setTimeout(
-          () => this.#productTourService.startPageTour('budget-list'),
-          TOUR_START_DELAY,
-        );
-      }
     });
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/template-list-item.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-list/create-budget/template-list-item.spec.ts
@@ -8,11 +8,26 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { setTestInput } from '@app/testing/signal-test-utils';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { TemplateListItem } from './template-list-item';
-// NOTE: BudgetTemplate type removed as it's no longer used in tests
+import { type TemplateViewModel } from './template-view-model';
 
-// NOTE: TestHostComponent removed due to NG0950 errors with input.required() in Angular 20
+const templateViewModel: TemplateViewModel = {
+  template: {
+    id: '00000000-0000-4000-8000-000000000111',
+    name: 'Mois standard',
+    description: 'Budget mensuel',
+    isDefault: true,
+    userId: 'user-123',
+    createdAt: '2026-07-28T00:00:00Z',
+    updatedAt: '2026-07-28T00:00:00Z',
+  },
+  income: 5_000,
+  expenses: 3_000,
+  netBalance: 2_000,
+  loading: false,
+};
 
 describe('TemplateListItem', () => {
   let component: TemplateListItem;
@@ -37,15 +52,11 @@ describe('TemplateListItem', () => {
       ],
     }).compileComponents();
 
-    // Test standalone component
     fixture = TestBed.createComponent(TemplateListItem);
     component = fixture.componentInstance;
   });
 
   describe('Standalone Component - Basic Structure', () => {
-    // NOTE: We test the component structure through the host component
-    // since Angular 20 required inputs cannot be set directly on standalone components
-
     it('should have input and output properties defined', () => {
       // These are the properties that should exist on the component class with new Angular input/output APIs
       expect(component.templateViewModel).toBeDefined();
@@ -68,6 +79,24 @@ describe('TemplateListItem', () => {
     });
   });
 
-  // NOTE: Integration tests removed due to NG0950 errors with input.required()
-  // in Angular 20. Component behavior is adequately tested in higher-level integration tests.
+  it('renders the translated details action without selecting the template', () => {
+    const showDetails = vi.fn();
+    const selectTemplate = vi.fn();
+    component.showDetails.subscribe(showDetails);
+    component.selectTemplate.subscribe(selectTemplate);
+    setTestInput(component.templateViewModel, templateViewModel);
+
+    fixture.detectChanges();
+
+    const detailsButton = fixture.nativeElement.querySelector(
+      'button',
+    ) as HTMLButtonElement | null;
+    expect(detailsButton?.textContent).toContain('Détails');
+    expect(detailsButton?.textContent).not.toContain('template.details');
+
+    detailsButton?.click();
+
+    expect(showDetails).toHaveBeenCalledWith(templateViewModel);
+    expect(selectTemplate).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/current-month.ts
@@ -350,12 +350,11 @@ export default class Dashboard {
     });
 
     afterNextRender(() => {
-      if (!this.#productTourService.hasSeenPageTour('dashboard')) {
-        setTimeout(
-          () => this.#productTourService.startPageTour('dashboard'),
-          TOUR_START_DELAY,
-        );
-      }
+      const tourTimeout = setTimeout(
+        () => this.#productTourService.startFirstRunTour(),
+        TOUR_START_DELAY,
+      );
+      this.#destroyRef.onDestroy(() => clearTimeout(tourTimeout));
     });
   }
 

--- a/frontend/projects/webapp/src/app/feature/savings-goals/list/savings-goals-list-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/list/savings-goals-list-page.spec.ts
@@ -4,10 +4,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { describe, beforeEach, expect, it, vi } from 'vitest';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { ApiError } from '@core/api/api-error';
-import {
-  ProductTourService,
-  type ProductTourService as ProductTourServiceType,
-} from '@core/product-tour/product-tour.service';
 import { TitleDisplay } from '@core/routing';
 import SavingsGoalsListPage from './savings-goals-list-page';
 import { SavingsGoalsDialogService } from '../services/savings-goals-dialog.service';
@@ -48,13 +44,6 @@ describe('SavingsGoalsListPage', () => {
         { provide: SavingsGoalsDialogService, useValue: dialogs },
         { provide: MatSnackBar, useValue: snackBar },
         { provide: TitleDisplay, useValue: { currentTitle: signal('') } },
-        {
-          provide: ProductTourService,
-          useValue: {
-            hasSeenPageTour: vi.fn().mockReturnValue(true),
-            startPageTour: vi.fn(),
-          } satisfies Partial<ProductTourServiceType>,
-        },
       ],
     }).compileComponents();
 

--- a/frontend/projects/webapp/src/app/feature/savings-goals/list/savings-goals-list-page.ts
+++ b/frontend/projects/webapp/src/app/feature/savings-goals/list/savings-goals-list-page.ts
@@ -1,9 +1,4 @@
-import {
-  afterNextRender,
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -11,10 +6,6 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { TitleDisplay } from '@core/routing';
 import { isApiError } from '@core/api/api-error';
 import { ApiErrorLocalizer } from '@core/api/api-error-localizer';
-import {
-  ProductTourService,
-  TOUR_START_DELAY,
-} from '@core/product-tour/product-tour.service';
 import { BaseLoading } from '@ui/loading';
 import { StateCard } from '@ui/state-card/state-card';
 import { SavingsGoalStore } from '../services/savings-goals-store';
@@ -119,19 +110,9 @@ export default class SavingsGoalsListPage {
   readonly #snackBar = inject(MatSnackBar);
   readonly #transloco = inject(TranslocoService);
   readonly #errorLocalizer = inject(ApiErrorLocalizer);
-  readonly #productTour = inject(ProductTourService);
 
   constructor() {
     this.store.refresh();
-
-    afterNextRender(() => {
-      if (!this.#productTour.hasSeenPageTour('savings-goals')) {
-        setTimeout(
-          () => this.#productTour.startPageTour('savings-goals'),
-          TOUR_START_DELAY,
-        );
-      }
-    });
   }
 
   protected async onCreate(): Promise<void> {

--- a/frontend/projects/webapp/src/app/layout/main-layout.spec.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.spec.ts
@@ -85,7 +85,8 @@ function mockWindowLocation(): {
 type MainLayoutWithPrivates = MainLayout & {
   isHandset(): boolean;
   closeDrawerOnMobile(drawer: { close: () => void }): void;
-  startPageTour(): void;
+  requestPageTour(): void;
+  startRequestedPageTour(): void;
 };
 
 // Mock PulpeBreadcrumb component
@@ -369,14 +370,16 @@ describe('MainLayout', () => {
       ['/budget-templates', 'templates-list'],
       ['/budget', 'budget-list'],
       ['/budget/123', 'budget-details'],
-    ] as const)('maps %s to the %s tour', (url, expectedPageId) => {
+    ] as const)('maps %s to the %s tour', async (url, expectedPageId) => {
       mockRouter.url = url;
       mockRouter.events.next(new NavigationEnd(1, url, url));
-
-      (component as unknown as MainLayoutWithPrivates).startPageTour();
+      const layout = component as unknown as MainLayoutWithPrivates;
+      layout.requestPageTour();
+      layout.startRequestedPageTour();
 
       expect(mockProductTourService.startPageTour).toHaveBeenCalledWith(
         expectedPageId,
+        undefined,
       );
     });
   });

--- a/frontend/projects/webapp/src/app/layout/main-layout.spec.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.spec.ts
@@ -368,6 +368,8 @@ describe('MainLayout', () => {
   describe('Product Tour Routing', () => {
     it.each([
       ['/budget-templates', 'templates-list'],
+      ['/budget-templates/', 'templates-list'],
+      ['/budget-templates?source=menu', 'templates-list'],
       ['/budget', 'budget-list'],
       ['/budget/123', 'budget-details'],
     ] as const)('maps %s to the %s tour', async (url, expectedPageId) => {
@@ -381,6 +383,19 @@ describe('MainLayout', () => {
         expectedPageId,
         undefined,
       );
+    });
+
+    it.each([
+      '/budget-templates/create',
+      '/budget-templates/details/template-123',
+    ])('does not expose the templates list tour on %s', (url) => {
+      mockRouter.url = url;
+      mockRouter.events.next(new NavigationEnd(1, url, url));
+      const layout = component as unknown as MainLayoutWithPrivates;
+      layout.requestPageTour();
+      layout.startRequestedPageTour();
+
+      expect(mockProductTourService.startPageTour).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/projects/webapp/src/app/layout/main-layout.spec.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.spec.ts
@@ -7,7 +7,7 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { TestBed, type ComponentFixture } from '@angular/core/testing';
-import { Router, type NavigationEnd, ActivatedRoute } from '@angular/router';
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -85,6 +85,7 @@ function mockWindowLocation(): {
 type MainLayoutWithPrivates = MainLayout & {
   isHandset(): boolean;
   closeDrawerOnMobile(drawer: { close: () => void }): void;
+  startPageTour(): void;
 };
 
 // Mock PulpeBreadcrumb component
@@ -139,6 +140,9 @@ describe('MainLayout', () => {
   };
   let mockDialog: {
     open: ReturnType<typeof vi.fn>;
+  };
+  let mockProductTourService: {
+    startPageTour: ReturnType<typeof vi.fn>;
   };
   let breakpointSubject: Subject<{ matches: boolean }>;
 
@@ -196,6 +200,9 @@ describe('MainLayout', () => {
     mockDialog = {
       open: vi.fn().mockReturnValue({ afterClosed: () => EMPTY }),
     };
+    mockProductTourService = {
+      startPageTour: vi.fn(),
+    };
 
     // Configure TestBed
     TestBed.configureTestingModule({
@@ -247,7 +254,7 @@ describe('MainLayout', () => {
         },
         {
           provide: ProductTourService,
-          useValue: { startPageTour: vi.fn() },
+          useValue: mockProductTourService,
         },
         {
           provide: LoadingIndicator,
@@ -325,6 +332,52 @@ describe('MainLayout', () => {
     it('should observe breakpoint changes', () => {
       fixture.detectChanges();
       expect(mockBreakpointObserver.observe).toHaveBeenCalled();
+    });
+
+    it('anchors the navigation tour to the visible desktop or handset control', () => {
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="desktop-navigation"][data-tour="navigation"]',
+        ),
+      ).toBeTruthy();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="menu-toggle"][data-tour="navigation"]',
+        ),
+      ).toBeNull();
+
+      breakpointSubject.next({ matches: true });
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="desktop-navigation"][data-tour="navigation"]',
+        ),
+      ).toBeNull();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="menu-toggle"][data-tour="navigation"]',
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('Product Tour Routing', () => {
+    it.each([
+      ['/budget-templates', 'templates-list'],
+      ['/budget', 'budget-list'],
+      ['/budget/123', 'budget-details'],
+    ] as const)('maps %s to the %s tour', (url, expectedPageId) => {
+      mockRouter.url = url;
+      mockRouter.events.next(new NavigationEnd(1, url, url));
+
+      (component as unknown as MainLayoutWithPrivates).startPageTour();
+
+      expect(mockProductTourService.startPageTour).toHaveBeenCalledWith(
+        expectedPageId,
+      );
     });
   });
 

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -335,6 +335,8 @@ interface NavigationItem {
                 <button
                   matButton
                   [matMenuTriggerFor]="userMenu"
+                  (click)="rememberUserMenuTrigger($event)"
+                  (menuClosed)="startRequestedPageTour()"
                   [attr.aria-label]="
                     isLoggingOut()
                       ? ('layout.loggingOut' | transloco)
@@ -385,7 +387,7 @@ interface NavigationItem {
               @if (currentTourPageId()) {
                 <button
                   mat-menu-item
-                  (click)="startPageTour()"
+                  (click)="requestPageTour()"
                   [attr.aria-label]="'navigation.discoverPage' | transloco"
                   data-testid="page-tour-button"
                 >
@@ -940,10 +942,27 @@ export default class MainLayout {
     });
   }
 
-  protected startPageTour(): void {
-    const pageId = this.currentTourPageId();
+  #requestedPageTour: TourPageId | null = null;
+  #userMenuTrigger: HTMLElement | null = null;
+
+  protected rememberUserMenuTrigger(event: Event): void {
+    if (event.currentTarget instanceof HTMLElement) {
+      this.#userMenuTrigger = event.currentTarget;
+    }
+  }
+
+  protected requestPageTour(): void {
+    this.#requestedPageTour = this.currentTourPageId();
+  }
+
+  protected startRequestedPageTour(): void {
+    const pageId = this.#requestedPageTour;
+    this.#requestedPageTour = null;
     if (pageId) {
-      this.#productTourService.startPageTour(pageId);
+      this.#productTourService.startPageTour(
+        pageId,
+        this.#userMenuTrigger ?? undefined,
+      );
     }
   }
 

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -856,12 +856,13 @@ export default class MainLayout {
 
   // Current tour page ID based on route
   protected readonly currentTourPageId = computed((): TourPageId | null => {
-    const url = this.#currentRoute();
-    if (url.includes(`/${ROUTES.DASHBOARD}`)) return 'dashboard';
-    if (url.match(/\/budget\/[^/]+$/)) return 'budget-details';
-    if (url.includes(`/${ROUTES.BUDGET_TEMPLATES}`)) return 'templates-list';
-    if (url.includes(`/${ROUTES.BUDGET}`)) return 'budget-list';
-    if (url.match(/\/savings-goals$/)) return 'savings-goals';
+    const path =
+      this.#currentRoute().split(/[?#]/, 1)[0]?.replace(/\/+$/, '') || '/';
+    if (path === `/${ROUTES.DASHBOARD}`) return 'dashboard';
+    if (path.match(/\/budget\/[^/]+$/)) return 'budget-details';
+    if (path === `/${ROUTES.BUDGET_TEMPLATES}`) return 'templates-list';
+    if (path === `/${ROUTES.BUDGET}`) return 'budget-list';
+    if (path === `/${ROUTES.SAVINGS_GOALS}`) return 'savings-goals';
     return null;
   });
 

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -263,6 +263,7 @@ interface NavigationItem {
                 (click)="drawer.toggle()"
                 aria-label="Toggle navigation"
                 data-testid="menu-toggle"
+                data-tour="navigation"
               >
                 <mat-icon>menu</mat-icon>
               </button>
@@ -856,8 +857,8 @@ export default class MainLayout {
     const url = this.#currentRoute();
     if (url.includes(`/${ROUTES.DASHBOARD}`)) return 'dashboard';
     if (url.match(/\/budget\/[^/]+$/)) return 'budget-details';
-    if (url.includes(`/${ROUTES.BUDGET}`)) return 'budget-list';
     if (url.includes(`/${ROUTES.BUDGET_TEMPLATES}`)) return 'templates-list';
+    if (url.includes(`/${ROUTES.BUDGET}`)) return 'budget-list';
     if (url.match(/\/savings-goals$/)) return 'savings-goals';
     return null;
   });

--- a/frontend/projects/webapp/src/app/ui/password-criteria/password-criteria.ts
+++ b/frontend/projects/webapp/src/app/ui/password-criteria/password-criteria.ts
@@ -73,7 +73,7 @@ export function passwordCriteria(
           [class.text-primary]="criterion.isMet"
           [class.text-on-surface-variant]="!criterion.isMet"
         >
-          <mat-icon aria-hidden="true" class="!text-base !w-4 !h-4">
+          <mat-icon inline aria-hidden="true" class="text-base! leading-none!">
             {{ criterion.isMet ? 'check_circle' : 'radio_button_unchecked' }}
           </mat-icon>
           <!-- count ne sert qu'au label minLength ; les autres clés l'ignorent. -->

--- a/frontend/projects/webapp/src/app/ui/password-criteria/password-criteria.ts
+++ b/frontend/projects/webapp/src/app/ui/password-criteria/password-criteria.ts
@@ -47,6 +47,7 @@ export function passwordCriteria(
  */
 @Component({
   selector: 'pulpe-password-criteria',
+  host: { class: 'block' },
   imports: [MatIconModule, TranslocoPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "driver.js": "^1.4.0"
+    "driver.js": "^1.8.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       driver.js:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.5
@@ -236,8 +236,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       driver.js:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.8.0
+        version: 1.8.0
       lottie-web:
         specifier: ^5.13.0
         version: 5.13.0
@@ -4740,8 +4740,8 @@ packages:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
 
-  driver.js@1.4.0:
-    resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
+  driver.js@1.8.0:
+    resolution: {integrity: sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -12848,7 +12848,7 @@ snapshots:
 
   dotenv@17.2.3: {}
 
-  driver.js@1.4.0: {}
+  driver.js@1.8.0: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
# Stabilize webapp first-run guidance

## ✅ Type of PR

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Fixes the signup layout, onboarding budget horizon, and detached product-tour steps. Updates Driver.js to 1.8, restores keyboard focus, localizes and scopes page tours, restores the budget-template details label, and prevents compact Material icons from being clipped.

## 🚶‍➡️ Behavior

- Password criteria stay in the form flow and their status icons render completely.
- A new account receives the current budget plus all twelve future months used by the dashboard projection.
- Product tours wait for live targets, match the current route and vocabulary, and preserve keyboard focus and reduced-motion preferences.
- Budget creation displays the localized `Détails` action.

## 🧪 Steps to test

- [x] Run `pnpm quality`.
- [x] Run the frontend unit suite: 2,448 tests passed.
- [x] Run the focused authentication tests: 4 unit tests and 2 mocked E2E tests passed.
- [x] Run the product-tour keyboard E2E scenario.
- [x] Verify the updated signup, dashboard, budget, model, and goal screens in the local browser.
