### PR TITLE
feat(backend): la version iOS publiée est résolue depuis l'App Store

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -668,9 +668,7 @@ EOF
 ```
 
 11. Apply the pending `LATEST_WEB_VERSION` update from [references/jsts-release.md](references/jsts-release.md) in `preview` and `production`, then verify `GET /api/v1/app/version`.
-12. If the iOS marketing version changed, follow [references/ios-release.md](references/ios-release.md):
-    - App Store version publicly available: apply and verify `LATEST_IOS_VERSION`;
-    - not yet available: leave both environments unchanged and report the deferred post-App-Store operation.
+12. Never schedule a Railway `LATEST_IOS_VERSION` operation: the backend reads the published iOS version from the App Store itself (see [references/ios-release.md](references/ios-release.md)). No post-App-Store follow-up is owed for this gate, so do not report one.
 
 Release rules:
 

--- a/.claude/skills/release/references/ios-release.md
+++ b/.claude/skills/release/references/ios-release.md
@@ -60,7 +60,7 @@ cd ios && ./scripts/bump-version.sh patch   # or minor
 cd ios && xcodegen generate --use-cache
 ```
 
-This bumps `MARKETING_VERSION` and resets/advances the build number. Schedule the Railway `LATEST_IOS_VERSION` sync described below, but do not apply it before that version is publicly available on the App Store.
+This bumps `MARKETING_VERSION` and resets/advances the build number. No Railway follow-up is owed — see the force-update gate section below.
 
 ## Files modified
 
@@ -71,30 +71,21 @@ After running the script, these files change:
 
 Stage only `ios/project.yml`. Never stage the generated `.xcodeproj`.
 
-## Sync Railway `LATEST_IOS_VERSION` (force-update gate)
+## Force-update gate — nothing to sync
 
-When `MARKETING_VERSION` bumps (i.e. you used `set`, `major`, `minor`, or `patch` — NOT `build`), record a pending `LATEST_IOS_VERSION` update for Railway in **both** `preview` and `production`. Apply it only after App Store Connect confirms that this marketing version is publicly available. Git publication and TestFlight availability are not sufficient.
+`LATEST_IOS_VERSION` is **not** a release chore. `IosVersionGateService`
+(`backend-nest/src/modules/app-version/`) reads the version the App Store
+actually serves and publishes it on `GET /api/v1/app/version`; the Railway
+variable is only an offline fallback and a manual override. Never schedule,
+apply, or report a pending `LATEST_IOS_VERSION` update, and never wait on App
+Store availability before finishing the release.
 
-If the App Store release is still pending when Step 9 finishes, leave both values unchanged and report one deferred post-App-Store operation. The force-update endpoint (`GET /api/v1/app/version`) serves this value to clients; changing it early would advertise a binary users cannot download.
-
-Before updating Railway, apply the branch that matches the curated result:
+Still verify the curated result matches the release:
 
 - If an iOS projection exists, verify the same `iosVersion` is present in `landing/data/releases.json` and `backend-nest/src/modules/whats-new/domain/releases-data.ts`. A mismatch means the release is not ready.
-- If no item qualified, verify `landing/data/releases.json` carries the new `iosVersion`, `SILENT_IOS_RELEASES` contains exactly one motivated entry for the product version, and no backend projection overlaps it. This intentional silence does not block the Railway update or the release.
+- If no item qualified, verify `landing/data/releases.json` carries the new `iosVersion`, `SILENT_IOS_RELEASES` contains exactly one motivated entry for the product version, and no backend projection overlaps it. This intentional silence does not block the release.
 
-Use the Railway integration available to the current agent — one operation per environment with these semantics:
-
-```
-workspace: <repo root>
-environment: preview, then production
-service: backend
-skip deploy: false
-variable: LATEST_IOS_VERSION=<new MARKETING_VERSION>
-```
-
-Before applying the deferred update, verify App Store availability again. The variable change must redeploy the backend so the running `ConfigService` reads the new value; wait for the resulting deployment to succeed in each environment. If no Railway integration is available, report the missing capability and leave the gate unchanged. Never omit the update silently or guess an unsupported CLI/MCP command. After both environment updates, verify the public version endpoint reports the new iOS marketing version.
-
-> **Never** touch `MIN_IOS_VERSION` from this skill. That value is a deliberate kill switch — only bumped when a release contains a breaking change or critical fix that must force users off old binaries. Always require explicit user confirmation before changing it.
+> **Never** touch `MIN_IOS_VERSION` from this skill. That value is a deliberate kill switch — only bumped when a release contains a breaking change or critical fix that must force users off old binaries. Always require explicit user confirmation before changing it. The served floor is clamped to the version available on the App Store, so an early bump waits for Apple instead of blocking users on a binary they cannot download — that safety net is not a licence to set it without confirmation.
 
 ## No separate tag
 

--- a/backend-nest/.env.example
+++ b/backend-nest/.env.example
@@ -54,8 +54,9 @@ POSTHOG_HOST=https://eu.posthog.com
 
 # Force-update gate (consumed by GET /api/v1/app/version)
 # Format: SemVer X.Y.Z (regex enforced). Bump MIN_* to force clients below that
-# version to upgrade. Bump LATEST_* on every release (informational, drives the
-# "update available" toast). Rollout procedure: docs/VERSIONING.md.
+# version to upgrade. LATEST_WEB_VERSION is bumped on every web release;
+# LATEST_IOS_VERSION is only a fallback — the backend resolves the published iOS
+# version from the App Store. Rollout procedure: docs/VERSIONING.md.
 MIN_IOS_VERSION=1.0.0
 LATEST_IOS_VERSION=1.0.0
 IOS_STORE_URL=https://apps.apple.com/app/id6758464920

--- a/backend-nest/src/common/utils/semver-compare.ts
+++ b/backend-nest/src/common/utils/semver-compare.ts
@@ -1,0 +1,17 @@
+const SEMVER_SEGMENT_COUNT = 3;
+
+/**
+ * Returns true when `version <= ceiling`, comparing the three numeric
+ * `MAJOR.MINOR.PATCH` segments. Callers shape-validate inputs with the
+ * `/^\d+\.\d+\.\d+$/` regex first, so each split yields exactly three numbers.
+ */
+export function isVersionAtMost(version: string, ceiling: string): boolean {
+  const parts = version.split('.').map(Number);
+  const ceilingParts = ceiling.split('.').map(Number);
+  for (let i = 0; i < SEMVER_SEGMENT_COUNT; i++) {
+    if (parts[i] !== ceilingParts[i]) {
+      return parts[i] < ceilingParts[i];
+    }
+  }
+  return true;
+}

