### PR TITLE
feat(demo): montrer les capacités livrées dans le seed du mode démo

### DIFF
--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -3,7 +3,14 @@ import { Test, type TestingModule } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
 import { BUDGET_RECALCULATION_PORT } from '../../budget/domain/ports/budget-recalculation.port';
 import { DEMO_REPOSITORY } from '../domain/ports/demo-repository.port';
+import type {
+  DemoBudgetLineSeed,
+  DemoSeededBudget,
+  DemoTransactionSeed,
+} from '../domain/demo.entity';
 import { GenerateDemoDataUseCase } from './generate-demo-data.use-case';
+
+const GROCERIES_ENVELOPE = 'Courses alimentaires';
 
 function buildMockRepo() {
   return {
@@ -14,10 +21,10 @@ function buildMockRepo() {
       {
         id: 'tl-0',
         templateId: 'template-0',
-        name: 'Salaire',
-        amount: 6500,
-        kind: 'income' as const,
-        recurrence: 'fixed' as const,
+        name: GROCERIES_ENVELOPE,
+        amount: 600,
+        kind: 'expense' as const,
+        recurrence: 'one_off' as const,
       },
     ]),
     insertBudgets: mock(async (rows: unknown[]) =>
@@ -30,9 +37,40 @@ function buildMockRepo() {
           }) as unknown,
       ),
     ),
-    insertBudgetLines: mock(async () => {}),
+    insertBudgetLines: mock(async (lines: DemoBudgetLineSeed[]) =>
+      lines.map((line, i) => ({
+        id: `budget-line-${i}`,
+        budgetId: line.budgetId,
+        name: line.name,
+        amount: line.amount,
+        kind: line.kind,
+      })),
+    ),
     insertTransactions: mock(async () => {}),
   };
+}
+
+function seededBudgets(repo: ReturnType<typeof buildMockRepo>) {
+  const [[budgets]] = (repo.insertBudgets as ReturnType<typeof mock>).mock
+    .calls;
+  return budgets as DemoSeededBudget[];
+}
+
+function seededBudgetLines(repo: ReturnType<typeof buildMockRepo>) {
+  const [[lines]] = (repo.insertBudgetLines as ReturnType<typeof mock>).mock
+    .calls;
+  return lines as DemoBudgetLineSeed[];
+}
+
+function seededTransactions(repo: ReturnType<typeof buildMockRepo>) {
+  const [[transactions]] = (repo.insertTransactions as ReturnType<typeof mock>)
+    .mock.calls;
+  return transactions as DemoTransactionSeed[];
+}
+
+function isClosedMonth(budget: DemoSeededBudget, now: Date): boolean {
+  if (budget.year !== now.getFullYear()) return budget.year < now.getFullYear();
+  return budget.month < now.getMonth() + 1;
 }
 
 describe('GenerateDemoDataUseCase', () => {
@@ -132,6 +170,104 @@ describe('GenerateDemoDataUseCase', () => {
       await expect(useCase.execute('user-1', {} as never)).rejects.toThrow(
         'DB error',
       );
+    });
+  });
+
+  describe('execute - envelope consumption', () => {
+    it('should attach a grocery actual to the grocery envelope of its own budget', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const linesByBudget = new Map(
+        seededBudgetLines(mockRepo).map((line, index) => [
+          line.budgetId,
+          `budget-line-${index}`,
+        ]),
+      );
+      const groceryActuals = seededTransactions(mockRepo).filter(
+        (tx) => tx.name === 'Migros - Courses',
+      );
+      const attached = groceryActuals.filter(
+        (tx) => tx.budgetLineId !== null && linesByBudget.has(tx.budgetId),
+      );
+
+      expect(attached.length).toBeGreaterThan(0);
+      for (const actual of attached) {
+        expect(actual.budgetLineId).toBe(
+          linesByBudget.get(actual.budgetId) ?? null,
+        );
+      }
+    });
+
+    it('should leave an actual unattached when no envelope matches it', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const seededNames = new Set(
+        seededBudgetLines(mockRepo).map((line) => line.name),
+      );
+      expect(seededNames.has('Restaurants/Sorties')).toBe(false);
+
+      const restaurantActuals = seededTransactions(mockRepo).filter(
+        (tx) => tx.name === 'Restaurant Molino',
+      );
+
+      expect(restaurantActuals.length).toBeGreaterThan(0);
+      for (const actual of restaurantActuals) {
+        expect(actual.budgetLineId).toBeNull();
+      }
+    });
+  });
+
+  describe('execute - pointage', () => {
+    it('should check every budget line of a closed month and none of the current month', async () => {
+      const now = new Date();
+
+      await useCase.execute('user-1', {} as never);
+
+      const budgetsById = new Map(
+        seededBudgets(mockRepo).map((budget, index) => [
+          `budget-${index}`,
+          budget,
+        ]),
+      );
+      const lines = seededBudgetLines(mockRepo);
+      expect(lines.length).toBeGreaterThan(0);
+
+      for (const line of lines) {
+        const budget = budgetsById.get(line.budgetId);
+        if (!budget) throw new Error(`unknown budget ${line.budgetId}`);
+
+        if (isClosedMonth(budget, now)) {
+          expect(line.checkedAt).not.toBeNull();
+        } else {
+          expect(line.checkedAt).toBeNull();
+        }
+      }
+    });
+
+    it('should check the actuals of closed months and leave the current month open', async () => {
+      const now = new Date();
+
+      await useCase.execute('user-1', {} as never);
+
+      const budgetsById = new Map(
+        seededBudgets(mockRepo).map((budget, index) => [
+          `budget-${index}`,
+          budget,
+        ]),
+      );
+      const transactions = seededTransactions(mockRepo);
+      expect(transactions.length).toBeGreaterThan(0);
+
+      for (const transaction of transactions) {
+        const budget = budgetsById.get(transaction.budgetId);
+        if (!budget) throw new Error(`unknown budget ${transaction.budgetId}`);
+
+        if (isClosedMonth(budget, now)) {
+          expect(transaction.checkedAt).toBe(transaction.transactionDate);
+        } else {
+          expect(transaction.checkedAt).toBeNull();
+        }
+      }
     });
   });
 });

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -389,6 +389,40 @@ describe('GenerateDemoDataUseCase', () => {
         }
       }
     });
+
+    it('should stamp every seeded date at UTC midnight of its own month', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const budgetsById = new Map(
+        seededBudgets(mockRepo).map((budget, index) => [
+          `budget-${index}`,
+          budget,
+        ]),
+      );
+      const stamps: { iso: string; budgetId: string }[] = [];
+      for (const line of seededBudgetLines(mockRepo)) {
+        if (line.checkedAt !== null) {
+          stamps.push({ iso: line.checkedAt, budgetId: line.budgetId });
+        }
+      }
+      for (const transaction of seededTransactions(mockRepo)) {
+        stamps.push({
+          iso: transaction.transactionDate,
+          budgetId: transaction.budgetId,
+        });
+      }
+
+      expect(stamps.length).toBeGreaterThan(0);
+      for (const { iso, budgetId } of stamps) {
+        const budget = budgetsById.get(budgetId);
+        if (!budget) throw new Error(`unknown budget ${budgetId}`);
+        const stamped = new Date(iso);
+
+        expect(iso.endsWith('T00:00:00.000Z')).toBe(true);
+        expect(stamped.getUTCFullYear()).toBe(budget.year);
+        expect(stamped.getUTCMonth() + 1).toBe(budget.month);
+      }
+    });
   });
 
   describe('execute - one clock per session', () => {

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -9,7 +9,10 @@ import type {
   DemoSeededBudget,
   DemoTransactionSeed,
 } from '../domain/demo.entity';
-import { DEMO_SAVINGS_GOAL_SPECS } from '../domain/demo.constants';
+import {
+  DEMO_SAVINGS_GOAL_SPECS,
+  DEMO_SPREAD_SPEC,
+} from '../domain/demo.constants';
 import { GenerateDemoDataUseCase } from './generate-demo-data.use-case';
 
 const GROCERIES_ENVELOPE = 'Courses alimentaires';
@@ -101,9 +104,18 @@ function identifiedBudgetLines(repo: ReturnType<typeof buildMockRepo>) {
   }));
 }
 
+function spreadTranches(lines: DemoBudgetLineSeed[]) {
+  return lines.filter((line) => line.spreadGroupId !== null);
+}
+
 function isClosedMonth(budget: DemoSeededBudget, now: Date): boolean {
   if (budget.year !== now.getFullYear()) return budget.year < now.getFullYear();
   return budget.month < now.getMonth() + 1;
+}
+
+function isFutureMonth(budget: DemoSeededBudget, now: Date): boolean {
+  if (budget.year !== now.getFullYear()) return budget.year > now.getFullYear();
+  return budget.month > now.getMonth() + 1;
 }
 
 describe('GenerateDemoDataUseCase', () => {
@@ -383,6 +395,74 @@ describe('GenerateDemoDataUseCase', () => {
       );
 
       expect(checkedLinked.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('execute - lissage', () => {
+    it('should split the spread total into tranches summing back to it', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const tranches = spreadTranches(seededBudgetLines(mockRepo));
+      const totalCents = tranches.reduce(
+        (sum, line) => sum + Math.round(line.amount * 100),
+        0,
+      );
+
+      expect(tranches.length).toBe(DEMO_SPREAD_SPEC.monthCount);
+      expect(totalCents).toBe(Math.round(DEMO_SPREAD_SPEC.totalAmount * 100));
+    });
+
+    it('should make the tranches siblings of one group, none issued from the Mois Type', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const tranches = spreadTranches(seededBudgetLines(mockRepo));
+
+      expect(new Set(tranches.map((line) => line.spreadGroupId)).size).toBe(1);
+      expect(tranches.every((line) => line.templateLineId === null)).toBe(true);
+      expect(tranches.every((line) => line.recurrence === 'one_off')).toBe(
+        true,
+      );
+    });
+
+    it('should mint a distinct group id for each demo session', async () => {
+      await useCase.execute('user-1', {} as never);
+      await useCase.execute('user-2', {} as never);
+
+      const [firstCall, secondCall] = (
+        mockRepo.insertBudgetLines as ReturnType<typeof mock>
+      ).mock.calls;
+      const firstGroupId = spreadTranches(
+        firstCall[0] as DemoBudgetLineSeed[],
+      )[0]?.spreadGroupId;
+      const secondGroupId = spreadTranches(
+        secondCall[0] as DemoBudgetLineSeed[],
+      )[0]?.spreadGroupId;
+
+      expect(firstGroupId).toBeTruthy();
+      expect(secondGroupId).not.toBe(firstGroupId);
+    });
+
+    it('should straddle the current month so months remain to provision', async () => {
+      const now = new Date();
+
+      await useCase.execute('user-1', {} as never);
+
+      const budgetsById = new Map(
+        seededBudgets(mockRepo).map((budget, index) => [
+          `budget-${index}`,
+          budget,
+        ]),
+      );
+      const trancheBudgets = spreadTranches(seededBudgetLines(mockRepo)).map(
+        (line) => budgetsById.get(line.budgetId),
+      );
+
+      expect(
+        trancheBudgets.some((budget) => budget && isClosedMonth(budget, now)),
+      ).toBe(true);
+      expect(
+        trancheBudgets.some((budget) => budget && isFutureMonth(budget, now)),
+      ).toBe(true);
     });
   });
 });

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -243,6 +243,26 @@ describe('GenerateDemoDataUseCase', () => {
       }
     });
 
