### PR TITLE
fix(landing): rendre au menu replié son absence de l'arbre de rendu

### DIFF
--- a/landing/app/accessibility.test.tsx
+++ b/landing/app/accessibility.test.tsx
@@ -681,7 +681,7 @@ describe("landing accessibility contracts", () => {
     );
   });
 
-  it("keeps the closed mobile panel viewport-sized for instant compositing", () => {
+  it("keeps the closed mobile panel out of the render tree", () => {
     assert.match(componentSources.header, /className="group peer"/);
     assert.match(
       componentSources.header,
@@ -689,12 +689,42 @@ describe("landing accessibility contracts", () => {
     );
     assert.match(componentSources.header, /\binert\b/);
     assert.match(componentSources.header, /aria-hidden="true"/);
-    assert.match(componentSources.header, /\bfixed\b[^"]*\bh-screen\b/);
-    assert.match(
-      componentSources.header,
-      /pointer-events-none[^"]*peer-open:pointer-events-auto[^"]*peer-open:opacity-100/,
+    // Toutes les classes qui suivent se lisent sur le panneau lui-même. Portées
+    // par n'importe quel `className` du fichier, elles passaient en le laissant
+    // peint au repos — l'état même qui a causé le défaut.
+    const panelClasses = componentSources.header.match(
+      /<nav\s+id=\{MOBILE_NAV_PANEL_ID\}[^>]*?\sclassName="([^"]*)"/,
+    )?.[1];
+    assert.ok(panelClasses, "le panneau mobile doit porter un className");
+    const panelHas = (token: string) =>
+      panelClasses.split(/\s+/).includes(token);
+
+    assert.ok(panelHas("fixed") && panelHas("h-screen"));
+    // Replié, le panneau vaut `display: none`. `opacity: 0` le laisserait dans
+    // l'arbre de rendu, où Safari 26 lit le fond des éléments fixes pour teinter
+    // sa barre du bas : le bouton vert du menu, ancré en bas d'un panneau plein
+    // écran, lui donnait son aplat sur toute la landing.
+    assert.ok(panelHas("hidden"), "replié, le panneau doit quitter le rendu");
+    // `max-lg:` et non `peer-open:` seul : `:is(:where(.peer):is([open])~*)` pèse
+    // (0,2,0) contre (0,1,0) pour `lg:hidden`, qui perdrait donc sur un écran
+    // large — le panneau resterait ouvert par-dessus la barre de bureau.
+    assert.ok(
+      panelHas("max-lg:peer-open:flex") && !panelHas("peer-open:flex"),
+      "l'ouverture doit être bornée sous le point de rupture desktop",
     );
-    assert.match(componentSources.header, /will-change-\[opacity\]/);
+    assert.ok(panelHas("lg:hidden"));
+    // Le fondu, que la bascule de `display` casserait sinon.
+    assert.ok(
+      panelHas("transition-[opacity,display]") &&
+        panelHas("transition-discrete") &&
+        panelHas("peer-open:starting:opacity-0"),
+      "le fondu doit survivre à la bascule de display",
+    );
+    assert.ok(
+      panelHas("pointer-events-none") &&
+        panelHas("peer-open:pointer-events-auto") &&
+        panelHas("peer-open:opacity-100"),
+    );
     assert.equal(componentSources.header.match(/tabIndex=\{-1\}/g)?.length, 2);
     assert.doesNotMatch(componentSources.header, /\binvisible\b/);
     assert.doesNotMatch(componentSources.header, /\bbackdrop-blur-xl\b/);

--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
+/* Les tests citent des classes en clair pour garder un composant sur sa forme.
+   Sans cette exclusion, le détecteur de Tailwind les lit comme du balisage et
+   émet leurs règles dans le bundle, où rien ne les porte. */
+@source not "../**/*.test.*";
+
 /* Posée par le script inline du layout dès la fin du parsing, bien avant
    l'hydratation : la navbar réagit au scroll sans dépendre du bundle. */
 @custom-variant scrolled (html[data-scrolled] &);

--- a/landing/components/sections/Header.tsx
+++ b/landing/components/sections/Header.tsx
@@ -105,15 +105,24 @@ export function Header() {
           </summary>
         </details>
 
-        {/* Hors du `<details>` et toujours peint pour que Safari compose la
-            couche fixe avant l'ouverture. `inert` retire ses liens du clavier
-            et de l'arbre d'accessibilité ; le script couvre aussi Safari 15. */}
+        {/* Hors du `<details>` parce que le `<nav>` de la barre porte un
+            `backdrop-filter` en état scrollé. Replié, le panneau sort de l'arbre
+            de rendu (`display: none`) : Safari 26 teinte sa barre du bas avec le
+            fond d'un élément fixe qui l'atteint, et `opacity: 0` ne suffit pas à
+            l'en soustraire — le bouton vert du menu, ancré en bas, lui donnait
+            son aplat sur toute la landing. La bascule de `display` s'anime
+            comme le reste : `allow-discrete` la retient le temps du fondu, et
+            `@starting-style` donne à l'ouverture son opacité de départ.
+            L'ouverture est bornée à `max-lg` : son sélecteur pèse plus lourd
+            que `lg:hidden`, qui ne la rattraperait pas sur un écran large.
+            `inert` retire ses liens du clavier et de l'arbre d'accessibilité ;
+            le script couvre les navigateurs qui l'ignorent encore. */}
         <nav
           id={MOBILE_NAV_PANEL_ID}
           aria-label="Navigation mobile"
           aria-hidden="true"
           inert
-          className="pointer-events-none fixed inset-x-0 top-0 z-10 flex h-screen overflow-y-auto bg-surface pt-24 pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] opacity-0 transition-opacity duration-300 will-change-[opacity] peer-open:pointer-events-auto peer-open:opacity-100 lg:hidden motion-reduce:transition-none"
+          className="pointer-events-none fixed inset-x-0 top-0 z-10 hidden h-screen overflow-y-auto bg-surface pt-24 pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] opacity-0 transition-[opacity,display] transition-discrete duration-300 will-change-[opacity] peer-open:pointer-events-auto peer-open:opacity-100 peer-open:starting:opacity-0 max-lg:peer-open:flex lg:hidden motion-reduce:transition-none"
         >
           {/* Les liens s'ancrent sous la barre, le CTA au bas de l'écran, à
               portée de pouce. Centré, le bloc flottait au milieu d'un plein

--- a/landing/components/sections/Header.tsx
+++ b/landing/components/sections/Header.tsx
@@ -122,7 +122,7 @@ export function Header() {
           aria-label="Navigation mobile"
           aria-hidden="true"
           inert
-          className="pointer-events-none fixed inset-x-0 top-0 z-10 hidden h-screen overflow-y-auto bg-surface pt-24 pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] opacity-0 transition-[opacity,display] transition-discrete duration-300 will-change-[opacity] peer-open:pointer-events-auto peer-open:opacity-100 peer-open:starting:opacity-0 max-lg:peer-open:flex lg:hidden motion-reduce:transition-none"
+          className="pointer-events-none fixed inset-x-0 top-0 z-10 hidden h-screen overflow-y-auto bg-surface pt-24 pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] opacity-0 transition-[opacity,display] transition-discrete duration-300 peer-open:pointer-events-auto peer-open:opacity-100 peer-open:starting:opacity-0 max-lg:peer-open:flex lg:hidden motion-reduce:transition-none"
         >
           {/* Les liens s'ancrent sous la barre, le CTA au bas de l'écran, à
               portée de pouce. Centré, le bloc flottait au milieu d'un plein


### PR DESCRIPTION
Sur Safari iOS 26, la bande derrière la barre d'URL était vert vif sur toute la landing, y compris sous des sections entièrement claires. Signalé sur iPhone, reproduit sur simulateur iOS 26.5.

Attendu : la barre du bas de Safari est translucide et la page défile dessous. C'est ce que fait `pulpe.app` aujourd'hui, et ce que `preview` a perdu.

## Ce qui se passait

Safari 26 ne lit plus `meta[name=theme-color]`. Il teinte sa barre du bas avec le fond des éléments `fixed` qui atteignent ce bord, et bascule alors de sa barre en verre à un aplat opaque. `opacity: 0` ne soustrait pas un élément à cette lecture ; seul `display: none` le fait.

Le panneau du menu mobile est `fixed inset-x-0 top-0 h-screen`, donc il atteint ce bord, et il restait peint en permanence — un choix qui se voulait assumé, pour que Safari compose sa couche avant la première ouverture.

Tant que son CTA était centré verticalement, il n'y avait rien à lire en bas. #566 a ancré ce CTA au bas du panneau (`h-full` + `mt-auto`) pour le mettre à portée de pouce : Safari y a trouvé `#006e25`, le vert de la marque, et l'a posé sur toute la landing — menu fermé compris.

La couleur le dit seule : la bande vaut exactement `bg-primary`, mesurée à `rgb(0, 107, 36)` au pixel. `pulpe.app`, qui garde le CTA au milieu du panneau, garde sa barre en verre.

## Le correctif

Replié, le panneau sort de l'arbre de rendu. Le fondu survit à la bascule de `display` par `transition-behavior: allow-discrete`, et `@starting-style` donne à l'ouverture son opacité de départ — la manière standard d'animer une entrée depuis `display: none`, disponible partout depuis Safari 17.4.

L'ouverture est bornée sous le point de rupture (`max-lg:peer-open:flex`). Non bornée, son sélecteur `:is(:where(.peer):is([open])~*)` pèse (0,2,0) contre (0,1,0) pour `lg:hidden` : le panneau se serait ouvert par-dessus la barre de bureau, quel que soit l'ordre des règles.

Trois fichiers, +54/-10. Le design de #566 est intact : liens en haut, CTA en bas.

## Fausses pistes écartées

Deux tentatives précédentes visaient à donner à Safari une _autre_ couleur à lire — une cale portant le fond de page, puis le fond du `StickyCTA` déplacé sur un enfant `absolute`. Les deux produisaient une bande opaque couleur fond : le défaut restait, repeint. Elles sont hors de cette branche, et `StickyCTA.tsx` y est identique à `preview`.

## Vérification

- 73/73 tests (`landing`), typecheck, eslint, prettier, `next build`
- Garde sondée par mutation : retirer `hidden`, `max-lg:peer-open:flex`, `lg:hidden`, `transition-discrete` ou `peer-open:starting:opacity-0` fait échouer le test à chaque fois. Elle lit la liste de classes du panneau lui-même : déplacer ces classes sur un enfant, ce qui laisserait le panneau peint au repos, échoue aussi
- CSS généré contrôlé : `transition-property: opacity,display`, `transition-behavior: allow-discrete`, le `@starting-style` sur le bon sélecteur `peer`, et l'ouverture bien enfermée dans `@media not all and (min-width:64rem)`
- Mesuré au navigateur sur chargement neuf, `<details>` forcé ouvert : `display: none` à 1280px, `display: flex` et panneau plein écran à 900px
- Rendu Safari iOS 26.5 sur simulateur, sur le build de cette branche : le titre de la section témoignage se lit **à travers** la barre du bas, mesuré au pixel (`rgb(25,27,24)`, les glyphes du titre, à 20px et 40px du bord). Menu ouvert puis refermé : le panneau apparaît et disparaît, la position de défilement est conservée

## Nettoyage

Citer une classe en clair dans une assertion suffisait à en faire émettre la règle dans le bundle CSS, où aucun composant ne la porte. `@source not` sort les tests du détecteur de Tailwind ; trois règles mortes disparaissent, dont deux antérieures à cette branche.