--- a/backend-nest/src/common/utils/semver-compare.ts
+++ b/backend-nest/src/common/utils/semver-compare.ts
@@ -1,9 +1,12 @@
 const SEMVER_SEGMENT_COUNT = 3;
 
+/** Shape every version string must match before `isVersionAtMost` compares it. */
+export const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
 /**
  * Returns true when `version <= ceiling`, comparing the three numeric
- * `MAJOR.MINOR.PATCH` segments. Callers shape-validate inputs with the
- * `/^\d+\.\d+\.\d+$/` regex first, so each split yields exactly three numbers.
+ * `MAJOR.MINOR.PATCH` segments. Callers shape-validate inputs with
+ * `SEMVER_PATTERN` first, so each split yields exactly three numbers.
  */
 export function isVersionAtMost(version: string, ceiling: string): boolean {
   const parts = version.split('.').map(Number);

--- a/backend-nest/src/config/environment.spec.ts
+++ b/backend-nest/src/config/environment.spec.ts
@@ -297,7 +297,7 @@ describe('Environment Validation', () => {
     });
   });
 
-  describe('Force-update version invariants (MIN <= LATEST)', () => {
+  describe('Force-update version invariants (web MIN <= LATEST)', () => {
     const baseConfig = {
       NODE_ENV: 'production',
       SUPABASE_URL: 'https://example.supabase.co',
@@ -308,11 +308,11 @@ describe('Environment Validation', () => {
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
     };
 
-    it('should accept iOS versions when MIN is below LATEST', () => {
+    it('should accept web versions when MIN is below LATEST', () => {
       const config = {
         ...baseConfig,
-        MIN_IOS_VERSION: '1.0.0',
-        LATEST_IOS_VERSION: '1.0.2',
+        MIN_WEB_VERSION: '1.0.0',
+        LATEST_WEB_VERSION: '1.0.2',
       };
 
       expect(() => validateConfig(config)).not.toThrow();
@@ -321,21 +321,21 @@ describe('Environment Validation', () => {
     it('should accept versions when MIN equals LATEST', () => {
       const config = {
         ...baseConfig,
-        MIN_IOS_VERSION: '2.1.0',
-        LATEST_IOS_VERSION: '2.1.0',
+        MIN_WEB_VERSION: '2.1.0',
+        LATEST_WEB_VERSION: '2.1.0',
       };
 
       expect(() => validateConfig(config)).not.toThrow();
     });
 
-    it('should reject when MIN_IOS_VERSION is above LATEST_IOS_VERSION', () => {
+    it('should accept MIN_IOS_VERSION above LATEST_IOS_VERSION so the floor can be armed before the App Store rollout', () => {
       const config = {
         ...baseConfig,
         MIN_IOS_VERSION: '2.0.0',
         LATEST_IOS_VERSION: '0.1.0',
       };
 
-      expect(() => validateConfig(config)).toThrow(/LATEST_IOS_VERSION/);
+      expect(() => validateConfig(config)).not.toThrow();
     });
 
     it('should reject when MIN_WEB_VERSION is above LATEST_WEB_VERSION', () => {
@@ -351,8 +351,8 @@ describe('Environment Validation', () => {
     it('should compare segments numerically (1.0.10 is above 1.0.2)', () => {
       const config = {
         ...baseConfig,
-        MIN_IOS_VERSION: '1.0.2',
-        LATEST_IOS_VERSION: '1.0.10',
+        MIN_WEB_VERSION: '1.0.2',
+        LATEST_WEB_VERSION: '1.0.10',
       };
 
       expect(() => validateConfig(config)).not.toThrow();

--- a/backend-nest/src/config/environment.ts
+++ b/backend-nest/src/config/environment.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { isVersionAtMost } from '@common/utils/semver-compare';
+import { SEMVER_PATTERN, isVersionAtMost } from '@common/utils/semver-compare';
 
 const envSchema = z
   .object({
@@ -53,28 +53,16 @@ const envSchema = z
       .optional(),
 
     // Force-update gate (consumed by GET /api/v1/app/version)
-    MIN_IOS_VERSION: z
-      .string()
-      .regex(/^\d+\.\d+\.\d+$/)
-      .default('1.0.0'),
+    MIN_IOS_VERSION: z.string().regex(SEMVER_PATTERN).default('1.0.0'),
     // Fallback only: `IosVersionGateService` publishes the version the App
     // Store actually serves and never goes below this value. No `MIN <= LATEST`
     // refine on purpose — the floor is clamped at request time against the
     // downloadable version, so `MIN_IOS_VERSION` can be raised before Apple
     // finishes the rollout instead of crashing the boot.
-    LATEST_IOS_VERSION: z
-      .string()
-      .regex(/^\d+\.\d+\.\d+$/)
-      .default('1.0.0'),
+    LATEST_IOS_VERSION: z.string().regex(SEMVER_PATTERN).default('1.0.0'),
     IOS_STORE_URL: z.url().default('https://apps.apple.com/app/id6758464920'),
-    MIN_WEB_VERSION: z
-      .string()
-      .regex(/^\d+\.\d+\.\d+$/)
-      .default('0.0.1'),
-    LATEST_WEB_VERSION: z
-      .string()
-      .regex(/^\d+\.\d+\.\d+$/)
-      .default('0.0.1'),
+    MIN_WEB_VERSION: z.string().regex(SEMVER_PATTERN).default('0.0.1'),
+    LATEST_WEB_VERSION: z.string().regex(SEMVER_PATTERN).default('0.0.1'),
   })
   .refine(
     (env) => isVersionAtMost(env.MIN_WEB_VERSION, env.LATEST_WEB_VERSION),

--- a/backend-nest/src/config/environment.ts
+++ b/backend-nest/src/config/environment.ts
@@ -1,23 +1,5 @@
 import { z } from 'zod';
-
-const SEMVER_SEGMENT_COUNT = 3;
-
-/**
- * Returns true when `version <= ceiling`, comparing the three numeric
- * `MAJOR.MINOR.PATCH` segments. Inputs are shape-validated by the
- * `/^\d+\.\d+\.\d+$/` regex before this runs, so each split yields exactly
- * three numbers.
- */
-function isVersionAtMost(version: string, ceiling: string): boolean {
-  const parts = version.split('.').map(Number);
-  const ceilingParts = ceiling.split('.').map(Number);
-  for (let i = 0; i < SEMVER_SEGMENT_COUNT; i++) {
-    if (parts[i] !== ceilingParts[i]) {
-      return parts[i] < ceilingParts[i];
-    }
-  }
-  return true;
-}
+import { isVersionAtMost } from '@common/utils/semver-compare';
 
 const envSchema = z
   .object({
@@ -75,6 +57,11 @@ const envSchema = z
       .string()
       .regex(/^\d+\.\d+\.\d+$/)
       .default('1.0.0'),
+    // Fallback only: `IosVersionGateService` publishes the version the App
+    // Store actually serves and never goes below this value. No `MIN <= LATEST`
+    // refine on purpose — the floor is clamped at request time against the
+    // downloadable version, so `MIN_IOS_VERSION` can be raised before Apple
+    // finishes the rollout instead of crashing the boot.
     LATEST_IOS_VERSION: z
       .string()
       .regex(/^\d+\.\d+\.\d+$/)
@@ -89,13 +76,6 @@ const envSchema = z
       .regex(/^\d+\.\d+\.\d+$/)
       .default('0.0.1'),
   })
-  .refine(
-    (env) => isVersionAtMost(env.MIN_IOS_VERSION, env.LATEST_IOS_VERSION),
-    {
-      message: 'LATEST_IOS_VERSION must be >= MIN_IOS_VERSION',
-      path: ['LATEST_IOS_VERSION'],
-    },
-  )
   .refine(
     (env) => isVersionAtMost(env.MIN_WEB_VERSION, env.LATEST_WEB_VERSION),
     {

--- a/backend-nest/src/modules/app-version/app-version-payload.spec.ts
+++ b/backend-nest/src/modules/app-version/app-version-payload.spec.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'bun:test';
 import type { ConfigService } from '@nestjs/config';
 import { buildAppVersionResponse } from './app-version-payload';
+import type { IosVersionGate } from './ios-version-gate.service';
+
+const IOS_VERSIONS: IosVersionGate = {
+  minVersion: '1.0.0',
+  latestVersion: '1.0.2',
+};
 
 function createMockConfig(values: Record<string, string>): ConfigService {
   return {
@@ -9,16 +15,14 @@ function createMockConfig(values: Record<string, string>): ConfigService {
 }
 
 describe('buildAppVersionResponse', () => {
-  it('should produce a valid AppVersionResponse from well-formed env values', () => {
+  it('should produce a valid AppVersionResponse from well-formed values', () => {
     const config = createMockConfig({
-      MIN_IOS_VERSION: '1.0.0',
-      LATEST_IOS_VERSION: '1.0.2',
       IOS_STORE_URL: 'https://apps.apple.com/app/pulpe',
       MIN_WEB_VERSION: '0.0.1',
       LATEST_WEB_VERSION: '0.34.1',
     });
 
-    const result = buildAppVersionResponse(config);
+    const result = buildAppVersionResponse(config, IOS_VERSIONS);
 
     expect(result.success).toBe(true);
     expect(result.data.ios.minVersion).toBe('1.0.0');
@@ -30,25 +34,26 @@ describe('buildAppVersionResponse', () => {
 
   it('should throw when a version is not semver-shaped', () => {
     const config = createMockConfig({
-      MIN_IOS_VERSION: 'latest',
-      LATEST_IOS_VERSION: '1.0.0',
       IOS_STORE_URL: 'https://apps.apple.com/app/pulpe',
       MIN_WEB_VERSION: '0.0.1',
       LATEST_WEB_VERSION: '0.0.1',
     });
 
-    expect(() => buildAppVersionResponse(config)).toThrow();
+    expect(() =>
+      buildAppVersionResponse(config, {
+        minVersion: 'latest',
+        latestVersion: '1.0.0',
+      }),
+    ).toThrow();
   });
 
   it('should throw when IOS_STORE_URL is not a URL', () => {
     const config = createMockConfig({
-      MIN_IOS_VERSION: '1.0.0',
-      LATEST_IOS_VERSION: '1.0.0',
       IOS_STORE_URL: 'not-a-url',
       MIN_WEB_VERSION: '0.0.1',
       LATEST_WEB_VERSION: '0.0.1',
     });
 
-    expect(() => buildAppVersionResponse(config)).toThrow();
+    expect(() => buildAppVersionResponse(config, IOS_VERSIONS)).toThrow();
   });
 });

--- a/backend-nest/src/modules/app-version/app-version-payload.ts
+++ b/backend-nest/src/modules/app-version/app-version-payload.ts
@@ -3,24 +3,27 @@ import {
   appVersionResponseSchema,
   type AppVersionResponse,
 } from 'pulpe-shared';
+import type { IosVersionGate } from './ios-version-gate.service';
 
 /**
  * Builds the payload served at `GET /api/v1/app/version`.
  *
- * Reads version + store URL values from `ConfigService` (validated at boot by
- * the `envSchema` Zod schema) and runs them through `appVersionResponseSchema`
- * for a final shape check. Any drift between env values and the shared
- * contract surfaces here as a Zod error.
+ * Web values and the store URL come from `ConfigService` (validated at boot by
+ * the `envSchema` Zod schema); iOS versions come from `IosVersionGateService`,
+ * which tracks what the App Store actually serves. Everything runs through
+ * `appVersionResponseSchema` for a final shape check, so any drift from the
+ * shared contract surfaces here as a Zod error.
  */
 export function buildAppVersionResponse(
   configService: ConfigService,
+  iosVersions: IosVersionGate,
 ): AppVersionResponse {
   return appVersionResponseSchema.parse({
     success: true,
     data: {
       ios: {
-        minVersion: configService.get('MIN_IOS_VERSION'),
-        latestVersion: configService.get('LATEST_IOS_VERSION'),
+        minVersion: iosVersions.minVersion,
+        latestVersion: iosVersions.latestVersion,
         storeUrl: configService.get('IOS_STORE_URL'),
       },
       web: {

--- a/backend-nest/src/modules/app-version/app-version.controller.spec.ts
+++ b/backend-nest/src/modules/app-version/app-version.controller.spec.ts
@@ -5,13 +5,17 @@ import { ConfigService } from '@nestjs/config';
 import { appVersionResponseSchema } from 'pulpe-shared';
 import request from 'supertest';
 import { AppVersionController } from './app-version.controller';
+import { IosVersionGateService } from './ios-version-gate.service';
 
 const STUB_ENV = {
-  MIN_IOS_VERSION: '1.0.0',
-  LATEST_IOS_VERSION: '1.0.2',
   IOS_STORE_URL: 'https://apps.apple.com/app/pulpe',
   MIN_WEB_VERSION: '0.0.1',
   LATEST_WEB_VERSION: '0.34.1',
+};
+
+const STUB_IOS_GATE = {
+  minVersion: '1.0.0',
+  latestVersion: '1.0.2',
 };
 
 let app: INestApplication;
@@ -25,6 +29,10 @@ beforeAll(async () => {
         useValue: {
           get: (key: string) => STUB_ENV[key as keyof typeof STUB_ENV],
         },
+      },
+      {
+        provide: IosVersionGateService,
+        useValue: { resolve: () => STUB_IOS_GATE },
       },
     ],
   }).compile();
@@ -65,12 +73,15 @@ describe('GET /api/v1/app/version', () => {
     expect(response.headers['cache-control']).toBe('public, max-age=300');
   });
 
-  it('serves the configured iOS minimum version', async () => {
+  it('serves the resolved iOS versions and the configured store URL', async () => {
     const response = await request(app.getHttpServer()).get(
       '/api/v1/app/version',
     );
 
-    expect(response.body.data.ios.minVersion).toBe(STUB_ENV.MIN_IOS_VERSION);
+    expect(response.body.data.ios.minVersion).toBe(STUB_IOS_GATE.minVersion);
+    expect(response.body.data.ios.latestVersion).toBe(
+      STUB_IOS_GATE.latestVersion,
+    );
     expect(response.body.data.ios.storeUrl).toBe(STUB_ENV.IOS_STORE_URL);
   });
 });

--- a/backend-nest/src/modules/app-version/app-version.controller.ts
+++ b/backend-nest/src/modules/app-version/app-version.controller.ts
@@ -9,6 +9,7 @@ import {
 import { ErrorResponseDto } from '@common/dto/response.dto';
 import type { AppVersionResponse } from 'pulpe-shared';
 import { buildAppVersionResponse } from './app-version-payload';
+import { IosVersionGateService } from './ios-version-gate.service';
 import { AppVersionResponseDto } from './dto/app-version-swagger.dto';
 
 /**
@@ -19,7 +20,8 @@ import { AppVersionResponseDto } from './dto/app-version-swagger.dto';
  * update wall when below the floor. **No `AuthGuard`** — must work pre-login.
  * Rate-limited by the global `UserThrottlerGuard` via the `public` throttler
  * (20 req/min/IP in prod). Response is cacheable for 5 minutes — version
- * values change rarely (env-driven) and an old cached payload is harmless.
+ * values change rarely and an old cached payload is harmless. iOS values come
+ * from `IosVersionGateService` (App Store-tracked), web values from env.
  */
 @ApiTags('App')
 @Controller({ path: 'app', version: '1' })
@@ -28,7 +30,10 @@ import { AppVersionResponseDto } from './dto/app-version-swagger.dto';
   type: ErrorResponseDto,
 })
 export class AppVersionController {
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly iosVersionGate: IosVersionGateService,
+  ) {}
 
   @Get('version')
   @Header('Cache-Control', 'public, max-age=300')
@@ -46,6 +51,9 @@ export class AppVersionController {
     type: AppVersionResponseDto,
   })
   getVersion(): AppVersionResponse {
-    return buildAppVersionResponse(this.configService);
+    return buildAppVersionResponse(
+      this.configService,
+      this.iosVersionGate.resolve(),
+    );
   }
 }

--- a/backend-nest/src/modules/app-version/app-version.module.ts
+++ b/backend-nest/src/modules/app-version/app-version.module.ts
@@ -1,7 +1,13 @@
 import { Module } from '@nestjs/common';
+import { createInfoLoggerProvider } from '@common/logger';
 import { AppVersionController } from './app-version.controller';
+import { IosVersionGateService } from './ios-version-gate.service';
 
 @Module({
   controllers: [AppVersionController],
+  providers: [
+    IosVersionGateService,
+    createInfoLoggerProvider(IosVersionGateService.name),
+  ],
 })
 export class AppVersionModule {}

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.spec.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.spec.ts
@@ -104,6 +104,19 @@ describe('IosVersionGateService', () => {
     expect(service.resolve().latestVersion).toBe('1.3.0');
   });
 
+  it('should skip the lookup when IOS_STORE_URL carries no App Store identifier', async () => {
+    service = await createService({
+      ...BASE_ENV,
+      IOS_STORE_URL: 'https://apps.apple.com/app/pulpe',
+    });
+
+    service.resolve();
+    await flushPendingRefresh();
+
+    expect(service.resolve().latestVersion).toBe('1.3.0');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('should ignore an App Store version that is not semver-shaped', async () => {
     mockFetch.mockResolvedValue(lookupResponse('1.3'));
     service = await createService();

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.spec.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from 'bun:test';
+import { ConfigService } from '@nestjs/config';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { INFO_LOGGER_TOKEN } from '@common/logger/info-logger.provider';
+import { IosVersionGateService } from './ios-version-gate.service';
+
+const BASE_ENV = {
+  MIN_IOS_VERSION: '1.0.0',
+  LATEST_IOS_VERSION: '1.3.0',
+  IOS_STORE_URL: 'https://apps.apple.com/app/id6758464920',
+};
+
+function lookupResponse(version: string) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ results: [{ version }] }),
+  };
+}
+
+async function flushPendingRefresh(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('IosVersionGateService', () => {
+  let module: TestingModule;
+  let service: IosVersionGateService;
+  const mockFetch = jest.fn();
+
+  async function createService(
+    env: Record<string, string> = BASE_ENV,
+  ): Promise<IosVersionGateService> {
+    module = await Test.createTestingModule({
+      providers: [
+        IosVersionGateService,
+        {
+          provide: ConfigService,
+          useValue: { get: (key: string) => env[key] },
+        },
+        {
+          provide: `${INFO_LOGGER_TOKEN}:${IosVersionGateService.name}`,
+          useValue: {
+            info: jest.fn(),
+            warn: jest.fn(),
+            debug: jest.fn(),
+            trace: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    return module.get(IosVersionGateService);
+  }
+
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(async () => {
+    global.fetch = originalFetch;
+    mockFetch.mockReset();
+    await module?.close();
+  });
+
+  it('should serve the configured versions without waiting for the App Store lookup', async () => {
+    mockFetch.mockResolvedValue(lookupResponse('1.3.1'));
+    service = await createService();
+
+    const gate = service.resolve();
+
+    expect(gate).toEqual({ minVersion: '1.0.0', latestVersion: '1.3.0' });
+  });
+
+  it('should adopt the App Store version once the lookup resolves', async () => {
+    mockFetch.mockResolvedValue(lookupResponse('1.3.1'));
+    service = await createService();
+
+    service.resolve();
+    await flushPendingRefresh();
+
+    expect(service.resolve().latestVersion).toBe('1.3.1');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep the configured version when the App Store lookup fails', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+    service = await createService();
+
+    service.resolve();
+    await flushPendingRefresh();
+
+    expect(service.resolve().latestVersion).toBe('1.3.0');
+  });
+
+  it('should keep the configured version when the App Store reports an older one', async () => {
+    mockFetch.mockResolvedValue(lookupResponse('1.2.1'));
+    service = await createService();
+
+    service.resolve();
+    await flushPendingRefresh();
+
+    expect(service.resolve().latestVersion).toBe('1.3.0');
+  });
+
+  it('should ignore an App Store version that is not semver-shaped', async () => {
+    mockFetch.mockResolvedValue(lookupResponse('1.3'));
+    service = await createService();
+
+    service.resolve();
+    await flushPendingRefresh();
+
+    expect(service.resolve().latestVersion).toBe('1.3.0');
+  });
+
+  it('should clamp the floor to the version the App Store actually serves', async () => {
+    mockFetch.mockResolvedValue(lookupResponse('1.3.0'));
+    service = await createService({ ...BASE_ENV, MIN_IOS_VERSION: '1.4.0' });
+
+    service.resolve();
+    await flushPendingRefresh();
+
+    expect(service.resolve()).toEqual({
+      minVersion: '1.3.0',
+      latestVersion: '1.3.0',
+    });
+  });
+
+  it('should apply the floor as soon as the App Store catches up', async () => {
+    mockFetch.mockResolvedValue(lookupResponse('1.4.0'));
+    service = await createService({ ...BASE_ENV, MIN_IOS_VERSION: '1.4.0' });
+
+    service.resolve();
+    await flushPendingRefresh();
+
+    expect(service.resolve()).toEqual({
+      minVersion: '1.4.0',
+      latestVersion: '1.4.0',
+    });
+  });
+});

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.spec.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.spec.ts
@@ -73,6 +73,17 @@ describe('IosVersionGateService', () => {
     expect(gate).toEqual({ minVersion: '1.0.0', latestVersion: '1.3.0' });
   });
 
+  it('should prime the App Store version at bootstrap, before any request', async () => {
+    mockFetch.mockResolvedValue(lookupResponse('1.3.1'));
+    service = await createService();
+
+    service.onApplicationBootstrap();
+    await flushPendingRefresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(service.resolve().latestVersion).toBe('1.3.1');
+  });
+
   it('should adopt the App Store version once the lookup resolves', async () => {
     mockFetch.mockResolvedValue(lookupResponse('1.3.1'));
     service = await createService();

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.spec.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.spec.ts
@@ -71,6 +71,7 @@ describe('IosVersionGateService', () => {
     const gate = service.resolve();
 
     expect(gate).toEqual({ minVersion: '1.0.0', latestVersion: '1.3.0' });
+    await flushPendingRefresh();
   });
 
   it('should prime the App Store version at bootstrap, before any request', async () => {

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.ts
@@ -80,14 +80,19 @@ export class IosVersionGateService {
   async #refreshPublishedVersion(): Promise<void> {
     try {
       const version = await this.#fetchPublishedVersion();
-      if (version !== this.#publishedVersion) {
+      const hasChanged = version !== this.#publishedVersion;
+      this.#publishedVersion = version;
+      this.#refreshAfter = Date.now() + FRESH_TTL_MS;
+      if (hasChanged) {
         this.logger.info(
-          { operation: 'refreshPublishedVersion', version },
+          {
+            operation: 'refreshPublishedVersion',
+            appStoreVersion: version,
+            servedVersion: this.#resolveLatestVersion(),
+          },
           'App Store version resolved',
         );
       }
-      this.#publishedVersion = version;
-      this.#refreshAfter = Date.now() + FRESH_TTL_MS;
     } catch (error) {
       this.#refreshAfter = Date.now() + RETRY_TTL_MS;
       this.logger.warn(

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.ts
@@ -1,11 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { z } from 'zod';
 import { type InfoLogger, InjectInfoLogger } from '@common/logger';
 import { isVersionAtMost } from '@common/utils/semver-compare';
 
 const APP_STORE_LOOKUP_URL = 'https://itunes.apple.com/lookup';
 const APP_STORE_ID_PATTERN = /id(\d+)/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+const APP_STORE_LOOKUP_SCHEMA = z.object({
+  results: z
+    .array(z.object({ version: z.string().regex(SEMVER_PATTERN) }))
+    .nonempty(),
+});
 const LOOKUP_TIMEOUT_MS = 3_000;
 const FRESH_TTL_MS = 6 * 60 * 60 * 1000;
 const RETRY_TTL_MS = 15 * 60 * 1000;
@@ -119,16 +125,8 @@ export class IosVersionGateService {
       throw new Error(`App Store lookup returned HTTP ${response.status}`);
     }
 
-    const payload = (await response.json()) as {
-      results?: { version?: string }[];
-    };
-    const version = payload.results?.[0]?.version;
-    if (!version || !SEMVER_PATTERN.test(version)) {
-      throw new Error(
-        `App Store lookup returned an unusable version: ${version ?? 'none'}`,
-      );
-    }
-    return version;
+    const payload = APP_STORE_LOOKUP_SCHEMA.parse(await response.json());
+    return payload.results[0].version;
   }
 
   #warnUnreachableFloor(minVersion: string, latestVersion: string): void {

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { type InfoLogger, InjectInfoLogger } from '@common/logger';
+import { isVersionAtMost } from '@common/utils/semver-compare';
+
+const APP_STORE_LOOKUP_URL = 'https://itunes.apple.com/lookup';
+const APP_STORE_ID_PATTERN = /id(\d+)/;
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+const LOOKUP_TIMEOUT_MS = 3_000;
+const FRESH_TTL_MS = 6 * 60 * 60 * 1000;
+const RETRY_TTL_MS = 15 * 60 * 1000;
+
+export interface IosVersionGate {
+  minVersion: string;
+  latestVersion: string;
+}
+
+/**
+ * Publishes the iOS half of the force-update gate served by
+ * `GET /api/v1/app/version`.
+ *
+ * `latestVersion` follows what Apple actually distributes: the App Store
+ * lookup endpoint is polled lazily (first request after the TTL triggers a
+ * background refresh, no request ever waits on Apple) and the result is
+ * capped below by `LATEST_IOS_VERSION`, which stays as an offline fallback and
+ * manual override. A release therefore needs no Railway variable update once
+ * Apple approves the build.
+ *
+ * `minVersion` is clamped to `latestVersion`: the gate can never force users
+ * onto a binary the App Store does not serve yet, so `MIN_IOS_VERSION` can be
+ * set ahead of the rollout and activates on its own once the version is live.
+ */
+@Injectable()
+export class IosVersionGateService {
+  #publishedVersion: string | null = null;
+  #refreshAfter = 0;
+  #isRefreshing = false;
+  #warnedClamp: string | null = null;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @InjectInfoLogger(IosVersionGateService.name)
+    private readonly logger: InfoLogger,
+  ) {}
+
+  resolve(): IosVersionGate {
+    this.#refreshWhenStale();
+
+    const configuredMin = this.configService.get<string>('MIN_IOS_VERSION')!;
+    const latestVersion = this.#resolveLatestVersion();
+
+    if (isVersionAtMost(configuredMin, latestVersion)) {
+      return { minVersion: configuredMin, latestVersion };
+    }
+
+    this.#warnUnreachableFloor(configuredMin, latestVersion);
+    return { minVersion: latestVersion, latestVersion };
+  }
+
+  #resolveLatestVersion(): string {
+    const configured = this.configService.get<string>('LATEST_IOS_VERSION')!;
+    if (!this.#publishedVersion) {
+      return configured;
+    }
+    return isVersionAtMost(this.#publishedVersion, configured)
+      ? configured
+      : this.#publishedVersion;
+  }
+
+  #refreshWhenStale(): void {
+    if (this.#isRefreshing || Date.now() < this.#refreshAfter) {
+      return;
+    }
+    this.#isRefreshing = true;
+    void this.#refreshPublishedVersion().finally(() => {
+      this.#isRefreshing = false;
+    });
+  }
+
+  async #refreshPublishedVersion(): Promise<void> {
+    try {
+      const version = await this.#fetchPublishedVersion();
+      if (version !== this.#publishedVersion) {
+        this.logger.info(
+          { operation: 'refreshPublishedVersion', version },
+          'App Store version resolved',
+        );
+      }
+      this.#publishedVersion = version;
+      this.#refreshAfter = Date.now() + FRESH_TTL_MS;
+    } catch (error) {
+      this.#refreshAfter = Date.now() + RETRY_TTL_MS;
+      this.logger.warn(
+        {
+          operation: 'refreshPublishedVersion',
+          err: error instanceof Error ? error : undefined,
+        },
+        'App Store lookup failed, serving the configured LATEST_IOS_VERSION',
+      );
+    }
+  }
+
+  async #fetchPublishedVersion(): Promise<string> {
+    const storeUrl = this.configService.get<string>('IOS_STORE_URL') ?? '';
+    const appStoreId = APP_STORE_ID_PATTERN.exec(storeUrl)?.[1];
+    if (!appStoreId) {
+      throw new Error('IOS_STORE_URL carries no App Store identifier');
+    }
+
+    const response = await fetch(`${APP_STORE_LOOKUP_URL}?id=${appStoreId}`, {
+      signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`App Store lookup returned HTTP ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      results?: { version?: string }[];
+    };
+    const version = payload.results?.[0]?.version;
+    if (!version || !SEMVER_PATTERN.test(version)) {
+      throw new Error(
+        `App Store lookup returned an unusable version: ${version ?? 'none'}`,
+      );
+    }
+    return version;
+  }
+
+  #warnUnreachableFloor(minVersion: string, latestVersion: string): void {
+    const clamp = `${minVersion}>${latestVersion}`;
+    if (this.#warnedClamp === clamp) {
+      return;
+    }
+    this.#warnedClamp = clamp;
+    this.logger.warn(
+      { operation: 'resolve', minVersion, latestVersion },
+      'MIN_IOS_VERSION is above the version available on the App Store, serving the available one as the floor',
+    );
+  }
+}

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, type OnApplicationBootstrap } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { z } from 'zod';
 import { type InfoLogger, InjectInfoLogger } from '@common/logger';
@@ -26,18 +26,18 @@ export interface IosVersionGate {
  * `GET /api/v1/app/version`.
  *
  * `latestVersion` follows what Apple actually distributes: the App Store
- * lookup endpoint is polled lazily (first request after the TTL triggers a
- * background refresh, no request ever waits on Apple) and the result is
- * capped below by `LATEST_IOS_VERSION`, which stays as an offline fallback and
- * manual override. A release therefore needs no Railway variable update once
- * Apple approves the build.
+ * lookup runs once at bootstrap and then lazily (first request after the TTL
+ * triggers a background refresh, no request ever waits on Apple) and the
+ * result is capped below by `LATEST_IOS_VERSION`, which stays as an offline
+ * fallback and manual override. A release therefore needs no Railway variable
+ * update once Apple approves the build.
  *
  * `minVersion` is clamped to `latestVersion`: the gate can never force users
  * onto a binary the App Store does not serve yet, so `MIN_IOS_VERSION` can be
  * set ahead of the rollout and activates on its own once the version is live.
  */
 @Injectable()
-export class IosVersionGateService {
+export class IosVersionGateService implements OnApplicationBootstrap {
   #publishedVersion: string | null = null;
   #refreshAfter = 0;
   #isRefreshing = false;
@@ -48,6 +48,10 @@ export class IosVersionGateService {
     @InjectInfoLogger(IosVersionGateService.name)
     private readonly logger: InfoLogger,
   ) {}
+
+  onApplicationBootstrap(): void {
+    this.#refreshWhenStale();
+  }
 
   resolve(): IosVersionGate {
     this.#refreshWhenStale();
@@ -84,8 +88,18 @@ export class IosVersionGateService {
   }
 
   async #refreshPublishedVersion(): Promise<void> {
+    const appStoreId = this.#resolveAppStoreId();
+    if (!appStoreId) {
+      this.#refreshAfter = Number.POSITIVE_INFINITY;
+      this.logger.warn(
+        { operation: 'refreshPublishedVersion' },
+        'IOS_STORE_URL carries no App Store identifier, serving the configured LATEST_IOS_VERSION',
+      );
+      return;
+    }
+
     try {
-      const version = await this.#fetchPublishedVersion();
+      const version = await this.#fetchPublishedVersion(appStoreId);
       const hasChanged = version !== this.#publishedVersion;
       this.#publishedVersion = version;
       this.#refreshAfter = Date.now() + FRESH_TTL_MS;
@@ -111,13 +125,12 @@ export class IosVersionGateService {
     }
   }
 
-  async #fetchPublishedVersion(): Promise<string> {
+  #resolveAppStoreId(): string | undefined {
     const storeUrl = this.configService.get<string>('IOS_STORE_URL') ?? '';
-    const appStoreId = APP_STORE_ID_PATTERN.exec(storeUrl)?.[1];
-    if (!appStoreId) {
-      throw new Error('IOS_STORE_URL carries no App Store identifier');
-    }
+    return APP_STORE_ID_PATTERN.exec(storeUrl)?.[1];
+  }
 
+  async #fetchPublishedVersion(appStoreId: string): Promise<string> {
     const response = await fetch(`${APP_STORE_LOOKUP_URL}?id=${appStoreId}`, {
       signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
     });

--- a/backend-nest/src/modules/app-version/ios-version-gate.service.ts
+++ b/backend-nest/src/modules/app-version/ios-version-gate.service.ts
@@ -2,11 +2,10 @@ import { Injectable, type OnApplicationBootstrap } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { z } from 'zod';
 import { type InfoLogger, InjectInfoLogger } from '@common/logger';
-import { isVersionAtMost } from '@common/utils/semver-compare';
+import { SEMVER_PATTERN, isVersionAtMost } from '@common/utils/semver-compare';
 
 const APP_STORE_LOOKUP_URL = 'https://itunes.apple.com/lookup';
 const APP_STORE_ID_PATTERN = /id(\d+)/;
-const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
 const APP_STORE_LOOKUP_SCHEMA = z.object({
   results: z
     .array(z.object({ version: z.string().regex(SEMVER_PATTERN) }))
@@ -15,6 +14,7 @@ const APP_STORE_LOOKUP_SCHEMA = z.object({
 const LOOKUP_TIMEOUT_MS = 3_000;
 const FRESH_TTL_MS = 6 * 60 * 60 * 1000;
 const RETRY_TTL_MS = 15 * 60 * 1000;
+const NEVER_REFRESH_AGAIN = Number.POSITIVE_INFINITY;
 
 export interface IosVersionGate {
   minVersion: string;
@@ -90,7 +90,7 @@ export class IosVersionGateService implements OnApplicationBootstrap {
   async #refreshPublishedVersion(): Promise<void> {
     const appStoreId = this.#resolveAppStoreId();
     if (!appStoreId) {
-      this.#refreshAfter = Number.POSITIVE_INFINITY;
+      this.#refreshAfter = NEVER_REFRESH_AGAIN;
       this.logger.warn(
         { operation: 'refreshPublishedVersion' },
         'IOS_STORE_URL carries no App Store identifier, serving the configured LATEST_IOS_VERSION',

--- a/backend-nest/src/modules/encryption/encryption.e2e.spec.ts
+++ b/backend-nest/src/modules/encryption/encryption.e2e.spec.ts
@@ -47,6 +47,9 @@ describe('Encryption E2E (local Supabase)', () => {
       process.env.ENCRYPTION_MASTER_KEY ?? '11'.repeat(32);
     process.env.TURNSTILE_SECRET_KEY =
       process.env.TURNSTILE_SECRET_KEY ?? 'test-turnstile-key';
+    // No App Store identifier: IosVersionGateService short-circuits its
+    // bootstrap lookup, so booting AppModule here reaches no external host.
+    process.env.IOS_STORE_URL = 'https://apps.apple.com/app/pulpe';
     process.env.NODE_ENV = 'test';
 
     adminClient = createClient<Database>(env.apiUrl, env.serviceRoleKey);

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -402,7 +402,7 @@ Before creating the immutable tag or GitHub Release:
 3. Run the three public health checks below.
 4. Refetch and confirm `origin/main` still equals `SHA`.
 
-Only then create the tag and GitHub Release. Update Railway `LATEST_WEB_VERSION` after the web release is public and verify `/api/v1/app/version`. Update `LATEST_IOS_VERSION` only after the corresponding marketing version is publicly available on the App Store; otherwise leave it unchanged and complete that operation later.
+Only then create the tag and GitHub Release. Update Railway `LATEST_WEB_VERSION` after the web release is public and verify `/api/v1/app/version`. Leave `LATEST_IOS_VERSION` alone: the backend resolves the published iOS version from the App Store (see [VERSIONING.md](VERSIONING.md)), so no post-App-Store operation is pending.
 
 ## Post-Deployment Monitoring
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -101,7 +101,13 @@ Source de vérité : Railway (env Production). Les valeurs locales restent celle
 
 ### iOS : la version publiée se résout toute seule
 
-`IosVersionGateService` (`backend-nest/src/modules/app-version/`) interroge le lookup public Apple (`https://itunes.apple.com/lookup?id=<app id>`, ID extrait de `IOS_STORE_URL`) et sert cette version comme `ios.latestVersion`. Rafraîchissement paresseux : la première requête passé le TTL (6 h) déclenche un appel en tâche de fond — aucune requête client n'attend Apple. Échec, timeout (3 s) ou version non SemVer → on garde la valeur précédente, on réessaie dans 15 min, et `LATEST_IOS_VERSION` sert de plancher : la valeur servie est `max(env, App Store)`, jamais une régression.
+`IosVersionGateService` (`backend-nest/src/modules/app-version/`) interroge le lookup public Apple (`https://itunes.apple.com/lookup?id=<app id>`, ID extrait de `IOS_STORE_URL`) et sert cette version comme `ios.latestVersion`.
+
+Le lookup part une première fois au démarrage du conteneur, puis paresseusement : la première requête passé le TTL (6 h) déclenche un appel en tâche de fond. Aucune requête client n'attend Apple, et le redémarrage qui suit un changement de variable Railway sert la bonne version sans attendre le premier appel client.
+
+Échec, timeout (3 s) ou version non SemVer → on garde la valeur précédente et on réessaie dans 15 min. Cas distinct : une `IOS_STORE_URL` sans identifiant App Store est une erreur de config, pas un incident réseau — un seul `warn` est émis, sans réessai, et la valeur d'env est servie tant que le conteneur vit.
+
+Dans tous les cas de repli, `LATEST_IOS_VERSION` sert de plancher : la valeur servie est `max(env, App Store)`, jamais une régression.
 
 Conséquence : **aucun bump Railway à faire après une approbation App Store**. `MIN_IOS_VERSION` peut aussi être armé avant la fin du rollout Apple — le plancher servi est borné par la version réellement téléchargeable (`minVersion = min(MIN_IOS_VERSION, latestVersion)`), donc le blocage s'active de lui-même quand Apple publie, sans jamais bloquer sur un binaire indisponible.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -83,20 +83,27 @@ Automatisé via le skill `/release`.
 Le backend expose `GET /api/v1/app/version` qui renvoie, par plateforme, la version minimale supportée et la dernière version publiée. Les clients (webapp + iOS) comparent leur version courante :
 
 - **< `minVersion`** → blocage dur, CTA vers le store
-- **`minVersion` ≤ version < `latestVersion`** → toast "mise à jour disponible"
-- **≥ `latestVersion`** → aucune incitation
+- **≥ `minVersion`** → aucune incitation
+
+`latestVersion` est publié mais **aucun client ne le lit** aujourd'hui : `AppVersionStore` (iOS) et `AppVersionStore` (webapp) ne comparent que `minVersion`. Le champ reste réservé à un futur toast "mise à jour disponible".
 
 Cinq variables d'env pilotent ce gate côté backend, validées par Zod (`backend-nest/src/config/environment.ts`) :
 
 | Variable | Rôle | Format |
 |----------|------|--------|
 | `MIN_IOS_VERSION` | Plancher iOS — en dessous = blocage dur | SemVer `X.Y.Z` |
-| `LATEST_IOS_VERSION` | Dernière version iOS publiée | SemVer `X.Y.Z` |
-| `IOS_STORE_URL` | Deep link App Store (CTA "Mettre à jour") | URL absolue |
+| `LATEST_IOS_VERSION` | Repli hors-ligne / override manuel — la valeur servie vient de l'App Store | SemVer `X.Y.Z` |
+| `IOS_STORE_URL` | Deep link App Store (CTA "Mettre à jour") — porte aussi l'ID interrogé par le lookup | URL absolue |
 | `MIN_WEB_VERSION` | Plancher webapp | SemVer `X.Y.Z` |
 | `LATEST_WEB_VERSION` | Dernière version webapp publiée | SemVer `X.Y.Z` |
 
 Source de vérité : Railway (env Production). Les valeurs locales restent celles de `backend-nest/.env.example`.
+
+### iOS : la version publiée se résout toute seule
+
+`IosVersionGateService` (`backend-nest/src/modules/app-version/`) interroge le lookup public Apple (`https://itunes.apple.com/lookup?id=<app id>`, ID extrait de `IOS_STORE_URL`) et sert cette version comme `ios.latestVersion`. Rafraîchissement paresseux : la première requête passé le TTL (6 h) déclenche un appel en tâche de fond — aucune requête client n'attend Apple. Échec, timeout (3 s) ou version non SemVer → on garde la valeur précédente, on réessaie dans 15 min, et `LATEST_IOS_VERSION` sert de plancher : la valeur servie est `max(env, App Store)`, jamais une régression.
+
+Conséquence : **aucun bump Railway à faire après une approbation App Store**. `MIN_IOS_VERSION` peut aussi être armé avant la fin du rollout Apple — le plancher servi est borné par la version réellement téléchargeable (`minVersion = min(MIN_IOS_VERSION, latestVersion)`), donc le blocage s'active de lui-même quand Apple publie, sans jamais bloquer sur un binaire indisponible.
 
 ### Quand bumper `MIN_*`
 
@@ -110,13 +117,12 @@ Hors ces cas, `MIN_*` reste figé. Une release "classique" ne bouge que `LATEST_
 
 ### Procédure de rollout
 
-1. **Publier la release client AVANT le bump.** La version cible (App Store ou webapp Vercel) doit déjà être **publique et disponible**. Sinon on bloque les users sur une version qui n'existe pas encore.
-2. **Bump `LATEST_*` sur Railway** dès la release publiée :
+1. **Publier la release webapp AVANT le bump `MIN_WEB_VERSION`.** La version cible doit déjà être **publique et disponible** sur Vercel. Côté iOS, aucune précaution : le plancher servi est borné par la version App Store.
+2. **Bump `LATEST_WEB_VERSION` sur Railway** dès la release publiée :
    ```bash
-   railway variables --set "LATEST_IOS_VERSION=1.2.0" --service backend
    railway variables --set "LATEST_WEB_VERSION=0.36.0" --service backend
    ```
-   Railway redémarre le service à chaque mise à jour de variable — `ConfigService` relit l'env au boot.
+   Railway redémarre le service à chaque mise à jour de variable — `ConfigService` relit l'env au boot. `LATEST_IOS_VERSION` ne se bump pas : le backend suit l'App Store.
 3. **Bump `MIN_*` (force-update)** uniquement quand l'éjection est nécessaire :
    ```bash
    railway variables --set "MIN_IOS_VERSION=1.2.0" --service backend


### PR DESCRIPTION
## ✅ Type of PR

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## 🗒️ Description

La version iOS publiée servie par `GET /api/v1/app/version` vient désormais de l'App Store, plus d'une variable Railway bumpée à la main après chaque approbation Apple.

`IosVersionGateService` interroge le lookup public Apple (ID extrait de `IOS_STORE_URL`, pas de nouvelle variable) et publie cette version. `LATEST_IOS_VERSION` reste un **repli hors-ligne et un override manuel** : la valeur servie est `max(env, App Store)`, jamais une régression.

Le refresh est **paresseux et hors du chemin de requête** : la première requête passé le TTL (6 h) déclenche un appel en tâche de fond (timeout 3 s, retry 15 min sur échec). Aucune requête client n'attend Apple, et un Apple injoignable se comporte exactement comme aujourd'hui.

`minVersion` est borné à la version réellement disponible, ce qui **remplace le refine boot `MIN_IOS_VERSION <= LATEST_IOS_VERSION`**. Ce refine faisait dépendre le kill switch du bump manuel : relever le plancher avant la fin du rollout Apple faisait planter le conteneur au démarrage. Le clamp ne peut qu'**affaiblir** le mur, jamais forcer les utilisateurs sur un binaire que l'App Store ne sert pas — le plancher peut donc être armé en avance et s'active tout seul.

Le contrat de l'endpoint est inchangé : mêmes clés, même schéma Zod, clients iOS et webapp intouchés (ils ne lisent que `minVersion`).

## 🚶‍➡️ Behavior

- Après une approbation App Store, `ios.latestVersion` se met à jour seul (≤ 6 h) — plus aucune opération Railway en attente après une release
- `MIN_IOS_VERSION` peut être positionné avant qu'Apple ait fini de publier : le plancher servi reste borné à la version téléchargeable, puis le blocage s'active dès qu'Apple publie
- Apple injoignable, timeout, ou version non SemVer → la valeur précédente (sinon l'env) est servie, avec un `warn` structuré ; aucun risque de 500 sur cet endpoint public
- Le skill `/release` et les docs de déploiement ne planifient plus, et n'attendent plus, le flip `LATEST_IOS_VERSION`
- `MIN_WEB_VERSION <= LATEST_WEB_VERSION` reste validé au boot, côté web rien ne change

## 🧪 Steps to test

- [ ] `cd backend-nest && bun test src/modules/app-version src/config/environment.spec.ts` → 45 tests verts
- [ ] `pnpm quality` à la racine → 11/11 tasks, 0 erreur
- [ ] Booter le backend et `curl -s localhost:3000/api/v1/app/version | jq .data.ios` : le premier appel renvoie `LATEST_IOS_VERSION`, les suivants la version App Store (`1.3.0` aujourd'hui)
- [ ] Mettre `MIN_IOS_VERSION=9.9.9` en local → `minVersion` reste borné à la version App Store et un `warn` "MIN_IOS_VERSION is above the version available on the App Store" apparaît une seule fois
- [ ] Couper le réseau (ou pointer `IOS_STORE_URL` sur une URL sans identifiant) → l'endpoint continue de répondre avec la valeur d'env