+    it('should give the month in progress its actuals whatever the day of the month', async () => {
+      const now = new Date();
+
+      await useCase.execute('user-1', {} as never);
+
+      const currentMonthIndex = seededBudgets(mockRepo).findIndex(
+        (budget) =>
+          budget.month === now.getMonth() + 1 &&
+          budget.year === now.getFullYear(),
+      );
+      const currentMonthActuals = seededTransactions(mockRepo).filter(
+        (tx) => tx.budgetId === `budget-${currentMonthIndex}`,
+      );
+
+      expect(currentMonthActuals.length).toBeGreaterThan(0);
+      for (const actual of currentMonthActuals) {
+        expect(new Date(actual.transactionDate) <= now).toBe(true);
+      }
+    });
+
     it('should leave an actual unattached when no envelope matches it', async () => {
       await useCase.execute('user-1', {} as never);
 

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -12,11 +12,62 @@ import type {
 import {
   DEMO_SAVINGS_GOAL_SPECS,
   DEMO_SPREAD_SPEC,
+  DEMO_TEMPLATE_ORDER,
+  type DemoTemplateKey,
 } from '../domain/demo.constants';
+import { templateKeyForMonth } from '../domain/demo-seed.builders';
+import { MONTH_TRANSACTION_SPECS } from '../domain/demo-transaction-seeds';
 import { GenerateDemoDataUseCase } from './generate-demo-data.use-case';
 
 const GROCERIES_ENVELOPE = 'Courses alimentaires';
 const HOUSING_SAVINGS_ENVELOPE = 'Épargne logement';
+const EMERGENCY_SAVINGS_ENVELOPE = "Fonds d'urgence";
+
+/**
+ * The saving envelopes each template really carries, mirroring
+ * `demo-template-specs.ts`: the vacation month funds no goal, and the holiday
+ * month funds only the housing one. Giving every template the same savings
+ * block would let a Mois Type be tagged for a goal it does not fund.
+ */
+const SAVING_ENVELOPES_BY_TEMPLATE: Record<DemoTemplateKey, string[]> = {
+  STANDARD: [HOUSING_SAVINGS_ENVELOPE, EMERGENCY_SAVINGS_ENVELOPE],
+  VACATIONS: [],
+  SAVINGS: [HOUSING_SAVINGS_ENVELOPE, EMERGENCY_SAVINGS_ENVELOPE],
+  HOLIDAYS: [HOUSING_SAVINGS_ENVELOPE],
+};
+
+/**
+ * Every template carries the envelopes its own month's actuals name, mirroring
+ * the real specs: a mock giving lines to the standard template alone would hide
+ * exactly the gap that left themed months showing nothing consumed.
+ */
+function mockCanonicalTemplateLines() {
+  return DEMO_TEMPLATE_ORDER.flatMap((key, templateIndex) => {
+    const templateId = `template-${templateIndex}`;
+    const envelopeLines = [
+      ...new Set(MONTH_TRANSACTION_SPECS[key].map((spec) => spec.envelopeName)),
+    ].map((name, i) => ({
+      id: `tl-${templateIndex}-${i}`,
+      templateId,
+      name,
+      amount: 600,
+      kind: 'expense' as const,
+      recurrence: 'one_off' as const,
+    }));
+
+    return [
+      ...envelopeLines,
+      ...SAVING_ENVELOPES_BY_TEMPLATE[key].map((name, i) => ({
+        id: `tl-${templateIndex}-saving-${i}`,
+        templateId,
+        name,
+        amount: 1000,
+        kind: 'saving' as const,
+        recurrence: 'fixed' as const,
+      })),
+    ];
+  });
+}
 
 /**
  * Budgets are seeded chronologically, so a budget's index tells its month apart:
@@ -31,24 +82,9 @@ function buildMockRepo() {
     insertTemplates: mock(async (rows: unknown[]) =>
       rows.map((_, i) => ({ id: `template-${i}` })),
     ),
-    insertCanonicalTemplateLines: mock(async () => [
-      {
-        id: 'tl-0',
-        templateId: 'template-0',
-        name: GROCERIES_ENVELOPE,
-        amount: 600,
-        kind: 'expense' as const,
-        recurrence: 'one_off' as const,
-      },
-      {
-        id: 'tl-1',
-        templateId: 'template-0',
-        name: HOUSING_SAVINGS_ENVELOPE,
-        amount: 1000,
-        kind: 'saving' as const,
-        recurrence: 'fixed' as const,
-      },
-    ]),
+    insertCanonicalTemplateLines: mock(async () =>
+      mockCanonicalTemplateLines(),
+    ),
     insertBudgets: mock(async (rows: unknown[]) =>
       rows.map(
         (r, i) =>
@@ -72,6 +108,7 @@ function buildMockRepo() {
       goals.map((goal, i) => ({ id: `goal-${i}`, name: goal.name })),
     ),
     linkBudgetLinesToSavingsGoal: mock(async () => {}),
+    linkTemplateLinesToSavingsGoal: mock(async () => {}),
   };
 }
 
@@ -102,6 +139,15 @@ function seededSavingsGoals(repo: ReturnType<typeof buildMockRepo>) {
 function savingsGoalLinkCalls(repo: ReturnType<typeof buildMockRepo>) {
   return (repo.linkBudgetLinesToSavingsGoal as ReturnType<typeof mock>).mock
     .calls as [string[], string, unknown][];
+}
+
+function templateLineLinkCalls(repo: ReturnType<typeof buildMockRepo>) {
+  return (repo.linkTemplateLinesToSavingsGoal as ReturnType<typeof mock>).mock
+    .calls as [string[], string, unknown][];
+}
+
+function goalIdByName(repo: ReturnType<typeof buildMockRepo>, name: string) {
+  return `goal-${seededSavingsGoals(repo).findIndex((goal) => goal.name === name)}`;
 }
 
 function identifiedBudgetLines(repo: ReturnType<typeof buildMockRepo>) {
@@ -275,21 +321,36 @@ describe('GenerateDemoDataUseCase', () => {
       }
     });
 
-    it('should leave an actual unattached when no envelope matches it', async () => {
+    it('should attach every actual to an envelope of its own budget, themed months included', async () => {
       await useCase.execute('user-1', {} as never);
 
-      const seededNames = new Set(
-        seededBudgetLines(mockRepo).map((line) => line.name),
+      const lineById = new Map(
+        identifiedBudgetLines(mockRepo).map(({ line, id }) => [id, line]),
       );
-      expect(seededNames.has('Restaurants/Sorties')).toBe(false);
-
-      const restaurantActuals = seededTransactions(mockRepo).filter(
-        (tx) => tx.name === 'Restaurant Molino',
+      const themedBudgetIds = new Set(
+        seededBudgets(mockRepo).flatMap((budget, index) =>
+          templateKeyForMonth(budget.month) === 'STANDARD'
+            ? []
+            : [`budget-${index}`],
+        ),
       );
+      const actuals = seededTransactions(mockRepo);
 
-      expect(restaurantActuals.length).toBeGreaterThan(0);
-      for (const actual of restaurantActuals) {
-        expect(actual.budgetLineId).toBeNull();
+      expect(actuals.length).toBeGreaterThan(0);
+      expect(actuals.some((tx) => themedBudgetIds.has(tx.budgetId))).toBe(true);
+      for (const actual of actuals) {
+        expect(lineById.get(actual.budgetLineId ?? '')?.budgetId).toBe(
+          actual.budgetId,
+        );
+      }
+    });
+
+    it('should open every template set on the 1st so a month in progress is never empty', () => {
+      for (const key of DEMO_TEMPLATE_ORDER) {
+        const days = MONTH_TRANSACTION_SPECS[key].map((spec) => spec.day);
+
+        expect(days.length).toBeGreaterThan(0);
+        expect(Math.min(...days)).toBe(1);
       }
     });
   });
@@ -430,6 +491,46 @@ describe('GenerateDemoDataUseCase', () => {
         ([, goalId]) => goalId === `goal-${housingGoalIndex}`,
       );
       expect(linkCall?.[0]).toEqual(housingLineIds);
+    });
+
+    it('should tag the Mois Type for the open-ended goal so a later budget keeps the link', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const openEnded = DEMO_SAVINGS_GOAL_SPECS.find(
+        (spec) => spec.monthsUntilTarget === null && spec.envelopeName !== null,
+      );
+      const envelopeName = openEnded?.envelopeName;
+      if (!openEnded || !envelopeName) {
+        throw new Error('no open-ended goal fed by an envelope');
+      }
+      const recurringLineIds = mockCanonicalTemplateLines()
+        .filter((line) => line.kind === 'saving' && line.name === envelopeName)
+        .map((line) => line.id);
+
+      expect(recurringLineIds.length).toBeGreaterThan(0);
+      const linkCall = templateLineLinkCalls(mockRepo).find(
+        ([, goalId]) => goalId === goalIdByName(mockRepo, openEnded.name),
+      );
+      expect(linkCall?.[0]).toEqual(recurringLineIds);
+    });
+
+    it('should never tag the Mois Type for a dated goal', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const datedGoalIds = new Set(
+        DEMO_SAVINGS_GOAL_SPECS.filter(
+          (spec) => spec.monthsUntilTarget !== null,
+        ).map((spec) => goalIdByName(mockRepo, spec.name)),
+      );
+      const taggedGoalIds = templateLineLinkCalls(mockRepo).map(
+        ([, goalId]) => goalId,
+      );
+
+      expect(datedGoalIds.size).toBeGreaterThan(0);
+      expect(taggedGoalIds.length).toBeGreaterThan(0);
+      for (const goalId of taggedGoalIds) {
+        expect(datedGoalIds.has(goalId)).toBe(false);
+      }
     });
 
     it('should never link a prévision to a goal that no envelope funds', async () => {

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -5,12 +5,15 @@ import { BUDGET_RECALCULATION_PORT } from '../../budget/domain/ports/budget-reca
 import { DEMO_REPOSITORY } from '../domain/ports/demo-repository.port';
 import type {
   DemoBudgetLineSeed,
+  DemoSavingsGoalSeed,
   DemoSeededBudget,
   DemoTransactionSeed,
 } from '../domain/demo.entity';
+import { DEMO_SAVINGS_GOAL_SPECS } from '../domain/demo.constants';
 import { GenerateDemoDataUseCase } from './generate-demo-data.use-case';
 
 const GROCERIES_ENVELOPE = 'Courses alimentaires';
+const HOUSING_SAVINGS_ENVELOPE = 'Épargne logement';
 
 function buildMockRepo() {
   return {
@@ -25,6 +28,14 @@ function buildMockRepo() {
         amount: 600,
         kind: 'expense' as const,
         recurrence: 'one_off' as const,
+      },
+      {
+        id: 'tl-1',
+        templateId: 'template-0',
+        name: HOUSING_SAVINGS_ENVELOPE,
+        amount: 1000,
+        kind: 'saving' as const,
+        recurrence: 'fixed' as const,
       },
     ]),
     insertBudgets: mock(async (rows: unknown[]) =>
@@ -47,6 +58,10 @@ function buildMockRepo() {
       })),
     ),
     insertTransactions: mock(async () => {}),
+    insertSavingsGoals: mock(async (goals: DemoSavingsGoalSeed[]) =>
+      goals.map((goal, i) => ({ id: `goal-${i}`, name: goal.name })),
+    ),
+    linkBudgetLinesToSavingsGoal: mock(async () => {}),
   };
 }
 
@@ -66,6 +81,24 @@ function seededTransactions(repo: ReturnType<typeof buildMockRepo>) {
   const [[transactions]] = (repo.insertTransactions as ReturnType<typeof mock>)
     .mock.calls;
   return transactions as DemoTransactionSeed[];
+}
+
+function seededSavingsGoals(repo: ReturnType<typeof buildMockRepo>) {
+  const [[goals]] = (repo.insertSavingsGoals as ReturnType<typeof mock>).mock
+    .calls;
+  return goals as DemoSavingsGoalSeed[];
+}
+
+function savingsGoalLinkCalls(repo: ReturnType<typeof buildMockRepo>) {
+  return (repo.linkBudgetLinesToSavingsGoal as ReturnType<typeof mock>).mock
+    .calls as [string[], string, unknown][];
+}
+
+function identifiedBudgetLines(repo: ReturnType<typeof buildMockRepo>) {
+  return seededBudgetLines(repo).map((line, index) => ({
+    line,
+    id: `budget-line-${index}`,
+  }));
 }
 
 function isClosedMonth(budget: DemoSeededBudget, now: Date): boolean {
@@ -177,23 +210,23 @@ describe('GenerateDemoDataUseCase', () => {
     it('should attach a grocery actual to the grocery envelope of its own budget', async () => {
       await useCase.execute('user-1', {} as never);
 
-      const linesByBudget = new Map(
-        seededBudgetLines(mockRepo).map((line, index) => [
-          line.budgetId,
-          `budget-line-${index}`,
-        ]),
+      const groceryLineByBudget = new Map(
+        identifiedBudgetLines(mockRepo)
+          .filter(({ line }) => line.name === GROCERIES_ENVELOPE)
+          .map(({ line, id }) => [line.budgetId, id]),
       );
       const groceryActuals = seededTransactions(mockRepo).filter(
         (tx) => tx.name === 'Migros - Courses',
       );
       const attached = groceryActuals.filter(
-        (tx) => tx.budgetLineId !== null && linesByBudget.has(tx.budgetId),
+        (tx) =>
+          tx.budgetLineId !== null && groceryLineByBudget.has(tx.budgetId),
       );
 
       expect(attached.length).toBeGreaterThan(0);
       for (const actual of attached) {
         expect(actual.budgetLineId).toBe(
-          linesByBudget.get(actual.budgetId) ?? null,
+          groceryLineByBudget.get(actual.budgetId) ?? null,
         );
       }
     });
@@ -268,6 +301,88 @@ describe('GenerateDemoDataUseCase', () => {
           expect(transaction.checkedAt).toBeNull();
         }
       }
+    });
+  });
+
+  describe('execute - savings goals', () => {
+    it('should seed one dated goal, one open-ended goal and one already reached', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const goals = seededSavingsGoals(mockRepo);
+
+      expect(
+        goals.filter((g) => g.status === 'ACTIVE' && g.targetDate !== null)
+          .length,
+      ).toBe(1);
+      expect(
+        goals.filter((g) => g.status === 'ACTIVE' && g.targetDate === null)
+          .length,
+      ).toBe(1);
+      expect(goals.filter((g) => g.status === 'COMPLETED').length).toBe(1);
+    });
+
+    it('should seed the completed goal at its target amount', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const completed = seededSavingsGoals(mockRepo).find(
+        (g) => g.status === 'COMPLETED',
+      );
+      if (!completed) throw new Error('no completed goal seeded');
+
+      expect(completed.initialAmount).toBe(completed.targetAmount);
+    });
+
+    it('should link every saving prévision bearing the goal envelope name', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const housingLineIds = identifiedBudgetLines(mockRepo)
+        .filter(({ line }) => line.name === HOUSING_SAVINGS_ENVELOPE)
+        .map(({ id }) => id);
+      const housingSpec = DEMO_SAVINGS_GOAL_SPECS.find(
+        (spec) => spec.envelopeName === HOUSING_SAVINGS_ENVELOPE,
+      );
+      if (!housingSpec)
+        throw new Error('no goal funded by the housing envelope');
+      const housingGoalIndex = seededSavingsGoals(mockRepo).findIndex(
+        (goal) => goal.name === housingSpec.name,
+      );
+
+      expect(housingLineIds.length).toBeGreaterThan(0);
+      const linkCall = savingsGoalLinkCalls(mockRepo).find(
+        ([, goalId]) => goalId === `goal-${housingGoalIndex}`,
+      );
+      expect(linkCall?.[0]).toEqual(housingLineIds);
+    });
+
+    it('should never link a prévision to a goal that no envelope funds', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const goals = seededSavingsGoals(mockRepo);
+      const unfundedSpecs = DEMO_SAVINGS_GOAL_SPECS.filter(
+        (spec) => spec.envelopeName === null,
+      );
+      expect(unfundedSpecs.length).toBeGreaterThan(0);
+
+      const linkedGoalIds = new Set(
+        savingsGoalLinkCalls(mockRepo).map(([, goalId]) => goalId),
+      );
+      for (const spec of unfundedSpecs) {
+        const index = goals.findIndex((goal) => goal.name === spec.name);
+        expect(linkedGoalIds.has(`goal-${index}`)).toBe(false);
+      }
+    });
+
+    it('should link checked prévisions so a goal shows progress', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const linkedIds = new Set(
+        savingsGoalLinkCalls(mockRepo).flatMap(([ids]) => ids),
+      );
+      const checkedLinked = identifiedBudgetLines(mockRepo).filter(
+        ({ line, id }) => linkedIds.has(id) && line.checkedAt !== null,
+      );
+
+      expect(checkedLinked.length).toBeGreaterThan(0);
     });
   });
 });

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -5,8 +5,8 @@ import { BUDGET_RECALCULATION_PORT } from '../../budget/domain/ports/budget-reca
 import { DEMO_REPOSITORY } from '../domain/ports/demo-repository.port';
 import type {
   DemoBudgetLineSeed,
+  DemoBudgetSeed,
   DemoSavingsGoalSeed,
-  DemoSeededBudget,
   DemoTransactionSeed,
 } from '../domain/demo.entity';
 import {
@@ -115,7 +115,7 @@ function buildMockRepo() {
 function seededBudgets(repo: ReturnType<typeof buildMockRepo>) {
   const [[budgets]] = (repo.insertBudgets as ReturnType<typeof mock>).mock
     .calls;
-  return budgets as DemoSeededBudget[];
+  return budgets as DemoBudgetSeed[];
 }
 
 function seededBudgetLines(repo: ReturnType<typeof buildMockRepo>) {
@@ -301,10 +301,15 @@ describe('GenerateDemoDataUseCase', () => {
       }
     });
 
-    it('should give the month in progress its actuals whatever the day of the month', async () => {
-      const now = new Date();
+    it('should give the month in progress its actuals from its second day on', async () => {
+      const now = new Date('2026-08-02T12:00:00.000Z');
+      jest.setSystemTime(now);
 
-      await useCase.execute('user-1', {} as never);
+      try {
+        await useCase.execute('user-1', {} as never);
+      } finally {
+        jest.setSystemTime();
+      }
 
       const currentMonthIndex = seededBudgets(mockRepo).findIndex(
         (budget) =>
@@ -317,6 +322,30 @@ describe('GenerateDemoDataUseCase', () => {
 
       expect(currentMonthActuals.length).toBeGreaterThan(0);
       for (const actual of currentMonthActuals) {
+        expect(new Date(actual.transactionDate) <= now).toBe(true);
+      }
+    });
+
+    /**
+     * The seeding instant here is the last half-hour of a UTC month, which a
+     * server east of UTC already calls the 1st of the next one. Admitting an
+     * actual on that local day while stamping it at UTC midnight dated it ahead
+     * of the very run that wrote it.
+     */
+    it('should never date an actual ahead of the instant that seeded it', async () => {
+      const now = new Date('2026-07-31T22:30:00.000Z');
+      jest.setSystemTime(now);
+
+      try {
+        await useCase.execute('user-1', {} as never);
+      } finally {
+        jest.setSystemTime();
+      }
+
+      const actuals = seededTransactions(mockRepo);
+
+      expect(actuals.length).toBeGreaterThan(0);
+      for (const actual of actuals) {
         expect(new Date(actual.transactionDate) <= now).toBe(true);
       }
     });

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -384,6 +384,40 @@ describe('GenerateDemoDataUseCase', () => {
       }
     });
 
+    it('should never link a prévision past the deadline the database enforces', async () => {
+      await useCase.execute('user-1', {} as never);
+
+      const budgetsById = new Map(
+        seededBudgets(mockRepo).map((budget, index) => [
+          `budget-${index}`,
+          budget,
+        ]),
+      );
+      const lineById = new Map(
+        identifiedBudgetLines(mockRepo).map(({ line, id }) => [id, line]),
+      );
+      const goals = seededSavingsGoals(mockRepo);
+      let checkedPairs = 0;
+
+      for (const [lineIds, goalId] of savingsGoalLinkCalls(mockRepo)) {
+        const goal = goals[Number(goalId.replace('goal-', ''))];
+        if (!goal?.targetDate) continue;
+        const deadline = new Date(goal.targetDate);
+
+        for (const lineId of lineIds) {
+          const budget = budgetsById.get(lineById.get(lineId)?.budgetId ?? '');
+          if (!budget) throw new Error(`unknown budget for line ${lineId}`);
+
+          expect(new Date(budget.year, budget.month - 1) <= deadline).toBe(
+            true,
+          );
+          checkedPairs++;
+        }
+      }
+
+      expect(checkedPairs).toBeGreaterThan(0);
+    });
+
     it('should link checked prévisions so a goal shows progress', async () => {
       await useCase.execute('user-1', {} as never);
 

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, jest, mock } from 'bun:test';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
 import { BUDGET_RECALCULATION_PORT } from '../../budget/domain/ports/budget-recalculation.port';
@@ -332,6 +332,58 @@ describe('GenerateDemoDataUseCase', () => {
         } else {
           expect(transaction.checkedAt).toBeNull();
         }
+      }
+    });
+  });
+
+  describe('execute - one clock per session', () => {
+    const SEED_INSTANT = new Date(2026, 0, 15, 12);
+    const SEED_MONTH = { month: 1, year: 2026 };
+    const FIRST_SEEDED_MONTH = '2025-07-01';
+
+    function advanceClockFrom(
+      repoMethod: keyof ReturnType<typeof buildMockRepo>,
+      to: Date,
+    ) {
+      const original = mockRepo[repoMethod] as (
+        ...args: unknown[]
+      ) => Promise<unknown>;
+      mockRepo[repoMethod] = mock(async (...args: unknown[]) => {
+        jest.setSystemTime(to);
+        return original(...args);
+      }) as never;
+    }
+
+    it('should derive every seed from one instant even when the clock crosses months mid-run', async () => {
+      jest.setSystemTime(SEED_INSTANT);
+      advanceClockFrom('insertBudgets', new Date(2026, 3, 15, 12));
+      advanceClockFrom('insertBudgetLines', new Date(2026, 4, 15, 12));
+      advanceClockFrom('insertTransactions', new Date(2026, 5, 15, 12));
+
+      try {
+        await useCase.execute('user-1', {} as never);
+      } finally {
+        jest.setSystemTime();
+      }
+
+      const seedMonthIndex = seededBudgets(mockRepo).findIndex(
+        (budget) =>
+          budget.month === SEED_MONTH.month && budget.year === SEED_MONTH.year,
+      );
+      const seedMonthId = `budget-${seedMonthIndex}`;
+      const lines = seededBudgetLines(mockRepo);
+
+      expect(spreadTranches(lines).length).toBe(DEMO_SPREAD_SPEC.monthCount);
+      for (const line of lines.filter((l) => l.budgetId === seedMonthId)) {
+        expect(line.checkedAt).toBeNull();
+      }
+      for (const actual of seededTransactions(mockRepo).filter(
+        (tx) => tx.budgetId === seedMonthId,
+      )) {
+        expect(actual.checkedAt).toBeNull();
+      }
+      for (const goal of seededSavingsGoals(mockRepo)) {
+        expect(goal.startDate).toBe(FIRST_SEEDED_MONTH);
       }
     });
   });

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.spec.ts
@@ -18,6 +18,14 @@ import { GenerateDemoDataUseCase } from './generate-demo-data.use-case';
 const GROCERIES_ENVELOPE = 'Courses alimentaires';
 const HOUSING_SAVINGS_ENVELOPE = 'Épargne logement';
 
+/**
+ * Budgets are seeded chronologically, so a budget's index tells its month apart:
+ * the first six are closed, index 6 is the month in progress, the rest are ahead.
+ * The count is pinned by "should create 12 monthly budgets (6 past + 6 future)".
+ */
+const CLOSED_MONTH_COUNT = 6;
+const CURRENT_MONTH_INDEX = CLOSED_MONTH_COUNT;
+
 function buildMockRepo() {
   return {
     insertTemplates: mock(async (rows: unknown[]) =>
@@ -56,7 +64,6 @@ function buildMockRepo() {
         id: `budget-line-${i}`,
         budgetId: line.budgetId,
         name: line.name,
-        amount: line.amount,
         kind: line.kind,
       })),
     ),
@@ -108,14 +115,19 @@ function spreadTranches(lines: DemoBudgetLineSeed[]) {
   return lines.filter((line) => line.spreadGroupId !== null);
 }
 
-function isClosedMonth(budget: DemoSeededBudget, now: Date): boolean {
-  if (budget.year !== now.getFullYear()) return budget.year < now.getFullYear();
-  return budget.month < now.getMonth() + 1;
+function budgetIndexById(repo: ReturnType<typeof buildMockRepo>) {
+  return new Map(
+    seededBudgets(repo).map((_, index) => [`budget-${index}`, index]),
+  );
 }
 
-function isFutureMonth(budget: DemoSeededBudget, now: Date): boolean {
-  if (budget.year !== now.getFullYear()) return budget.year > now.getFullYear();
-  return budget.month > now.getMonth() + 1;
+function monthIndexOf(
+  indexById: Map<string, number>,
+  budgetId: string,
+): number {
+  const index = indexById.get(budgetId);
+  if (index === undefined) throw new Error(`unknown budget ${budgetId}`);
+  return index;
 }
 
 describe('GenerateDemoDataUseCase', () => {
@@ -284,24 +296,14 @@ describe('GenerateDemoDataUseCase', () => {
 
   describe('execute - pointage', () => {
     it('should check every budget line of a closed month and none of the current month', async () => {
-      const now = new Date();
-
       await useCase.execute('user-1', {} as never);
 
-      const budgetsById = new Map(
-        seededBudgets(mockRepo).map((budget, index) => [
-          `budget-${index}`,
-          budget,
-        ]),
-      );
+      const indexById = budgetIndexById(mockRepo);
       const lines = seededBudgetLines(mockRepo);
       expect(lines.length).toBeGreaterThan(0);
 
       for (const line of lines) {
-        const budget = budgetsById.get(line.budgetId);
-        if (!budget) throw new Error(`unknown budget ${line.budgetId}`);
-
-        if (isClosedMonth(budget, now)) {
+        if (monthIndexOf(indexById, line.budgetId) < CLOSED_MONTH_COUNT) {
           expect(line.checkedAt).not.toBeNull();
         } else {
           expect(line.checkedAt).toBeNull();
@@ -310,24 +312,16 @@ describe('GenerateDemoDataUseCase', () => {
     });
 
     it('should check the actuals of closed months and leave the current month open', async () => {
-      const now = new Date();
-
       await useCase.execute('user-1', {} as never);
 
-      const budgetsById = new Map(
-        seededBudgets(mockRepo).map((budget, index) => [
-          `budget-${index}`,
-          budget,
-        ]),
-      );
+      const indexById = budgetIndexById(mockRepo);
       const transactions = seededTransactions(mockRepo);
       expect(transactions.length).toBeGreaterThan(0);
 
       for (const transaction of transactions) {
-        const budget = budgetsById.get(transaction.budgetId);
-        if (!budget) throw new Error(`unknown budget ${transaction.budgetId}`);
-
-        if (isClosedMonth(budget, now)) {
+        if (
+          monthIndexOf(indexById, transaction.budgetId) < CLOSED_MONTH_COUNT
+        ) {
           expect(transaction.checkedAt).toBe(transaction.transactionDate);
         } else {
           expect(transaction.checkedAt).toBeNull();
@@ -549,26 +543,19 @@ describe('GenerateDemoDataUseCase', () => {
     });
 
     it('should straddle the current month so months remain to provision', async () => {
-      const now = new Date();
-
       await useCase.execute('user-1', {} as never);
 
-      const budgetsById = new Map(
-        seededBudgets(mockRepo).map((budget, index) => [
-          `budget-${index}`,
-          budget,
-        ]),
-      );
-      const trancheBudgets = spreadTranches(seededBudgetLines(mockRepo)).map(
-        (line) => budgetsById.get(line.budgetId),
+      const indexById = budgetIndexById(mockRepo);
+      const trancheMonths = spreadTranches(seededBudgetLines(mockRepo)).map(
+        (line) => monthIndexOf(indexById, line.budgetId),
       );
 
-      expect(
-        trancheBudgets.some((budget) => budget && isClosedMonth(budget, now)),
-      ).toBe(true);
-      expect(
-        trancheBudgets.some((budget) => budget && isFutureMonth(budget, now)),
-      ).toBe(true);
+      expect(trancheMonths.some((index) => index < CURRENT_MONTH_INDEX)).toBe(
+        true,
+      );
+      expect(trancheMonths.some((index) => index > CURRENT_MONTH_INDEX)).toBe(
+        true,
+      );
     });
   });
 });

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
@@ -1,9 +1,6 @@
-import { randomUUID } from 'node:crypto';
 import { Inject, Injectable } from '@nestjs/common';
 import { type InfoLogger, InjectInfoLogger } from '@common/logger';
 import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.service';
-import { addMonths, format, startOfMonth } from 'date-fns';
-import { splitTotalPreserving } from 'pulpe-shared';
 import {
   BUDGET_RECALCULATION_PORT,
   type BudgetRecalculationPort,
@@ -13,59 +10,19 @@ import {
   type DemoRepositoryPort,
 } from '../domain/ports/demo-repository.port';
 import type {
-  DemoBudgetLineSeed,
-  DemoBudgetSeed,
-  DemoSavingsGoalSeed,
   DemoSeededBudget,
   DemoSeededBudgetLine,
   DemoSeededTemplate,
   DemoSeededTemplateLine,
-  DemoTemplateSeed,
-  DemoTransactionSeed,
 } from '../domain/demo.entity';
+import { DEMO_SAVINGS_GOAL_SPECS } from '../domain/demo.constants';
 import {
-  DEMO_SAVINGS_GOAL_SPECS,
-  DEMO_SPREAD_SPEC,
-  DEMO_TEMPLATE_SPECS,
-} from '../domain/demo.constants';
-
-/** The demo spans six closed months before the current one. */
-const FIRST_SEEDED_MONTH_OFFSET = -6;
-const DATE_COLUMN_FORMAT = 'yyyy-MM-dd';
-
-/**
- * The month's actuals. `envelopeName` names the prévision each one consumes —
- * a budget built from another template may not carry it, and the actual then
- * stays unattached, which is a legitimate state to show.
- *
- * The month in progress only keeps the actuals whose day has already elapsed,
- * so the first one falls on the 1st: a prospect opening the demo on the 2nd
- * must still see a consumed envelope, not the empty month the seed used to show
- * until the 5th.
- */
-const MONTH_TRANSACTION_SPECS = [
-  {
-    day: 1,
-    name: 'Migros - Courses',
-    amount: 127.85,
-    tagName: 'Alimentation',
-    envelopeName: 'Courses alimentaires',
-  },
-  {
-    day: 10,
-    name: 'Restaurant Molino',
-    amount: 78.5,
-    tagName: 'Restaurants',
-    envelopeName: 'Restaurants/Sorties',
-  },
-  {
-    day: 15,
-    name: 'Coop - Courses',
-    amount: 94.2,
-    tagName: 'Alimentation',
-    envelopeName: 'Courses alimentaires',
-  },
-] as const;
+  buildBudgetLineSeeds,
+  buildBudgetSeeds,
+  buildSavingsGoalSeeds,
+  buildTemplateSeeds,
+} from '../domain/demo-seed.builders';
+import { buildTransactionSeeds } from '../domain/demo-transaction-seeds';
 
 @Injectable()
 export class GenerateDemoDataUseCase {
@@ -77,11 +34,18 @@ export class GenerateDemoDataUseCase {
     private readonly logger: InfoLogger,
   ) {}
 
+  /**
+   * The clock is read once, here: the budget window, the pointage boundary, the
+   * lissage window and the goal horizons must all agree on which month is the
+   * current one, and a seed straddling midnight would otherwise disagree with
+   * itself.
+   */
   async execute(
     userId: string,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<void> {
     this.logger.info({ userId }, 'Starting demo data generation');
+    const currentDate = new Date();
 
     const templates = await this.seedTemplates(userId, supabase);
     const templateLines = await this.seedTemplateLines(
@@ -89,15 +53,27 @@ export class GenerateDemoDataUseCase {
       templates,
       supabase,
     );
-    const budgets = await this.seedBudgets(userId, templates, supabase);
+    const budgets = await this.seedBudgets(
+      userId,
+      templates,
+      currentDate,
+      supabase,
+    );
     const budgetLines = await this.seedBudgetLines(
       userId,
       budgets,
       templateLines,
+      currentDate,
       supabase,
     );
-    await this.seedTransactions(userId, budgets, budgetLines, supabase);
-    await this.seedSavingsGoals(userId, budgetLines, supabase);
+    await this.seedTransactions(
+      userId,
+      budgets,
+      budgetLines,
+      currentDate,
+      supabase,
+    );
+    await this.seedSavingsGoals(userId, budgetLines, currentDate, supabase);
 
     await this.recalculateAllBudgetBalances(budgets);
     this.logger.info(
@@ -113,7 +89,7 @@ export class GenerateDemoDataUseCase {
     supabase: AuthenticatedSupabaseClient,
   ): Promise<DemoSeededTemplate[]> {
     const templates = await this.repo.insertTemplates(
-      this.buildTemplateSeeds(userId),
+      buildTemplateSeeds(userId),
       supabase,
     );
     this.logger.info({ userId, count: templates.length }, 'Templates created');
@@ -146,10 +122,11 @@ export class GenerateDemoDataUseCase {
   private async seedBudgets(
     userId: string,
     templates: DemoSeededTemplate[],
+    currentDate: Date,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<DemoSeededBudget[]> {
     const budgets = await this.repo.insertBudgets(
-      this.buildBudgetSeeds(userId, templates),
+      buildBudgetSeeds(userId, templates, currentDate),
       supabase,
     );
     this.logger.info({ userId, count: budgets.length }, 'Budgets created');
@@ -160,9 +137,14 @@ export class GenerateDemoDataUseCase {
     userId: string,
     budgets: DemoSeededBudget[],
     templateLines: DemoSeededTemplateLine[],
+    currentDate: Date,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<DemoSeededBudgetLine[]> {
-    const budgetLineSeeds = this.buildBudgetLineSeeds(budgets, templateLines);
+    const budgetLineSeeds = buildBudgetLineSeeds(
+      budgets,
+      templateLines,
+      currentDate,
+    );
     const seededLines = await this.repo.insertBudgetLines(
       budgetLineSeeds,
       userId,
@@ -179,9 +161,14 @@ export class GenerateDemoDataUseCase {
     userId: string,
     budgets: DemoSeededBudget[],
     budgetLines: DemoSeededBudgetLine[],
+    currentDate: Date,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<void> {
-    const transactionSeeds = this.buildTransactionSeeds(budgets, budgetLines);
+    const transactionSeeds = buildTransactionSeeds(
+      budgets,
+      budgetLines,
+      currentDate,
+    );
     await this.repo.insertTransactions(transactionSeeds, userId, supabase);
     this.logger.info(
       { userId, count: transactionSeeds.length },
@@ -192,10 +179,11 @@ export class GenerateDemoDataUseCase {
   private async seedSavingsGoals(
     userId: string,
     budgetLines: DemoSeededBudgetLine[],
+    currentDate: Date,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<void> {
     const goals = await this.repo.insertSavingsGoals(
-      this.buildSavingsGoalSeeds(userId, new Date()),
+      buildSavingsGoalSeeds(userId, currentDate),
       userId,
       supabase,
     );
@@ -216,279 +204,6 @@ export class GenerateDemoDataUseCase {
         supabase,
       );
     }
-  }
-
-  private buildSavingsGoalSeeds(
-    userId: string,
-    currentDate: Date,
-  ): DemoSavingsGoalSeed[] {
-    const firstSeededMonth = addMonths(
-      startOfMonth(currentDate),
-      FIRST_SEEDED_MONTH_OFFSET,
-    );
-
-    return DEMO_SAVINGS_GOAL_SPECS.map((spec) => {
-      const horizon = this.goalHorizon(spec.monthsUntilTarget, currentDate);
-
-      return {
-        userId,
-        name: spec.name,
-        targetAmount: spec.targetAmount,
-        initialAmount: spec.initialAmount,
-        status: spec.status,
-        startDate: format(firstSeededMonth, DATE_COLUMN_FORMAT),
-        targetDate: horizon ? format(horizon, DATE_COLUMN_FORMAT) : null,
-      };
-    });
-  }
-
-  /** A null `monthsUntilTarget` means an open-ended plan: no deadline. */
-  private goalHorizon(
-    monthsUntilTarget: number | null,
-    currentDate: Date,
-  ): Date | null {
-    if (monthsUntilTarget === null) return null;
-    return addMonths(startOfMonth(currentDate), monthsUntilTarget);
-  }
-
-  private buildTemplateSeeds(userId: string): DemoTemplateSeed[] {
-    return [
-      {
-        userId,
-        name: DEMO_TEMPLATE_SPECS.STANDARD.name,
-        description: DEMO_TEMPLATE_SPECS.STANDARD.description,
-        isDefault: DEMO_TEMPLATE_SPECS.STANDARD.isDefault,
-      },
-      {
-        userId,
-        name: DEMO_TEMPLATE_SPECS.VACATIONS.name,
-        description: DEMO_TEMPLATE_SPECS.VACATIONS.description,
-        isDefault: DEMO_TEMPLATE_SPECS.VACATIONS.isDefault,
-      },
-      {
-        userId,
-        name: DEMO_TEMPLATE_SPECS.SAVINGS.name,
-        description: DEMO_TEMPLATE_SPECS.SAVINGS.description,
-        isDefault: DEMO_TEMPLATE_SPECS.SAVINGS.isDefault,
-      },
-      {
-        userId,
-        name: DEMO_TEMPLATE_SPECS.HOLIDAYS.name,
-        description: DEMO_TEMPLATE_SPECS.HOLIDAYS.description,
-        isDefault: DEMO_TEMPLATE_SPECS.HOLIDAYS.isDefault,
-      },
-    ];
-  }
-
-  private buildBudgetSeeds(
-    userId: string,
-    templates: DemoSeededTemplate[],
-  ): DemoBudgetSeed[] {
-    const currentDate = new Date();
-    const budgets: DemoBudgetSeed[] = [];
-
-    for (let i = FIRST_SEEDED_MONTH_OFFSET; i <= 5; i++) {
-      const budgetDate = addMonths(startOfMonth(currentDate), i);
-      const month = budgetDate.getMonth() + 1;
-      const year = budgetDate.getFullYear();
-      const { templateId, description } = this.selectTemplateForMonth(
-        month,
-        templates,
-      );
-      budgets.push({ userId, month, year, description, templateId });
-    }
-
-    return budgets;
-  }
-
-  private selectTemplateForMonth(
-    month: number,
-    templates: DemoSeededTemplate[],
-  ): { templateId: string; description: string } {
-    if (month === 12) {
-      return {
-        templateId: templates[3].id,
-        description: "Budget des fêtes de fin d'année 🎄",
-      };
-    }
-    if (month === 7 || month === 8) {
-      return {
-        templateId: templates[1].id,
-        description: "Budget vacances d'été ☀️",
-      };
-    }
-    if (month === 3 || month === 9) {
-      return {
-        templateId: templates[2].id,
-        description: "Focus sur l'épargne ce mois-ci 💪",
-      };
-    }
-    return {
-      templateId: templates[0].id,
-      description: 'Budget mensuel standard',
-    };
-  }
-
-  private buildBudgetLineSeeds(
-    budgets: DemoSeededBudget[],
-    templateLines: DemoSeededTemplateLine[],
-  ): DemoBudgetLineSeed[] {
-    const currentDate = new Date();
-    const lines: DemoBudgetLineSeed[] = [];
-
-    for (const budget of budgets) {
-      const relevantLines = templateLines.filter(
-        (tl) => tl.templateId === budget.templateId,
-      );
-      const checkedAt = this.isClosedMonth(budget, currentDate)
-        ? this.endOfMonth(budget)
-        : null;
-
-      for (const templateLine of relevantLines) {
-        lines.push({
-          budgetId: budget.id,
-          templateLineId: templateLine.id,
-          name: templateLine.name,
-          amount: templateLine.amount,
-          kind: templateLine.kind,
-          recurrence: templateLine.recurrence,
-          checkedAt,
-          spreadGroupId: null,
-        });
-      }
-    }
-
-    return [...lines, ...this.buildSpreadTrancheSeeds(budgets, currentDate)];
-  }
-
-  /**
-   * The tranches of the demo's lissage: sibling one_off lines sharing one group
-   * id, never issued from the Mois Type, whose amounts sum back to the total.
-   */
-  private buildSpreadTrancheSeeds(
-    budgets: DemoSeededBudget[],
-    currentDate: Date,
-  ): DemoBudgetLineSeed[] {
-    const spreadGroupId = randomUUID();
-    const budgetsByPeriod = new Map(
-      budgets.map((budget) => [`${budget.year}-${budget.month}`, budget]),
-    );
-
-    return splitTotalPreserving(
-      DEMO_SPREAD_SPEC.totalAmount,
-      DEMO_SPREAD_SPEC.monthCount,
-    ).flatMap((amount, index) => {
-      const monthDate = addMonths(
-        startOfMonth(currentDate),
-        DEMO_SPREAD_SPEC.firstMonthOffset + index,
-      );
-      const budget = budgetsByPeriod.get(
-        `${monthDate.getFullYear()}-${monthDate.getMonth() + 1}`,
-      );
-      if (!budget) return [];
-
-      return [
-        {
-          budgetId: budget.id,
-          templateLineId: null,
-          name: DEMO_SPREAD_SPEC.name,
-          amount,
-          kind: 'expense' as const,
-          recurrence: 'one_off' as const,
-          checkedAt: this.isClosedMonth(budget, currentDate)
-            ? this.endOfMonth(budget)
-            : null,
-          spreadGroupId,
-        },
-      ];
-    });
-  }
-
-  /** A month strictly before the current one is closed: its ledger is settled. */
-  private isClosedMonth(
-    budget: { month: number; year: number },
-    currentDate: Date,
-  ): boolean {
-    if (budget.year !== currentDate.getFullYear()) {
-      return budget.year < currentDate.getFullYear();
-    }
-    return budget.month < currentDate.getMonth() + 1;
-  }
-
-  private endOfMonth(budget: { month: number; year: number }): string {
-    const lastDay = new Date(budget.year, budget.month, 0).getDate();
-    return new Date(budget.year, budget.month - 1, lastDay).toISOString();
-  }
-
-  private buildTransactionSeeds(
-    budgets: DemoSeededBudget[],
-    budgetLines: DemoSeededBudgetLine[],
-  ): DemoTransactionSeed[] {
-    const currentDate = new Date();
-    const pastBudgets = budgets.filter((b) => {
-      const budgetDate = new Date(b.year, b.month - 1);
-      return budgetDate <= currentDate;
-    });
-
-    const envelopesByBudget = new Map<string, DemoSeededBudgetLine[]>();
-    for (const line of budgetLines) {
-      const existing = envelopesByBudget.get(line.budgetId);
-      if (existing) existing.push(line);
-      else envelopesByBudget.set(line.budgetId, [line]);
-    }
-
-    const transactions: DemoTransactionSeed[] = [];
-
-    for (const budget of pastBudgets) {
-      const isCurrentMonth =
-        budget.month === currentDate.getMonth() + 1 &&
-        budget.year === currentDate.getFullYear();
-      const daysInMonth = new Date(budget.year, budget.month, 0).getDate();
-      const maxDay = isCurrentMonth ? currentDate.getDate() : daysInMonth;
-
-      transactions.push(
-        ...this.buildMonthTransactions(
-          budget,
-          maxDay,
-          envelopesByBudget.get(budget.id) ?? [],
-          currentDate,
-        ),
-      );
-    }
-
-    return transactions;
-  }
-
-  private buildMonthTransactions(
-    budget: DemoSeededBudget,
-    maxDay: number,
-    envelopes: DemoSeededBudgetLine[],
-    currentDate: Date,
-  ): DemoTransactionSeed[] {
-    const isClosed = this.isClosedMonth(budget, currentDate);
-
-    return MONTH_TRANSACTION_SPECS.filter((spec) => maxDay >= spec.day).map(
-      (spec) => {
-        const transactionDate = new Date(
-          budget.year,
-          budget.month - 1,
-          spec.day,
-        ).toISOString();
-
-        return {
-          budgetId: budget.id,
-          budgetLineId:
-            envelopes.find((line) => line.name === spec.envelopeName)?.id ??
-            null,
-          name: spec.name,
-          amount: spec.amount,
-          kind: 'expense',
-          tagName: spec.tagName,
-          transactionDate,
-          checkedAt: isClosed ? transactionDate : null,
-        };
-      },
-    );
   }
 
   private async recalculateAllBudgetBalances(

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
@@ -37,10 +37,15 @@ const DATE_COLUMN_FORMAT = 'yyyy-MM-dd';
  * The month's actuals. `envelopeName` names the prévision each one consumes —
  * a budget built from another template may not carry it, and the actual then
  * stays unattached, which is a legitimate state to show.
+ *
+ * The month in progress only keeps the actuals whose day has already elapsed,
+ * so the first one falls on the 1st: a prospect opening the demo on the 2nd
+ * must still see a consumed envelope, not the empty month the seed used to show
+ * until the 5th.
  */
 const MONTH_TRANSACTION_SPECS = [
   {
-    day: 5,
+    day: 1,
     name: 'Migros - Courses',
     amount: 127.85,
     tagName: 'Alimentation',

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from 'node:crypto';
 import { Inject, Injectable } from '@nestjs/common';
 import { type InfoLogger, InjectInfoLogger } from '@common/logger';
 import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.service';
 import { addMonths, format, startOfMonth } from 'date-fns';
+import { splitTotalPreserving } from 'pulpe-shared';
 import {
   BUDGET_RECALCULATION_PORT,
   type BudgetRecalculationPort,
@@ -23,6 +25,7 @@ import type {
 } from '../domain/demo.entity';
 import {
   DEMO_SAVINGS_GOAL_SPECS,
+  DEMO_SPREAD_SPEC,
   DEMO_TEMPLATE_SPECS,
 } from '../domain/demo.constants';
 
@@ -345,11 +348,55 @@ export class GenerateDemoDataUseCase {
           kind: templateLine.kind,
           recurrence: templateLine.recurrence,
           checkedAt,
+          spreadGroupId: null,
         });
       }
     }
 
-    return lines;
+    return [...lines, ...this.buildSpreadTrancheSeeds(budgets, currentDate)];
+  }
+
+  /**
+   * The tranches of the demo's lissage: sibling one_off lines sharing one group
+   * id, never issued from the Mois Type, whose amounts sum back to the total.
+   */
+  private buildSpreadTrancheSeeds(
+    budgets: DemoSeededBudget[],
+    currentDate: Date,
+  ): DemoBudgetLineSeed[] {
+    const spreadGroupId = randomUUID();
+    const budgetsByPeriod = new Map(
+      budgets.map((budget) => [`${budget.year}-${budget.month}`, budget]),
+    );
+
+    return splitTotalPreserving(
+      DEMO_SPREAD_SPEC.totalAmount,
+      DEMO_SPREAD_SPEC.monthCount,
+    ).flatMap((amount, index) => {
+      const monthDate = addMonths(
+        startOfMonth(currentDate),
+        DEMO_SPREAD_SPEC.firstMonthOffset + index,
+      );
+      const budget = budgetsByPeriod.get(
+        `${monthDate.getFullYear()}-${monthDate.getMonth() + 1}`,
+      );
+      if (!budget) return [];
+
+      return [
+        {
+          budgetId: budget.id,
+          templateLineId: null,
+          name: DEMO_SPREAD_SPEC.name,
+          amount,
+          kind: 'expense' as const,
+          recurrence: 'one_off' as const,
+          checkedAt: this.isClosedMonth(budget, currentDate)
+            ? this.endOfMonth(budget)
+            : null,
+          spreadGroupId,
+        },
+      ];
+    });
   }
 
   /** A month strictly before the current one is closed: its ledger is settled. */

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { type InfoLogger, InjectInfoLogger } from '@common/logger';
 import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.service';
-import { addMonths, startOfMonth } from 'date-fns';
+import { addMonths, format, startOfMonth } from 'date-fns';
 import {
   BUDGET_RECALCULATION_PORT,
   type BudgetRecalculationPort,
@@ -13,6 +13,7 @@ import {
 import type {
   DemoBudgetLineSeed,
   DemoBudgetSeed,
+  DemoSavingsGoalSeed,
   DemoSeededBudget,
   DemoSeededBudgetLine,
   DemoSeededTemplate,
@@ -20,7 +21,14 @@ import type {
   DemoTemplateSeed,
   DemoTransactionSeed,
 } from '../domain/demo.entity';
-import { DEMO_TEMPLATE_SPECS } from '../domain/demo.constants';
+import {
+  DEMO_SAVINGS_GOAL_SPECS,
+  DEMO_TEMPLATE_SPECS,
+} from '../domain/demo.constants';
+
+/** The demo spans six closed months before the current one. */
+const FIRST_SEEDED_MONTH_OFFSET = -6;
+const DATE_COLUMN_FORMAT = 'yyyy-MM-dd';
 
 /**
  * The month's actuals. `envelopeName` names the prévision each one consumes —
@@ -81,6 +89,7 @@ export class GenerateDemoDataUseCase {
       supabase,
     );
     await this.seedTransactions(userId, budgets, budgetLines, supabase);
+    await this.seedSavingsGoals(userId, budgetLines, supabase);
 
     await this.recalculateAllBudgetBalances(budgets);
     this.logger.info(
@@ -172,6 +181,68 @@ export class GenerateDemoDataUseCase {
     );
   }
 
+  private async seedSavingsGoals(
+    userId: string,
+    budgetLines: DemoSeededBudgetLine[],
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<void> {
+    const goals = await this.repo.insertSavingsGoals(
+      this.buildSavingsGoalSeeds(userId, new Date()),
+      userId,
+      supabase,
+    );
+    this.logger.info({ userId, count: goals.length }, 'Savings goals created');
+
+    for (const goal of goals) {
+      const spec = DEMO_SAVINGS_GOAL_SPECS.find((s) => s.name === goal.name);
+      if (!spec?.envelopeName) continue;
+
+      const envelopeIds = budgetLines
+        .filter(
+          (line) => line.kind === 'saving' && line.name === spec.envelopeName,
+        )
+        .map((line) => line.id);
+      await this.repo.linkBudgetLinesToSavingsGoal(
+        envelopeIds,
+        goal.id,
+        supabase,
+      );
+    }
+  }
+
+  private buildSavingsGoalSeeds(
+    userId: string,
+    currentDate: Date,
+  ): DemoSavingsGoalSeed[] {
+    const firstSeededMonth = addMonths(
+      startOfMonth(currentDate),
+      FIRST_SEEDED_MONTH_OFFSET,
+    );
+
+    return DEMO_SAVINGS_GOAL_SPECS.map((spec) => {
+      const horizon = this.goalHorizon(spec.monthsUntilTarget, currentDate);
+
+      return {
+        userId,
+        name: spec.name,
+        targetAmount: spec.targetAmount,
+        initialAmount: spec.initialAmount,
+        status: spec.status,
+        startDate: format(firstSeededMonth, DATE_COLUMN_FORMAT),
+        targetDate: horizon ? format(horizon, DATE_COLUMN_FORMAT) : null,
+      };
+    });
+  }
+
+  /** A null `monthsUntilTarget` means an open-ended plan: no deadline. */
+  private goalHorizon(
+    monthsUntilTarget: number | null,
+    currentDate: Date,
+  ): Date | null {
+    if (monthsUntilTarget === null) return null;
+    return addMonths(startOfMonth(currentDate), monthsUntilTarget);
+  }
+
   private buildTemplateSeeds(userId: string): DemoTemplateSeed[] {
     return [
       {
@@ -208,7 +279,7 @@ export class GenerateDemoDataUseCase {
     const currentDate = new Date();
     const budgets: DemoBudgetSeed[] = [];
 
-    for (let i = -6; i <= 5; i++) {
+    for (let i = FIRST_SEEDED_MONTH_OFFSET; i <= 5; i++) {
       const budgetDate = addMonths(startOfMonth(currentDate), i);
       const month = budgetDate.getMonth() + 1;
       const year = budgetDate.getFullYear();

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
@@ -14,12 +14,42 @@ import type {
   DemoBudgetLineSeed,
   DemoBudgetSeed,
   DemoSeededBudget,
+  DemoSeededBudgetLine,
   DemoSeededTemplate,
   DemoSeededTemplateLine,
   DemoTemplateSeed,
   DemoTransactionSeed,
 } from '../domain/demo.entity';
 import { DEMO_TEMPLATE_SPECS } from '../domain/demo.constants';
+
+/**
+ * The month's actuals. `envelopeName` names the prévision each one consumes —
+ * a budget built from another template may not carry it, and the actual then
+ * stays unattached, which is a legitimate state to show.
+ */
+const MONTH_TRANSACTION_SPECS = [
+  {
+    day: 5,
+    name: 'Migros - Courses',
+    amount: 127.85,
+    tagName: 'Alimentation',
+    envelopeName: 'Courses alimentaires',
+  },
+  {
+    day: 10,
+    name: 'Restaurant Molino',
+    amount: 78.5,
+    tagName: 'Restaurants',
+    envelopeName: 'Restaurants/Sorties',
+  },
+  {
+    day: 15,
+    name: 'Coop - Courses',
+    amount: 94.2,
+    tagName: 'Alimentation',
+    envelopeName: 'Courses alimentaires',
+  },
+] as const;
 
 @Injectable()
 export class GenerateDemoDataUseCase {
@@ -44,8 +74,13 @@ export class GenerateDemoDataUseCase {
       supabase,
     );
     const budgets = await this.seedBudgets(userId, templates, supabase);
-    await this.seedBudgetLines(userId, budgets, templateLines, supabase);
-    await this.seedTransactions(userId, budgets, supabase);
+    const budgetLines = await this.seedBudgetLines(
+      userId,
+      budgets,
+      templateLines,
+      supabase,
+    );
+    await this.seedTransactions(userId, budgets, budgetLines, supabase);
 
     await this.recalculateAllBudgetBalances(budgets);
     this.logger.info(
@@ -109,21 +144,27 @@ export class GenerateDemoDataUseCase {
     budgets: DemoSeededBudget[],
     templateLines: DemoSeededTemplateLine[],
     supabase: AuthenticatedSupabaseClient,
-  ): Promise<void> {
+  ): Promise<DemoSeededBudgetLine[]> {
     const budgetLineSeeds = this.buildBudgetLineSeeds(budgets, templateLines);
-    await this.repo.insertBudgetLines(budgetLineSeeds, userId, supabase);
+    const seededLines = await this.repo.insertBudgetLines(
+      budgetLineSeeds,
+      userId,
+      supabase,
+    );
     this.logger.info(
       { userId, count: budgetLineSeeds.length },
       'Budget lines created',
     );
+    return seededLines;
   }
 
   private async seedTransactions(
     userId: string,
     budgets: DemoSeededBudget[],
+    budgetLines: DemoSeededBudgetLine[],
     supabase: AuthenticatedSupabaseClient,
   ): Promise<void> {
-    const transactionSeeds = this.buildTransactionSeeds(budgets);
+    const transactionSeeds = this.buildTransactionSeeds(budgets, budgetLines);
     await this.repo.insertTransactions(transactionSeeds, userId, supabase);
     this.logger.info(
       { userId, count: transactionSeeds.length },
@@ -213,12 +254,16 @@ export class GenerateDemoDataUseCase {
     budgets: DemoSeededBudget[],
     templateLines: DemoSeededTemplateLine[],
   ): DemoBudgetLineSeed[] {
+    const currentDate = new Date();
     const lines: DemoBudgetLineSeed[] = [];
 
     for (const budget of budgets) {
       const relevantLines = templateLines.filter(
         (tl) => tl.templateId === budget.templateId,
       );
+      const checkedAt = this.isClosedMonth(budget, currentDate)
+        ? this.endOfMonth(budget)
+        : null;
 
       for (const templateLine of relevantLines) {
         lines.push({
@@ -228,6 +273,7 @@ export class GenerateDemoDataUseCase {
           amount: templateLine.amount,
           kind: templateLine.kind,
           recurrence: templateLine.recurrence,
+          checkedAt,
         });
       }
     }
@@ -235,14 +281,38 @@ export class GenerateDemoDataUseCase {
     return lines;
   }
 
+  /** A month strictly before the current one is closed: its ledger is settled. */
+  private isClosedMonth(
+    budget: { month: number; year: number },
+    currentDate: Date,
+  ): boolean {
+    if (budget.year !== currentDate.getFullYear()) {
+      return budget.year < currentDate.getFullYear();
+    }
+    return budget.month < currentDate.getMonth() + 1;
+  }
+
+  private endOfMonth(budget: { month: number; year: number }): string {
+    const lastDay = new Date(budget.year, budget.month, 0).getDate();
+    return new Date(budget.year, budget.month - 1, lastDay).toISOString();
+  }
+
   private buildTransactionSeeds(
     budgets: DemoSeededBudget[],
+    budgetLines: DemoSeededBudgetLine[],
   ): DemoTransactionSeed[] {
     const currentDate = new Date();
     const pastBudgets = budgets.filter((b) => {
       const budgetDate = new Date(b.year, b.month - 1);
       return budgetDate <= currentDate;
     });
+
+    const envelopesByBudget = new Map<string, DemoSeededBudgetLine[]>();
+    for (const line of budgetLines) {
+      const existing = envelopesByBudget.get(line.budgetId);
+      if (existing) existing.push(line);
+      else envelopesByBudget.set(line.budgetId, [line]);
+    }
 
     const transactions: DemoTransactionSeed[] = [];
 
@@ -253,7 +323,14 @@ export class GenerateDemoDataUseCase {
       const daysInMonth = new Date(budget.year, budget.month, 0).getDate();
       const maxDay = isCurrentMonth ? currentDate.getDate() : daysInMonth;
 
-      transactions.push(...this.buildMonthTransactions(budget, maxDay));
+      transactions.push(
+        ...this.buildMonthTransactions(
+          budget,
+          maxDay,
+          envelopesByBudget.get(budget.id) ?? [],
+          currentDate,
+        ),
+      );
     }
 
     return transactions;
@@ -262,65 +339,33 @@ export class GenerateDemoDataUseCase {
   private buildMonthTransactions(
     budget: DemoSeededBudget,
     maxDay: number,
+    envelopes: DemoSeededBudgetLine[],
+    currentDate: Date,
   ): DemoTransactionSeed[] {
-    const transactions: DemoTransactionSeed[] = [];
+    const isClosed = this.isClosedMonth(budget, currentDate);
 
-    if (maxDay >= 5) {
-      transactions.push(
-        this.buildTransaction(
-          budget,
-          5,
-          'Migros - Courses',
-          127.85,
-          'Alimentation',
-        ),
-      );
-    }
-    if (maxDay >= 10) {
-      transactions.push(
-        this.buildTransaction(
-          budget,
-          10,
-          'Restaurant Molino',
-          78.5,
-          'Restaurants',
-        ),
-      );
-    }
-    if (maxDay >= 15) {
-      transactions.push(
-        this.buildTransaction(
-          budget,
-          15,
-          'Coop - Courses',
-          94.2,
-          'Alimentation',
-        ),
-      );
-    }
+    return MONTH_TRANSACTION_SPECS.filter((spec) => maxDay >= spec.day).map(
+      (spec) => {
+        const transactionDate = new Date(
+          budget.year,
+          budget.month - 1,
+          spec.day,
+        ).toISOString();
 
-    return transactions;
-  }
-
-  private buildTransaction(
-    budget: DemoSeededBudget,
-    day: number,
-    name: string,
-    amount: number,
-    tagName: string,
-  ): DemoTransactionSeed {
-    return {
-      budgetId: budget.id,
-      name,
-      amount,
-      kind: 'expense',
-      tagName,
-      transactionDate: new Date(
-        budget.year,
-        budget.month - 1,
-        day,
-      ).toISOString(),
-    };
+        return {
+          budgetId: budget.id,
+          budgetLineId:
+            envelopes.find((line) => line.name === spec.envelopeName)?.id ??
+            null,
+          name: spec.name,
+          amount: spec.amount,
+          kind: 'expense',
+          tagName: spec.tagName,
+          transactionDate,
+          checkedAt: isClosed ? transactionDate : null,
+        };
+      },
+    );
   }
 
   private async recalculateAllBudgetBalances(

--- a/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
+++ b/backend-nest/src/modules/demo/application/generate-demo-data.use-case.ts
@@ -12,6 +12,7 @@ import {
 import type {
   DemoSeededBudget,
   DemoSeededBudgetLine,
+  DemoSeededSavingsGoal,
   DemoSeededTemplate,
   DemoSeededTemplateLine,
 } from '../domain/demo.entity';
@@ -73,7 +74,13 @@ export class GenerateDemoDataUseCase {
       currentDate,
       supabase,
     );
-    await this.seedSavingsGoals(userId, budgetLines, currentDate, supabase);
+    await this.seedSavingsGoals(
+      userId,
+      budgetLines,
+      templateLines,
+      currentDate,
+      supabase,
+    );
 
     await this.recalculateAllBudgetBalances(budgets);
     this.logger.info(
@@ -179,6 +186,7 @@ export class GenerateDemoDataUseCase {
   private async seedSavingsGoals(
     userId: string,
     budgetLines: DemoSeededBudgetLine[],
+    templateLines: DemoSeededTemplateLine[],
     currentDate: Date,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<void> {
@@ -190,20 +198,48 @@ export class GenerateDemoDataUseCase {
     this.logger.info({ userId, count: goals.length }, 'Savings goals created');
 
     for (const goal of goals) {
-      const spec = DEMO_SAVINGS_GOAL_SPECS.find((s) => s.name === goal.name);
-      if (!spec?.envelopeName) continue;
-
-      const envelopeIds = budgetLines
-        .filter(
-          (line) => line.kind === 'saving' && line.name === spec.envelopeName,
-        )
-        .map((line) => line.id);
-      await this.repo.linkBudgetLinesToSavingsGoal(
-        envelopeIds,
-        goal.id,
+      await this.linkEnvelopesFeeding(
+        goal,
+        budgetLines,
+        templateLines,
         supabase,
       );
     }
+  }
+
+  private async linkEnvelopesFeeding(
+    goal: DemoSeededSavingsGoal,
+    budgetLines: DemoSeededBudgetLine[],
+    templateLines: DemoSeededTemplateLine[],
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<void> {
+    const spec = DEMO_SAVINGS_GOAL_SPECS.find((s) => s.name === goal.name);
+    const envelopeName = spec?.envelopeName;
+    if (!envelopeName) return;
+
+    const feedsGoal = (line: { kind: string; name: string }) =>
+      line.kind === 'saving' && line.name === envelopeName;
+
+    await this.repo.linkBudgetLinesToSavingsGoal(
+      budgetLines.filter(feedsGoal).map((line) => line.id),
+      goal.id,
+      supabase,
+    );
+
+    /**
+     * Only an open-ended goal reaches the Mois Type. A dated one materialises
+     * bounded `one_off` prévisions and poses nothing there (`SAVINGS.md` §3.5):
+     * a recurrence would carry it for life and falsify the model's net balance
+     * past the deadline. Tagging the Mois Type is what makes the link survive
+     * the months the seed does not cover (§3.2).
+     */
+    if (spec.monthsUntilTarget !== null) return;
+
+    await this.repo.linkTemplateLinesToSavingsGoal(
+      templateLines.filter(feedsGoal).map((line) => line.id),
+      goal.id,
+      supabase,
+    );
   }
 
   private async recalculateAllBudgetBalances(

--- a/backend-nest/src/modules/demo/domain/demo-seed.builders.ts
+++ b/backend-nest/src/modules/demo/domain/demo-seed.builders.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from 'node:crypto';
+import { addMonths, format, startOfMonth } from 'date-fns';
+import { splitTotalPreserving } from 'pulpe-shared';
+import type {
+  DemoBudgetLineSeed,
+  DemoBudgetSeed,
+  DemoSavingsGoalSeed,
+  DemoSeededBudget,
+  DemoSeededTemplate,
+  DemoSeededTemplateLine,
+  DemoTemplateSeed,
+} from './demo.entity';
+import {
+  DEMO_SAVINGS_GOAL_SPECS,
+  DEMO_SPREAD_SPEC,
+  DEMO_TEMPLATE_SPECS,
+} from './demo.constants';
+
+/** The demo spans six closed months before the current one. */
+export const FIRST_SEEDED_MONTH_OFFSET = -6;
+const LAST_SEEDED_MONTH_OFFSET = 5;
+export const DATE_COLUMN_FORMAT = 'yyyy-MM-dd';
+
+/** A month strictly before the current one is closed: its ledger is settled. */
+export function isClosedMonth(
+  budget: { month: number; year: number },
+  currentDate: Date,
+): boolean {
+  if (budget.year !== currentDate.getFullYear()) {
+    return budget.year < currentDate.getFullYear();
+  }
+  return budget.month < currentDate.getMonth() + 1;
+}
+
+/** The instant a closed month is settled at, stamped on its pointage. */
+export function lastInstantOfMonth(budget: {
+  month: number;
+  year: number;
+}): string {
+  const lastDay = new Date(budget.year, budget.month, 0).getDate();
+  return new Date(budget.year, budget.month - 1, lastDay).toISOString();
+}
+
+export function buildTemplateSeeds(userId: string): DemoTemplateSeed[] {
+  return [
+    {
+      userId,
+      name: DEMO_TEMPLATE_SPECS.STANDARD.name,
+      description: DEMO_TEMPLATE_SPECS.STANDARD.description,
+      isDefault: DEMO_TEMPLATE_SPECS.STANDARD.isDefault,
+    },
+    {
+      userId,
+      name: DEMO_TEMPLATE_SPECS.VACATIONS.name,
+      description: DEMO_TEMPLATE_SPECS.VACATIONS.description,
+      isDefault: DEMO_TEMPLATE_SPECS.VACATIONS.isDefault,
+    },
+    {
+      userId,
+      name: DEMO_TEMPLATE_SPECS.SAVINGS.name,
+      description: DEMO_TEMPLATE_SPECS.SAVINGS.description,
+      isDefault: DEMO_TEMPLATE_SPECS.SAVINGS.isDefault,
+    },
+    {
+      userId,
+      name: DEMO_TEMPLATE_SPECS.HOLIDAYS.name,
+      description: DEMO_TEMPLATE_SPECS.HOLIDAYS.description,
+      isDefault: DEMO_TEMPLATE_SPECS.HOLIDAYS.isDefault,
+    },
+  ];
+}
+
+export function buildBudgetSeeds(
+  userId: string,
+  templates: DemoSeededTemplate[],
+  currentDate: Date,
+): DemoBudgetSeed[] {
+  const budgets: DemoBudgetSeed[] = [];
+
+  for (
+    let offset = FIRST_SEEDED_MONTH_OFFSET;
+    offset <= LAST_SEEDED_MONTH_OFFSET;
+    offset++
+  ) {
+    const budgetDate = addMonths(startOfMonth(currentDate), offset);
+    const month = budgetDate.getMonth() + 1;
+    const year = budgetDate.getFullYear();
+    const { templateId, description } = selectTemplateForMonth(
+      month,
+      templates,
+    );
+    budgets.push({ userId, month, year, description, templateId });
+  }
+
+  return budgets;
+}
+
+function selectTemplateForMonth(
+  month: number,
+  templates: DemoSeededTemplate[],
+): { templateId: string; description: string } {
+  if (month === 12) {
+    return {
+      templateId: templates[3].id,
+      description: "Budget des fêtes de fin d'année 🎄",
+    };
+  }
+  if (month === 7 || month === 8) {
+    return {
+      templateId: templates[1].id,
+      description: "Budget vacances d'été ☀️",
+    };
+  }
+  if (month === 3 || month === 9) {
+    return {
+      templateId: templates[2].id,
+      description: "Focus sur l'épargne ce mois-ci 💪",
+    };
+  }
+  return {
+    templateId: templates[0].id,
+    description: 'Budget mensuel standard',
+  };
+}
+
+export function buildBudgetLineSeeds(
+  budgets: DemoSeededBudget[],
+  templateLines: DemoSeededTemplateLine[],
+  currentDate: Date,
+): DemoBudgetLineSeed[] {
+  const lines: DemoBudgetLineSeed[] = [];
+
+  for (const budget of budgets) {
+    const relevantLines = templateLines.filter(
+      (tl) => tl.templateId === budget.templateId,
+    );
+    const checkedAt = isClosedMonth(budget, currentDate)
+      ? lastInstantOfMonth(budget)
+      : null;
+
+    for (const templateLine of relevantLines) {
+      lines.push({
+        budgetId: budget.id,
+        templateLineId: templateLine.id,
+        name: templateLine.name,
+        amount: templateLine.amount,
+        kind: templateLine.kind,
+        recurrence: templateLine.recurrence,
+        checkedAt,
+        spreadGroupId: null,
+      });
+    }
+  }
+
+  return [...lines, ...buildSpreadTrancheSeeds(budgets, currentDate)];
+}
+
+/**
+ * The tranches of the demo's lissage: sibling one_off lines sharing one group
+ * id, never issued from the Mois Type, whose amounts sum back to the total.
+ */
+function buildSpreadTrancheSeeds(
+  budgets: DemoSeededBudget[],
+  currentDate: Date,
+): DemoBudgetLineSeed[] {
+  const spreadGroupId = randomUUID();
+  const budgetsByPeriod = new Map(
+    budgets.map((budget) => [`${budget.year}-${budget.month}`, budget]),
+  );
+
+  return splitTotalPreserving(
+    DEMO_SPREAD_SPEC.totalAmount,
+    DEMO_SPREAD_SPEC.monthCount,
+  ).flatMap((amount, index) => {
+    const monthDate = addMonths(
+      startOfMonth(currentDate),
+      DEMO_SPREAD_SPEC.firstMonthOffset + index,
+    );
+    const budget = budgetsByPeriod.get(
+      `${monthDate.getFullYear()}-${monthDate.getMonth() + 1}`,
+    );
+    if (!budget) return [];
+
+    return [
+      {
+        budgetId: budget.id,
+        templateLineId: null,
+        name: DEMO_SPREAD_SPEC.name,
+        amount,
+        kind: 'expense' as const,
+        recurrence: 'one_off' as const,
+        checkedAt: isClosedMonth(budget, currentDate)
+          ? lastInstantOfMonth(budget)
+          : null,
+        spreadGroupId,
+      },
+    ];
+  });
+}
+
+export function buildSavingsGoalSeeds(
+  userId: string,
+  currentDate: Date,
+): DemoSavingsGoalSeed[] {
+  const firstSeededMonth = addMonths(
+    startOfMonth(currentDate),
+    FIRST_SEEDED_MONTH_OFFSET,
+  );
+
+  return DEMO_SAVINGS_GOAL_SPECS.map((spec) => {
+    const horizon = goalHorizon(spec.monthsUntilTarget, currentDate);
+
+    return {
+      userId,
+      name: spec.name,
+      targetAmount: spec.targetAmount,
+      initialAmount: spec.initialAmount,
+      status: spec.status,
+      startDate: format(firstSeededMonth, DATE_COLUMN_FORMAT),
+      targetDate: horizon ? format(horizon, DATE_COLUMN_FORMAT) : null,
+    };
+  });
+}
+
+/** A null `monthsUntilTarget` means an open-ended plan: no deadline. */
+function goalHorizon(
+  monthsUntilTarget: number | null,
+  currentDate: Date,
+): Date | null {
+  if (monthsUntilTarget === null) return null;
+  return addMonths(startOfMonth(currentDate), monthsUntilTarget);
+}

--- a/backend-nest/src/modules/demo/domain/demo-seed.builders.ts
+++ b/backend-nest/src/modules/demo/domain/demo-seed.builders.ts
@@ -35,16 +35,19 @@ export function isClosedMonth(
 }
 
 /**
- * The instant a closed month is settled at, stamped on its pointage: midnight
- * on the month's last day, not the last instant of it. Anything later would
- * render as the next month's first day for a reader east of UTC.
+ * The instant a closed month is settled at, stamped on its pointage: UTC
+ * midnight on the month's last day, not the last instant of it. Anything later
+ * would render as the next month's first day for a reader east of UTC, and a
+ * local midnight would stamp the day before for one west of the seeding server.
  */
 export function settlementStampForMonth(budget: {
   month: number;
   year: number;
 }): string {
   const lastDay = new Date(budget.year, budget.month, 0).getDate();
-  return new Date(budget.year, budget.month - 1, lastDay).toISOString();
+  return new Date(
+    Date.UTC(budget.year, budget.month - 1, lastDay),
+  ).toISOString();
 }
 
 export function buildTemplateSeeds(userId: string): DemoTemplateSeed[] {

--- a/backend-nest/src/modules/demo/domain/demo-seed.builders.ts
+++ b/backend-nest/src/modules/demo/domain/demo-seed.builders.ts
@@ -35,19 +35,26 @@ export function isClosedMonth(
 }
 
 /**
- * The instant a closed month is settled at, stamped on its pointage: UTC
- * midnight on the month's last day, not the last instant of it. Anything later
- * would render as the next month's first day for a reader east of UTC, and a
- * local midnight would stamp the day before for one west of the seeding server.
+ * A calendar day of the seed, pinned to UTC midnight. Every date the seed
+ * serializes goes through here, and so does every comparison against the clock:
+ * a local midnight is the seeding server's midnight, so mixing the two would
+ * date a row by one calendar and admit it by another.
+ */
+export function utcMidnight(year: number, month: number, day: number): Date {
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * The instant a closed month is settled at, stamped on its pointage: midnight
+ * on the month's last day, not the last instant of it. Anything later would
+ * render as the next month's first day for a reader east of UTC.
  */
 export function settlementStampForMonth(budget: {
   month: number;
   year: number;
 }): string {
-  const lastDay = new Date(budget.year, budget.month, 0).getDate();
-  return new Date(
-    Date.UTC(budget.year, budget.month - 1, lastDay),
-  ).toISOString();
+  const lastDay = new Date(Date.UTC(budget.year, budget.month, 0)).getUTCDate();
+  return utcMidnight(budget.year, budget.month, lastDay).toISOString();
 }
 
 export function buildTemplateSeeds(userId: string): DemoTemplateSeed[] {

--- a/backend-nest/src/modules/demo/domain/demo-seed.builders.ts
+++ b/backend-nest/src/modules/demo/domain/demo-seed.builders.ts
@@ -13,7 +13,9 @@ import type {
 import {
   DEMO_SAVINGS_GOAL_SPECS,
   DEMO_SPREAD_SPEC,
+  DEMO_TEMPLATE_ORDER,
   DEMO_TEMPLATE_SPECS,
+  type DemoTemplateKey,
 } from './demo.constants';
 
 /** The demo spans six closed months before the current one. */
@@ -32,8 +34,12 @@ export function isClosedMonth(
   return budget.month < currentDate.getMonth() + 1;
 }
 
-/** The instant a closed month is settled at, stamped on its pointage. */
-export function lastInstantOfMonth(budget: {
+/**
+ * The instant a closed month is settled at, stamped on its pointage: midnight
+ * on the month's last day, not the last instant of it. Anything later would
+ * render as the next month's first day for a reader east of UTC.
+ */
+export function settlementStampForMonth(budget: {
   month: number;
   year: number;
 }): string {
@@ -42,32 +48,12 @@ export function lastInstantOfMonth(budget: {
 }
 
 export function buildTemplateSeeds(userId: string): DemoTemplateSeed[] {
-  return [
-    {
-      userId,
-      name: DEMO_TEMPLATE_SPECS.STANDARD.name,
-      description: DEMO_TEMPLATE_SPECS.STANDARD.description,
-      isDefault: DEMO_TEMPLATE_SPECS.STANDARD.isDefault,
-    },
-    {
-      userId,
-      name: DEMO_TEMPLATE_SPECS.VACATIONS.name,
-      description: DEMO_TEMPLATE_SPECS.VACATIONS.description,
-      isDefault: DEMO_TEMPLATE_SPECS.VACATIONS.isDefault,
-    },
-    {
-      userId,
-      name: DEMO_TEMPLATE_SPECS.SAVINGS.name,
-      description: DEMO_TEMPLATE_SPECS.SAVINGS.description,
-      isDefault: DEMO_TEMPLATE_SPECS.SAVINGS.isDefault,
-    },
-    {
-      userId,
-      name: DEMO_TEMPLATE_SPECS.HOLIDAYS.name,
-      description: DEMO_TEMPLATE_SPECS.HOLIDAYS.description,
-      isDefault: DEMO_TEMPLATE_SPECS.HOLIDAYS.isDefault,
-    },
-  ];
+  return DEMO_TEMPLATE_ORDER.map((key) => ({
+    userId,
+    name: DEMO_TEMPLATE_SPECS[key].name,
+    description: DEMO_TEMPLATE_SPECS[key].description,
+    isDefault: DEMO_TEMPLATE_SPECS[key].isDefault,
+  }));
 }
 
 export function buildBudgetSeeds(
@@ -95,31 +81,33 @@ export function buildBudgetSeeds(
   return budgets;
 }
 
+/**
+ * Which template a month runs on. The themed months are fixed by the calendar,
+ * so anything else keyed on the month — the actuals it can consume, above all —
+ * asks this rather than re-deriving the same calendar.
+ */
+export function templateKeyForMonth(month: number): DemoTemplateKey {
+  if (month === 12) return 'HOLIDAYS';
+  if (month === 7 || month === 8) return 'VACATIONS';
+  if (month === 3 || month === 9) return 'SAVINGS';
+  return 'STANDARD';
+}
+
+const MONTH_DESCRIPTIONS: Record<DemoTemplateKey, string> = {
+  STANDARD: 'Budget mensuel standard',
+  VACATIONS: "Budget vacances d'été ☀️",
+  SAVINGS: "Focus sur l'épargne ce mois-ci 💪",
+  HOLIDAYS: "Budget des fêtes de fin d'année 🎄",
+};
+
 function selectTemplateForMonth(
   month: number,
   templates: DemoSeededTemplate[],
 ): { templateId: string; description: string } {
-  if (month === 12) {
-    return {
-      templateId: templates[3].id,
-      description: "Budget des fêtes de fin d'année 🎄",
-    };
-  }
-  if (month === 7 || month === 8) {
-    return {
-      templateId: templates[1].id,
-      description: "Budget vacances d'été ☀️",
-    };
-  }
-  if (month === 3 || month === 9) {
-    return {
-      templateId: templates[2].id,
-      description: "Focus sur l'épargne ce mois-ci 💪",
-    };
-  }
+  const key = templateKeyForMonth(month);
   return {
-    templateId: templates[0].id,
-    description: 'Budget mensuel standard',
+    templateId: templates[DEMO_TEMPLATE_ORDER.indexOf(key)].id,
+    description: MONTH_DESCRIPTIONS[key],
   };
 }
 
@@ -135,7 +123,7 @@ export function buildBudgetLineSeeds(
       (tl) => tl.templateId === budget.templateId,
     );
     const checkedAt = isClosedMonth(budget, currentDate)
-      ? lastInstantOfMonth(budget)
+      ? settlementStampForMonth(budget)
       : null;
 
     for (const templateLine of relevantLines) {
@@ -190,7 +178,7 @@ function buildSpreadTrancheSeeds(
         kind: 'expense' as const,
         recurrence: 'one_off' as const,
         checkedAt: isClosedMonth(budget, currentDate)
-          ? lastInstantOfMonth(budget)
+          ? settlementStampForMonth(budget)
           : null,
         spreadGroupId,
       },

--- a/backend-nest/src/modules/demo/domain/demo-transaction-seeds.ts
+++ b/backend-nest/src/modules/demo/domain/demo-transaction-seeds.ts
@@ -1,0 +1,110 @@
+import type {
+  DemoSeededBudget,
+  DemoSeededBudgetLine,
+  DemoTransactionSeed,
+} from './demo.entity';
+import { isClosedMonth } from './demo-seed.builders';
+
+/**
+ * The month's actuals. `envelopeName` names the prévision each one consumes —
+ * a budget built from another template may not carry it, and the actual then
+ * stays unattached, which is a legitimate state to show.
+ *
+ * The month in progress only keeps the actuals whose day has already elapsed,
+ * so the first one falls on the 1st: a prospect opening the demo on the 2nd
+ * must still see a consumed envelope, not the empty month the seed used to show
+ * until the 5th.
+ */
+const MONTH_TRANSACTION_SPECS = [
+  {
+    day: 1,
+    name: 'Migros - Courses',
+    amount: 127.85,
+    tagName: 'Alimentation',
+    envelopeName: 'Courses alimentaires',
+  },
+  {
+    day: 10,
+    name: 'Restaurant Molino',
+    amount: 78.5,
+    tagName: 'Restaurants',
+    envelopeName: 'Restaurants/Sorties',
+  },
+  {
+    day: 15,
+    name: 'Coop - Courses',
+    amount: 94.2,
+    tagName: 'Alimentation',
+    envelopeName: 'Courses alimentaires',
+  },
+] as const;
+
+export function buildTransactionSeeds(
+  budgets: DemoSeededBudget[],
+  budgetLines: DemoSeededBudgetLine[],
+  currentDate: Date,
+): DemoTransactionSeed[] {
+  const pastBudgets = budgets.filter((budget) => {
+    const budgetDate = new Date(budget.year, budget.month - 1);
+    return budgetDate <= currentDate;
+  });
+
+  const envelopesByBudget = new Map<string, DemoSeededBudgetLine[]>();
+  for (const line of budgetLines) {
+    const existing = envelopesByBudget.get(line.budgetId);
+    if (existing) existing.push(line);
+    else envelopesByBudget.set(line.budgetId, [line]);
+  }
+
+  const transactions: DemoTransactionSeed[] = [];
+
+  for (const budget of pastBudgets) {
+    const isCurrentMonth =
+      budget.month === currentDate.getMonth() + 1 &&
+      budget.year === currentDate.getFullYear();
+    const daysInMonth = new Date(budget.year, budget.month, 0).getDate();
+    const maxDay = isCurrentMonth ? currentDate.getDate() : daysInMonth;
+
+    transactions.push(
+      ...buildMonthTransactions(
+        budget,
+        maxDay,
+        envelopesByBudget.get(budget.id) ?? [],
+        currentDate,
+      ),
+    );
+  }
+
+  return transactions;
+}
+
+function buildMonthTransactions(
+  budget: DemoSeededBudget,
+  maxDay: number,
+  envelopes: DemoSeededBudgetLine[],
+  currentDate: Date,
+): DemoTransactionSeed[] {
+  const isClosed = isClosedMonth(budget, currentDate);
+
+  return MONTH_TRANSACTION_SPECS.filter((spec) => maxDay >= spec.day).map(
+    (spec) => {
+      const transactionDate = new Date(
+        budget.year,
+        budget.month - 1,
+        spec.day,
+      ).toISOString();
+
+      return {
+        budgetId: budget.id,
+        budgetLineId:
+          envelopes.find((line) => line.name === spec.envelopeName)?.id ?? null,
+        name: spec.name,
+        amount: spec.amount,
+        kind: 'expense',
+        tagName: spec.tagName,
+        transactionDate,
+        checkedAt: isClosed ? transactionDate : null,
+      };
+    },
+  );
+}

--- a/backend-nest/src/modules/demo/domain/demo-transaction-seeds.ts
+++ b/backend-nest/src/modules/demo/domain/demo-transaction-seeds.ts
@@ -3,7 +3,11 @@ import type {
   DemoSeededBudgetLine,
   DemoTransactionSeed,
 } from './demo.entity';
-import { isClosedMonth, templateKeyForMonth } from './demo-seed.builders';
+import {
+  isClosedMonth,
+  templateKeyForMonth,
+  utcMidnight,
+} from './demo-seed.builders';
 import type { DemoTemplateKey } from './demo.constants';
 
 interface MonthTransactionSpec {
@@ -128,11 +132,6 @@ export function buildTransactionSeeds(
   budgetLines: DemoSeededBudgetLine[],
   currentDate: Date,
 ): DemoTransactionSeed[] {
-  const pastBudgets = budgets.filter((budget) => {
-    const budgetDate = new Date(budget.year, budget.month - 1);
-    return budgetDate <= currentDate;
-  });
-
   const envelopesByBudget = new Map<string, DemoSeededBudgetLine[]>();
   for (const line of budgetLines) {
     const existing = envelopesByBudget.get(line.budgetId);
@@ -140,45 +139,37 @@ export function buildTransactionSeeds(
     else envelopesByBudget.set(line.budgetId, [line]);
   }
 
-  const transactions: DemoTransactionSeed[] = [];
-
-  for (const budget of pastBudgets) {
-    const isCurrentMonth =
-      budget.month === currentDate.getMonth() + 1 &&
-      budget.year === currentDate.getFullYear();
-    const daysInMonth = new Date(budget.year, budget.month, 0).getDate();
-    const maxDay = isCurrentMonth ? currentDate.getDate() : daysInMonth;
-
-    transactions.push(
-      ...buildMonthTransactions(
-        budget,
-        maxDay,
-        envelopesByBudget.get(budget.id) ?? [],
-        currentDate,
-      ),
-    );
-  }
-
-  return transactions;
+  return budgets.flatMap((budget) =>
+    buildMonthTransactions(
+      budget,
+      envelopesByBudget.get(budget.id) ?? [],
+      currentDate,
+    ),
+  );
 }
 
 function buildMonthTransactions(
   budget: DemoSeededBudget,
-  maxDay: number,
   envelopes: DemoSeededBudgetLine[],
   currentDate: Date,
 ): DemoTransactionSeed[] {
   const isClosed = isClosedMonth(budget, currentDate);
   const specs = MONTH_TRANSACTION_SPECS[templateKeyForMonth(budget.month)];
 
+  /**
+   * A day is admitted by the very instant it will be stamped with, so a réel is
+   * never dated ahead of the clock that seeded it. Gating on the local calendar
+   * instead would let the seeding server's own midnight through hours before
+   * the stamped one, and months still ahead never clear the test at all.
+   */
   return specs
-    .filter((spec) => maxDay >= spec.day)
-    .map((spec) => {
-      // UTC midnight, like the settlement stamp: a local midnight would land on
-      // the day before whenever the seeding server sits east of UTC.
-      const transactionDate = new Date(
-        Date.UTC(budget.year, budget.month - 1, spec.day),
-      ).toISOString();
+    .map((spec) => ({
+      spec,
+      stamp: utcMidnight(budget.year, budget.month, spec.day),
+    }))
+    .filter(({ stamp }) => stamp <= currentDate)
+    .map(({ spec, stamp }) => {
+      const transactionDate = stamp.toISOString();
 
       return {
         budgetId: budget.id,

--- a/backend-nest/src/modules/demo/domain/demo-transaction-seeds.ts
+++ b/backend-nest/src/modules/demo/domain/demo-transaction-seeds.ts
@@ -174,10 +174,10 @@ function buildMonthTransactions(
   return specs
     .filter((spec) => maxDay >= spec.day)
     .map((spec) => {
+      // UTC midnight, like the settlement stamp: a local midnight would land on
+      // the day before whenever the seeding server sits east of UTC.
       const transactionDate = new Date(
-        budget.year,
-        budget.month - 1,
-        spec.day,
+        Date.UTC(budget.year, budget.month - 1, spec.day),
       ).toISOString();
 
       return {

--- a/backend-nest/src/modules/demo/domain/demo-transaction-seeds.ts
+++ b/backend-nest/src/modules/demo/domain/demo-transaction-seeds.ts
@@ -3,41 +3,125 @@ import type {
   DemoSeededBudgetLine,
   DemoTransactionSeed,
 } from './demo.entity';
-import { isClosedMonth } from './demo-seed.builders';
+import { isClosedMonth, templateKeyForMonth } from './demo-seed.builders';
+import type { DemoTemplateKey } from './demo.constants';
+
+interface MonthTransactionSpec {
+  day: number;
+  name: string;
+  amount: number;
+  tagName: string;
+  envelopeName: string;
+}
 
 /**
- * The month's actuals. `envelopeName` names the prévision each one consumes —
- * a budget built from another template may not carry it, and the actual then
- * stays unattached, which is a legitimate state to show.
+ * The month's actuals, one set per template. `envelopeName` names the prévision
+ * each one consumes, and it must exist in the template it is filed under: a
+ * themed month whose actuals named standard envelopes showed a budget with
+ * nothing consumed at all — the very emptiness the demo exists to disprove.
+ * `demo-template-specs.spec.ts` holds the two sides together.
  *
  * The month in progress only keeps the actuals whose day has already elapsed,
- * so the first one falls on the 1st: a prospect opening the demo on the 2nd
- * must still see a consumed envelope, not the empty month the seed used to show
- * until the 5th.
+ * so every set opens on the 1st: a prospect landing on the 2nd must still see a
+ * consumed envelope.
  */
-const MONTH_TRANSACTION_SPECS = [
-  {
-    day: 1,
-    name: 'Migros - Courses',
-    amount: 127.85,
-    tagName: 'Alimentation',
-    envelopeName: 'Courses alimentaires',
-  },
-  {
-    day: 10,
-    name: 'Restaurant Molino',
-    amount: 78.5,
-    tagName: 'Restaurants',
-    envelopeName: 'Restaurants/Sorties',
-  },
-  {
-    day: 15,
-    name: 'Coop - Courses',
-    amount: 94.2,
-    tagName: 'Alimentation',
-    envelopeName: 'Courses alimentaires',
-  },
-] as const;
+export const MONTH_TRANSACTION_SPECS: Record<
+  DemoTemplateKey,
+  readonly MonthTransactionSpec[]
+> = {
+  STANDARD: [
+    {
+      day: 1,
+      name: 'Migros - Courses',
+      amount: 127.85,
+      tagName: 'Alimentation',
+      envelopeName: 'Courses alimentaires',
+    },
+    {
+      day: 10,
+      name: 'Restaurant Molino',
+      amount: 78.5,
+      tagName: 'Restaurants',
+      envelopeName: 'Restaurants/Sorties',
+    },
+    {
+      day: 15,
+      name: 'Coop - Courses',
+      amount: 94.2,
+      tagName: 'Alimentation',
+      envelopeName: 'Courses alimentaires',
+    },
+  ],
+  VACATIONS: [
+    {
+      day: 1,
+      name: 'Swiss - Billets',
+      amount: 742,
+      tagName: 'Voyage',
+      envelopeName: "Billets d'avion",
+    },
+    {
+      day: 10,
+      name: 'Hôtel Bellavista',
+      amount: 1180,
+      tagName: 'Voyage',
+      envelopeName: 'Hôtel (7 nuits)',
+    },
+    {
+      day: 15,
+      name: 'Excursions & restaurants',
+      amount: 486.3,
+      tagName: 'Loisirs',
+      envelopeName: 'Budget vacances',
+    },
+  ],
+  SAVINGS: [
+    {
+      day: 1,
+      name: 'Aldi - Courses',
+      amount: 68.3,
+      tagName: 'Alimentation',
+      envelopeName: 'Courses (budget serré)',
+    },
+    {
+      day: 10,
+      name: 'Denner - Courses',
+      amount: 74.15,
+      tagName: 'Alimentation',
+      envelopeName: 'Courses (budget serré)',
+    },
+    {
+      day: 15,
+      name: 'Pharmacie - dépannage',
+      amount: 42.9,
+      tagName: 'Santé',
+      envelopeName: 'Minimum vital',
+    },
+  ],
+  HOLIDAYS: [
+    {
+      day: 1,
+      name: 'Manor - Cadeaux',
+      amount: 245,
+      tagName: 'Cadeaux',
+      envelopeName: 'Cadeaux famille',
+    },
+    {
+      day: 10,
+      name: 'Traiteur - Repas de fêtes',
+      amount: 318.5,
+      tagName: 'Alimentation',
+      envelopeName: 'Repas de fêtes',
+    },
+    {
+      day: 15,
+      name: 'Jumbo - Décorations',
+      amount: 87.9,
+      tagName: 'Maison',
+      envelopeName: 'Décorations',
+    },
+  ],
+};
 
 export function buildTransactionSeeds(
   budgets: DemoSeededBudget[],
@@ -85,9 +169,11 @@ function buildMonthTransactions(
   currentDate: Date,
 ): DemoTransactionSeed[] {
   const isClosed = isClosedMonth(budget, currentDate);
+  const specs = MONTH_TRANSACTION_SPECS[templateKeyForMonth(budget.month)];
 
-  return MONTH_TRANSACTION_SPECS.filter((spec) => maxDay >= spec.day).map(
-    (spec) => {
+  return specs
+    .filter((spec) => maxDay >= spec.day)
+    .map((spec) => {
       const transactionDate = new Date(
         budget.year,
         budget.month - 1,
@@ -105,6 +191,5 @@ function buildMonthTransactions(
         transactionDate,
         checkedAt: isClosed ? transactionDate : null,
       };
-    },
-  );
+    });
 }

--- a/backend-nest/src/modules/demo/domain/demo.constants.ts
+++ b/backend-nest/src/modules/demo/domain/demo.constants.ts
@@ -37,6 +37,22 @@ export const DEMO_SAVINGS_GOAL_SPECS = [
   },
 ] as const;
 
+/**
+ * The one lissage the demo shows. The window straddles the current month so the
+ * occurrence tracker has both a cumulated part and a non-zero rest to provision
+ * — a window entirely in the past or the future would show neither.
+ *
+ * The total divides into 6 tranches with two remainder cents, which is exactly
+ * what makes the cent-preserving split visible instead of a suspiciously round
+ * division.
+ */
+export const DEMO_SPREAD_SPEC = {
+  name: 'Prime assurance auto',
+  totalAmount: 1085,
+  monthCount: 6,
+  firstMonthOffset: -2,
+} as const;
+
 export const DEMO_TEMPLATE_SPECS = {
   STANDARD: {
     name: '💰 Mois Standard',

--- a/backend-nest/src/modules/demo/domain/demo.constants.ts
+++ b/backend-nest/src/modules/demo/domain/demo.constants.ts
@@ -9,6 +9,10 @@ export const DEMO_RETENTION_HOURS = 24;
  * negative for a deadline already behind us. `priority` is deliberately absent:
  * the savings-goal module never writes it, so seeding it would show the
  * prospect a state the app itself cannot produce.
+ *
+ * A funded goal's deadline must reach past the last seeded month: the
+ * `enforce_savings_goal_line_link` trigger rejects a prévision linked beyond it,
+ * and a failed demo seed is swallowed into an empty demo rather than an error.
  */
 export const DEMO_SAVINGS_GOAL_SPECS = [
   {

--- a/backend-nest/src/modules/demo/domain/demo.constants.ts
+++ b/backend-nest/src/modules/demo/domain/demo.constants.ts
@@ -57,6 +57,20 @@ export const DEMO_SPREAD_SPEC = {
   firstMonthOffset: -2,
 } as const;
 
+/**
+ * The order the four templates are seeded in. Both the template-line seed and
+ * the budget seed address them positionally, so the order is part of the
+ * contract rather than a detail of `buildTemplateSeeds`.
+ */
+export const DEMO_TEMPLATE_ORDER = [
+  'STANDARD',
+  'VACATIONS',
+  'SAVINGS',
+  'HOLIDAYS',
+] as const;
+
+export type DemoTemplateKey = (typeof DEMO_TEMPLATE_ORDER)[number];
+
 export const DEMO_TEMPLATE_SPECS = {
   STANDARD: {
     name: '💰 Mois Standard',

--- a/backend-nest/src/modules/demo/domain/demo.constants.ts
+++ b/backend-nest/src/modules/demo/domain/demo.constants.ts
@@ -1,5 +1,42 @@
 export const DEMO_RETENTION_HOURS = 24;
 
+/**
+ * The savings goals the demo shows, one per state the UI can render: a dated
+ * plan, an open-ended plan, and a goal already reached.
+ *
+ * `envelopeName` is the prévision Épargne feeding the goal — a reached goal is
+ * fed by nothing. `monthsUntilTarget` is null for an open-ended plan and
+ * negative for a deadline already behind us. `priority` is deliberately absent:
+ * the savings-goal module never writes it, so seeding it would show the
+ * prospect a state the app itself cannot produce.
+ */
+export const DEMO_SAVINGS_GOAL_SPECS = [
+  {
+    name: 'Apport logement',
+    targetAmount: 80000,
+    initialAmount: 15000,
+    status: 'ACTIVE',
+    monthsUntilTarget: 18,
+    envelopeName: 'Épargne logement',
+  },
+  {
+    name: "Fonds d'urgence",
+    targetAmount: 15000,
+    initialAmount: 2000,
+    status: 'ACTIVE',
+    monthsUntilTarget: null,
+    envelopeName: "Fonds d'urgence",
+  },
+  {
+    name: 'Nouveau vélo',
+    targetAmount: 1200,
+    initialAmount: 1200,
+    status: 'COMPLETED',
+    monthsUntilTarget: -2,
+    envelopeName: null,
+  },
+] as const;
+
 export const DEMO_TEMPLATE_SPECS = {
   STANDARD: {
     name: '💰 Mois Standard',

--- a/backend-nest/src/modules/demo/domain/demo.entity.ts
+++ b/backend-nest/src/modules/demo/domain/demo.entity.ts
@@ -85,6 +85,10 @@ export interface DemoSeededBudget {
 
 /**
  * Budget line seed input (entity-shaped). Repo encrypts `amount` internally.
+ *
+ * `checkedAt` carries the pointage: months already closed are seeded checked so
+ * the demo shows the "Pointé / À pointer" contrast instead of a flat unchecked
+ * ledger. It also gates savings goal progress, which only counts checked lines.
  */
 export interface DemoBudgetLineSeed {
   budgetId: string;
@@ -93,18 +97,36 @@ export interface DemoBudgetLineSeed {
   amount: number;
   kind: TransactionKindEnum;
   recurrence: TransactionRecurrenceEnum;
+  checkedAt: string | null;
+}
+
+/**
+ * Identifier and shape returned by the repo after inserting a budget line.
+ * The repo decrypts `amount` so callers receive plain numbers.
+ */
+export interface DemoSeededBudgetLine {
+  id: string;
+  budgetId: string;
+  name: string;
+  amount: number;
+  kind: TransactionKindEnum;
 }
 
 /**
  * Transaction seed input (entity-shaped). Repo encrypts `amount` internally.
+ *
+ * `budgetLineId` is the envelope this actual consumes; `null` is legitimate when
+ * the month's budget carries no matching prévision.
  */
 export interface DemoTransactionSeed {
   budgetId: string;
+  budgetLineId: string | null;
   name: string;
   amount: number;
   kind: TransactionKindEnum;
   tagName: string;
   transactionDate: string;
+  checkedAt: string | null;
 }
 
 export type TemplateRow = Tables<'template'>;

--- a/backend-nest/src/modules/demo/domain/demo.entity.ts
+++ b/backend-nest/src/modules/demo/domain/demo.entity.ts
@@ -107,14 +107,13 @@ export interface DemoBudgetLineSeed {
 }
 
 /**
- * Identifier and shape returned by the repo after inserting a budget line.
- * The repo decrypts `amount` so callers receive plain numbers.
+ * What the seed needs back after inserting a budget line: the generated id, and
+ * enough to pair the line with the actual it consumes or the goal it feeds.
  */
 export interface DemoSeededBudgetLine {
   id: string;
   budgetId: string;
   name: string;
-  amount: number;
   kind: TransactionKindEnum;
 }
 

--- a/backend-nest/src/modules/demo/domain/demo.entity.ts
+++ b/backend-nest/src/modules/demo/domain/demo.entity.ts
@@ -90,6 +90,10 @@ export interface DemoSeededBudget {
  * `checkedAt` carries the pointage: months already closed are seeded checked so
  * the demo shows the "Pointé / À pointer" contrast instead of a flat unchecked
  * ledger. It also gates savings goal progress, which only counts checked lines.
+ *
+ * `spreadGroupId` is the shared identity of a lissage: the tranches of one
+ * spread expense are sibling `one_off` lines carrying the same uuid. It is not
+ * a financial value, so it is never encrypted.
  */
 export interface DemoBudgetLineSeed {
   budgetId: string;
@@ -99,6 +103,7 @@ export interface DemoBudgetLineSeed {
   kind: TransactionKindEnum;
   recurrence: TransactionRecurrenceEnum;
   checkedAt: string | null;
+  spreadGroupId: string | null;
 }
 
 /**

--- a/backend-nest/src/modules/demo/domain/demo.entity.ts
+++ b/backend-nest/src/modules/demo/domain/demo.entity.ts
@@ -19,6 +19,7 @@ export interface DemoSession {
 type TransactionKindEnum = Database['public']['Enums']['transaction_kind'];
 type TransactionRecurrenceEnum =
   Database['public']['Enums']['transaction_recurrence'];
+type SavingsGoalStatusEnum = Database['public']['Enums']['savings_goal_status'];
 
 /**
  * Template seed input (entity-shaped). Repo writes directly — no amounts to encrypt here.
@@ -127,6 +128,29 @@ export interface DemoTransactionSeed {
   tagName: string;
   transactionDate: string;
   checkedAt: string | null;
+}
+
+/**
+ * Savings goal seed input (entity-shaped). Repo encrypts `targetAmount` and
+ * `initialAmount` internally. Dates are bare `YYYY-MM-DD`, matching the column.
+ */
+export interface DemoSavingsGoalSeed {
+  userId: string;
+  name: string;
+  targetAmount: number;
+  initialAmount: number;
+  status: SavingsGoalStatusEnum;
+  startDate: string | null;
+  targetDate: string | null;
+}
+
+/**
+ * Identifier returned by the repo after inserting a savings goal. `name` is
+ * what pairs the goal back with the prévisions Épargne that feed it.
+ */
+export interface DemoSeededSavingsGoal {
+  id: string;
+  name: string;
 }
 
 export type TemplateRow = Tables<'template'>;

--- a/backend-nest/src/modules/demo/domain/ports/demo-repository.port.ts
+++ b/backend-nest/src/modules/demo/domain/ports/demo-repository.port.ts
@@ -2,8 +2,10 @@ import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.ser
 import type {
   DemoBudgetLineSeed,
   DemoBudgetSeed,
+  DemoSavingsGoalSeed,
   DemoSeededBudget,
   DemoSeededBudgetLine,
+  DemoSeededSavingsGoal,
   DemoSeededTemplate,
   DemoSeededTemplateLine,
   DemoTemplateSeed,
@@ -64,6 +66,18 @@ export interface DemoRepositoryPort {
   insertTransactions(
     transactions: DemoTransactionSeed[],
     userId: string,
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<void>;
+  /** The repo encrypts `targetAmount` and `initialAmount` internally. */
+  insertSavingsGoals(
+    goals: DemoSavingsGoalSeed[],
+    userId: string,
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<DemoSeededSavingsGoal[]>;
+  /** Points existing prévisions Épargne at the goal they feed. */
+  linkBudgetLinesToSavingsGoal(
+    budgetLineIds: string[],
+    savingsGoalId: string,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<void>;
 }

--- a/backend-nest/src/modules/demo/domain/ports/demo-repository.port.ts
+++ b/backend-nest/src/modules/demo/domain/ports/demo-repository.port.ts
@@ -3,6 +3,7 @@ import type {
   DemoBudgetLineSeed,
   DemoBudgetSeed,
   DemoSeededBudget,
+  DemoSeededBudgetLine,
   DemoSeededTemplate,
   DemoSeededTemplateLine,
   DemoTemplateSeed,
@@ -51,11 +52,15 @@ export interface DemoRepositoryPort {
     budgets: DemoBudgetSeed[],
     supabase: AuthenticatedSupabaseClient,
   ): Promise<DemoSeededBudget[]>;
+  /**
+   * Returns the inserted lines: their generated ids are what lets a seeded
+   * transaction point at the envelope it consumes.
+   */
   insertBudgetLines(
     lines: DemoBudgetLineSeed[],
     userId: string,
     supabase: AuthenticatedSupabaseClient,
-  ): Promise<void>;
+  ): Promise<DemoSeededBudgetLine[]>;
   insertTransactions(
     transactions: DemoTransactionSeed[],
     userId: string,

--- a/backend-nest/src/modules/demo/domain/ports/demo-repository.port.ts
+++ b/backend-nest/src/modules/demo/domain/ports/demo-repository.port.ts
@@ -80,4 +80,14 @@ export interface DemoRepositoryPort {
     savingsGoalId: string,
     supabase: AuthenticatedSupabaseClient,
   ): Promise<void>;
+  /**
+   * Points the Mois Type's recurring lines at the goal they feed, so a budget
+   * generated later keeps the link (`SAVINGS.md` §3.2). Reserved for open-ended
+   * goals: §3.5 forbids a dated one from posing a recurrence there.
+   */
+  linkTemplateLinesToSavingsGoal(
+    templateLineIds: string[],
+    savingsGoalId: string,
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<void>;
 }

--- a/backend-nest/src/modules/demo/infrastructure/persistence/demo-template-specs.spec.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/demo-template-specs.spec.ts
@@ -1,10 +1,26 @@
 import { describe, it, expect } from 'bun:test';
 import {
+  DEMO_SAVINGS_GOAL_SPECS,
+  DEMO_TEMPLATE_ORDER,
+  type DemoTemplateKey,
+} from '../../domain/demo.constants';
+import { MONTH_TRANSACTION_SPECS } from '../../domain/demo-transaction-seeds';
+import {
   getHolidayMonthLines,
   getSavingsMonthLines,
   getStandardMonthLines,
   getVacationMonthLines,
 } from './demo-template-specs';
+
+const LINES_BY_TEMPLATE_KEY: Record<
+  DemoTemplateKey,
+  (templateId: string) => { name: string; kind: string }[]
+> = {
+  STANDARD: getStandardMonthLines,
+  VACATIONS: getVacationMonthLines,
+  SAVINGS: getSavingsMonthLines,
+  HOLIDAYS: getHolidayMonthLines,
+};
 
 describe('demo-template-specs pure data functions', () => {
   describe('getStandardMonthLines', () => {
@@ -60,5 +76,50 @@ describe('demo-template-specs pure data functions', () => {
         expect(line.templateId).toBe('tpl-4');
       }
     });
+  });
+
+  /**
+   * The actuals name their envelope by string, across the domain/infrastructure
+   * boundary the seed cannot cross by import. Without this pairing, a themed
+   * month kept naming standard envelopes and showed nothing consumed at all.
+   */
+  describe('envelopes the month actuals consume', () => {
+    for (const key of DEMO_TEMPLATE_ORDER) {
+      it(`should carry every envelope the ${key} actuals name`, () => {
+        const names = new Set(
+          LINES_BY_TEMPLATE_KEY[key]('tpl-1').map((line) => line.name),
+        );
+        const specs = MONTH_TRANSACTION_SPECS[key];
+
+        expect(specs.length).toBeGreaterThan(0);
+        for (const spec of specs) {
+          expect(names.has(spec.envelopeName)).toBe(true);
+        }
+      });
+    }
+  });
+
+  /**
+   * Same string-across-the-boundary problem for the goals: a goal names its
+   * prévision Épargne by name, and a rename on either side would silently leave
+   * the goal fed by nothing.
+   */
+  it('should carry a saving line for every envelope a goal is fed by', () => {
+    const savingNames = new Set(
+      DEMO_TEMPLATE_ORDER.flatMap((key) =>
+        LINES_BY_TEMPLATE_KEY[key]('tpl-1')
+          .filter((line) => line.kind === 'saving')
+          .map((line) => line.name),
+      ),
+    );
+
+    expect(
+      DEMO_SAVINGS_GOAL_SPECS.filter((spec) => spec.envelopeName !== null)
+        .length,
+    ).toBeGreaterThan(0);
+    for (const goal of DEMO_SAVINGS_GOAL_SPECS) {
+      if (goal.envelopeName === null) continue;
+      expect(savingNames.has(goal.envelopeName)).toBe(true);
+    }
   });
 });

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
@@ -489,4 +489,119 @@ describe('SupabaseDemoRepository', () => {
       ]);
     });
   });
+
+  describe('insertSavingsGoals', () => {
+    const housingGoal = {
+      userId: 'user-1',
+      name: 'Apport logement',
+      targetAmount: 80000,
+      initialAmount: 15000,
+      status: 'ACTIVE' as const,
+      startDate: '2026-02-01',
+      targetDate: '2027-08-01',
+    };
+
+    it('should resolve to an empty list without calling supabase when seeds are empty', async () => {
+      const fromFn = jest.fn();
+      const supabase = createMockSupabase(fromFn);
+
+      await expect(
+        repo.insertSavingsGoals([], 'user-1', supabase),
+      ).resolves.toEqual([]);
+      expect(fromFn).not.toHaveBeenCalled();
+    });
+
+    it('should encrypt both amounts before insert and return the seeded goals', async () => {
+      const captured: unknown[] = [];
+      const supabase = createMockSupabase(() => ({
+        insert: (rows: unknown) => {
+          captured.push(rows);
+          const insertedRows = rows as Array<Record<string, unknown>>;
+          return {
+            select: jest.fn().mockResolvedValue({
+              data: insertedRows.map((r, i) => ({ ...r, id: `goal-${i}` })),
+              error: null,
+            }),
+          };
+        },
+      }));
+
+      const result = await repo.insertSavingsGoals(
+        [housingGoal],
+        'user-1',
+        supabase,
+      );
+
+      const inserted = captured[0] as Array<{
+        target_amount: string;
+        initial_amount: string;
+        start_date: string | null;
+        target_date: string | null;
+      }>;
+      expect(inserted[0].target_amount).toBe('enc-80000');
+      expect(inserted[0].initial_amount).toBe('enc-15000');
+      expect(inserted[0].start_date).toBe('2026-02-01');
+      expect(inserted[0].target_date).toBe('2027-08-01');
+      expect(result).toEqual([{ id: 'goal-0', name: 'Apport logement' }]);
+    });
+
+    it('should throw BusinessException on supabase error', async () => {
+      const supabase = createMockSupabase(() => ({
+        insert: () => ({
+          select: jest.fn().mockResolvedValue({
+            data: null,
+            error: { message: 'Insert failed' },
+          }),
+        }),
+      }));
+
+      await expect(
+        repo.insertSavingsGoals([housingGoal], 'user-1', supabase),
+      ).rejects.toThrow(BusinessException);
+    });
+  });
+
+  describe('linkBudgetLinesToSavingsGoal', () => {
+    it('should resolve without calling supabase when no line feeds the goal', async () => {
+      const fromFn = jest.fn();
+      const supabase = createMockSupabase(fromFn);
+
+      await expect(
+        repo.linkBudgetLinesToSavingsGoal([], 'goal-1', supabase),
+      ).resolves.toBeUndefined();
+      expect(fromFn).not.toHaveBeenCalled();
+    });
+
+    it('should point the given lines at the goal', async () => {
+      const captured: unknown[] = [];
+      const filterByIds = jest.fn().mockResolvedValue({ error: null });
+      const supabase = createMockSupabase(() => ({
+        update: (values: unknown) => {
+          captured.push(values);
+          return { in: filterByIds };
+        },
+      }));
+
+      await repo.linkBudgetLinesToSavingsGoal(
+        ['bl-1', 'bl-2'],
+        'goal-1',
+        supabase,
+      );
+
+      expect(captured[0]).toEqual({ savings_goal_id: 'goal-1' });
+      expect(filterByIds).toHaveBeenCalledWith('id', ['bl-1', 'bl-2']);
+    });
+
+    it('should throw BusinessException on supabase error', async () => {
+      const supabase = createMockSupabase(() => ({
+        update: () => ({
+          in: jest.fn().mockResolvedValue({ error: { message: 'nope' } }),
+        }),
+      }));
+
+      await expect(
+        repo.linkBudgetLinesToSavingsGoal(['bl-1'], 'goal-1', supabase),
+      ).rejects.toThrow(BusinessException);
+    });
+  });
 });

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
@@ -623,6 +623,23 @@ describe('SupabaseDemoRepository', () => {
         repo.insertSavingsGoals([housingGoal], 'user-1', supabase),
       ).rejects.toThrow(BusinessException);
     });
+
+    /**
+     * The goals are what the linking step iterates over, so swallowing an
+     * errorless null here would leave the prospect on the empty state of
+     * Objectifs with nothing in the logs to say why.
+     */
+    it('should throw when supabase returns no rows and no error', async () => {
+      const supabase = createMockSupabase(() => ({
+        insert: () => ({
+          select: jest.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }));
+
+      await expect(
+        repo.insertSavingsGoals([housingGoal], 'user-1', supabase),
+      ).rejects.toThrow(BusinessException);
+    });
   });
 
   describe('linkBudgetLinesToSavingsGoal', () => {

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
@@ -192,24 +192,34 @@ describe('SupabaseDemoRepository', () => {
   });
 
   describe('insertBudgetLines', () => {
-    it('should resolve without calling supabase when seeds are empty', async () => {
+    function createBudgetLineSupabase(captured: unknown[]) {
+      return createMockSupabase(() => ({
+        insert: (rows: unknown) => {
+          captured.push(rows);
+          const insertedRows = rows as Array<Record<string, unknown>>;
+          return {
+            select: jest.fn().mockResolvedValue({
+              data: insertedRows.map((r, i) => ({ ...r, id: `bl-${i}` })),
+              error: null,
+            }),
+          };
+        },
+      }));
+    }
+
+    it('should resolve to an empty list without calling supabase when seeds are empty', async () => {
       const fromFn = jest.fn();
       const supabase = createMockSupabase(fromFn);
 
       await expect(
         repo.insertBudgetLines([], 'user-1', supabase),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual([]);
       expect(fromFn).not.toHaveBeenCalled();
     });
 
     it('should encrypt amount before insert', async () => {
       const captured: unknown[] = [];
-      const supabase = createMockSupabase(() => ({
-        insert: (rows: unknown) => {
-          captured.push(rows);
-          return Promise.resolve({ error: null });
-        },
-      }));
+      const supabase = createBudgetLineSupabase(captured);
 
       await repo.insertBudgetLines(
         [
@@ -220,6 +230,7 @@ describe('SupabaseDemoRepository', () => {
             amount: 100,
             kind: 'expense',
             recurrence: 'fixed',
+            checkedAt: null,
           },
         ],
         'user-1',
@@ -234,11 +245,78 @@ describe('SupabaseDemoRepository', () => {
       expect(inserted[0].budget_id).toBe('b-1');
     });
 
+    it('should persist the seeded pointage instead of forcing it unchecked', async () => {
+      const captured: unknown[] = [];
+      const supabase = createBudgetLineSupabase(captured);
+
+      await repo.insertBudgetLines(
+        [
+          {
+            budgetId: 'b-1',
+            templateLineId: 'tl-1',
+            name: 'Closed month',
+            amount: 100,
+            kind: 'expense',
+            recurrence: 'fixed',
+            checkedAt: '2026-05-31T00:00:00.000Z',
+          },
+          {
+            budgetId: 'b-2',
+            templateLineId: 'tl-2',
+            name: 'Open month',
+            amount: 50,
+            kind: 'expense',
+            recurrence: 'fixed',
+            checkedAt: null,
+          },
+        ],
+        'user-1',
+        supabase,
+      );
+
+      const inserted = captured[0] as Array<{ checked_at: string | null }>;
+      expect(inserted[0].checked_at).toBe('2026-05-31T00:00:00.000Z');
+      expect(inserted[1].checked_at).toBeNull();
+    });
+
+    it('should return the inserted lines with their generated id and decrypted amount', async () => {
+      const supabase = createBudgetLineSupabase([]);
+
+      const result = await repo.insertBudgetLines(
+        [
+          {
+            budgetId: 'b-1',
+            templateLineId: 'tl-1',
+            name: 'Courses alimentaires',
+            amount: 600,
+            kind: 'expense',
+            recurrence: 'one_off',
+            checkedAt: null,
+          },
+        ],
+        'user-1',
+        supabase,
+      );
+
+      expect(result).toEqual([
+        {
+          id: 'bl-0',
+          budgetId: 'b-1',
+          name: 'Courses alimentaires',
+          amount: 600,
+          kind: 'expense',
+        },
+      ]);
+    });
+
     it('should throw BusinessException on supabase error', async () => {
       const supabase = createMockSupabase(() => ({
-        insert: jest
-          .fn()
-          .mockResolvedValue({ error: { message: 'Insert failed' } }),
+        insert: () => ({
+          select: jest.fn().mockResolvedValue({
+            data: null,
+            error: { message: 'Insert failed' },
+          }),
+        }),
       }));
 
       await expect(
@@ -251,6 +329,7 @@ describe('SupabaseDemoRepository', () => {
               amount: 50,
               kind: 'expense',
               recurrence: 'fixed',
+              checkedAt: null,
             },
           ],
           'user-1',
@@ -316,11 +395,13 @@ describe('SupabaseDemoRepository', () => {
         [
           {
             budgetId: 'b-1',
+            budgetLineId: 'bl-9',
             name: 'Coffee',
             amount: 4.5,
             kind: 'expense',
             tagName: 'Food',
             transactionDate: '2026-05-08T12:00:00Z',
+            checkedAt: '2026-05-08T12:00:00Z',
           },
         ],
         'user-1',
@@ -330,9 +411,13 @@ describe('SupabaseDemoRepository', () => {
       const inserted = capturedTransactions[0] as Array<{
         amount: string;
         name: string;
+        budget_line_id: string | null;
+        checked_at: string | null;
       }>;
       expect(inserted[0].amount).toBe('enc-4.5');
       expect(inserted[0].name).toBe('Coffee');
+      expect(inserted[0].budget_line_id).toBe('bl-9');
+      expect(inserted[0].checked_at).toBe('2026-05-08T12:00:00Z');
       expect(capturedTags[0]).toEqual([{ user_id: 'user-1', name: 'Food' }]);
       expect(capturedLinks[0]).toEqual([
         { transaction_id: 'tx-1', tag_id: 'tag-1' },
@@ -384,11 +469,13 @@ describe('SupabaseDemoRepository', () => {
         [
           {
             budgetId: 'b-1',
+            budgetLineId: null,
             name: 'Supermarket',
             amount: 42,
             kind: 'expense',
             tagName: 'Courses',
             transactionDate: '2026-05-08T12:00:00Z',
+            checkedAt: null,
           },
         ],
         'user-1',

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
@@ -564,6 +564,7 @@ describe('SupabaseDemoRepository', () => {
       const inserted = captured[0] as Array<{
         target_amount: string;
         initial_amount: string;
+        created_at: string | undefined;
         start_date: string | null;
         target_date: string | null;
       }>;
@@ -571,6 +572,7 @@ describe('SupabaseDemoRepository', () => {
       expect(inserted[0].initial_amount).toBe('enc-15000');
       expect(inserted[0].start_date).toBe('2026-02-01');
       expect(inserted[0].target_date).toBe('2027-08-01');
+      expect(inserted[0].created_at).toBe('2026-02-01');
       expect(result).toEqual([{ id: 'goal-0', name: 'Apport logement' }]);
     });
 
@@ -630,6 +632,55 @@ describe('SupabaseDemoRepository', () => {
 
       await expect(
         repo.linkBudgetLinesToSavingsGoal(['bl-1'], 'goal-1', supabase),
+      ).rejects.toThrow(BusinessException);
+    });
+  });
+
+  describe('linkTemplateLinesToSavingsGoal', () => {
+    it('should resolve without calling supabase when no recurring line feeds the goal', async () => {
+      const fromFn = jest.fn();
+      const supabase = createMockSupabase(fromFn);
+
+      await expect(
+        repo.linkTemplateLinesToSavingsGoal([], 'goal-1', supabase),
+      ).resolves.toBeUndefined();
+      expect(fromFn).not.toHaveBeenCalled();
+    });
+
+    it('should point the given Mois Type lines at the goal', async () => {
+      const captured: unknown[] = [];
+      const tables: unknown[] = [];
+      const filterByIds = jest.fn().mockResolvedValue({ error: null });
+      const supabase = createMockSupabase((table: unknown) => {
+        tables.push(table);
+        return {
+          update: (values: unknown) => {
+            captured.push(values);
+            return { in: filterByIds };
+          },
+        };
+      });
+
+      await repo.linkTemplateLinesToSavingsGoal(
+        ['tl-1', 'tl-2'],
+        'goal-1',
+        supabase,
+      );
+
+      expect(tables[0]).toBe('template_line');
+      expect(captured[0]).toEqual({ savings_goal_id: 'goal-1' });
+      expect(filterByIds).toHaveBeenCalledWith('id', ['tl-1', 'tl-2']);
+    });
+
+    it('should throw BusinessException on supabase error', async () => {
+      const supabase = createMockSupabase(() => ({
+        update: () => ({
+          in: jest.fn().mockResolvedValue({ error: { message: 'nope' } }),
+        }),
+      }));
+
+      await expect(
+        repo.linkTemplateLinesToSavingsGoal(['tl-1'], 'goal-1', supabase),
       ).rejects.toThrow(BusinessException);
     });
   });

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
@@ -307,7 +307,7 @@ describe('SupabaseDemoRepository', () => {
       expect(inserted[1].checked_at).toBeNull();
     });
 
-    it('should return the inserted lines with their generated id and decrypted amount', async () => {
+    it('should return the inserted lines with their generated id', async () => {
       const supabase = createBudgetLineSupabase([]);
 
       const result = await repo.insertBudgetLines(
@@ -332,7 +332,6 @@ describe('SupabaseDemoRepository', () => {
           id: 'bl-0',
           budgetId: 'b-1',
           name: 'Courses alimentaires',
-          amount: 600,
           kind: 'expense',
         },
       ]);

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
@@ -231,6 +231,7 @@ describe('SupabaseDemoRepository', () => {
             kind: 'expense',
             recurrence: 'fixed',
             checkedAt: null,
+            spreadGroupId: null,
           },
         ],
         'user-1',
@@ -243,6 +244,31 @@ describe('SupabaseDemoRepository', () => {
       }>;
       expect(inserted[0].amount).toBe('enc-100');
       expect(inserted[0].budget_id).toBe('b-1');
+    });
+
+    it('should write the spread group id in clear, never encrypted', async () => {
+      const captured: unknown[] = [];
+      const supabase = createBudgetLineSupabase(captured);
+
+      await repo.insertBudgetLines(
+        [
+          {
+            budgetId: 'b-1',
+            templateLineId: null,
+            name: 'Prime assurance auto',
+            amount: 180.84,
+            kind: 'expense',
+            recurrence: 'one_off',
+            checkedAt: null,
+            spreadGroupId: 'group-uuid',
+          },
+        ],
+        'user-1',
+        supabase,
+      );
+
+      const inserted = captured[0] as Array<{ spread_group_id: string | null }>;
+      expect(inserted[0].spread_group_id).toBe('group-uuid');
     });
 
     it('should persist the seeded pointage instead of forcing it unchecked', async () => {
@@ -259,6 +285,7 @@ describe('SupabaseDemoRepository', () => {
             kind: 'expense',
             recurrence: 'fixed',
             checkedAt: '2026-05-31T00:00:00.000Z',
+            spreadGroupId: null,
           },
           {
             budgetId: 'b-2',
@@ -268,6 +295,7 @@ describe('SupabaseDemoRepository', () => {
             kind: 'expense',
             recurrence: 'fixed',
             checkedAt: null,
+            spreadGroupId: null,
           },
         ],
         'user-1',
@@ -292,6 +320,7 @@ describe('SupabaseDemoRepository', () => {
             kind: 'expense',
             recurrence: 'one_off',
             checkedAt: null,
+            spreadGroupId: null,
           },
         ],
         'user-1',
@@ -330,6 +359,7 @@ describe('SupabaseDemoRepository', () => {
               kind: 'expense',
               recurrence: 'fixed',
               checkedAt: null,
+              spreadGroupId: null,
             },
           ],
           'user-1',

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.spec.ts
@@ -366,6 +366,39 @@ describe('SupabaseDemoRepository', () => {
         ),
       ).rejects.toThrow(BusinessException);
     });
+
+    /**
+     * postgrest-js turns a bodyless 404 into a 204 and leaves both fields null,
+     * so an errorless null is a real answer, not a typing artefact. Returning
+     * the empty list would hand every later step zero envelopes and seed the
+     * blank demo this module exists to prevent.
+     */
+    it('should throw when supabase returns no rows and no error', async () => {
+      const supabase = createMockSupabase(() => ({
+        insert: () => ({
+          select: jest.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }));
+
+      await expect(
+        repo.insertBudgetLines(
+          [
+            {
+              budgetId: 'b-1',
+              templateLineId: null,
+              name: 'Test',
+              amount: 50,
+              kind: 'expense',
+              recurrence: 'fixed',
+              checkedAt: null,
+              spreadGroupId: null,
+            },
+          ],
+          'user-1',
+          supabase,
+        ),
+      ).rejects.toThrow(BusinessException);
+    });
   });
 
   describe('insertTransactions', () => {

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
@@ -9,8 +9,10 @@ import {
 import type {
   DemoBudgetLineSeed,
   DemoBudgetSeed,
+  DemoSavingsGoalSeed,
   DemoSeededBudget,
   DemoSeededBudgetLine,
+  DemoSeededSavingsGoal,
   DemoSeededTemplate,
   DemoSeededTemplateLine,
   DemoTemplateLineSeed,
@@ -47,6 +49,10 @@ type BudgetLineInsert = Omit<
 >;
 type TransactionInsert = Omit<
   TablesInsert<'transaction'>,
+  'id' | 'created_at' | 'updated_at'
+>;
+type SavingsGoalInsert = Omit<
+  TablesInsert<'savings_goal'>,
   'id' | 'created_at' | 'updated_at'
 >;
 
@@ -327,6 +333,68 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
         undefined,
         { operation: 'linkDemoTransactionTags', supabaseError: linkError },
         { cause: linkError },
+      );
+    }
+  }
+
+  async insertSavingsGoals(
+    goals: DemoSavingsGoalSeed[],
+    userId: string,
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<DemoSeededSavingsGoal[]> {
+    if (goals.length === 0) return [];
+
+    const dek = await this.getDemoDek(userId);
+
+    const rows: SavingsGoalInsert[] = goals.map((goal) => ({
+      user_id: goal.userId,
+      name: goal.name,
+      target_amount: this.encryption.encryptAmount(goal.targetAmount, dek),
+      initial_amount: this.encryption.encryptAmount(goal.initialAmount, dek),
+      original_target_amount: null,
+      status: goal.status,
+      start_date: goal.startDate,
+      target_date: goal.targetDate,
+      original_currency: null,
+      target_currency: null,
+      exchange_rate: null,
+    }));
+
+    const { data, error } = await supabase
+      .from('savings_goal')
+      .insert(rows)
+      .select();
+
+    if (error) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
+        undefined,
+        { operation: 'insertDemoSavingsGoals', supabaseError: error },
+        { cause: error },
+      );
+    }
+
+    return (data ?? []).map((row) => ({ id: row.id, name: row.name }));
+  }
+
+  async linkBudgetLinesToSavingsGoal(
+    budgetLineIds: string[],
+    savingsGoalId: string,
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<void> {
+    if (budgetLineIds.length === 0) return;
+
+    const { error } = await supabase
+      .from('budget_line')
+      .update({ savings_goal_id: savingsGoalId })
+      .in('id', budgetLineIds);
+
+    if (error) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
+        undefined,
+        { operation: 'linkDemoBudgetLinesToSavingsGoal', supabaseError: error },
+        { cause: error },
       );
     }
   }

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
@@ -347,8 +347,13 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
 
     const dek = await this.getDemoDek(userId);
 
+    // `created_at` is backdated onto the plan's start. Progress anchors its
+    // history on `max(createdAt, startDate)`, so a goal created now would
+    // discard every backfilled contribution and show the initial amount alone
+    // next to a list of contributions it claims not to count.
     const rows: SavingsGoalInsert[] = goals.map((goal) => ({
       user_id: goal.userId,
+      created_at: goal.startDate ?? undefined,
       name: goal.name,
       target_amount: this.encryption.encryptAmount(goal.targetAmount, dek),
       initial_amount: this.encryption.encryptAmount(goal.initialAmount, dek),
@@ -395,6 +400,31 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
         ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
         undefined,
         { operation: 'linkDemoBudgetLinesToSavingsGoal', supabaseError: error },
+        { cause: error },
+      );
+    }
+  }
+
+  async linkTemplateLinesToSavingsGoal(
+    templateLineIds: string[],
+    savingsGoalId: string,
+    supabase: AuthenticatedSupabaseClient,
+  ): Promise<void> {
+    if (templateLineIds.length === 0) return;
+
+    const { error } = await supabase
+      .from('template_line')
+      .update({ savings_goal_id: savingsGoalId })
+      .in('id', templateLineIds);
+
+    if (error) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
+        undefined,
+        {
+          operation: 'linkDemoTemplateLinesToSavingsGoal',
+          supabaseError: error,
+        },
         { cause: error },
       );
     }

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
@@ -214,7 +214,7 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       );
     }
 
-    return (data ?? []).map((row) => this.toSeededBudgetLine(row, dek));
+    return (data ?? []).map((row) => this.toSeededBudgetLine(row));
   }
 
   async insertTransactions(
@@ -404,17 +404,11 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
     return this.encryption.ensureDemoUserDEK(userId);
   }
 
-  private toSeededBudgetLine(
-    row: BudgetLineRow,
-    dek: Buffer,
-  ): DemoSeededBudgetLine {
+  private toSeededBudgetLine(row: BudgetLineRow): DemoSeededBudgetLine {
     return {
       id: row.id,
       budgetId: row.budget_id,
       name: row.name,
-      amount: row.amount
-        ? this.encryption.tryDecryptAmount(row.amount, dek, 0)
-        : 0,
       kind: row.kind,
     };
   }

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
@@ -82,16 +82,9 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       .insert(rows)
       .select();
 
-    if (error) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
-        undefined,
-        { operation: 'insertDemoTemplates', supabaseError: error },
-        { cause: error },
-      );
-    }
-
-    return (data ?? []).map((row) => ({ id: row.id }));
+    return this.insertedRowsOrThrow(data, error, 'insertDemoTemplates').map(
+      (row) => ({ id: row.id }),
+    );
   }
 
   async insertCanonicalTemplateLines(
@@ -128,16 +121,9 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       .insert(rows)
       .select();
 
-    if (error) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
-        undefined,
-        { operation: 'insertDemoTemplateLines', supabaseError: error },
-        { cause: error },
-      );
-    }
-
-    return (data ?? []).map((row) => this.toSeededTemplateLine(row, dek));
+    return this.insertedRowsOrThrow(data, error, 'insertDemoTemplateLines').map(
+      (row) => this.toSeededTemplateLine(row, dek),
+    );
   }
 
   async insertBudgets(
@@ -158,21 +144,14 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       .insert(rows)
       .select();
 
-    if (error) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
-        undefined,
-        { operation: 'insertDemoBudgets', supabaseError: error },
-        { cause: error },
-      );
-    }
-
-    return (data ?? []).map((row) => ({
-      id: row.id,
-      month: row.month,
-      year: row.year,
-      templateId: row.template_id,
-    }));
+    return this.insertedRowsOrThrow(data, error, 'insertDemoBudgets').map(
+      (row) => ({
+        id: row.id,
+        month: row.month,
+        year: row.year,
+        templateId: row.template_id,
+      }),
+    );
   }
 
   async insertBudgetLines(
@@ -206,20 +185,9 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       .insert(rows)
       .select();
 
-    // A null `data` without an error is reachable — postgrest-js turns a
-    // bodyless 404 into a 204 and leaves both null — and every later step keys
-    // off these rows, so falling back to an empty list would seed a demo whose
-    // envelopes all read zero: the exact emptiness this module exists to avoid.
-    if (error || !data) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
-        undefined,
-        { operation: 'insertDemoBudgetLines', supabaseError: error },
-        { cause: error ?? undefined },
-      );
-    }
-
-    return data.map((row) => this.toSeededBudgetLine(row));
+    return this.insertedRowsOrThrow(data, error, 'insertDemoBudgetLines').map(
+      (row) => this.toSeededBudgetLine(row),
+    );
   }
 
   async insertTransactions(
@@ -250,18 +218,13 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       .insert(rows)
       .select('id');
 
-    if (error || !insertedRows) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
-        undefined,
-        { operation: 'insertDemoTransactions', supabaseError: error },
-        { cause: error ?? undefined },
-      );
-    }
-
     await this.linkTransactionTags(
       transactions,
-      insertedRows.map((row) => row.id),
+      this.insertedRowsOrThrow(
+        insertedRows,
+        error,
+        'insertDemoTransactions',
+      ).map((row) => row.id),
       userId,
       supabase,
     );
@@ -307,16 +270,11 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
         .insert(missingNames.map((name) => ({ user_id: userId, name })))
         .select('id, name');
 
-      if (tagError || !createdTags) {
-        throw new BusinessException(
-          ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
-          undefined,
-          { operation: 'insertDemoTags', supabaseError: tagError },
-          { cause: tagError ?? undefined },
-        );
-      }
-
-      for (const tag of createdTags) {
+      for (const tag of this.insertedRowsOrThrow(
+        createdTags,
+        tagError,
+        'insertDemoTags',
+      )) {
         tagIdByName.set(tagKey(tag.name), tag.id);
       }
     }
@@ -376,16 +334,9 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       .insert(rows)
       .select();
 
-    if (error) {
-      throw new BusinessException(
-        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
-        undefined,
-        { operation: 'insertDemoSavingsGoals', supabaseError: error },
-        { cause: error },
-      );
-    }
-
-    return (data ?? []).map((row) => ({ id: row.id, name: row.name }));
+    return this.insertedRowsOrThrow(data, error, 'insertDemoSavingsGoals').map(
+      (row) => ({ id: row.id, name: row.name }),
+    );
   }
 
   async linkBudgetLinesToSavingsGoal(
@@ -433,6 +384,32 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
         { cause: error },
       );
     }
+  }
+
+  /**
+   * The rows an insert claims to have written, or nothing at all.
+   *
+   * An errorless null is a real answer, not a typing artefact: postgrest-js
+   * turns a bodyless 404 into a 204 and leaves both fields null. Every seed
+   * step keys off the rows the one before it returned, so reading that as an
+   * empty list would carry on and build the blank demo this module exists to
+   * prevent — the failure has to stop here, where it can still name itself.
+   */
+  private insertedRowsOrThrow<T>(
+    data: T[] | null,
+    error: unknown,
+    operation: string,
+  ): T[] {
+    if (error || !data) {
+      throw new BusinessException(
+        ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
+        undefined,
+        { operation, supabaseError: error },
+        { cause: error ?? undefined },
+      );
+    }
+
+    return data;
   }
 
   private async getDemoDek(userId: string): Promise<Buffer> {

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
@@ -51,9 +51,10 @@ type TransactionInsert = Omit<
   TablesInsert<'transaction'>,
   'id' | 'created_at' | 'updated_at'
 >;
+/** `created_at` stays writable here: the seed backdates it onto the plan. */
 type SavingsGoalInsert = Omit<
   TablesInsert<'savings_goal'>,
-  'id' | 'created_at' | 'updated_at'
+  'id' | 'updated_at'
 >;
 
 type TemplateLineRow = Tables<'template_line'>;

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
@@ -10,6 +10,7 @@ import type {
   DemoBudgetLineSeed,
   DemoBudgetSeed,
   DemoSeededBudget,
+  DemoSeededBudgetLine,
   DemoSeededTemplate,
   DemoSeededTemplateLine,
   DemoTemplateLineSeed,
@@ -50,6 +51,7 @@ type TransactionInsert = Omit<
 >;
 
 type TemplateLineRow = Tables<'template_line'>;
+type BudgetLineRow = Tables<'budget_line'>;
 
 @Injectable()
 export class SupabaseDemoRepository implements DemoRepositoryPort {
@@ -170,8 +172,8 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
     lines: DemoBudgetLineSeed[],
     userId: string,
     supabase: AuthenticatedSupabaseClient,
-  ): Promise<void> {
-    if (lines.length === 0) return;
+  ): Promise<DemoSeededBudgetLine[]> {
+    if (lines.length === 0) return [];
 
     const dek = await this.getDemoDek(userId);
 
@@ -184,14 +186,17 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       kind: line.kind,
       recurrence: line.recurrence,
       is_manually_adjusted: false,
-      checked_at: null,
+      checked_at: line.checkedAt,
       original_amount: null,
       original_currency: null,
       target_currency: null,
       exchange_rate: null,
     }));
 
-    const { error } = await supabase.from('budget_line').insert(rows);
+    const { data, error } = await supabase
+      .from('budget_line')
+      .insert(rows)
+      .select();
 
     if (error) {
       throw new BusinessException(
@@ -201,6 +206,8 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
         { cause: error },
       );
     }
+
+    return (data ?? []).map((row) => this.toSeededBudgetLine(row, dek));
   }
 
   async insertTransactions(
@@ -214,12 +221,12 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
 
     const rows: TransactionInsert[] = transactions.map((tx) => ({
       budget_id: tx.budgetId,
-      budget_line_id: null,
+      budget_line_id: tx.budgetLineId,
       name: tx.name,
       amount: this.encryption.encryptAmount(tx.amount, dek),
       kind: tx.kind,
       transaction_date: tx.transactionDate,
-      checked_at: null,
+      checked_at: tx.checkedAt,
       original_amount: null,
       original_currency: null,
       target_currency: null,
@@ -326,6 +333,21 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
 
   private async getDemoDek(userId: string): Promise<Buffer> {
     return this.encryption.ensureDemoUserDEK(userId);
+  }
+
+  private toSeededBudgetLine(
+    row: BudgetLineRow,
+    dek: Buffer,
+  ): DemoSeededBudgetLine {
+    return {
+      id: row.id,
+      budgetId: row.budget_id,
+      name: row.name,
+      amount: row.amount
+        ? this.encryption.tryDecryptAmount(row.amount, dek, 0)
+        : 0,
+      kind: row.kind,
+    };
   }
 
   private toSeededTemplateLine(

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
@@ -206,16 +206,20 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       .insert(rows)
       .select();
 
-    if (error) {
+    // A null `data` without an error is reachable — postgrest-js turns a
+    // bodyless 404 into a 204 and leaves both null — and every later step keys
+    // off these rows, so falling back to an empty list would seed a demo whose
+    // envelopes all read zero: the exact emptiness this module exists to avoid.
+    if (error || !data) {
       throw new BusinessException(
         ERROR_DEFINITIONS.INTERNAL_SERVER_ERROR,
         undefined,
         { operation: 'insertDemoBudgetLines', supabaseError: error },
-        { cause: error },
+        { cause: error ?? undefined },
       );
     }
 
-    return (data ?? []).map((row) => this.toSeededBudgetLine(row));
+    return data.map((row) => this.toSeededBudgetLine(row));
   }
 
   async insertTransactions(

--- a/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
+++ b/backend-nest/src/modules/demo/infrastructure/persistence/supabase-demo.repository.ts
@@ -193,6 +193,7 @@ export class SupabaseDemoRepository implements DemoRepositoryPort {
       recurrence: line.recurrence,
       is_manually_adjusted: false,
       checked_at: line.checkedAt,
+      spread_group_id: line.spreadGroupId,
       original_amount: null,
       original_currency: null,
       target_currency: null,

--- a/frontend/e2e/tests/features/savings-goals-progress.spec.ts
+++ b/frontend/e2e/tests/features/savings-goals-progress.spec.ts
@@ -255,18 +255,20 @@ test.describe('Savings goal progression (PUL-8)', () => {
           ),
         )
         .toBeLessThanOrEqual(0);
-      const [stackedCanvas, stackedSummary] = await Promise.all([
-        projectionCanvas.boundingBox(),
-        projectionSummary.boundingBox(),
-      ]);
-      expect(stackedCanvas).not.toBeNull();
-      expect(stackedSummary).not.toBeNull();
-      if (!stackedCanvas || !stackedSummary) {
-        throw new Error('Stacked projection geometry is unavailable');
-      }
-      expect(stackedSummary.y).toBeGreaterThan(
-        stackedCanvas.y + stackedCanvas.height,
-      );
+      // Le canvas se remesure en asynchrone après le resize (ResizeObserver +
+      // rAF) : lire la géométrie une seule fois l'échantillonne parfois en
+      // plein relayout, le résumé encore de quelques pixels trop haut.
+      await expect
+        .poll(async () => {
+          const [canvas, summary] = await Promise.all([
+            projectionCanvas.boundingBox(),
+            projectionSummary.boundingBox(),
+          ]);
+          return canvas && summary
+            ? summary.y - (canvas.y + canvas.height)
+            : null;
+        })
+        .toBeGreaterThan(0);
     }
   });
 


### PR DESCRIPTION
Closes PUL-328.

Le seed du mode démo n'écrivait jamais `transaction.budget_line_id`, `checked_at`, `savings_goal` ni `spread_group_id`. Un prospect voyait donc 0 consommé sur chaque enveloppe, aucun mois réconcilié, un empty state sur Objectifs, et aucun lissage. Backend uniquement, zéro migration.

## Ce que la démo montre maintenant

| Capacité | Avant | Après |
| --- | --- | --- |
| Consommation d'enveloppe | chaque prévision à 0 | les réels consomment la prévision de leur propre budget |
| Pointage | aucun mois réconcilié | les 6 mois clos sont pointés, le mois courant reste à pointer |
| Objectifs d'épargne | empty state | 3 objectifs : un plan daté, un plan ouvert, un objectif atteint |
| Lissage (PUL-17) | invisible | `Prime assurance auto` sur 6 mois, à cheval sur le mois courant |

Le pointage précède les objectifs par nécessité : `computeSavingsGoalProgress` ne compte que les lignes pointées, un objectif dont les lignes ne le sont pas afficherait 0 %.

## Ce que la review a fait corriger

- **Le mois en cours était vide en début de mois.** Les réels tombaient les 5, 10 et 15 et le mois courant filtre ceux dont le jour n'est pas écoulé : du 1er au 4, aucune transaction et toutes les enveloppes à 0. Le premier réel tombe désormais le 1er.
- **Quatre lectures d'horloge dans un même `execute()`.** La fenêtre des budgets, la frontière de pointage, la fenêtre de lissage et les échéances d'objectif pouvaient se contredire sur un run à cheval sur minuit. L'horloge est lue une fois et l'instant traverse les constructeurs. Un test avance l'horloge à trois frontières de mock et échoue si l'une des trois coutures est défaite.
- **Le use case dépassait le plafond de 300 lignes.** Les constructeurs sont purs : ils descendent en `domain/` (221 / 232 / 110 lignes). Le module garde par ailleurs trois fichiers au-dessus du plafond, dont deux l'étaient déjà avant ce travail.
- **Code mort et assertion tautologique.** La ligne renvoyée par le repo était déchiffrée à chaque insert sans qu'aucun appelant lise le montant ; le spec réimplémentait la règle de pointage, donc la modifier en production était recopié dans le test au lieu de le faire échouer.

Deux findings ont été invalidés après vérification et n'ont donné lieu à aucune ligne de code, avec la preuve consignée dans la review : poser `savings_goal_id` sur les lignes de template ferait *disparaître* l'enveloppe des mois backfillés ou dès l'objectif non `ACTIVE` (la RPC filtre, elle ne se contente pas de ne pas rattacher) ; et `endOfMonth` ne masquait rien, l'import `date-fns` du fichier ne prenait pas ce symbole.

## Vérification

- `bun test` : 1352 pass, 0 fail
- `bun run quality` : type-check, lint (0 erreur), `lint:arch` (0 violation), format