### PR TITLE
fix: une épargne hors horizon d'objectif ne vide plus la page budget

### DIFF
--- a/.claude/rules/03-frameworks-and-libraries/angular-store-pattern.md
+++ b/.claude/rules/03-frameworks-and-libraries/angular-store-pattern.md
@@ -50,7 +50,7 @@ export class FeatureApi {
 
 Zod validation enforced by design — no schema, no call.
 
-## Store Anatomy (6 sections)
+## Store Anatomy (5 sections)
 
 ```typescript
 @Service({ autoProvided: false })
@@ -61,7 +61,6 @@ export class FeatureStore {
 
   // ── 2. State ──
   readonly #budgetId = signal<string | null>(null);
-  readonly #errorMessage = signal<string | null>(null);
 
   // ── 3. Resource (data loading) ──
   readonly #resource = resource({
@@ -75,17 +74,22 @@ export class FeatureStore {
   // ── 4. Selectors (computed) ──
   readonly data = computed(() => this.#resource.value() ?? null);
   readonly isLoading = computed(() => this.#resource.isLoading());
-  readonly error = computed(() => this.#resource.error() || this.#errorMessage());
+  readonly error = this.#resource.error;
 
   // ── 5. Mutations (public methods) ──
-  async createItem(data: ItemCreate): Promise<void> { /* ... */ }
-  async deleteItem(id: string): Promise<void> { /* ... */ }
-
-  // ── 6. Private utils ──
-  #setError(msg: string): void { this.#errorMessage.set(msg); }
-  #clearError(): void { this.#errorMessage.set(null); }
+  // `null` = it went through; a string = the reason the caller must surface.
+  async createItem(data: ItemCreate): Promise<string | null> { /* ... */ }
+  async deleteItem(id: string): Promise<string | null> { /* ... */ }
 }
 ```
+
+### Where a failure lands
+
+A store's `error` signal says **one thing: the resource could not be loaded**.
+Pages render it as a card that replaces the whole screen, so anything else
+written there blanks the page. A refused mutation is not an unloadable
+resource — it travels back through the mutation's own return value, and the
+caller decides how to surface it (a toast, an inline message).
 
 ## Store Variants
 
@@ -137,7 +141,7 @@ readonly #dashboardResource = rxResource({
 ## Mutations: async/await
 
 ```typescript
-async createItem(data: ItemCreate): Promise<void> {
+async createItem(data: ItemCreate): Promise<string | null> {
   const tempId = `temp-${uuidv4()}`;
 
   // 1. Optimistic update
@@ -160,10 +164,11 @@ async createItem(data: ItemCreate): Promise<void> {
         ),
       };
     });
+    return null;
   } catch {
-    // 4. Rollback
+    // 4. Rollback, then hand the reason back to the caller
     this.#resource.reload();
-    this.#setError("Erreur lors de l'ajout");
+    return "Erreur lors de l'ajout";
   }
 }
 ```
@@ -338,12 +343,10 @@ All `ApiClient` errors are `ApiError` instances:
 import { isApiError } from '@core/api/api-error';
 
 catch (error) {
-  if (isApiError(error) && error.code === 'ERR_NOT_FOUND') {
-    this.#setError('Élément introuvable');
-  } else {
-    this.#setError('Erreur inattendue');
-  }
   this.#logger.error('Operation failed', error);
+  return isApiError(error) && error.code === 'ERR_NOT_FOUND'
+    ? 'Élément introuvable'
+    : 'Erreur inattendue';
 }
 ```
 
@@ -359,11 +362,13 @@ catch (error) {
 | `effect()` for derived state | `computed()` or `linkedSignal()` |
 | Mutate signal arrays in place | Spread: `[...items, newItem]` |
 | `#staleData` signal in store | Cache fallback via `api.cache.get()` in selector |
+| `error` mixing resource and mutation failures | `error = this.#resource.error`; mutations return their reason |
+| Reading success from `response !== undefined` | A `void` mutation resolves `undefined` on success too — read the returned reason |
 
 ## Reference Implementations
 
 | Store | File | Pattern |
 |-------|------|---------|
-| `BudgetDetailsStore` | `feature/budget/budget-details/store/` | `resource()`, optimistic updates, temp IDs, cache-first loader, prefetch |
+| `BudgetDetailsStore` | `feature/budget/budget-details/store/` | `resource()`, optimistic updates, temp IDs, cache-first loader, prefetch, mutation reasons returned to the caller |
 | `CurrentMonthStore` | `feature/current-month/services/` | `resource()`, SWR, cache-first loader, invalidation version |
 | `BudgetListStore` | `feature/budget/budget-list/` | `resource()`, cache-first loader, linkedSignal |

--- a/backend-nest/src/common/utils/tag-links.util.ts
+++ b/backend-nest/src/common/utils/tag-links.util.ts
@@ -3,7 +3,10 @@ import {
   type ErrorDefinition,
 } from '@common/constants/error-definitions';
 import { BusinessException } from '@common/exceptions/business.exception';
-import { isSavingsGoalLinkDenied } from '@common/utils/savings-goal-link';
+import {
+  isSavingsGoalLinkDenied,
+  isSavingsGoalLinkOutsideHorizon,
+} from '@common/utils/savings-goal-link';
 import type { AuthenticatedSupabaseClient } from '@modules/supabase/supabase.service';
 import type { Json } from '../../types/database.types';
 
@@ -189,6 +192,16 @@ function throwAtomicTaggedUpdateError(
   if (isSavingsGoalLinkDenied(error)) {
     throwTaggedBusinessError(
       ERROR_DEFINITIONS.SAVINGS_GOAL_NOT_FOUND,
+      undefined,
+      params,
+      error,
+    );
+  }
+  // Same trigger, horizon branch. Only budget_line carries the deadline bound,
+  // so template-line callers simply never raise it.
+  if (isSavingsGoalLinkOutsideHorizon(error)) {
+    throwTaggedBusinessError(
+      ERROR_DEFINITIONS.SAVINGS_GOAL_LINE_OUTSIDE_HORIZON,
       undefined,
       params,
       error,

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.spec.ts
@@ -376,6 +376,45 @@ describe('SupabaseBudgetLineRepository', () => {
         'Failed to delete budget line after tag linking failure',
       );
     });
+
+    it('maps a line past the goal deadline to a dedicated 422', async () => {
+      const provider = createMockProvider(() => ({
+        insert: () => ({
+          select: () => ({
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: {
+                code: 'P0001',
+                message: 'Savings goal line outside target horizon',
+              },
+            }),
+          }),
+        }),
+      }));
+      repo = createRepository(
+        provider,
+        createMockEncryption(),
+        createMockLogger(),
+      );
+
+      const rejection = repo.insert({
+        budgetId: 'budget-1',
+        name: 'Épargne',
+        amount: 300,
+        kind: 'saving',
+        recurrence: 'fixed',
+        isManuallyAdjusted: false,
+        savingsGoalId: '550e8400-e29b-41d4-a716-446655440000',
+      });
+
+      await expect(rejection).rejects.toThrow(BusinessException);
+      await expect(rejection).rejects.toMatchObject({
+        code: 'ERR_SAVINGS_GOAL_LINE_OUTSIDE_HORIZON',
+      });
+      await rejection.catch((error: BusinessException) => {
+        expect(error.getStatus()).toBe(422);
+      });
+    });
   });
 
   describe('delete', () => {
@@ -714,6 +753,74 @@ describe('SupabaseBudgetLineRepository', () => {
           'ERR_SAVINGS_GOAL_NOT_FOUND',
         );
       }
+    });
+
+    it('maps a re-tagged line past the goal deadline to a dedicated 422', async () => {
+      const provider = createMockProvider(() => ({
+        update: () => ({
+          eq: () => ({
+            select: () => ({
+              single: jest.fn().mockResolvedValue({
+                data: null,
+                error: {
+                  code: 'P0001',
+                  message: 'Savings goal line outside target horizon',
+                },
+              }),
+            }),
+          }),
+        }),
+      }));
+      repo = createRepository(
+        provider,
+        createMockEncryption(),
+        createMockLogger(),
+      );
+
+      const rejection = repo.update('line-1', {
+        savingsGoalId: '550e8400-e29b-41d4-a716-446655440000',
+      });
+
+      await expect(rejection).rejects.toThrow(BusinessException);
+      await expect(rejection).rejects.toMatchObject({
+        code: 'ERR_SAVINGS_GOAL_LINE_OUTSIDE_HORIZON',
+      });
+      await rejection.catch((error: BusinessException) => {
+        expect(error.getStatus()).toBe(422);
+      });
+    });
+
+    // The webapp edit dialog always sends tagIds, so the real-world re-tagging
+    // path is the atomic RPC one, not the plain UPDATE above.
+    it('maps a re-tagged line past the goal deadline to a 422 on the tagged RPC path', async () => {
+      const provider = createMockProvider(
+        () => ({}),
+        jest.fn().mockResolvedValue({
+          data: null,
+          error: {
+            code: 'P0001',
+            message: 'Savings goal line outside target horizon',
+          },
+        }),
+      );
+      repo = createRepository(
+        provider,
+        createMockEncryption(),
+        createMockLogger(),
+      );
+
+      const rejection = repo.update('line-1', {
+        savingsGoalId: '550e8400-e29b-41d4-a716-446655440000',
+        tagIds: ['tag-1'],
+      });
+
+      await expect(rejection).rejects.toThrow(BusinessException);
+      await expect(rejection).rejects.toMatchObject({
+        code: 'ERR_SAVINGS_GOAL_LINE_OUTSIDE_HORIZON',
+      });
+      await rejection.catch((error: BusinessException) => {
+        expect(error.getStatus()).toBe(422);
+      });
     });
   });
 

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -326,6 +326,17 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
         );
       }
 
+      // Same trigger, horizon branch: the budget's period is past the goal's
+      // pay-day-aware deadline. Business rejection, not a server fault.
+      if (isSavingsGoalLinkOutsideHorizon(error)) {
+        throw new BusinessException(
+          ERROR_DEFINITIONS.SAVINGS_GOAL_LINE_OUTSIDE_HORIZON,
+          undefined,
+          loggingContext,
+          { cause: error ?? undefined },
+        );
+      }
+
       throw new BusinessException(
         ERROR_DEFINITIONS.BUDGET_LINE_CREATE_FAILED,
         undefined,
@@ -698,6 +709,17 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
       if (isSavingsGoalLinkDenied(error)) {
         throw new BusinessException(
           ERROR_DEFINITIONS.SAVINGS_GOAL_NOT_FOUND,
+          undefined,
+          loggingContext,
+          { cause: error },
+        );
+      }
+
+      // Same trigger, horizon branch: re-tagging a line onto a goal whose
+      // deadline precedes its budget's period.
+      if (isSavingsGoalLinkOutsideHorizon(error)) {
+        throw new BusinessException(
+          ERROR_DEFINITIONS.SAVINGS_GOAL_LINE_OUTSIDE_HORIZON,
           undefined,
           loggingContext,
           { cause: error },

--- a/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
+++ b/backend-nest/src/modules/budget-line/infrastructure/persistence/supabase-budget-line.repository.ts
@@ -333,7 +333,7 @@ export class SupabaseBudgetLineRepository implements BudgetLineRepositoryPort {
           ERROR_DEFINITIONS.SAVINGS_GOAL_LINE_OUTSIDE_HORIZON,
           undefined,
           loggingContext,
-          { cause: error ?? undefined },
+          { cause: error },
         );
       }
 

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -1038,6 +1038,7 @@
     "pickerLabel": "Objectif",
     "pickerNone": "Aucun objectif",
     "pickerEmpty": "Aucun objectif disponible",
+    "pickerOutsideHorizon": "Échéance dépassée · {{month}}",
     "loadError": "Impossible de charger tes objectifs.",
     "nameRequired": "Le nom est requis",
     "targetAmountRequired": "Le montant cible doit être positif",

--- a/frontend/projects/webapp/public/i18n/fr.json
+++ b/frontend/projects/webapp/public/i18n/fr.json
@@ -1415,7 +1415,7 @@
     "templateUpdateFailed": "La mise à jour du modèle a échoué — réessaie",
     "templateDeleteFailed": "La suppression du modèle a échoué — réessaie",
     "savingsGoalBaselineRecalculationFailed": "L'objectif et sa prévision mensuelle ont bien été créés, mais les soldes n'ont pas pu être actualisés — recharge la page sans recréer l'objectif",
-    "savingsGoalLineOutsideHorizon": "Certaines périodes dépassent l'échéance de cet objectif — raccourcis le lissage ou choisis un autre objectif",
+    "savingsGoalLineOutsideHorizon": "Cette épargne tombe après l'échéance de ton objectif — repousse l'échéance ou choisis un autre objectif",
     "savingsGoalPlanConflict": "Le plan a changé — resimule",
     "savingsGoalPlanLineInvalid": "Ton plan n'est plus à jour — recharge la page et resimule",
     "savingsGoalPlanMonthUnprovisionable": "Un mois du plan n'a pas de modèle par défaut — impossible d'y créer la prévision d'épargne",

--- a/frontend/projects/webapp/src/app/core/api/api-error-localizer.spec.ts
+++ b/frontend/projects/webapp/src/app/core/api/api-error-localizer.spec.ts
@@ -47,7 +47,9 @@ describe('ApiErrorLocalizer', () => {
     );
   });
 
-  it('should explain when a spread exceeds its savings-goal deadline', () => {
+  // Same code now reaches a single line as well as a spread, so the copy must
+  // read correctly for both — no "raccourcis le lissage".
+  it('should explain when a saving falls past its savings-goal deadline', () => {
     const error = new ApiError(
       'Savings goal line outside target horizon',
       'ERR_SAVINGS_GOAL_LINE_OUTSIDE_HORIZON',
@@ -55,7 +57,7 @@ describe('ApiErrorLocalizer', () => {
       null,
     );
     expect(service.localizeApiError(error)).toBe(
-      "Certaines périodes dépassent l'échéance de cet objectif — raccourcis le lissage ou choisis un autre objectif",
+      "Cette épargne tombe après l'échéance de ton objectif — repousse l'échéance ou choisis un autre objectif",
     );
   });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-dialog.service.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-dialog.service.ts
@@ -7,6 +7,7 @@ import type {
   BudgetLine,
   BudgetLineSavingsWithdrawalCreate,
   BudgetLineUpdate,
+  BudgetPeriod,
   SupportedCurrency,
   Transaction,
   TransactionCreate,
@@ -216,9 +217,10 @@ export class BudgetDetailsDialogService {
 
   async openEditBudgetLineDialog(
     budgetLine: BudgetLine,
+    budgetPeriod: BudgetPeriod,
   ): Promise<BudgetLineUpdate | undefined> {
     const dialogRef = this.#dialog.open(EditBudgetLineDialog, {
-      data: { budgetLine },
+      data: { budgetLine, budgetPeriod },
       width: '400px',
       maxWidth: '90vw',
     });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-details-page.ts
@@ -26,6 +26,7 @@ import { BudgetDetailsStore } from './store/budget-details-store';
 import { BudgetItemsContainer } from './components/budget-items-container';
 import { BudgetDetailsDialogService } from './budget-details-dialog.service';
 import {
+  openMutationErrorSnackbar,
   spreadCreateEcho,
   submitSavingsWithdrawalWithRetry,
   submitSpreadWithRetry,
@@ -244,7 +245,10 @@ export default class BudgetDetailsPage {
     } else if (result.mode === 'savingsWithdrawal') {
       await this.#openSavingsWithdrawalFlow(budget, result.prefill);
     } else {
-      await this.store.createBudgetLine(result.value);
+      const error = await this.store.createBudgetLine(result.value);
+      if (error) {
+        openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      }
     }
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.spec.ts
@@ -336,6 +336,21 @@ describe('AddBudgetLineDialog', () => {
         value: expect.objectContaining({ savingsGoalId: SAVINGS_GOAL_ID }),
       });
     });
+
+    // The server refuses the WHOLE fan-out as soon as one month falls past the
+    // goal's deadline, and the fan-out reaches the LAST selected month. Handing
+    // the picker the anchor (juin 2026) would green-light a goal that expires
+    // before novembre 2026, the default end of the spread range.
+    it('validates a savings goal against the last spread month, not the anchor', () => {
+      const { component } = configureDialog();
+      component['model'].update((m) => ({ ...m, kind: 'saving' }));
+
+      expect(component['budgetPeriod']()).toEqual({ year: 2026, month: 6 });
+
+      component['setMode']('spread');
+
+      expect(component['budgetPeriod']()).toEqual({ year: 2026, month: 11 });
+    });
   });
 
   describe('currency create rules', () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.ts
@@ -22,6 +22,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { TranslocoPipe } from '@jsverse/transloco';
 import {
   splitTotalPreserving,
+  type BudgetPeriod,
   type TransactionKind,
   type TransactionRecurrence,
 } from 'pulpe-shared';
@@ -231,6 +232,7 @@ interface AddBudgetLineModel {
           @if (model().kind === 'saving') {
             <pulpe-savings-goal-picker-field
               [value]="model().savingsGoalId"
+              [budgetPeriod]="budgetPeriod"
               (valueChanged)="
                 model.update((m) => ({ ...m, savingsGoalId: $event }))
               "
@@ -464,6 +466,12 @@ export class AddBudgetLineDialog {
   readonly #staleRateNotifier = inject(StaleRateNotifier);
 
   protected readonly currency = this.#settings.currency;
+
+  // The period a created line lands in — bounds which savings goals it can link.
+  protected readonly budgetPeriod: BudgetPeriod = {
+    month: this.#data.budgetMonth,
+    year: this.#data.budgetYear,
+  };
 
   protected readonly model = signal<AddBudgetLineModel>({
     name: '',

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/create/dialog.ts
@@ -232,7 +232,7 @@ interface AddBudgetLineModel {
           @if (model().kind === 'saving') {
             <pulpe-savings-goal-picker-field
               [value]="model().savingsGoalId"
-              [budgetPeriod]="budgetPeriod"
+              [budgetPeriod]="budgetPeriod()"
               (valueChanged)="
                 model.update((m) => ({ ...m, savingsGoalId: $event }))
               "
@@ -467,12 +467,6 @@ export class AddBudgetLineDialog {
 
   protected readonly currency = this.#settings.currency;
 
-  // The period a created line lands in — bounds which savings goals it can link.
-  protected readonly budgetPeriod: BudgetPeriod = {
-    month: this.#data.budgetMonth,
-    year: this.#data.budgetYear,
-  };
-
   protected readonly model = signal<AddBudgetLineModel>({
     name: '',
     kind: 'expense',
@@ -588,6 +582,20 @@ export class AddBudgetLineDialog {
   protected readonly selectedCount = computed(
     () => this.selectedMonths().length,
   );
+
+  // The period a created line lands in — bounds which savings goals it can link.
+  // A spread fans the line out over `selectedMonths()`, and the server refuses
+  // the WHOLE batch as soon as one month falls past a goal's deadline. The last
+  // selected month is the one that decides, so it is the period the picker must
+  // validate against — the anchor alone would green-light a goal that expires
+  // mid-range. Falls back to the anchor when there is nothing to spread over.
+  protected readonly budgetPeriod = computed<BudgetPeriod>(() => {
+    const months = this.selectedMonths();
+    if (this.#mode() !== 'spread' || months.length === 0) {
+      return { month: this.#data.budgetMonth, year: this.#data.budgetYear };
+    }
+    return months[months.length - 1];
+  });
 
   // The aggregated total of the plan. In `total` mode the entered amount IS the
   // total; in `perMonth` mode it is the per-month amount × the selected count.

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/edit/dialog.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/edit/dialog.spec.ts
@@ -51,7 +51,10 @@ function configureDialog(
       { provide: MatDialogRef, useValue: dialogRef },
       {
         provide: MAT_DIALOG_DATA,
-        useValue: { budgetLine } satisfies EditBudgetLineDialogData,
+        useValue: {
+          budgetLine,
+          budgetPeriod: { month: 1, year: 2026 },
+        } satisfies EditBudgetLineDialogData,
       },
       { provide: UserSettingsStore, useValue: settings },
       { provide: CurrencyConverterService, useValue: converter },

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/edit/dialog.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/budget-line/edit/dialog.ts
@@ -19,6 +19,7 @@ import { FormField, form, minLength, required } from '@angular/forms/signals';
 import {
   type BudgetLine,
   type BudgetLineUpdate,
+  type BudgetPeriod,
   type TransactionKind,
   type TransactionRecurrence,
 } from 'pulpe-shared';
@@ -44,6 +45,8 @@ import { budgetLineUpdateFromFormSchema } from './dialog.schema';
 
 export interface EditBudgetLineDialogData {
   budgetLine: BudgetLine;
+  /** Period of the budget the line belongs to — bounds its savings-goal links. */
+  budgetPeriod: BudgetPeriod;
 }
 
 interface EditBudgetLineModel {
@@ -150,6 +153,7 @@ interface EditBudgetLineModel {
           @if (model().kind === 'saving') {
             <pulpe-savings-goal-picker-field
               [value]="model().savingsGoalId"
+              [budgetPeriod]="budgetPeriod"
               (valueChanged)="
                 model.update((m) => ({ ...m, savingsGoalId: $event }))
               "
@@ -192,6 +196,8 @@ export class EditBudgetLineDialog {
 
   protected readonly originalCurrency =
     this.#data.budgetLine.originalCurrency ?? null;
+
+  protected readonly budgetPeriod = this.#data.budgetPeriod;
 
   protected readonly showCurrencySelector = computed(() =>
     isCurrencyPickerVisible({

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.spec.ts
@@ -78,6 +78,7 @@ interface MockStore {
   deleteBudgetLine: ReturnType<typeof vi.fn>;
   deleteTransaction: ReturnType<typeof vi.fn>;
   resetBudgetLineFromTemplate: ReturnType<typeof vi.fn>;
+  spreadExistingBudgetLine: ReturnType<typeof vi.fn>;
   postponeBudgetLine: ReturnType<typeof vi.fn>;
   postponeTransaction: ReturnType<typeof vi.fn>;
   toggleCheck: ReturnType<typeof vi.fn>;
@@ -114,6 +115,7 @@ function createMockStore(): MockStore {
     deleteBudgetLine: vi.fn(),
     deleteTransaction: vi.fn(),
     resetBudgetLineFromTemplate: vi.fn(),
+    spreadExistingBudgetLine: vi.fn().mockResolvedValue({}),
     // A mutation now answers with its refusal motive, so `null` is its success.
     postponeBudgetLine: vi.fn().mockResolvedValue(null),
     postponeTransaction: vi.fn().mockResolvedValue(null),
@@ -412,6 +414,171 @@ describe('BudgetItemsContainer — orchestration', () => {
       expect.objectContaining({ duration: 5000 }),
     );
   });
+});
+
+describe('BudgetItemsContainer — a refused gesture speaks for itself', () => {
+  const LINE_ID = '55555555-5555-4555-8555-555555555555';
+  const TX_ID = '66666666-6666-4666-8666-666666666666';
+  const MOTIVE = 'Le mois est clôturé';
+
+  let mockStore: MockStore;
+  let mockDialogService: MockDialogService;
+  let mockSnackBar: { open: ReturnType<typeof vi.fn> };
+  let component: BudgetItemsContainer;
+
+  // Every gesture reworked in this phase: the mutation it drives, how the user
+  // reaches it, and the confirmation it opens once the mutation goes through.
+  const gestures: {
+    name: string;
+    mutation: () => ReturnType<typeof vi.fn>;
+    arrange: () => void;
+    act: () => Promise<void>;
+    confirmation?: string;
+  }[] = [
+    {
+      name: 'editing a transaction',
+      mutation: () => mockStore.updateTransaction,
+      arrange: () => undefined,
+      act: () => component['handleUpdateTransaction'](TX_ID, { amount: 42 }),
+      confirmation: 'Modification enregistrée',
+    },
+    {
+      name: 'deleting a transaction',
+      mutation: () => mockStore.deleteTransaction,
+      arrange: () => mockDialogService.confirmDelete.mockResolvedValue(true),
+      act: () =>
+        component['handleDeleteTransaction'](
+          createMockTransaction({ id: TX_ID }),
+        ),
+      confirmation: 'Transaction supprimée',
+    },
+    {
+      name: 'adding an allocated transaction',
+      mutation: () => mockStore.createAllocatedTransaction,
+      arrange: () => {
+        mockStore.budgetDetails.set({ id: 'budget-1', month: 1, year: 2026 });
+        mockDialogService.openCreateAllocatedTransactionDialog.mockResolvedValue(
+          { name: 'Courses', amount: 42 },
+        );
+      },
+      act: () =>
+        component['openCreateAllocatedTransactionDialog'](
+          createMockBudgetLine({ id: LINE_ID }),
+        ),
+      confirmation: 'Transaction ajoutée',
+    },
+    {
+      name: 'resetting a forecast from the template',
+      mutation: () => mockStore.resetBudgetLineFromTemplate,
+      arrange: () => undefined,
+      act: () => component['handleResetFromTemplate'](LINE_ID),
+      confirmation: 'Prévision réinitialisée depuis le modèle',
+    },
+    {
+      name: 'deleting a forecast from the table',
+      mutation: () => mockStore.deleteBudgetLine,
+      arrange: () => {
+        mockStore.budgetDetails.set({
+          budgetLines: [createMockBudgetLine({ id: LINE_ID })],
+          transactions: [],
+        });
+        mockDialogService.confirmDelete.mockResolvedValue(true);
+      },
+      act: () => component['handleDeleteItem'](LINE_ID),
+    },
+    {
+      name: 'checking a transaction',
+      mutation: () => mockStore.toggleTransactionCheck,
+      arrange: () => undefined,
+      act: () => component['handleToggleTransactionCheck'](TX_ID),
+    },
+    {
+      name: 'cascading the check to allocated transactions',
+      mutation: () => mockStore.checkAllAllocatedTransactions,
+      arrange: () => {
+        mockStore.budgetDetails.set({
+          budgetLines: [createMockBudgetLine({ id: LINE_ID, checkedAt: null })],
+          transactions: [
+            createMockTransaction({
+              id: TX_ID,
+              budgetLineId: LINE_ID,
+              checkedAt: null,
+            }),
+          ],
+        });
+        mockDialogService.confirmCheckAllocatedTransactions.mockResolvedValue(
+          true,
+        );
+      },
+      act: () => component['handleToggleCheck'](LINE_ID),
+    },
+  ];
+
+  beforeEach(() => {
+    mockStore = createMockStore();
+    mockDialogService = createMockDialogService();
+    mockSnackBar = { open: vi.fn() };
+    component = setupComponent(
+      mockStore,
+      mockDialogService,
+      mockSnackBar,
+    ).componentInstance;
+  });
+
+  it.each(gestures)(
+    'reports the server motive and nothing else when $name is refused',
+    async ({ mutation, arrange, act }) => {
+      arrange();
+      mutation().mockResolvedValue(MOTIVE);
+
+      await act();
+
+      expect(mockSnackBar.open).toHaveBeenCalledTimes(1);
+      expect(mockSnackBar.open).toHaveBeenCalledWith(
+        MOTIVE,
+        'Fermer',
+        expect.objectContaining({
+          panelClass: ['bg-error-container', 'text-on-error-container'],
+        }),
+      );
+    },
+  );
+
+  it('announces a refused spread of an existing forecast', async () => {
+    const line = createMockBudgetLine({ id: LINE_ID, amount: 600 });
+    mockStore.budgetDetails.set({ id: 'budget-1', month: 1, year: 2026 });
+    mockStore.filteredBudgetLines.set([line]);
+    mockDialogService.openSpreadExisting.mockResolvedValue({
+      periods: [{ year: 2026, month: 2 }],
+    });
+    mockStore.spreadExistingBudgetLine.mockResolvedValue({ error: MOTIVE });
+
+    await component['handleSpreadBudgetLine'](component.budgetLineItems()[0]);
+
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      MOTIVE,
+      'Fermer',
+      expect.objectContaining({
+        panelClass: ['bg-error-container', 'text-on-error-container'],
+      }),
+    );
+  });
+
+  it.each(gestures.filter((gesture) => gesture.confirmation))(
+    'keeps the confirmation of $name when it goes through',
+    async ({ mutation, arrange, act, confirmation }) => {
+      arrange();
+      mutation().mockResolvedValue(null);
+
+      await act();
+
+      expect(mockSnackBar.open).toHaveBeenCalledWith(
+        confirmation,
+        'Fermer',
+        expect.anything(),
+      );
+    },
+  );
 });
 
 describe('BudgetItemsContainer — tag history', () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.spec.ts
@@ -119,9 +119,12 @@ function createMockStore(): MockStore {
     // A mutation now answers with its refusal motive, so `null` is its success.
     postponeBudgetLine: vi.fn().mockResolvedValue(null),
     postponeTransaction: vi.fn().mockResolvedValue(null),
-    toggleCheck: vi.fn().mockResolvedValue(null),
-    toggleTransactionCheck: vi.fn(),
-    checkAllAllocatedTransactions: vi.fn(),
+    // The 3 check mutations answer with a 3-way outcome; `applied` is their default success.
+    toggleCheck: vi.fn().mockResolvedValue({ status: 'applied' }),
+    toggleTransactionCheck: vi.fn().mockResolvedValue({ status: 'applied' }),
+    checkAllAllocatedTransactions: vi
+      .fn()
+      .mockResolvedValue({ status: 'applied' }),
     createAllocatedTransaction: vi.fn(),
     updateTransaction: vi.fn(),
     createSavingsWithdrawal: vi.fn(),
@@ -434,6 +437,8 @@ describe('BudgetItemsContainer — a refused gesture speaks for itself', () => {
     arrange: () => void;
     act: () => Promise<void>;
     confirmation?: string;
+    // The 3 check mutations answer with a 3-way CheckOutcome, not `string | null`.
+    isCheckOutcome?: boolean;
   }[] = [
     {
       name: 'editing a transaction',
@@ -491,10 +496,12 @@ describe('BudgetItemsContainer — a refused gesture speaks for itself', () => {
       mutation: () => mockStore.toggleTransactionCheck,
       arrange: () => undefined,
       act: () => component['handleToggleTransactionCheck'](TX_ID),
+      isCheckOutcome: true,
     },
     {
       name: 'cascading the check to allocated transactions',
       mutation: () => mockStore.checkAllAllocatedTransactions,
+      isCheckOutcome: true,
       arrange: () => {
         mockStore.budgetDetails.set({
           budgetLines: [createMockBudgetLine({ id: LINE_ID, checkedAt: null })],
@@ -527,9 +534,11 @@ describe('BudgetItemsContainer — a refused gesture speaks for itself', () => {
 
   it.each(gestures)(
     'reports the server motive and nothing else when $name is refused',
-    async ({ mutation, arrange, act }) => {
+    async ({ mutation, arrange, act, isCheckOutcome }) => {
       arrange();
-      mutation().mockResolvedValue(MOTIVE);
+      mutation().mockResolvedValue(
+        isCheckOutcome ? { status: 'failed', reason: MOTIVE } : MOTIVE,
+      );
 
       await act();
 
@@ -579,6 +588,35 @@ describe('BudgetItemsContainer — a refused gesture speaks for itself', () => {
       );
     },
   );
+});
+
+describe('BudgetItemsContainer — a skipped check stays silent', () => {
+  it('opens no toast when the store reports the toggle as skipped', async () => {
+    const lineId = '77777777-7777-4777-8777-777777777777';
+    const mockStore = createMockStore();
+    // checkedAt is set so the confirmation snackbar WOULD have a message to show
+    // if the container mistakenly fell through past the `skipped` outcome.
+    mockStore.budgetDetails.set({
+      budgetLines: [
+        createMockBudgetLine({
+          id: lineId,
+          checkedAt: '2024-01-01T00:00:00Z',
+        }),
+      ],
+      transactions: [],
+    });
+    mockStore.toggleCheck.mockResolvedValue({ status: 'skipped' });
+    const mockSnackBar = { open: vi.fn() };
+    const component = setupComponent(
+      mockStore,
+      createMockDialogService(),
+      mockSnackBar,
+    ).componentInstance;
+
+    await component['handleToggleCheck'](lineId);
+
+    expect(mockSnackBar.open).not.toHaveBeenCalled();
+  });
 });
 
 describe('BudgetItemsContainer — tag history', () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.spec.ts
@@ -70,7 +70,6 @@ interface MockStore {
   savingsWithdrawalOriginLabel: ReturnType<typeof signal<string>>;
   savingsWithdrawalDeficit: ReturnType<typeof signal<number>>;
   savingsGoalNameById: ReturnType<typeof signal<ReadonlyMap<string, string>>>;
-  error: ReturnType<typeof signal<string | null>>;
   setSearchText: ReturnType<typeof vi.fn>;
   setIsShowingOnlyUnchecked: ReturnType<typeof vi.fn>;
   createBudgetLine: ReturnType<typeof vi.fn>;
@@ -107,7 +106,6 @@ function createMockStore(): MockStore {
     savingsWithdrawalOriginLabel: signal(''),
     savingsWithdrawalDeficit: signal(0),
     savingsGoalNameById: signal<ReadonlyMap<string, string>>(new Map()),
-    error: signal<string | null>(null),
     setSearchText: vi.fn(),
     setIsShowingOnlyUnchecked: vi.fn(),
     createBudgetLine: vi.fn(),
@@ -116,9 +114,10 @@ function createMockStore(): MockStore {
     deleteBudgetLine: vi.fn(),
     deleteTransaction: vi.fn(),
     resetBudgetLineFromTemplate: vi.fn(),
-    postponeBudgetLine: vi.fn().mockResolvedValue(true),
-    postponeTransaction: vi.fn().mockResolvedValue(true),
-    toggleCheck: vi.fn().mockResolvedValue(true),
+    // A mutation now answers with its refusal motive, so `null` is its success.
+    postponeBudgetLine: vi.fn().mockResolvedValue(null),
+    postponeTransaction: vi.fn().mockResolvedValue(null),
+    toggleCheck: vi.fn().mockResolvedValue(null),
     toggleTransactionCheck: vi.fn(),
     checkAllAllocatedTransactions: vi.fn(),
     createAllocatedTransaction: vi.fn(),
@@ -376,15 +375,42 @@ describe('BudgetItemsContainer — orchestration', () => {
       value: spread,
     });
     mockStore.createBudgetLineSpread.mockResolvedValue({
-      lines: [],
-      createdBudgets: [],
-      skippedMonths: [],
+      data: { lines: [], createdBudgets: [], skippedMonths: [] },
     });
 
     await component.openAddBudgetLineDialog();
 
     expect(mockStore.createBudgetLineSpread).toHaveBeenCalledWith(spread);
     expect(mockStore.createBudgetLine).not.toHaveBeenCalled();
+  });
+
+  it('shows the server motive when a postpone is refused', async () => {
+    mockDialogService.confirmPostpone.mockResolvedValue(true);
+    mockStore.nextMonthLabel.set('septembre 2026');
+    mockStore.postponeBudgetLine.mockResolvedValue(
+      'Le mois suivant est déjà clôturé',
+    );
+
+    await component['handlePostponeBudgetLine']('line-1');
+
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      'Le mois suivant est déjà clôturé',
+      expect.anything(),
+      expect.objectContaining({ panelClass: expect.anything() }),
+    );
+  });
+
+  it('confirms the move when a postpone goes through', async () => {
+    mockDialogService.confirmPostpone.mockResolvedValue(true);
+    mockStore.nextMonthLabel.set('septembre 2026');
+
+    await component['handlePostponeBudgetLine']('line-1');
+
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      expect.stringContaining('septembre 2026'),
+      expect.anything(),
+      expect.objectContaining({ duration: 5000 }),
+    );
   });
 });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
@@ -58,6 +58,7 @@ import {
   computeEnvelopeSnackbarMessage,
   computeSpreadSnackbarMessage,
   computeTransactionSnackbarMessage,
+  openMutationErrorSnackbar,
   spreadCreateEcho,
   submitSavingsWithdrawalWithRetry,
   submitSpreadWithRetry,
@@ -436,7 +437,11 @@ export class BudgetItemsContainer {
   protected async handleUpdateBudgetLine(
     data: BudgetLineUpdate,
   ): Promise<void> {
-    await this.store.updateBudgetLine(data);
+    const error = await this.store.updateBudgetLine(data);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      return;
+    }
     this.#snackBar.open(
       this.#transloco.translate('budget.modificationSaved'),
       this.#transloco.translate('common.close'),
@@ -854,7 +859,10 @@ export class BudgetItemsContainer {
       await this.#openSavingsWithdrawalFlow(budget, result.prefill);
       return;
     }
-    await this.store.createBudgetLine(result.value);
+    const error = await this.store.createBudgetLine(result.value);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+    }
   }
 
   async #openSavingsWithdrawalFlow(
@@ -923,10 +931,7 @@ export class BudgetItemsContainer {
 
     const error = await this.store.deleteSavingsWithdrawal(groupId, scope);
     if (error) {
-      this.#snackBar.open(error, this.#transloco.translate('common.close'), {
-        duration: 5000,
-        panelClass: ['bg-error-container', 'text-on-error-container'],
-      });
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
       return;
     }
     this.#snackBar.open(

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
@@ -529,6 +529,10 @@ export class BudgetItemsContainer {
   #notifySpread(
     outcome: MutationOutcome<BudgetLineSpreadResponse['data']>,
   ): void {
+    if (outcome.error) {
+      openMutationErrorSnackbar(outcome.error, this.#snackBar, this.#transloco);
+      return;
+    }
     const spread = outcome.data;
     if (!spread) return;
     const snackbarRef = this.#snackBar.open(
@@ -590,14 +594,18 @@ export class BudgetItemsContainer {
         },
       );
 
-    if (transaction) {
-      await this.store.createAllocatedTransaction(transaction);
-      this.#snackBar.open(
-        this.#transloco.translate('budget.transactionAdded'),
-        this.#transloco.translate('common.close'),
-        { duration: 3000 },
-      );
+    if (!transaction) return;
+
+    const error = await this.store.createAllocatedTransaction(transaction);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      return;
     }
+    this.#snackBar.open(
+      this.#transloco.translate('budget.transactionAdded'),
+      this.#transloco.translate('common.close'),
+      { duration: 3000 },
+    );
   }
 
   protected async handleEditAllocatedTransaction(
@@ -623,7 +631,11 @@ export class BudgetItemsContainer {
     id: string,
     update: TransactionUpdate,
   ): Promise<void> {
-    await this.store.updateTransaction(id, update);
+    const error = await this.store.updateTransaction(id, update);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      return;
+    }
     this.#snackBar.open(
       this.#transloco.translate('budget.modificationSaved'),
       this.#transloco.translate('common.close'),
@@ -641,14 +653,18 @@ export class BudgetItemsContainer {
       }),
     });
 
-    if (confirmed) {
-      await this.store.deleteTransaction(transaction.id);
-      this.#snackBar.open(
-        this.#transloco.translate('transaction.deleted'),
-        this.#transloco.translate('common.close'),
-        { duration: 3000 },
-      );
+    if (!confirmed) return;
+
+    const error = await this.store.deleteTransaction(transaction.id);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      return;
     }
+    this.#snackBar.open(
+      this.#transloco.translate('transaction.deleted'),
+      this.#transloco.translate('common.close'),
+      { duration: 3000 },
+    );
   }
 
   protected async handleToggleCheck(budgetLineId: string): Promise<void> {
@@ -672,7 +688,16 @@ export class BudgetItemsContainer {
     }
 
     if (shouldCascade) {
-      await this.store.checkAllAllocatedTransactions(budgetLineId);
+      const cascadeError =
+        await this.store.checkAllAllocatedTransactions(budgetLineId);
+      if (cascadeError) {
+        openMutationErrorSnackbar(
+          cascadeError,
+          this.#snackBar,
+          this.#transloco,
+        );
+        return;
+      }
     }
 
     this.#showEnvelopeSnackbar(budgetLineId);
@@ -681,7 +706,11 @@ export class BudgetItemsContainer {
   protected async handleToggleTransactionCheck(
     transactionId: string,
   ): Promise<void> {
-    await this.store.toggleTransactionCheck(transactionId);
+    const error = await this.store.toggleTransactionCheck(transactionId);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      return;
+    }
     this.#showTransactionSnackbar(transactionId);
   }
 
@@ -715,27 +744,16 @@ export class BudgetItemsContainer {
   }
 
   protected async handleResetFromTemplate(budgetLineId: string): Promise<void> {
-    try {
-      await this.store.resetBudgetLineFromTemplate(budgetLineId);
-      this.#snackBar.open(
-        this.#transloco.translate('budget.forecastReset'),
-        this.#transloco.translate('common.close'),
-        { duration: 5000 },
-      );
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error
-          ? error.message
-          : this.#transloco.translate('common.error');
-      this.#snackBar.open(
-        errorMessage,
-        this.#transloco.translate('common.close'),
-        {
-          duration: 5000,
-          panelClass: ['bg-error-container', 'text-on-error-container'],
-        },
-      );
+    const error = await this.store.resetBudgetLineFromTemplate(budgetLineId);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      return;
     }
+    this.#snackBar.open(
+      this.#transloco.translate('budget.forecastReset'),
+      this.#transloco.translate('common.close'),
+      { duration: 5000 },
+    );
   }
 
   protected async handlePostponeBudgetLine(
@@ -817,15 +835,25 @@ export class BudgetItemsContainer {
     if (!confirmed) return;
 
     if (isBudgetLine) {
-      await this.store.deleteBudgetLine(id);
-    } else {
-      await this.store.deleteTransaction(id);
-      this.#snackBar.open(
-        this.#transloco.translate('transaction.deleted'),
-        this.#transloco.translate('common.close'),
-        { duration: 5000 },
-      );
+      // A removed forecast is its own confirmation: the row is gone. Only its
+      // refusal needs saying.
+      const error = await this.store.deleteBudgetLine(id);
+      if (error) {
+        openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      }
+      return;
     }
+
+    const error = await this.store.deleteTransaction(id);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      return;
+    }
+    this.#snackBar.open(
+      this.#transloco.translate('transaction.deleted'),
+      this.#transloco.translate('common.close'),
+      { duration: 5000 },
+    );
   }
 
   protected openTagHistoryDialog(): void {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
@@ -53,7 +53,10 @@ import { BudgetViewToggle } from './budget-view-toggle';
 import { BudgetTableCheckedFilter } from './budget-table/budget-table-checked-filter';
 import { BudgetTagFilter } from './budget-table/budget-tag-filter';
 import { BudgetDetailsDialogService } from '../budget-details-dialog.service';
-import { BudgetDetailsStore } from '../store/budget-details-store';
+import {
+  BudgetDetailsStore,
+  type MutationOutcome,
+} from '../store/budget-details-store';
 import { determineCheckBehavior } from '../store/budget-details-check.utils';
 import {
   computeEnvelopeSnackbarMessage,
@@ -523,10 +526,13 @@ export class BudgetItemsContainer {
     this.#notifySpread(outcome);
   }
 
-  #notifySpread(outcome: BudgetLineSpreadResponse['data'] | undefined): void {
-    if (!outcome) return;
+  #notifySpread(
+    outcome: MutationOutcome<BudgetLineSpreadResponse['data']>,
+  ): void {
+    const spread = outcome.data;
+    if (!spread) return;
     const snackbarRef = this.#snackBar.open(
-      computeSpreadSnackbarMessage(outcome, this.#transloco),
+      computeSpreadSnackbarMessage(spread, this.#transloco),
       this.#transloco.translate('budgetLine.spread.successAction'),
       { duration: 6000 },
     );
@@ -534,7 +540,7 @@ export class BudgetItemsContainer {
       .onAction()
       .pipe(takeUntilDestroyed(this.#destroyRef))
       .subscribe(() => {
-        this.store.setSpreadGroupId(outcome.spreadGroupId);
+        this.store.setSpreadGroupId(spread.spreadGroupId);
         this.#dialogService.openSpreadOccurrences(this.isMobile());
       });
   }
@@ -659,8 +665,11 @@ export class BudgetItemsContainer {
       behavior === 'ask-cascade' &&
       (await this.#dialogService.confirmCheckAllocatedTransactions());
 
-    const succeeded = await this.store.toggleCheck(budgetLineId);
-    if (!succeeded) return;
+    const error = await this.store.toggleCheck(budgetLineId);
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+      return;
+    }
 
     if (shouldCascade) {
       await this.store.checkAllAllocatedTransactions(budgetLineId);
@@ -756,25 +765,15 @@ export class BudgetItemsContainer {
     }
   }
 
-  async #postpone(mutate: () => Promise<boolean>): Promise<void> {
+  async #postpone(mutate: () => Promise<string | null>): Promise<void> {
     const nextMonthLabel = this.store.nextMonthLabel();
     const confirmed = await this.#dialogService.confirmPostpone(nextMonthLabel);
     if (!confirmed) return;
 
-    const succeeded = await mutate();
+    const error = await mutate();
 
-    if (!succeeded) {
-      const error = this.store.error();
-      this.#snackBar.open(
-        typeof error === 'string'
-          ? error
-          : this.#transloco.translate('budget.postponeError'),
-        this.#transloco.translate('common.close'),
-        {
-          duration: 5000,
-          panelClass: ['bg-error-container', 'text-on-error-container'],
-        },
-      );
+    if (error) {
+      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
       return;
     }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
@@ -26,6 +26,7 @@ import {
   type BudgetLine,
   type BudgetLineSpreadResponse,
   type BudgetLineUpdate,
+  type BudgetPeriod,
   type SupportedCurrency,
   type Transaction,
   type TransactionUpdate,
@@ -244,6 +245,7 @@ import {
         <pulpe-budget-table
           [tableData]="budgetTableData()"
           [savingsGoalNameById]="store.savingsGoalNameById()"
+          [budgetPeriod]="budgetPeriod()"
           (update)="handleUpdateBudgetLine($event)"
           (delete)="handleDeleteItem($event)"
           (add)="openAddBudgetLineDialog()"
@@ -379,6 +381,17 @@ export class BudgetItemsContainer {
     }),
   );
 
+  // Period of the displayed budget. Before it loads there is no table to edit
+  // from, so the current period is a harmless stand-in rather than a null case
+  // every consumer would have to carry.
+  readonly budgetPeriod = computed<BudgetPeriod>(() => {
+    const budget = this.store.budgetDetails();
+    const now = new Date();
+    return budget
+      ? { month: budget.month, year: budget.year }
+      : { month: now.getMonth() + 1, year: now.getFullYear() };
+  });
+
   readonly budgetTableData = computed(() =>
     filterTableRowsByTags(
       this.#tableRows(),
@@ -428,6 +441,7 @@ export class BudgetItemsContainer {
   ): Promise<void> {
     const result = await this.#dialogService.openEditBudgetLineDialog(
       item.data,
+      this.budgetPeriod(),
     );
     if (result) {
       await this.handleUpdateBudgetLine(result);

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-items-container.ts
@@ -681,18 +681,23 @@ export class BudgetItemsContainer {
       behavior === 'ask-cascade' &&
       (await this.#dialogService.confirmCheckAllocatedTransactions());
 
-    const error = await this.store.toggleCheck(budgetLineId);
-    if (error) {
-      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+    const outcome = await this.store.toggleCheck(budgetLineId);
+    if (outcome.status === 'failed') {
+      openMutationErrorSnackbar(
+        outcome.reason,
+        this.#snackBar,
+        this.#transloco,
+      );
       return;
     }
+    if (outcome.status === 'skipped') return;
 
     if (shouldCascade) {
-      const cascadeError =
+      const cascadeOutcome =
         await this.store.checkAllAllocatedTransactions(budgetLineId);
-      if (cascadeError) {
+      if (cascadeOutcome.status === 'failed') {
         openMutationErrorSnackbar(
-          cascadeError,
+          cascadeOutcome.reason,
           this.#snackBar,
           this.#transloco,
         );
@@ -706,11 +711,16 @@ export class BudgetItemsContainer {
   protected async handleToggleTransactionCheck(
     transactionId: string,
   ): Promise<void> {
-    const error = await this.store.toggleTransactionCheck(transactionId);
-    if (error) {
-      openMutationErrorSnackbar(error, this.#snackBar, this.#transloco);
+    const outcome = await this.store.toggleTransactionCheck(transactionId);
+    if (outcome.status === 'failed') {
+      openMutationErrorSnackbar(
+        outcome.reason,
+        this.#snackBar,
+        this.#transloco,
+      );
       return;
     }
+    if (outcome.status === 'skipped') return;
     this.#showTransactionSnackbar(transactionId);
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-table/budget-table.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/components/budget-table/budget-table.ts
@@ -24,6 +24,7 @@ import { RecurrenceLabelPipe } from '@ui/transaction-display';
 import {
   type BudgetLine,
   type BudgetLineUpdate,
+  type BudgetPeriod,
   type Transaction,
 } from 'pulpe-shared';
 import { AppCurrencyPipe } from '@core/currency';
@@ -304,6 +305,7 @@ export class BudgetTable {
   // Inputs
   readonly tableData = input.required<TableRowItem[]>();
   readonly savingsGoalNameById = input<ReadonlyMap<string, string>>(new Map());
+  readonly budgetPeriod = input.required<BudgetPeriod>();
 
   // Outputs
   readonly update = output<BudgetLineUpdate>();
@@ -367,6 +369,7 @@ export class BudgetTable {
       const result =
         await this.#budgetDetailsDialogService.openEditBudgetLineDialog(
           item.data,
+          this.budgetPeriod(),
         );
       if (result) this.update.emit(result);
     } catch (error) {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-state.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-state.ts
@@ -2,12 +2,10 @@ import { type WritableSignal, signal } from '@angular/core';
 
 export interface BudgetDetailsState {
   readonly budgetId: WritableSignal<string | null>;
-  readonly errorMessage: WritableSignal<string | null>;
 }
 
 export function createInitialBudgetDetailsState(): BudgetDetailsState {
   return {
     budgetId: signal<string | null>(null),
-    errorMessage: signal<string | null>(null),
   };
 }

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -27,6 +27,7 @@ import {
   createMockBudgetDetailsResponse,
   createMockTransaction,
 } from '../../../../testing/mock-factories';
+import { TranslocoService } from '@jsverse/transloco';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { createMockDataCache, type MockDataCache } from '@core/testing';
 
@@ -1967,6 +1968,79 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       expect(asyncMethods.sort()).toEqual(
         mutations.map((mutation) => mutation.name).sort(),
       );
+    });
+  });
+
+  // Two different ids both pass the #mutatingIds guard, so their toggles can be
+  // in flight at once. Each call must get its own outcome and its own rollback.
+  describe('concurrent mutations', () => {
+    it('gives each overlapping toggle its own outcome and rolls back the failed one', async () => {
+      const lineA = createMockBudgetLine({
+        id: 'line-a',
+        budgetId: mockBudgetId,
+        name: 'Loyer',
+        amount: 1500,
+        kind: 'expense',
+        recurrence: 'fixed',
+        checkedAt: null,
+      });
+      const lineB = createMockBudgetLine({
+        id: 'line-b',
+        budgetId: mockBudgetId,
+        name: 'Assurance',
+        amount: 300,
+        kind: 'expense',
+        recurrence: 'fixed',
+        checkedAt: null,
+      });
+
+      mockBudgetApi.getBudgetWithDetails$ = vi.fn().mockReturnValue(
+        of(
+          createMockBudgetDetailsResponse({
+            budget: { id: mockBudgetId },
+            budgetLines: [lineA, lineB],
+            transactions: [],
+          }),
+        ),
+      );
+
+      service.setBudgetId(mockBudgetId);
+      TestBed.tick();
+      await waitForResourceStable();
+
+      const firstCall$ = new Subject<{ data: typeof lineA }>();
+      const secondCall$ = new Subject<{ data: typeof lineB }>();
+      mockBudgetApi.toggleBudgetLineCheck$ = vi
+        .fn()
+        .mockReturnValueOnce(firstCall$)
+        .mockReturnValueOnce(secondCall$);
+
+      const first = service.toggleCheck('line-a');
+      const second = service.toggleCheck('line-b');
+      await vi.waitFor(() => {
+        expect(mockBudgetApi.toggleBudgetLineCheck$).toHaveBeenCalledTimes(2);
+      });
+
+      secondCall$.next({
+        data: { ...lineB, checkedAt: '2024-01-20T12:00:00Z' },
+      });
+      secondCall$.complete();
+      firstCall$.error(new Error('Server down'));
+
+      const transloco = TestBed.inject(TranslocoService);
+      expect(await first).toBe(
+        transloco.translate('budget.forecastToggleError'),
+      );
+      expect(await second).toBeNull();
+      expect(
+        service.budgetDetails()?.budgetLines.find((l) => l.id === 'line-a')
+          ?.checkedAt,
+      ).toBeNull();
+      // PROBE: does A's rollback clobber B's confirmed success?
+      expect(
+        service.budgetDetails()?.budgetLines.find((l) => l.id === 'line-b')
+          ?.checkedAt,
+      ).toBe('2024-01-20T12:00:00Z');
     });
   });
 });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -796,6 +796,37 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       });
     });
 
+    it('a mutation on a budget that never loaded leaves the cache untouched', async () => {
+      // The budget is selected but unreachable: params resolve to a cache key
+      // while the resource holds no value.
+      mockBudgetApi.getBudgetWithDetails$ = vi
+        .fn()
+        .mockReturnValue(throwError(() => new Error('Backend down')));
+      service.setBudgetId('budget-unreachable');
+      TestBed.tick();
+      await vi.waitFor(() => expect(service.error()).toBeTruthy());
+      mockBudgetApi.cache.set.mockClear();
+
+      // User acts anyway
+      mockBudgetApi.createBudgetLine$ = vi
+        .fn()
+        .mockReturnValue(of({ success: true, data: createMockBudgetLine() }));
+      await service.createBudgetLine({
+        budgetId: 'budget-unreachable',
+        name: 'Courses',
+        amount: 400,
+        kind: 'expense',
+        recurrence: 'one_off',
+        isManuallyAdjusted: false,
+      });
+
+      // No hole was written under the budget's key
+      expect(service.budgetDetails()).toBeNull();
+      for (const [, value] of mockBudgetApi.cache.set.mock.calls) {
+        expect(value).toBeDefined();
+      }
+    });
+
     it('user sees error message when network fails', async () => {
       mockBudgetApi.createBudgetLine$ = vi
         .fn()

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -13,7 +13,7 @@ import {
   type BudgetLineUpdate,
 } from 'pulpe-shared';
 
-import { BudgetDetailsStore } from './budget-details-store';
+import { BudgetDetailsStore, type CheckOutcome } from './budget-details-store';
 import { BudgetApi } from '@core/budget/budget-api';
 import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
 import { ApiError } from '@core/api/api-error';
@@ -353,6 +353,47 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       const localizer = TestBed.inject(ApiErrorLocalizer);
       expect(error).toBe(localizer.localizeApiError(horizonError));
       expect(service.error()).toBeUndefined();
+    });
+
+    // A 422 is a verdict the user already reads in a toast, so paging the
+    // on-call for it is noise. A 503 never reached a verdict — that one is a
+    // real fault and has to stay in the logs.
+    it('logs a create that broke but stays quiet on one the server refused', async () => {
+      const lineInput = {
+        budgetId: mockBudgetId,
+        name: 'Épargne hors horizon',
+        amount: 100,
+        kind: 'saving' as const,
+        recurrence: 'fixed' as const,
+        isManuallyAdjusted: false,
+      };
+      mockLogger.error.mockClear();
+
+      mockBudgetApi.createBudgetLine$ = vi
+        .fn()
+        .mockReturnValue(
+          throwError(
+            () =>
+              new ApiError(
+                'unprocessable',
+                API_ERROR_CODES.SAVINGS_GOAL_LINE_OUTSIDE_HORIZON,
+                422,
+                undefined,
+              ),
+          ),
+        );
+      await service.createBudgetLine(lineInput);
+
+      expect(mockLogger.error).not.toHaveBeenCalled();
+
+      mockBudgetApi.createBudgetLine$ = vi
+        .fn()
+        .mockReturnValue(
+          throwError(() => new ApiError('boom', undefined, 503, undefined)),
+        );
+      await service.createBudgetLine(lineInput);
+
+      expect(mockLogger.error).toHaveBeenCalledOnce();
     });
 
     // The spread submitter turns `retryable` into a "Réessayer" action. A 422 is
@@ -1153,9 +1194,9 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         }),
       );
 
-      const error = await service.toggleCheck('line-to-check');
+      const outcome = await service.toggleCheck('line-to-check');
 
-      expect(error).toBeNull();
+      expect(outcome).toEqual({ status: 'applied' });
       const updatedLine = service
         .budgetDetails()
         ?.budgetLines.find((line) => line.id === 'line-to-check');
@@ -1196,9 +1237,9 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         .fn()
         .mockReturnValue(throwError(() => new Error('Toggle failed')));
 
-      const error = await service.toggleCheck('line-toggle-fail');
+      const outcome = await service.toggleCheck('line-toggle-fail');
 
-      expect(error).toBeTruthy();
+      expect(outcome).toEqual({ status: 'failed', reason: expect.any(String) });
       expect(service.error()).toBeUndefined();
     });
 
@@ -1207,9 +1248,9 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       TestBed.tick();
       await waitForResourceStable();
 
-      const error = await service.toggleCheck('line-does-not-exist');
+      const outcome = await service.toggleCheck('line-does-not-exist');
 
-      expect(error).toBeNull();
+      expect(outcome).toEqual({ status: 'skipped' });
       expect(mockBudgetApi.toggleBudgetLineCheck$).not.toHaveBeenCalled();
     });
 
@@ -1863,6 +1904,10 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       { year: 2024, month: 3, amount: 750 },
     ];
 
+    // The 3 check mutations answer with a 3-way outcome; only `failed` carries a motive.
+    const checkOutcomeReason = (outcome: CheckOutcome): string | null =>
+      outcome.status === 'failed' ? outcome.reason : null;
+
     const mutations: {
       name: string;
       api: Exclude<keyof typeof mockBudgetApi, 'cache'>;
@@ -1904,12 +1949,16 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       {
         name: 'toggleCheck',
         api: 'toggleBudgetLineCheck$',
-        run: () => service.toggleCheck('line-2'),
+        run: async () =>
+          checkOutcomeReason(await service.toggleCheck('line-2')),
       },
       {
         name: 'checkAllAllocatedTransactions',
         api: 'checkBudgetLineTransactions$',
-        run: () => service.checkAllAllocatedTransactions('line-2'),
+        run: async () =>
+          checkOutcomeReason(
+            await service.checkAllAllocatedTransactions('line-2'),
+          ),
       },
       {
         name: 'createAllocatedTransaction',
@@ -1937,7 +1986,8 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       {
         name: 'toggleTransactionCheck',
         api: 'toggleTransactionCheck$',
-        run: () => service.toggleTransactionCheck('tx-1'),
+        run: async () =>
+          checkOutcomeReason(await service.toggleTransactionCheck('tx-1')),
       },
       {
         name: 'postponeTransaction',
@@ -2124,10 +2174,11 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       firstCall$.error(new Error('Server down'));
 
       const transloco = TestBed.inject(TranslocoService);
-      expect(await first).toBe(
-        transloco.translate('budget.forecastToggleError'),
-      );
-      expect(await second).toBeNull();
+      expect(await first).toEqual({
+        status: 'failed',
+        reason: transloco.translate('budget.forecastToggleError'),
+      });
+      expect(await second).toEqual({ status: 'applied' });
       expect(
         service.budgetDetails()?.budgetLines.find((l) => l.id === 'line-a')
           ?.checkedAt,

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -5,7 +5,7 @@ import {
   provideHttpClientTesting,
   HttpTestingController,
 } from '@angular/common/http/testing';
-import { of, throwError, Subject, ReplaySubject } from 'rxjs';
+import { of, throwError, Observable, Subject, ReplaySubject } from 'rxjs';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   API_ERROR_CODES,
@@ -231,6 +231,31 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       );
       expect(rentLine?.amount).toBe(1500);
       expect(rentLine?.kind).toBe('expense');
+    });
+
+    it('stops fetching the budget the user just left when they switch mid-load', async () => {
+      // Every budget answers with a request that never completes, so the first
+      // one is still in flight when the user moves on.
+      const isCancelled = new Map<string, boolean>();
+      mockBudgetApi.getBudgetWithDetails$ = vi.fn(
+        (budgetId: string) =>
+          new Observable(() => {
+            isCancelled.set(budgetId, false);
+            return () => isCancelled.set(budgetId, true);
+          }),
+      );
+
+      // User opens January, then navigates to February before it answers
+      service.setBudgetId(mockBudgetId);
+      TestBed.tick();
+      await vi.waitFor(() => expect(isCancelled.has(mockBudgetId)).toBe(true));
+
+      service.setBudgetId('budget-next');
+      TestBed.tick();
+      await vi.waitFor(() => expect(isCancelled.has('budget-next')).toBe(true));
+
+      // January's request was dropped instead of running to completion
+      expect(isCancelled.get(mockBudgetId)).toBe(true);
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -329,6 +329,48 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       expect(error).toBe(localizer.localizeApiError(horizonError));
       expect(service.error()).toBeUndefined();
     });
+
+    // The spread submitter turns `retryable` into a "Réessayer" action. A 422 is
+    // a verdict on this exact body, so replaying it can only earn the same 422.
+    it('marks a refused spread final and a broken one worth replaying', async () => {
+      const spreadInput = {
+        budgetId: mockBudgetId,
+        name: 'Épargne lissée',
+        amount: 100,
+        kind: 'saving' as const,
+        mode: 'perMonth' as const,
+        perMonthAmount: 100,
+        months: [{ month: 6, year: 2026 }],
+        spreadGroupId: 'group-1',
+      };
+
+      mockBudgetApi.createBudgetLineSpread$ = vi
+        .fn()
+        .mockReturnValue(
+          throwError(
+            () =>
+              new ApiError(
+                'unprocessable',
+                API_ERROR_CODES.SAVINGS_GOAL_LINE_OUTSIDE_HORIZON,
+                422,
+                undefined,
+              ),
+          ),
+        );
+      const refused = await service.createBudgetLineSpread(spreadInput);
+
+      mockBudgetApi.createBudgetLineSpread$ = vi
+        .fn()
+        .mockReturnValue(
+          throwError(() => new ApiError('boom', undefined, 503, undefined)),
+        );
+      const broken = await service.createBudgetLineSpread(spreadInput);
+
+      expect(refused.error).toBeTruthy();
+      expect(refused.retryable).toBe(false);
+      expect(broken.error).toBeTruthy();
+      expect(broken.retryable).toBe(true);
+    });
   });
 
   describe('User edits a budget line', () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -291,7 +291,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       // error() drives the full-page load-error card, which a refused line
       // must never trigger.
       expect(error).toBeTruthy();
-      expect(service.error()).toBeNull();
+      expect(service.error()).toBeUndefined();
     });
 
     it('surfaces the goal-horizon refusal instead of the generic add-failure copy', async () => {
@@ -316,7 +316,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
 
       const localizer = TestBed.inject(ApiErrorLocalizer);
       expect(error).toBe(localizer.localizeApiError(horizonError));
-      expect(service.error()).toBeNull();
+      expect(service.error()).toBeUndefined();
     });
   });
 
@@ -369,7 +369,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       // Same contract as create: the message goes back to the caller's toast,
       // never onto the page-level error signal.
       expect(error).toBeTruthy();
-      expect(service.error()).toBeNull();
+      expect(service.error()).toBeUndefined();
 
       // Original values are preserved (via reload)
       // User doesn't see the failed update stuck in UI
@@ -389,7 +389,11 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       const initialCount = service.budgetDetails()?.budgetLines.length || 0;
 
       // User deletes the rent expense
-      await service.deleteBudgetLine('line-2');
+      const error = await service.deleteBudgetLine('line-2');
+
+      // The delete mutation resolves `undefined` on SUCCESS too (its response is
+      // void), so a null message is the only thing that tells the two apart.
+      expect(error).toBeNull();
 
       // The line is no longer visible
       const remainingLines = service.budgetDetails()?.budgetLines;
@@ -403,10 +407,11 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         .mockReturnValue(throwError(() => new Error('Cannot delete')));
 
       // User tries to delete but server refuses
-      await service.deleteBudgetLine('line-2');
+      const error = await service.deleteBudgetLine('line-2');
 
-      // Error is shown
-      expect(service.error()).toBeTruthy();
+      // The caller gets the message to toast, and the page stays loaded.
+      expect(error).toBeTruthy();
+      expect(service.error()).toBeUndefined();
 
       // The line remains in the list (data reloaded from server)
       // User sees that deletion didn't go through
@@ -680,7 +685,11 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       mockBudgetApi.deleteTransaction$ = vi.fn().mockReturnValue(of({}));
 
       // User deletes the transaction
-      await service.deleteTransaction(transactionToDelete.id);
+      const error = await service.deleteTransaction(transactionToDelete.id);
+
+      // Same void-response trap as deleteBudgetLine: a null motive is the only
+      // thing that separates this success from a failure.
+      expect(error).toBeNull();
 
       // The transaction is no longer in the list
       const remainingTransactions = service.budgetDetails()?.transactions || [];
@@ -695,6 +704,18 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       service.setBudgetId(mockBudgetId);
       TestBed.tick();
       await waitForResourceStable();
+    });
+
+    it('surfaces the load-error card when the budget itself cannot be fetched', async () => {
+      mockBudgetApi.getBudgetWithDetails$ = vi
+        .fn()
+        .mockReturnValue(throwError(() => new Error('Backend down')));
+
+      service.setBudgetId('budget-unreachable');
+      TestBed.tick();
+      await vi.waitFor(() => {
+        expect(service.error()).toBeTruthy();
+      });
     });
 
     it('user sees error message when network fails', async () => {
@@ -714,7 +735,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
 
       // User sees that something went wrong, in a toast over a live budget
       expect(error).toBeTruthy();
-      expect(service.error()).toBeNull();
+      expect(service.error()).toBeUndefined();
     });
 
     it('user cannot add expenses with negative amounts', async () => {
@@ -743,7 +764,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
 
       // User sees an error occurred
       expect(error).toBeTruthy();
-      expect(service.error()).toBeNull();
+      expect(service.error()).toBeUndefined();
     });
   });
 
@@ -1025,9 +1046,9 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         }),
       );
 
-      const succeeded = await service.toggleCheck('line-to-check');
+      const error = await service.toggleCheck('line-to-check');
 
-      expect(succeeded).toBe(true);
+      expect(error).toBeNull();
       const updatedLine = service
         .budgetDetails()
         ?.budgetLines.find((line) => line.id === 'line-to-check');
@@ -1039,7 +1060,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       expect(unchangedTransaction?.checkedAt).toBeNull();
     });
 
-    it('returns false and sets an error when envelope toggle fails', async () => {
+    it('returns the message and leaves the page loaded when envelope toggle fails', async () => {
       const targetLine = createMockBudgetLine({
         id: 'line-toggle-fail',
         budgetId: mockBudgetId,
@@ -1068,20 +1089,20 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         .fn()
         .mockReturnValue(throwError(() => new Error('Toggle failed')));
 
-      const succeeded = await service.toggleCheck('line-toggle-fail');
+      const error = await service.toggleCheck('line-toggle-fail');
 
-      expect(succeeded).toBe(false);
-      expect(service.error()).toBeTruthy();
+      expect(error).toBeTruthy();
+      expect(service.error()).toBeUndefined();
     });
 
-    it('returns false and skips API call when envelope does not exist', async () => {
+    it('reports nothing and skips API call when envelope does not exist', async () => {
       service.setBudgetId(mockBudgetId);
       TestBed.tick();
       await waitForResourceStable();
 
-      const succeeded = await service.toggleCheck('line-does-not-exist');
+      const error = await service.toggleCheck('line-does-not-exist');
 
-      expect(succeeded).toBe(false);
+      expect(error).toBeNull();
       expect(mockBudgetApi.toggleBudgetLineCheck$).not.toHaveBeenCalled();
     });
 
@@ -1583,9 +1604,9 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
 
       const initialCount = service.budgetDetails()?.budgetLines.length ?? 0;
 
-      const succeeded = await service.postponeBudgetLine('line-2');
+      const error = await service.postponeBudgetLine('line-2');
 
-      expect(succeeded).toBe(true);
+      expect(error).toBeNull();
       const remaining = service.budgetDetails()?.budgetLines;
       expect(remaining?.length).toBe(initialCount - 1);
       expect(remaining?.find((l) => l.id === 'line-2')).toBeUndefined();
@@ -1597,10 +1618,10 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         .fn()
         .mockReturnValue(throwError(() => new Error('Cannot postpone')));
 
-      const succeeded = await service.postponeBudgetLine('line-2');
+      const error = await service.postponeBudgetLine('line-2');
 
-      expect(succeeded).toBe(false);
-      expect(service.error()).toBeTruthy();
+      expect(error).toBeTruthy();
+      expect(service.error()).toBeUndefined();
       expect(
         service.budgetDetails()?.budgetLines.find((l) => l.id === 'line-2'),
       ).toBeDefined();
@@ -1620,9 +1641,9 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
 
       const initialCount = service.budgetDetails()?.transactions.length ?? 0;
 
-      const succeeded = await service.postponeTransaction('tx-1');
+      const error = await service.postponeTransaction('tx-1');
 
-      expect(succeeded).toBe(true);
+      expect(error).toBeNull();
       const remaining = service.budgetDetails()?.transactions;
       expect(remaining?.length).toBe(initialCount - 1);
       expect(remaining?.find((t) => t.id === 'tx-1')).toBeUndefined();

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -92,6 +92,11 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
     deleteTransaction$: ReturnType<typeof vi.fn>;
     toggleTransactionCheck$: ReturnType<typeof vi.fn>;
     postponeTransaction$: ReturnType<typeof vi.fn>;
+    createBudgetLineSpread$: ReturnType<typeof vi.fn>;
+    spreadExistingBudgetLine$: ReturnType<typeof vi.fn>;
+    spreadExistingTransaction$: ReturnType<typeof vi.fn>;
+    createSavingsWithdrawal$: ReturnType<typeof vi.fn>;
+    deleteSavingsWithdrawal$: ReturnType<typeof vi.fn>;
     cache: MockDataCache;
   };
   let mockLogger: {
@@ -138,6 +143,11 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       deleteTransaction$: vi.fn(),
       toggleTransactionCheck$: vi.fn(),
       postponeTransaction$: vi.fn(),
+      createBudgetLineSpread$: vi.fn(),
+      spreadExistingBudgetLine$: vi.fn(),
+      spreadExistingTransaction$: vi.fn(),
+      createSavingsWithdrawal$: vi.fn(),
+      deleteSavingsWithdrawal$: vi.fn(),
       cache: createMockDataCache(),
     };
 
@@ -1743,6 +1753,220 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
       await waitForResourceStable();
 
       expect(service.hasNextMonthBudget()).toBe(false);
+    });
+  });
+
+  // The page renders error() as a card that REPLACES the budget, so a refused
+  // mutation must never write there. Most mutations went uncovered, which is how
+  // the defect survived its first fix — this guard drives every one of them, and
+  // the enumeration test at the end fails when a new one is added without a case.
+  describe('No mutation reports its refusal on the page error signal', () => {
+    const PERIODS = [
+      { year: 2024, month: 2, amount: 750 },
+      { year: 2024, month: 3, amount: 750 },
+    ];
+
+    const mutations: {
+      name: string;
+      api: Exclude<keyof typeof mockBudgetApi, 'cache'>;
+      run: () => Promise<string | null>;
+    }[] = [
+      {
+        name: 'createBudgetLine',
+        api: 'createBudgetLine$',
+        run: () =>
+          service.createBudgetLine({
+            budgetId: mockBudgetId,
+            name: 'Courses',
+            amount: 100,
+            kind: 'expense',
+            recurrence: 'one_off',
+            isManuallyAdjusted: false,
+          }),
+      },
+      {
+        name: 'updateBudgetLine',
+        api: 'updateBudgetLine$',
+        run: () => service.updateBudgetLine({ id: 'line-2', amount: 1600 }),
+      },
+      {
+        name: 'deleteBudgetLine',
+        api: 'deleteBudgetLine$',
+        run: () => service.deleteBudgetLine('line-2'),
+      },
+      {
+        name: 'resetBudgetLineFromTemplate',
+        api: 'resetBudgetLineFromTemplate$',
+        run: () => service.resetBudgetLineFromTemplate('line-2'),
+      },
+      {
+        name: 'postponeBudgetLine',
+        api: 'postponeBudgetLine$',
+        run: () => service.postponeBudgetLine('line-2'),
+      },
+      {
+        name: 'toggleCheck',
+        api: 'toggleBudgetLineCheck$',
+        run: () => service.toggleCheck('line-2'),
+      },
+      {
+        name: 'checkAllAllocatedTransactions',
+        api: 'checkBudgetLineTransactions$',
+        run: () => service.checkAllAllocatedTransactions('line-2'),
+      },
+      {
+        name: 'createAllocatedTransaction',
+        api: 'createTransaction$',
+        run: () =>
+          service.createAllocatedTransaction({
+            budgetId: mockBudgetId,
+            budgetLineId: 'line-2',
+            name: 'Courses',
+            amount: 30,
+            kind: 'expense',
+            transactionDate: '2024-01-10',
+          }),
+      },
+      {
+        name: 'updateTransaction',
+        api: 'updateTransaction$',
+        run: () => service.updateTransaction('tx-1', { amount: 60 }),
+      },
+      {
+        name: 'deleteTransaction',
+        api: 'deleteTransaction$',
+        run: () => service.deleteTransaction('tx-1'),
+      },
+      {
+        name: 'toggleTransactionCheck',
+        api: 'toggleTransactionCheck$',
+        run: () => service.toggleTransactionCheck('tx-1'),
+      },
+      {
+        name: 'postponeTransaction',
+        api: 'postponeTransaction$',
+        run: () => service.postponeTransaction('tx-1'),
+      },
+      // The four below answer with a payload wrapper; `.error` is the same motive.
+      {
+        name: 'createBudgetLineSpread',
+        api: 'createBudgetLineSpread$',
+        run: async () =>
+          (
+            await service.createBudgetLineSpread({
+              name: 'Prime',
+              kind: 'expense',
+              mode: 'perMonth',
+              perMonthAmount: 100,
+              months: [{ year: 2024, month: 2 }],
+              spreadGroupId: '11111111-1111-4111-8111-111111111111',
+            })
+          ).error ?? null,
+      },
+      {
+        name: 'spreadExistingBudgetLine',
+        api: 'spreadExistingBudgetLine$',
+        run: async () =>
+          (await service.spreadExistingBudgetLine('line-2', PERIODS)).error ??
+          null,
+      },
+      {
+        name: 'spreadExistingTransaction',
+        api: 'spreadExistingTransaction$',
+        run: async () =>
+          (await service.spreadExistingTransaction('tx-1', PERIODS)).error ??
+          null,
+      },
+      {
+        name: 'createSavingsWithdrawal',
+        api: 'createSavingsWithdrawal$',
+        run: async () =>
+          (
+            await service.createSavingsWithdrawal({
+              budgetId: mockBudgetId,
+              groupId: '22222222-2222-4222-8222-222222222222',
+              amount: 200,
+              incomeName: 'Pioche épargne',
+              savingName: 'Retrait épargne',
+            })
+          ).error ?? null,
+      },
+      {
+        name: 'deleteSavingsWithdrawal',
+        api: 'deleteSavingsWithdrawal$',
+        run: () =>
+          service.deleteSavingsWithdrawal(
+            '22222222-2222-4222-8222-222222222222',
+            'pair',
+          ),
+      },
+    ];
+
+    beforeEach(async () => {
+      // The transaction is allocated and unchecked so that no mutation guard
+      // short-circuits before its API call.
+      mockBudgetApi.getBudgetWithDetails$ = vi.fn().mockReturnValue(
+        of(
+          createMockBudgetDetailsResponse({
+            budget: {
+              id: mockBudgetId,
+              month: 1,
+              year: 2024,
+              templateId: 'template-1',
+            },
+            budgetLines: [
+              createMockBudgetLine({
+                id: 'line-2',
+                budgetId: mockBudgetId,
+                templateLineId: 'tpl-2',
+                amount: 1500,
+                kind: 'expense',
+              }),
+            ],
+            transactions: [
+              createMockTransaction({
+                id: 'tx-1',
+                budgetId: mockBudgetId,
+                budgetLineId: 'line-2',
+                amount: 50,
+                kind: 'expense',
+                checkedAt: null,
+              }),
+            ],
+          }),
+        ),
+      );
+      service.setBudgetId(mockBudgetId);
+      TestBed.tick();
+      await waitForResourceStable();
+    });
+
+    it.each(mutations)(
+      '$name hands its motive back and leaves the budget on screen',
+      async ({ api, run }) => {
+        mockBudgetApi[api] = vi
+          .fn()
+          .mockReturnValue(throwError(() => new Error('Server down')));
+
+        const error = await run();
+
+        expect(error).toBeTruthy();
+        expect(service.error()).toBeUndefined();
+      },
+    );
+
+    it('covers every mutation the store exposes', () => {
+      const asyncMethods = Object.getOwnPropertyNames(
+        BudgetDetailsStore.prototype,
+      ).filter(
+        (name) =>
+          Object.getOwnPropertyDescriptor(BudgetDetailsStore.prototype, name)
+            ?.value?.constructor?.name === 'AsyncFunction',
+      );
+
+      expect(asyncMethods.sort()).toEqual(
+        mutations.map((mutation) => mutation.name).sort(),
+      );
     });
   });
 });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -820,11 +820,9 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         isManuallyAdjusted: false,
       });
 
-      // No hole was written under the budget's key
+      // Nothing was written under the budget's key — not even a hole
       expect(service.budgetDetails()).toBeNull();
-      for (const [, value] of mockBudgetApi.cache.set.mock.calls) {
-        expect(value).toBeDefined();
-      }
+      expect(mockBudgetApi.cache.set).not.toHaveBeenCalled();
     });
 
     it('user sees error message when network fails', async () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-integration.spec.ts
@@ -7,11 +7,17 @@ import {
 } from '@angular/common/http/testing';
 import { of, throwError, Subject, ReplaySubject } from 'rxjs';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { BudgetLineCreate, BudgetLineUpdate } from 'pulpe-shared';
+import {
+  API_ERROR_CODES,
+  type BudgetLineCreate,
+  type BudgetLineUpdate,
+} from 'pulpe-shared';
 
 import { BudgetDetailsStore } from './budget-details-store';
 import { BudgetApi } from '@core/budget/budget-api';
 import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
+import { ApiError } from '@core/api/api-error';
+import { ApiErrorLocalizer } from '@core/api/api-error-localizer';
 import { Logger } from '@core/logging/logger';
 import { ApplicationConfiguration } from '@core/config/application-configuration';
 import { PostHogService } from '@core/analytics/posthog';
@@ -272,7 +278,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         .mockReturnValue(throwError(() => new Error('Network error')));
 
       // User tries to add an expense but server is down
-      await service.createBudgetLine({
+      const error = await service.createBudgetLine({
         budgetId: mockBudgetId,
         name: 'Failed expense',
         amount: 100,
@@ -281,11 +287,36 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         isManuallyAdjusted: false,
       });
 
-      // User sees an error occurred
-      expect(service.error()).toBeTruthy();
+      // The caller gets the message to toast, and the page stays loaded:
+      // error() drives the full-page load-error card, which a refused line
+      // must never trigger.
+      expect(error).toBeTruthy();
+      expect(service.error()).toBeNull();
+    });
 
-      // Budget lines remain unchanged (data is reloaded from server)
-      // This ensures user doesn't see incorrect optimistic data
+    it('surfaces the goal-horizon refusal instead of the generic add-failure copy', async () => {
+      const horizonError = new ApiError(
+        'unprocessable',
+        API_ERROR_CODES.SAVINGS_GOAL_LINE_OUTSIDE_HORIZON,
+        422,
+        undefined,
+      );
+      mockBudgetApi.createBudgetLine$ = vi
+        .fn()
+        .mockReturnValue(throwError(() => horizonError));
+
+      const error = await service.createBudgetLine({
+        budgetId: mockBudgetId,
+        name: 'Épargne hors horizon',
+        amount: 100,
+        kind: 'saving',
+        recurrence: 'fixed',
+        isManuallyAdjusted: false,
+      });
+
+      const localizer = TestBed.inject(ApiErrorLocalizer);
+      expect(error).toBe(localizer.localizeApiError(horizonError));
+      expect(service.error()).toBeNull();
     });
   });
 
@@ -329,14 +360,16 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         .mockReturnValue(throwError(() => new Error('Server error')));
 
       // User tries to update but server fails
-      await service.updateBudgetLine({
+      const error = await service.updateBudgetLine({
         id: 'line-2',
         name: 'Failed Update',
         amount: 9999,
       });
 
-      // Error is shown to user
-      expect(service.error()).toBeTruthy();
+      // Same contract as create: the message goes back to the caller's toast,
+      // never onto the page-level error signal.
+      expect(error).toBeTruthy();
+      expect(service.error()).toBeNull();
 
       // Original values are preserved (via reload)
       // User doesn't see the failed update stuck in UI
@@ -670,7 +703,7 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         .mockReturnValue(throwError(() => new Error('Network error')));
 
       // User tries to add an expense but network is down
-      await service.createBudgetLine({
+      const error = await service.createBudgetLine({
         budgetId: mockBudgetId,
         name: 'New expense',
         amount: 100,
@@ -679,8 +712,9 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
         isManuallyAdjusted: false,
       });
 
-      // User sees that something went wrong
-      expect(service.error()).toBeTruthy();
+      // User sees that something went wrong, in a toast over a live budget
+      expect(error).toBeTruthy();
+      expect(service.error()).toBeNull();
     });
 
     it('user cannot add expenses with negative amounts', async () => {
@@ -705,10 +739,11 @@ describe('BudgetDetailsStore - User Behavior Tests', () => {
           ),
         );
 
-      await service.createBudgetLine(invalidExpense);
+      const error = await service.createBudgetLine(invalidExpense);
 
       // User sees an error occurred
-      expect(service.error()).toBeTruthy();
+      expect(error).toBeTruthy();
+      expect(service.error()).toBeNull();
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-savings-withdrawal.spec.ts
@@ -190,7 +190,7 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
       const result = await store.createSavingsWithdrawal(WITHDRAWAL_INPUT);
 
       expect(createSavingsWithdrawal$).toHaveBeenCalledWith(WITHDRAWAL_INPUT);
-      expect(result?.groupId).toBe(WITHDRAWAL_INPUT.groupId);
+      expect(result.data?.groupId).toBe(WITHDRAWAL_INPUT.groupId);
     });
 
     it('routes a typed ApiError through the localizer instead of a blanket message', async () => {
@@ -200,9 +200,10 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
 
       const result = await store.createSavingsWithdrawal(WITHDRAWAL_INPUT);
 
-      expect(result).toBeUndefined();
+      expect(result.data).toBeUndefined();
       expect(localizeSpy).toHaveBeenCalledWith(conflictError);
-      expect(store.error()).toBe(localizer.localizeApiError(conflictError));
+      expect(result.error).toBe(localizer.localizeApiError(conflictError));
+      expect(store.error()).toBeUndefined();
     });
   });
 
@@ -230,7 +231,7 @@ describe('BudgetDetailsStore — savings withdrawal (PUL-292)', () => {
       );
 
       expect(error).toBe(localizer.localizeApiError(conflictError));
-      expect(store.error()).toBeNull();
+      expect(store.error()).toBeUndefined();
     });
   });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-spread.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store-spread.spec.ts
@@ -214,11 +214,12 @@ describe('BudgetDetailsStore — spread réalisé tracker', () => {
       const localizeSpy = vi.spyOn(localizer, 'localizeApiError');
 
       // Act
-      await store.createBudgetLineSpread(SPREAD_INPUT);
+      const outcome = await store.createBudgetLineSpread(SPREAD_INPUT);
 
       // Assert
       expect(localizeSpy).toHaveBeenCalledWith(recalcError);
-      expect(store.error()).toBe(localizer.localizeApiError(recalcError));
+      expect(outcome.error).toBe(localizer.localizeApiError(recalcError));
+      expect(store.error()).toBeUndefined();
     });
   });
 });

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -548,6 +548,13 @@ export class BudgetDetailsStore {
 
   // ── 5. Mutations (async/await) ──
 
+  // Same contract as #lastSavingsWithdrawalDeleteError: a create/update failure
+  // surfaces via the caller's snackbar (return value) and NEVER the page-level
+  // errorMessage, which the page renders as the generic load-error card — a
+  // refused line must not make the whole budget look unloadable. Single-flight
+  // (one dialog at a time), so a plain field is enough.
+  #lastBudgetLineWriteError: string | null = null;
+
   readonly #createBudgetLineMutation = cachedMutation<
     BudgetLineCreate & { id: string },
     { data: BudgetLine },
@@ -581,15 +588,29 @@ export class BudgetDetailsStore {
       }));
       this.#onFinancialMutationSuccess();
     },
-    onError: (_err, _args, previous) => {
+    onError: (error, _args, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(this.#transloco.translate('budget.forecastCreateError'));
+      this.#lastBudgetLineWriteError = this.#localizeError(
+        error,
+        'budget.forecastCreateError',
+      );
+      this.#logger.error('Budget line create failed', error);
     },
   });
 
-  async createBudgetLine(input: BudgetLineCreate): Promise<void> {
+  /** Returns the localized error message on failure, or `null` on success. */
+  async createBudgetLine(input: BudgetLineCreate): Promise<string | null> {
     const id = input.id ?? uuidv4();
-    await this.#createBudgetLineMutation.mutate({ ...input, id });
+    this.#lastBudgetLineWriteError = null;
+    const response = await this.#createBudgetLineMutation.mutate({
+      ...input,
+      id,
+    });
+    if (response !== undefined) return null;
+    return (
+      this.#lastBudgetLineWriteError ??
+      this.#transloco.translate('budget.forecastCreateError')
+    );
   }
 
   // PUL-17 — a spread fans out across N months (possibly auto-creating budgets),
@@ -762,14 +783,25 @@ export class BudgetDetailsStore {
       return previous;
     },
     onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (_err, _args, previous) => {
+    onError: (error, _args, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(this.#transloco.translate('budget.forecastUpdateError'));
+      this.#lastBudgetLineWriteError = this.#localizeError(
+        error,
+        'budget.forecastUpdateError',
+      );
+      this.#logger.error('Budget line update failed', error);
     },
   });
 
-  async updateBudgetLine(data: BudgetLineUpdate): Promise<void> {
-    await this.#updateBudgetLineMutation.mutate(data);
+  /** Returns the localized error message on failure, or `null` on success. */
+  async updateBudgetLine(data: BudgetLineUpdate): Promise<string | null> {
+    this.#lastBudgetLineWriteError = null;
+    const response = await this.#updateBudgetLineMutation.mutate(data);
+    if (response !== undefined) return null;
+    return (
+      this.#lastBudgetLineWriteError ??
+      this.#transloco.translate('budget.forecastUpdateError')
+    );
   }
 
   readonly #updateTransactionMutation = cachedMutation<

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -62,6 +62,16 @@ import {
   buildSpreadTracker,
 } from '../spread-occurrences/spread-occurrence.view-model';
 
+/**
+ * What a mutation that carries a payload gives back: the payload on success, the
+ * localized reason on refusal. Mutations with nothing to return say the same
+ * thing with a plain `string | null` — `null` meaning it went through.
+ */
+export interface MutationOutcome<T> {
+  data?: T;
+  error?: string;
+}
+
 const BUDGET_DETAIL_INVALIDATION_KEYS: string[][] = [
   ['budget', 'details'],
   ['budget', 'list'],
@@ -253,9 +263,10 @@ export class BudgetDetailsStore {
   );
   readonly isInitialLoading = this.#budgetDetailsResource.isInitialLoading;
   readonly hasValue = computed(() => this.budgetDetails() !== null);
-  readonly error = computed(
-    () => this.#budgetDetailsResource.error() || this.#state.errorMessage(),
-  );
+  // The page renders this as a card that REPLACES the whole budget, so it means
+  // one thing only: the budget could not be loaded. A refused mutation is not an
+  // unloadable budget — it travels back through its own return value instead.
+  readonly error = this.#budgetDetailsResource.error;
   readonly isStale = this.#budgetDetailsResource.isStale;
 
   // Goal id → name, for the linked-goal affordance on saving envelopes. Empty
@@ -548,12 +559,17 @@ export class BudgetDetailsStore {
 
   // ── 5. Mutations (async/await) ──
 
-  // Same contract as #lastSavingsWithdrawalDeleteError: a create/update failure
-  // surfaces via the caller's snackbar (return value) and NEVER the page-level
-  // errorMessage, which the page renders as the generic load-error card — a
-  // refused line must not make the whole budget look unloadable. Single-flight
-  // (one dialog at a time), so a plain field is enough.
-  #lastBudgetLineWriteError: string | null = null;
+  // Every mutation's onError writes its localized message here; every public
+  // method clears it before calling mutate and reads it after. That read is the
+  // ONLY valid failure test: `mutate()` resolves `undefined` on error, but two
+  // of these mutations are typed `void`, so `undefined` is also their success
+  // value — `response !== undefined` would report failure on every success.
+  //
+  // One field for all of them: everything but the three checks is single-flight
+  // (driven by a dialog), and the three checks — guarded per id by #mutatingIds,
+  // so two ids CAN fail at once — carry a constant message, so concurrent
+  // failures produce the same string and there is nothing to clobber.
+  #lastMutationError: string | null = null;
 
   readonly #createBudgetLineMutation = cachedMutation<
     BudgetLineCreate & { id: string },
@@ -590,7 +606,7 @@ export class BudgetDetailsStore {
     },
     onError: (error, _args, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#lastBudgetLineWriteError = this.#localizeError(
+      this.#lastMutationError = this.#localizeError(
         error,
         'budget.forecastCreateError',
       );
@@ -601,16 +617,9 @@ export class BudgetDetailsStore {
   /** Returns the localized error message on failure, or `null` on success. */
   async createBudgetLine(input: BudgetLineCreate): Promise<string | null> {
     const id = input.id ?? uuidv4();
-    this.#lastBudgetLineWriteError = null;
-    const response = await this.#createBudgetLineMutation.mutate({
-      ...input,
-      id,
-    });
-    if (response !== undefined) return null;
-    return (
-      this.#lastBudgetLineWriteError ??
-      this.#transloco.translate('budget.forecastCreateError')
-    );
+    this.#lastMutationError = null;
+    await this.#createBudgetLineMutation.mutate({ ...input, id });
+    return this.#lastMutationError;
   }
 
   // PUL-17 — a spread fans out across N months (possibly auto-creating budgets),
@@ -630,9 +639,13 @@ export class BudgetDetailsStore {
 
   async createBudgetLineSpread(
     input: BudgetLineSpreadCreate,
-  ): Promise<BudgetLineSpreadResponse['data'] | undefined> {
+  ): Promise<MutationOutcome<BudgetLineSpreadResponse['data']>> {
+    this.#lastMutationError = null;
     const response = await this.#createBudgetLineSpreadMutation.mutate(input);
-    return response?.data;
+    if (this.#lastMutationError !== null) {
+      return { error: this.#lastMutationError };
+    }
+    return { data: response?.data };
   }
 
   // PUL-292 — creating the pioche couple fans out across M and M+1 (possibly
@@ -653,18 +666,14 @@ export class BudgetDetailsStore {
 
   async createSavingsWithdrawal(
     input: BudgetLineSavingsWithdrawalCreate,
-  ): Promise<BudgetLineSavingsWithdrawalResponse['data'] | undefined> {
+  ): Promise<MutationOutcome<BudgetLineSavingsWithdrawalResponse['data']>> {
+    this.#lastMutationError = null;
     const response = await this.#createSavingsWithdrawalMutation.mutate(input);
-    return response?.data;
+    if (this.#lastMutationError !== null) {
+      return { error: this.#lastMutationError };
+    }
+    return { data: response?.data };
   }
-
-  // Set by the delete mutation's onError, read by the public method — so a delete
-  // failure surfaces via the caller's snackbar (return value) and NEVER the
-  // page-level errorMessage: a grouped delete that fails (e.g. the group was
-  // already removed in another tab) must not flip the whole page to the generic
-  // load-error card. Single-flight (one delete dialog at a time), so a plain
-  // field is enough.
-  #lastSavingsWithdrawalDeleteError: string | null = null;
 
   readonly #deleteSavingsWithdrawalMutation = cachedMutation<
     { groupId: string; scope: BudgetLineSavingsWithdrawalDeleteQuery['scope'] },
@@ -677,7 +686,7 @@ export class BudgetDetailsStore {
       this.#budgetApi.deleteSavingsWithdrawal$(groupId, scope),
     onSuccess: () => this.#onFinancialMutationSuccess(),
     onError: (error) => {
-      this.#lastSavingsWithdrawalDeleteError = this.#localizeError(
+      this.#lastMutationError = this.#localizeError(
         error,
         'budget.savingsWithdrawal.error',
       );
@@ -690,16 +699,9 @@ export class BudgetDetailsStore {
     groupId: string,
     scope: BudgetLineSavingsWithdrawalDeleteQuery['scope'],
   ): Promise<string | null> {
-    this.#lastSavingsWithdrawalDeleteError = null;
-    const response = await this.#deleteSavingsWithdrawalMutation.mutate({
-      groupId,
-      scope,
-    });
-    if (response !== undefined) return null;
-    return (
-      this.#lastSavingsWithdrawalDeleteError ??
-      this.#transloco.translate('budget.savingsWithdrawal.error')
-    );
+    this.#lastMutationError = null;
+    await this.#deleteSavingsWithdrawalMutation.mutate({ groupId, scope });
+    return this.#lastMutationError;
   }
 
   // PUL-17 v1.1 — total-preserving spread of an EXISTING source (prévision OR
@@ -727,12 +729,16 @@ export class BudgetDetailsStore {
   async spreadExistingBudgetLine(
     id: string,
     periods: SpreadFromExistingPeriod[],
-  ): Promise<BudgetLineSpreadResponse['data'] | undefined> {
+  ): Promise<MutationOutcome<BudgetLineSpreadResponse['data']>> {
+    this.#lastMutationError = null;
     const response = await this.#spreadExistingBudgetLineMutation.mutate({
       id,
       periods,
     });
-    return response?.data;
+    if (this.#lastMutationError !== null) {
+      return { error: this.#lastMutationError };
+    }
+    return { data: response?.data };
   }
 
   readonly #spreadExistingTransactionMutation = cachedMutation<
@@ -754,12 +760,16 @@ export class BudgetDetailsStore {
   async spreadExistingTransaction(
     id: string,
     periods: SpreadFromExistingPeriod[],
-  ): Promise<BudgetLineSpreadResponse['data'] | undefined> {
+  ): Promise<MutationOutcome<BudgetLineSpreadResponse['data']>> {
+    this.#lastMutationError = null;
     const response = await this.#spreadExistingTransactionMutation.mutate({
       id,
       periods,
     });
-    return response?.data;
+    if (this.#lastMutationError !== null) {
+      return { error: this.#lastMutationError };
+    }
+    return { data: response?.data };
   }
 
   readonly #updateBudgetLineMutation = cachedMutation<
@@ -785,7 +795,7 @@ export class BudgetDetailsStore {
     onSuccess: () => this.#onFinancialMutationSuccess(),
     onError: (error, _args, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#lastBudgetLineWriteError = this.#localizeError(
+      this.#lastMutationError = this.#localizeError(
         error,
         'budget.forecastUpdateError',
       );
@@ -795,13 +805,9 @@ export class BudgetDetailsStore {
 
   /** Returns the localized error message on failure, or `null` on success. */
   async updateBudgetLine(data: BudgetLineUpdate): Promise<string | null> {
-    this.#lastBudgetLineWriteError = null;
-    const response = await this.#updateBudgetLineMutation.mutate(data);
-    if (response !== undefined) return null;
-    return (
-      this.#lastBudgetLineWriteError ??
-      this.#transloco.translate('budget.forecastUpdateError')
-    );
+    this.#lastMutationError = null;
+    await this.#updateBudgetLineMutation.mutate(data);
+    return this.#lastMutationError;
   }
 
   readonly #updateTransactionMutation = cachedMutation<
@@ -827,14 +833,20 @@ export class BudgetDetailsStore {
     onSuccess: () => this.#onFinancialMutationSuccess(),
     onError: (_err, _args, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(
+      this.#failMutation(
         this.#transloco.translate('budget.transactionUpdateError'),
       );
     },
   });
 
-  async updateTransaction(id: string, data: TransactionUpdate): Promise<void> {
+  /** Returns the localized error message on failure, or `null` on success. */
+  async updateTransaction(
+    id: string,
+    data: TransactionUpdate,
+  ): Promise<string | null> {
+    this.#lastMutationError = null;
     await this.#updateTransactionMutation.mutate({ id, data });
+    return this.#lastMutationError;
   }
 
   readonly #deleteBudgetLineMutation = cachedMutation<
@@ -860,12 +872,17 @@ export class BudgetDetailsStore {
     onSuccess: () => this.#onFinancialMutationSuccess(),
     onError: (_err, _args, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(this.#transloco.translate('budget.forecastDeleteError'));
+      this.#failMutation(
+        this.#transloco.translate('budget.forecastDeleteError'),
+      );
     },
   });
 
-  async deleteBudgetLine(id: string): Promise<void> {
+  /** Returns the localized error message on failure, or `null` on success. */
+  async deleteBudgetLine(id: string): Promise<string | null> {
+    this.#lastMutationError = null;
     await this.#deleteBudgetLineMutation.mutate(id);
+    return this.#lastMutationError;
   }
 
   readonly #deleteTransactionMutation = cachedMutation<
@@ -888,14 +905,17 @@ export class BudgetDetailsStore {
     onSuccess: () => this.#onFinancialMutationSuccess(),
     onError: (_err, _args, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(
+      this.#failMutation(
         this.#transloco.translate('budget.transactionDeleteError'),
       );
     },
   });
 
-  async deleteTransaction(id: string): Promise<void> {
+  /** Returns the localized error message on failure, or `null` on success. */
+  async deleteTransaction(id: string): Promise<string | null> {
+    this.#lastMutationError = null;
     await this.#deleteTransactionMutation.mutate(id);
+    return this.#lastMutationError;
   }
 
   readonly #createAllocatedTransactionMutation = cachedMutation<
@@ -939,20 +959,23 @@ export class BudgetDetailsStore {
     },
     onError: (_err, _args, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(
+      this.#failMutation(
         this.#transloco.translate('budget.transactionCreateError'),
       );
     },
   });
 
+  /** Returns the localized error message on failure, or `null` on success. */
   async createAllocatedTransaction(
     transactionData: TransactionCreate,
-  ): Promise<void> {
+  ): Promise<string | null> {
     const id = transactionData.id ?? uuidv4();
+    this.#lastMutationError = null;
     await this.#createAllocatedTransactionMutation.mutate({
       ...transactionData,
       id,
     });
+    return this.#lastMutationError;
   }
 
   readonly #resetBudgetLineMutation = cachedMutation<
@@ -973,16 +996,25 @@ export class BudgetDetailsStore {
       this.#onFinancialMutationSuccess();
     },
     onError: (error) => {
-      this.#setError(this.#localizeError(error, 'budget.forecastResetError'));
+      this.#failMutation(
+        this.#localizeError(error, 'budget.forecastResetError'),
+      );
       this.#logger.error('Error resetting budget line from template', error);
     },
   });
 
-  async resetBudgetLineFromTemplate(id: string): Promise<void> {
-    if (this.#mutatingIds.has(id)) return;
+  /**
+   * Returns the localized error message on failure, or `null` on success.
+   * A guard that skips the call also returns `null`: the gesture was a duplicate
+   * of one already in flight, so there is nothing to tell the user about.
+   */
+  async resetBudgetLineFromTemplate(id: string): Promise<string | null> {
+    if (this.#mutatingIds.has(id)) return null;
     this.#mutatingIds.add(id);
+    this.#lastMutationError = null;
     try {
       await this.#resetBudgetLineMutation.mutate(id);
+      return this.#lastMutationError;
     } finally {
       this.#mutatingIds.delete(id);
     }
@@ -1012,12 +1044,14 @@ export class BudgetDetailsStore {
     },
   });
 
-  async postponeBudgetLine(id: string): Promise<boolean> {
-    if (this.#mutatingIds.has(id)) return false;
+  /** Returns the localized error message on failure, or `null` on success. */
+  async postponeBudgetLine(id: string): Promise<string | null> {
+    if (this.#mutatingIds.has(id)) return null;
     this.#mutatingIds.add(id);
+    this.#lastMutationError = null;
     try {
-      const result = await this.#postponeBudgetLineMutation.mutate(id);
-      return result !== undefined;
+      await this.#postponeBudgetLineMutation.mutate(id);
+      return this.#lastMutationError;
     } finally {
       this.#mutatingIds.delete(id);
     }
@@ -1047,12 +1081,14 @@ export class BudgetDetailsStore {
     },
   });
 
-  async postponeTransaction(id: string): Promise<boolean> {
-    if (this.#mutatingIds.has(id)) return false;
+  /** Returns the localized error message on failure, or `null` on success. */
+  async postponeTransaction(id: string): Promise<string | null> {
+    if (this.#mutatingIds.has(id)) return null;
     this.#mutatingIds.add(id);
+    this.#lastMutationError = null;
     try {
-      const result = await this.#postponeTransactionMutation.mutate(id);
-      return result !== undefined;
+      await this.#postponeTransactionMutation.mutate(id);
+      return this.#lastMutationError;
     } finally {
       this.#mutatingIds.delete(id);
     }
@@ -1093,23 +1129,27 @@ export class BudgetDetailsStore {
     },
     onError: (_err, _id, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(this.#transloco.translate('budget.forecastToggleError'));
+      this.#failMutation(
+        this.#transloco.translate('budget.forecastToggleError'),
+      );
     },
   });
 
-  async toggleCheck(id: string): Promise<boolean> {
-    if (this.#mutatingIds.has(id)) return false;
+  /** Returns the localized error message on failure, or `null` on success. */
+  async toggleCheck(id: string): Promise<string | null> {
+    if (this.#mutatingIds.has(id)) return null;
 
     const details = this.budgetDetails();
-    if (!details) return false;
+    if (!details) return null;
 
     const lineExists = details.budgetLines.some((l) => l.id === id);
-    if (!lineExists) return false;
+    if (!lineExists) return null;
 
     this.#mutatingIds.add(id);
+    this.#lastMutationError = null;
     try {
-      const result = await this.#toggleCheckMutation.mutate(id);
-      return result !== undefined;
+      await this.#toggleCheckMutation.mutate(id);
+      return this.#lastMutationError;
     } finally {
       this.#mutatingIds.delete(id);
     }
@@ -1149,17 +1189,20 @@ export class BudgetDetailsStore {
     },
     onError: (_err, _id, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(
+      this.#failMutation(
         this.#transloco.translate('budget.transactionToggleError'),
       );
     },
   });
 
-  async toggleTransactionCheck(id: string): Promise<void> {
-    if (this.#mutatingIds.has(id)) return;
+  /** Returns the localized error message on failure, or `null` on success. */
+  async toggleTransactionCheck(id: string): Promise<string | null> {
+    if (this.#mutatingIds.has(id)) return null;
     this.#mutatingIds.add(id);
+    this.#lastMutationError = null;
     try {
       await this.#toggleTransactionCheckMutation.mutate(id);
+      return this.#lastMutationError;
     } finally {
       this.#mutatingIds.delete(id);
     }
@@ -1213,21 +1256,26 @@ export class BudgetDetailsStore {
     },
     onError: (_err, _id, previous) => {
       if (previous) this.#budgetDetailsResource.set(previous);
-      this.#setError(this.#transloco.translate('budget.checkAllError'));
+      this.#failMutation(this.#transloco.translate('budget.checkAllError'));
     },
   });
 
-  async checkAllAllocatedTransactions(budgetLineId: string): Promise<void> {
-    if (this.#mutatingIds.has(budgetLineId)) return;
+  /** Returns the localized error message on failure, or `null` on success. */
+  async checkAllAllocatedTransactions(
+    budgetLineId: string,
+  ): Promise<string | null> {
+    if (this.#mutatingIds.has(budgetLineId)) return null;
     const details = this.budgetDetails();
-    if (!details) return;
+    if (!details) return null;
     const hasUnchecked = details.transactions.some(
       (tx) => tx.budgetLineId === budgetLineId && tx.checkedAt === null,
     );
-    if (!hasUnchecked) return;
+    if (!hasUnchecked) return null;
     this.#mutatingIds.add(budgetLineId);
+    this.#lastMutationError = null;
     try {
       await this.#checkAllAllocatedMutation.mutate(budgetLineId);
+      return this.#lastMutationError;
     } finally {
       this.#mutatingIds.delete(budgetLineId);
     }
@@ -1235,7 +1283,6 @@ export class BudgetDetailsStore {
 
   reloadBudgetDetails(): void {
     this.#budgetDetailsResource.reload();
-    this.#clearError();
   }
 
   // ── 6. Private utility methods ──
@@ -1250,8 +1297,8 @@ export class BudgetDetailsStore {
     });
   }
 
-  #setError(error: string): void {
-    this.#state.errorMessage.set(error);
+  #failMutation(message: string): void {
+    this.#lastMutationError = message;
   }
 
   // Shared failure path for the 2 postpone mutations (mirrors #handleSpreadError):
@@ -1259,7 +1306,7 @@ export class BudgetDetailsStore {
   // expected business errors (already-checked, concurrent-mod) are surfaced to
   // the user, not logged as noise.
   #handlePostponeError(error: unknown): void {
-    this.#setError(this.#localizeError(error, 'budget.postponeError'));
+    this.#failMutation(this.#localizeError(error, 'budget.postponeError'));
     if (!isApiError(error)) {
       this.#logger.error('Error postponing item to next month', error);
     }
@@ -1275,25 +1322,20 @@ export class BudgetDetailsStore {
 
   // Shared failure path for the 3 spread mutations (identical key + log).
   #handleSpreadError(error: unknown): void {
-    this.#setError(this.#localizeError(error, 'budgetLine.spread.error'));
+    this.#failMutation(this.#localizeError(error, 'budgetLine.spread.error'));
     this.#logger.error('Spread mutation failed', error);
   }
 
   // Shared failure path for the 2 savings-withdrawal mutations (PUL-292):
   // localize a typed ApiError via its code, else fall back to the generic key.
   #handleSavingsWithdrawalError(error: unknown): void {
-    this.#setError(
+    this.#failMutation(
       this.#localizeError(error, 'budget.savingsWithdrawal.error'),
     );
     this.#logger.error('Savings withdrawal mutation failed', error);
   }
 
-  #clearError(): void {
-    this.#state.errorMessage.set(null);
-  }
-
   #onFinancialMutationSuccess(): void {
-    this.#clearError();
     this.#prefetchAdjacentBudgets(null, this.nextBudgetId());
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -1405,11 +1405,12 @@ export class BudgetDetailsStore {
   #updateDetails(
     fn: (details: BudgetDetailsViewModel) => BudgetDetailsViewModel,
   ): void {
-    this.#budgetDetailsResource.update((details) => {
-      // Early return when resource has no value — cast required by cachedResource.update() signature
-      if (!details) return details as unknown as BudgetDetailsViewModel;
-      return fn(details);
-    });
+    // Read before updating rather than guarding inside the updater: `update()`
+    // must be handed a view model, and returning the absent value instead would
+    // write `undefined` through to the DataCache under this budget's key.
+    const current = this.#budgetDetailsResource.value();
+    if (!current) return;
+    this.#budgetDetailsResource.update(() => fn(current));
   }
 
   // Shared failure path for the 2 postpone mutations (mirrors #handleSpreadError):

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -66,14 +66,34 @@ import {
  * What a mutation that carries a payload gives back: the payload on success, the
  * localized reason on refusal. Mutations with nothing to return say the same
  * thing with a plain `string | null` — `null` meaning it went through.
+ *
+ * `retryable` says whether replaying the SAME request could land differently.
+ * Only the submitters that offer a "Réessayer" action read it; a refusal the
+ * server will repeat verbatim must not be offered a button that cannot work.
  */
 export interface MutationOutcome<T> {
   data?: T;
   error?: string;
+  retryable?: boolean;
 }
 
-/** Where a mutation's `onError` hands its localized reason back to the one call that made it. */
-type FailSink = (message: string) => void;
+/**
+ * A refusal the server decided on (any 4xx it will reach again from the same
+ * body) is final. A timeout, a rate limit, a 5xx or a transport failure is the
+ * request not getting a verdict — that is what replaying is for, and for the
+ * idempotent creates it is also what heals a lost post-commit response.
+ */
+function isRetryableFailure(error: unknown): boolean {
+  if (!isApiError(error)) return true;
+  return error.status >= 500 || error.status === 408 || error.status === 429;
+}
+
+/**
+ * Where a mutation's `onError` hands its localized reason back to the one call
+ * that made it. `retryable` is omitted by the mutations nobody offers a retry
+ * on, which is why it is optional rather than threaded through all of them.
+ */
+type FailSink = (message: string, retryable?: boolean) => void;
 
 /**
  * A `cachedMutation` built for ONE call, around that call's sink. Structural
@@ -721,11 +741,11 @@ export class BudgetDetailsStore {
   async createBudgetLineSpread(
     input: BudgetLineSpreadCreate,
   ): Promise<MutationOutcome<BudgetLineSpreadResponse['data']>> {
-    const { data, error } = await this.#runMutation(
+    const { data, error, retryable } = await this.#runMutation(
       this.#createBudgetLineSpreadMutation,
       input,
     );
-    return error !== null ? { error } : { data: data?.data };
+    return error !== null ? { error, retryable } : { data: data?.data };
   }
 
   // PUL-292 — creating the pioche couple fans out across M and M+1 (possibly
@@ -748,11 +768,11 @@ export class BudgetDetailsStore {
   async createSavingsWithdrawal(
     input: BudgetLineSavingsWithdrawalCreate,
   ): Promise<MutationOutcome<BudgetLineSavingsWithdrawalResponse['data']>> {
-    const { data, error } = await this.#runMutation(
+    const { data, error, retryable } = await this.#runMutation(
       this.#createSavingsWithdrawalMutation,
       input,
     );
-    return error !== null ? { error } : { data: data?.data };
+    return error !== null ? { error, retryable } : { data: data?.data };
   }
 
   readonly #deleteSavingsWithdrawalMutation = (fail: FailSink) =>
@@ -906,9 +926,10 @@ export class BudgetDetailsStore {
         return this.#rewindPoint(previous);
       },
       onSuccess: () => this.#onFinancialMutationSuccess(),
-      onError: (_err, _args, rewind) => {
+      onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.transactionUpdateError'));
+        this.#logger.error('Transaction update failed', error);
       },
     });
 
@@ -942,9 +963,10 @@ export class BudgetDetailsStore {
         return this.#rewindPoint(previous);
       },
       onSuccess: () => this.#onFinancialMutationSuccess(),
-      onError: (_err, _args, rewind) => {
+      onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.forecastDeleteError'));
+        this.#logger.error('Budget line delete failed', error);
       },
     });
 
@@ -972,9 +994,10 @@ export class BudgetDetailsStore {
         return this.#rewindPoint(previous);
       },
       onSuccess: () => this.#onFinancialMutationSuccess(),
-      onError: (_err, _args, rewind) => {
+      onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.transactionDeleteError'));
+        this.#logger.error('Transaction delete failed', error);
       },
     });
 
@@ -1027,9 +1050,10 @@ export class BudgetDetailsStore {
         }));
         this.#onFinancialMutationSuccess();
       },
-      onError: (_err, _args, rewind) => {
+      onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.transactionCreateError'));
+        this.#logger.error('Allocated transaction create failed', error);
       },
     });
 
@@ -1176,9 +1200,10 @@ export class BudgetDetailsStore {
         }));
         this.#onFinancialMutationSuccess();
       },
-      onError: (_err, _id, rewind) => {
+      onError: (error, _id, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.forecastToggleError'));
+        this.#logger.error('Budget line check toggle failed', error);
       },
     });
 
@@ -1229,9 +1254,10 @@ export class BudgetDetailsStore {
         }));
         this.#onFinancialMutationSuccess();
       },
-      onError: (_err, _id, rewind) => {
+      onError: (error, _id, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.transactionToggleError'));
+        this.#logger.error('Transaction check toggle failed', error);
       },
     });
 
@@ -1290,9 +1316,10 @@ export class BudgetDetailsStore {
         }));
         this.#onFinancialMutationSuccess();
       },
-      onError: (_err, _id, rewind) => {
+      onError: (error, _id, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.checkAllError'));
+        this.#logger.error('Bulk check-all failed', error);
       },
     });
 
@@ -1333,13 +1360,19 @@ export class BudgetDetailsStore {
   async #runMutation<TArgs, TResponse>(
     factory: MutationFactory<TArgs, TResponse>,
     args: TArgs,
-  ): Promise<{ data: TResponse | undefined; error: string | null }> {
+  ): Promise<{
+    data: TResponse | undefined;
+    error: string | null;
+    retryable: boolean;
+  }> {
     let error: string | null = null;
-    const mutation = factory((message) => {
+    let retryable = false;
+    const mutation = factory((message, isRetryable = false) => {
       error = message;
+      retryable = isRetryable;
     });
     const data = await mutation.mutate(args);
-    return { data, error };
+    return { data, error, retryable };
   }
 
   /** The pair `#rollback` needs, or `null` when there is nothing to undo. */
@@ -1397,14 +1430,20 @@ export class BudgetDetailsStore {
 
   // Shared failure path for the 3 spread mutations (identical key + log).
   #handleSpreadError(fail: FailSink, error: unknown): void {
-    fail(this.#localizeError(error, 'budgetLine.spread.error'));
+    fail(
+      this.#localizeError(error, 'budgetLine.spread.error'),
+      isRetryableFailure(error),
+    );
     this.#logger.error('Spread mutation failed', error);
   }
 
   // Shared failure path for the 2 savings-withdrawal mutations (PUL-292):
   // localize a typed ApiError via its code, else fall back to the generic key.
   #handleSavingsWithdrawalError(fail: FailSink, error: unknown): void {
-    fail(this.#localizeError(error, 'budget.savingsWithdrawal.error'));
+    fail(
+      this.#localizeError(error, 'budget.savingsWithdrawal.error'),
+      isRetryableFailure(error),
+    );
     this.#logger.error('Savings withdrawal mutation failed', error);
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -78,6 +78,17 @@ export interface MutationOutcome<T> {
 }
 
 /**
+ * What `toggleCheck`, `toggleTransactionCheck` and `checkAllAllocatedTransactions`
+ * hand back: the gesture ran, a guard short-circuited it (nothing to point to,
+ * already in flight), or it ran and the server refused it. Kept a union rather
+ * than two booleans so `{ applied: true, error: 'x' }` is not representable.
+ */
+export type CheckOutcome =
+  | { readonly status: 'applied' }
+  | { readonly status: 'skipped' }
+  | { readonly status: 'failed'; readonly reason: string };
+
+/**
  * A refusal the server decided on (any 4xx it will reach again from the same
  * body) is final. A timeout, a rate limit, a 5xx or a transport failure is the
  * request not getting a verdict — that is what replaying is for, and for the
@@ -715,7 +726,7 @@ export class BudgetDetailsStore {
       onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#localizeError(error, 'budget.forecastCreateError'));
-        this.#logger.error('Budget line create failed', error);
+        this.#logUnexpectedFailure('Budget line create failed', error);
       },
     });
 
@@ -794,7 +805,7 @@ export class BudgetDetailsStore {
       onSuccess: () => this.#onFinancialMutationSuccess(),
       onError: (error) => {
         fail(this.#localizeError(error, 'budget.savingsWithdrawal.error'));
-        this.#logger.error('Savings withdrawal delete failed', error);
+        this.#logUnexpectedFailure('Savings withdrawal delete failed', error);
       },
     });
 
@@ -893,7 +904,7 @@ export class BudgetDetailsStore {
       onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#localizeError(error, 'budget.forecastUpdateError'));
-        this.#logger.error('Budget line update failed', error);
+        this.#logUnexpectedFailure('Budget line update failed', error);
       },
     });
 
@@ -932,7 +943,7 @@ export class BudgetDetailsStore {
       onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.transactionUpdateError'));
-        this.#logger.error('Transaction update failed', error);
+        this.#logUnexpectedFailure('Transaction update failed', error);
       },
     });
 
@@ -969,7 +980,7 @@ export class BudgetDetailsStore {
       onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.forecastDeleteError'));
-        this.#logger.error('Budget line delete failed', error);
+        this.#logUnexpectedFailure('Budget line delete failed', error);
       },
     });
 
@@ -1000,7 +1011,7 @@ export class BudgetDetailsStore {
       onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.transactionDeleteError'));
-        this.#logger.error('Transaction delete failed', error);
+        this.#logUnexpectedFailure('Transaction delete failed', error);
       },
     });
 
@@ -1056,7 +1067,10 @@ export class BudgetDetailsStore {
       onError: (error, _args, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.transactionCreateError'));
-        this.#logger.error('Allocated transaction create failed', error);
+        this.#logUnexpectedFailure(
+          'Allocated transaction create failed',
+          error,
+        );
       },
     });
 
@@ -1088,7 +1102,10 @@ export class BudgetDetailsStore {
       },
       onError: (error) => {
         fail(this.#localizeError(error, 'budget.forecastResetError'));
-        this.#logger.error('Error resetting budget line from template', error);
+        this.#logUnexpectedFailure(
+          'Error resetting budget line from template',
+          error,
+        );
       },
     });
 
@@ -1206,23 +1223,26 @@ export class BudgetDetailsStore {
       onError: (error, _id, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.forecastToggleError'));
-        this.#logger.error('Budget line check toggle failed', error);
+        this.#logUnexpectedFailure('Budget line check toggle failed', error);
       },
     });
 
-  /** Returns the localized error message on failure, or `null` on success. */
-  async toggleCheck(id: string): Promise<string | null> {
-    if (this.#mutatingIds.has(id)) return null;
+  /** Applied, skipped by a guard, or failed with the localized reason — see `CheckOutcome`. */
+  async toggleCheck(id: string): Promise<CheckOutcome> {
+    if (this.#mutatingIds.has(id)) return { status: 'skipped' };
 
     const details = this.budgetDetails();
-    if (!details) return null;
+    if (!details) return { status: 'skipped' };
 
     const lineExists = details.budgetLines.some((l) => l.id === id);
-    if (!lineExists) return null;
+    if (!lineExists) return { status: 'skipped' };
 
     this.#mutatingIds.add(id);
     try {
-      return (await this.#runMutation(this.#toggleCheckMutation, id)).error;
+      const { error } = await this.#runMutation(this.#toggleCheckMutation, id);
+      return error
+        ? { status: 'failed', reason: error }
+        : { status: 'applied' };
     } finally {
       this.#mutatingIds.delete(id);
     }
@@ -1260,17 +1280,22 @@ export class BudgetDetailsStore {
       onError: (error, _id, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.transactionToggleError'));
-        this.#logger.error('Transaction check toggle failed', error);
+        this.#logUnexpectedFailure('Transaction check toggle failed', error);
       },
     });
 
-  /** Returns the localized error message on failure, or `null` on success. */
-  async toggleTransactionCheck(id: string): Promise<string | null> {
-    if (this.#mutatingIds.has(id)) return null;
+  /** Applied, skipped by a guard, or failed with the localized reason — see `CheckOutcome`. */
+  async toggleTransactionCheck(id: string): Promise<CheckOutcome> {
+    if (this.#mutatingIds.has(id)) return { status: 'skipped' };
     this.#mutatingIds.add(id);
     try {
-      return (await this.#runMutation(this.#toggleTransactionCheckMutation, id))
-        .error;
+      const { error } = await this.#runMutation(
+        this.#toggleTransactionCheckMutation,
+        id,
+      );
+      return error
+        ? { status: 'failed', reason: error }
+        : { status: 'applied' };
     } finally {
       this.#mutatingIds.delete(id);
     }
@@ -1322,26 +1347,30 @@ export class BudgetDetailsStore {
       onError: (error, _id, rewind) => {
         this.#rollback(rewind);
         fail(this.#transloco.translate('budget.checkAllError'));
-        this.#logger.error('Bulk check-all failed', error);
+        this.#logUnexpectedFailure('Bulk check-all failed', error);
       },
     });
 
-  /** Returns the localized error message on failure, or `null` on success. */
+  /** Applied, skipped by a guard, or failed with the localized reason — see `CheckOutcome`. */
   async checkAllAllocatedTransactions(
     budgetLineId: string,
-  ): Promise<string | null> {
-    if (this.#mutatingIds.has(budgetLineId)) return null;
+  ): Promise<CheckOutcome> {
+    if (this.#mutatingIds.has(budgetLineId)) return { status: 'skipped' };
     const details = this.budgetDetails();
-    if (!details) return null;
+    if (!details) return { status: 'skipped' };
     const hasUnchecked = details.transactions.some(
       (tx) => tx.budgetLineId === budgetLineId && tx.checkedAt === null,
     );
-    if (!hasUnchecked) return null;
+    if (!hasUnchecked) return { status: 'skipped' };
     this.#mutatingIds.add(budgetLineId);
     try {
-      return (
-        await this.#runMutation(this.#checkAllAllocatedMutation, budgetLineId)
-      ).error;
+      const { error } = await this.#runMutation(
+        this.#checkAllAllocatedMutation,
+        budgetLineId,
+      );
+      return error
+        ? { status: 'failed', reason: error }
+        : { status: 'applied' };
     } finally {
       this.#mutatingIds.delete(budgetLineId);
     }
@@ -1432,13 +1461,21 @@ export class BudgetDetailsStore {
       : this.#transloco.translate(fallbackKey);
   }
 
+  // A 4xx is the server's verdict on this exact body — a business refusal the
+  // user already reads in a toast, and an ERROR log the on-call would page on
+  // for nothing. Only a failure that never reached a verdict is worth logging,
+  // which is the same partition `isRetryableFailure` already draws.
+  #logUnexpectedFailure(message: string, error: unknown): void {
+    if (isRetryableFailure(error)) this.#logger.error(message, error);
+  }
+
   // Shared failure path for the 3 spread mutations (identical key + log).
   #handleSpreadError(fail: FailSink, error: unknown): void {
     fail(
       this.#localizeError(error, 'budgetLine.spread.error'),
       isRetryableFailure(error),
     );
-    this.#logger.error('Spread mutation failed', error);
+    this.#logUnexpectedFailure('Spread mutation failed', error);
   }
 
   // Shared failure path for the 2 savings-withdrawal mutations (PUL-292):
@@ -1448,7 +1485,7 @@ export class BudgetDetailsStore {
       this.#localizeError(error, 'budget.savingsWithdrawal.error'),
       isRetryableFailure(error),
     );
-    this.#logger.error('Savings withdrawal mutation failed', error);
+    this.#logUnexpectedFailure('Savings withdrawal mutation failed', error);
   }
 
   #onFinancialMutationSuccess(): void {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -72,6 +72,74 @@ export interface MutationOutcome<T> {
   error?: string;
 }
 
+/** Where a mutation's `onError` hands its localized reason back to the one call that made it. */
+type FailSink = (message: string) => void;
+
+/**
+ * A `cachedMutation` built for ONE call, around that call's sink. Structural
+ * rather than `CachedMutationRef`, whose `mutate(...args)` rest tuple is a
+ * conditional type that cannot resolve against an unbound `TArgs`.
+ */
+type MutationFactory<TArgs, TResponse> = (fail: FailSink) => {
+  mutate: (args: TArgs) => Promise<TResponse | undefined>;
+};
+
+/**
+ * What one call needs to undo its own optimistic write and nothing else: the
+ * state it found (`previous`) and the state it left behind (`optimistic`).
+ * `onMutate` captures both, so the pair is always a snapshot of THIS call.
+ */
+interface RewindPoint {
+  previous: BudgetDetailsViewModel;
+  optimistic: BudgetDetailsViewModel;
+}
+
+/**
+ * Takes this call's optimistic edits back out of `current`, row by row, leaving
+ * every row a concurrent call has since written. Reference identity is the
+ * discriminator: every optimistic writer in this store maps over the arrays and
+ * hands back the SAME object for the rows it does not touch, so `now === mine`
+ * means "still exactly what I wrote, safe to rewind" and anything else means
+ * "someone wrote this after me, it is theirs". With nothing else in flight
+ * `current` IS `optimistic`, so the result is `previous` — the whole-snapshot
+ * rewind, reached row by row.
+ */
+function rewindRows<T extends { id: string }>(
+  current: readonly T[],
+  previous: readonly T[],
+  optimistic: readonly T[],
+): T[] {
+  const currentById = new Map(current.map((row) => [row.id, row]));
+  const optimisticById = new Map(optimistic.map((row) => [row.id, row]));
+  const rewound: T[] = [];
+
+  // Rows older than this call, kept in their original order.
+  for (const was of previous) {
+    const now = currentById.get(was.id);
+    const mine = optimisticById.get(was.id);
+    if (was === mine) {
+      // Never mine to rewind — including when a sibling has since deleted it.
+      if (now !== undefined) rewound.push(now);
+    } else if (now === mine) {
+      // Mine and untouched since. `undefined === undefined` lands here too: the
+      // row this call optimistically removed comes back, in place.
+      rewound.push(was);
+    } else if (now !== undefined) {
+      rewound.push(now);
+    }
+  }
+
+  // Rows born after this call: drop the ones it added, keep a sibling's.
+  const previousIds = new Set(previous.map((row) => row.id));
+  for (const row of current) {
+    if (!previousIds.has(row.id) && row !== optimisticById.get(row.id)) {
+      rewound.push(row);
+    }
+  }
+
+  return rewound;
+}
+
 const BUDGET_DETAIL_INVALIDATION_KEYS: string[][] = [
   ['budget', 'details'],
   ['budget', 'list'],
@@ -559,149 +627,164 @@ export class BudgetDetailsStore {
 
   // ── 5. Mutations (async/await) ──
 
-  // Every mutation's onError writes its localized message here; every public
-  // method clears it before calling mutate and reads it after. That read is the
-  // ONLY valid failure test: `mutate()` resolves `undefined` on error, but two
-  // of these mutations are typed `void`, so `undefined` is also their success
-  // value — `response !== undefined` would report failure on every success.
+  // Nothing about a call's outcome lives on `this`. Every mutation is a factory
+  // taking the sink its one call reads back from, because a `cachedMutation`
+  // object holds ONE `callCounter` shared by every `mutate()` on it: a call that
+  // is no longer the latest runs NEITHER onSuccess NOR onError, so its rollback
+  // never fires and it writes no message anywhere. Two ids toggled inside one
+  // network window, or a dialog-driven create overlapping a row toggle, are
+  // enough to hit that. A fresh object per call starts its own counter at 0, so
+  // `thisCallId === callCounter` always holds and the callbacks always run.
   //
-  // One field for all of them: everything but the three checks is single-flight
-  // (driven by a dialog), and the three checks — guarded per id by #mutatingIds,
-  // so two ids CAN fail at once — carry a constant message, so concurrent
-  // failures produce the same string and there is nothing to clobber.
-  #lastMutationError: string | null = null;
+  // Reading the sink is also the ONLY valid failure test: `mutate()` resolves
+  // `undefined` on error, but two of these mutations are typed `void`, so
+  // `undefined` is their success value too.
+  //
+  // Because the callbacks now always run, so does every rollback — which is why
+  // none of them restores a whole snapshot any more. `previous` is captured in
+  // `onMutate`, so it predates every write a concurrent call has made since:
+  // replaying it wholesale erases a sibling's ALREADY CONFIRMED row while that
+  // sibling's own `mutate()` has returned success, leaving the user no signal at
+  // all. Nothing heals that on its own — `invalidateKeys` runs on ziflux's
+  // success path, so a failure invalidates nothing. `#rollback` therefore rewinds
+  // per row (see `rewindRows`) and yields any row someone else has written.
+  //
+  // Bounded, deliberate limit: when a sibling has overwritten the very row this
+  // call wrote, the rewind leaves the sibling's value in place rather than
+  // arbitrating between them. That one case does heal — a sibling can only have
+  // written a confirmed row by succeeding, and its success invalidated the
+  // budget keys, so a refetch is already on its way.
 
-  readonly #createBudgetLineMutation = cachedMutation<
-    BudgetLineCreate & { id: string },
-    { data: BudgetLine },
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (budgetLine) => this.#budgetApi.createBudgetLine$(budgetLine),
-    onMutate: (budgetLine) => {
-      const previous = this.budgetDetails();
-      const optimisticLine: BudgetLine = {
-        ...budgetLine,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        templateLineId: null,
-        savingsGoalId: budgetLine.savingsGoalId ?? null,
-        checkedAt: budgetLine.checkedAt ?? null,
-      };
-      this.#updateDetails((details) => ({
-        ...details,
-        budgetLines: [...details.budgetLines, optimisticLine],
-      }));
-      return previous;
-    },
-    onSuccess: (response, budgetLine) => {
-      this.#updateDetails((details) => ({
-        ...details,
-        budgetLines: details.budgetLines.map((line) =>
-          line.id === budgetLine.id ? response.data : line,
-        ),
-      }));
-      this.#onFinancialMutationSuccess();
-    },
-    onError: (error, _args, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#lastMutationError = this.#localizeError(
-        error,
-        'budget.forecastCreateError',
-      );
-      this.#logger.error('Budget line create failed', error);
-    },
-  });
+  readonly #createBudgetLineMutation = (fail: FailSink) =>
+    cachedMutation<
+      BudgetLineCreate & { id: string },
+      { data: BudgetLine },
+      RewindPoint | null
+    >({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (budgetLine) => this.#budgetApi.createBudgetLine$(budgetLine),
+      onMutate: (budgetLine) => {
+        const previous = this.budgetDetails();
+        const optimisticLine: BudgetLine = {
+          ...budgetLine,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          templateLineId: null,
+          savingsGoalId: budgetLine.savingsGoalId ?? null,
+          checkedAt: budgetLine.checkedAt ?? null,
+        };
+        this.#updateDetails((details) => ({
+          ...details,
+          budgetLines: [...details.budgetLines, optimisticLine],
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: (response, budgetLine) => {
+        this.#updateDetails((details) => ({
+          ...details,
+          budgetLines: details.budgetLines.map((line) =>
+            line.id === budgetLine.id ? response.data : line,
+          ),
+        }));
+        this.#onFinancialMutationSuccess();
+      },
+      onError: (error, _args, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#localizeError(error, 'budget.forecastCreateError'));
+        this.#logger.error('Budget line create failed', error);
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async createBudgetLine(input: BudgetLineCreate): Promise<string | null> {
     const id = input.id ?? uuidv4();
-    this.#lastMutationError = null;
-    await this.#createBudgetLineMutation.mutate({ ...input, id });
-    return this.#lastMutationError;
+    const { error } = await this.#runMutation(this.#createBudgetLineMutation, {
+      ...input,
+      id,
+    });
+    return error;
   }
 
   // PUL-17 — a spread fans out across N months (possibly auto-creating budgets),
   // so there is no single-budget optimistic shape to apply. We rely on the
   // cross-budget invalidation to refetch every touched month.
-  readonly #createBudgetLineSpreadMutation = cachedMutation<
-    BudgetLineSpreadCreate,
-    BudgetLineSpreadResponse,
-    void
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (data) => this.#budgetApi.createBudgetLineSpread$(data),
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (error) => this.#handleSpreadError(error),
-  });
+  readonly #createBudgetLineSpreadMutation = (fail: FailSink) =>
+    cachedMutation<BudgetLineSpreadCreate, BudgetLineSpreadResponse, void>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (data) => this.#budgetApi.createBudgetLineSpread$(data),
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (error) => this.#handleSpreadError(fail, error),
+    });
 
   async createBudgetLineSpread(
     input: BudgetLineSpreadCreate,
   ): Promise<MutationOutcome<BudgetLineSpreadResponse['data']>> {
-    this.#lastMutationError = null;
-    const response = await this.#createBudgetLineSpreadMutation.mutate(input);
-    if (this.#lastMutationError !== null) {
-      return { error: this.#lastMutationError };
-    }
-    return { data: response?.data };
+    const { data, error } = await this.#runMutation(
+      this.#createBudgetLineSpreadMutation,
+      input,
+    );
+    return error !== null ? { error } : { data: data?.data };
   }
 
   // PUL-292 — creating the pioche couple fans out across M and M+1 (possibly
   // auto-creating M+1), so there is no single-budget optimistic shape. Like the
   // spread create, we rely on the cross-budget prefix invalidation to refetch
   // every touched month (M's disponible + M+1's new Épargne).
-  readonly #createSavingsWithdrawalMutation = cachedMutation<
-    BudgetLineSavingsWithdrawalCreate,
-    BudgetLineSavingsWithdrawalResponse,
-    void
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (data) => this.#budgetApi.createSavingsWithdrawal$(data),
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (error) => this.#handleSavingsWithdrawalError(error),
-  });
+  readonly #createSavingsWithdrawalMutation = (fail: FailSink) =>
+    cachedMutation<
+      BudgetLineSavingsWithdrawalCreate,
+      BudgetLineSavingsWithdrawalResponse,
+      void
+    >({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (data) => this.#budgetApi.createSavingsWithdrawal$(data),
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (error) => this.#handleSavingsWithdrawalError(fail, error),
+    });
 
   async createSavingsWithdrawal(
     input: BudgetLineSavingsWithdrawalCreate,
   ): Promise<MutationOutcome<BudgetLineSavingsWithdrawalResponse['data']>> {
-    this.#lastMutationError = null;
-    const response = await this.#createSavingsWithdrawalMutation.mutate(input);
-    if (this.#lastMutationError !== null) {
-      return { error: this.#lastMutationError };
-    }
-    return { data: response?.data };
+    const { data, error } = await this.#runMutation(
+      this.#createSavingsWithdrawalMutation,
+      input,
+    );
+    return error !== null ? { error } : { data: data?.data };
   }
 
-  readonly #deleteSavingsWithdrawalMutation = cachedMutation<
-    { groupId: string; scope: BudgetLineSavingsWithdrawalDeleteQuery['scope'] },
-    BudgetLineDeleteResponse,
-    void
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: ({ groupId, scope }) =>
-      this.#budgetApi.deleteSavingsWithdrawal$(groupId, scope),
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (error) => {
-      this.#lastMutationError = this.#localizeError(
-        error,
-        'budget.savingsWithdrawal.error',
-      );
-      this.#logger.error('Savings withdrawal delete failed', error);
-    },
-  });
+  readonly #deleteSavingsWithdrawalMutation = (fail: FailSink) =>
+    cachedMutation<
+      {
+        groupId: string;
+        scope: BudgetLineSavingsWithdrawalDeleteQuery['scope'];
+      },
+      BudgetLineDeleteResponse,
+      void
+    >({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: ({ groupId, scope }) =>
+        this.#budgetApi.deleteSavingsWithdrawal$(groupId, scope),
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (error) => {
+        fail(this.#localizeError(error, 'budget.savingsWithdrawal.error'));
+        this.#logger.error('Savings withdrawal delete failed', error);
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async deleteSavingsWithdrawal(
     groupId: string,
     scope: BudgetLineSavingsWithdrawalDeleteQuery['scope'],
   ): Promise<string | null> {
-    this.#lastMutationError = null;
-    await this.#deleteSavingsWithdrawalMutation.mutate({ groupId, scope });
-    return this.#lastMutationError;
+    const { error } = await this.#runMutation(
+      this.#deleteSavingsWithdrawalMutation,
+      { groupId, scope },
+    );
+    return error;
   }
 
   // PUL-17 v1.1 — total-preserving spread of an EXISTING source (prévision OR
@@ -710,298 +793,277 @@ export class BudgetDetailsStore {
   // source — so no single-budget optimistic shape applies. Cross-budget
   // invalidation refetches every touched month; on success we wire the new
   // spreadGroupId so the occurrences panel can reload.
-  readonly #spreadExistingBudgetLineMutation = cachedMutation<
-    { id: string; periods: SpreadFromExistingPeriod[] },
-    BudgetLineSpreadResponse,
-    void
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: ({ id, periods }) =>
-      this.#budgetApi.spreadExistingBudgetLine$(id, periods),
-    onSuccess: (response) => {
-      this.setSpreadGroupId(response.data.spreadGroupId);
-      this.#onFinancialMutationSuccess();
-    },
-    onError: (error) => this.#handleSpreadError(error),
-  });
+  readonly #spreadExistingBudgetLineMutation = (fail: FailSink) =>
+    cachedMutation<
+      { id: string; periods: SpreadFromExistingPeriod[] },
+      BudgetLineSpreadResponse,
+      void
+    >({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: ({ id, periods }) =>
+        this.#budgetApi.spreadExistingBudgetLine$(id, periods),
+      onSuccess: (response) => {
+        this.setSpreadGroupId(response.data.spreadGroupId);
+        this.#onFinancialMutationSuccess();
+      },
+      onError: (error) => this.#handleSpreadError(fail, error),
+    });
 
   async spreadExistingBudgetLine(
     id: string,
     periods: SpreadFromExistingPeriod[],
   ): Promise<MutationOutcome<BudgetLineSpreadResponse['data']>> {
-    this.#lastMutationError = null;
-    const response = await this.#spreadExistingBudgetLineMutation.mutate({
-      id,
-      periods,
-    });
-    if (this.#lastMutationError !== null) {
-      return { error: this.#lastMutationError };
-    }
-    return { data: response?.data };
+    const { data, error } = await this.#runMutation(
+      this.#spreadExistingBudgetLineMutation,
+      { id, periods },
+    );
+    return error !== null ? { error } : { data: data?.data };
   }
 
-  readonly #spreadExistingTransactionMutation = cachedMutation<
-    { id: string; periods: SpreadFromExistingPeriod[] },
-    BudgetLineSpreadResponse,
-    void
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: ({ id, periods }) =>
-      this.#budgetApi.spreadExistingTransaction$(id, periods),
-    onSuccess: (response) => {
-      this.setSpreadGroupId(response.data.spreadGroupId);
-      this.#onFinancialMutationSuccess();
-    },
-    onError: (error) => this.#handleSpreadError(error),
-  });
+  readonly #spreadExistingTransactionMutation = (fail: FailSink) =>
+    cachedMutation<
+      { id: string; periods: SpreadFromExistingPeriod[] },
+      BudgetLineSpreadResponse,
+      void
+    >({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: ({ id, periods }) =>
+        this.#budgetApi.spreadExistingTransaction$(id, periods),
+      onSuccess: (response) => {
+        this.setSpreadGroupId(response.data.spreadGroupId);
+        this.#onFinancialMutationSuccess();
+      },
+      onError: (error) => this.#handleSpreadError(fail, error),
+    });
 
   async spreadExistingTransaction(
     id: string,
     periods: SpreadFromExistingPeriod[],
   ): Promise<MutationOutcome<BudgetLineSpreadResponse['data']>> {
-    this.#lastMutationError = null;
-    const response = await this.#spreadExistingTransactionMutation.mutate({
-      id,
-      periods,
-    });
-    if (this.#lastMutationError !== null) {
-      return { error: this.#lastMutationError };
-    }
-    return { data: response?.data };
+    const { data, error } = await this.#runMutation(
+      this.#spreadExistingTransactionMutation,
+      { id, periods },
+    );
+    return error !== null ? { error } : { data: data?.data };
   }
 
-  readonly #updateBudgetLineMutation = cachedMutation<
-    BudgetLineUpdate,
-    { data: BudgetLine },
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (data) => this.#budgetApi.updateBudgetLine$(data.id, data),
-    onMutate: (data) => {
-      const previous = this.budgetDetails();
-      this.#updateDetails((details) => ({
-        ...details,
-        budgetLines: details.budgetLines.map((line) =>
-          line.id === data.id
-            ? { ...line, ...data, updatedAt: new Date().toISOString() }
-            : line,
-        ),
-      }));
-      return previous;
-    },
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (error, _args, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#lastMutationError = this.#localizeError(
-        error,
-        'budget.forecastUpdateError',
-      );
-      this.#logger.error('Budget line update failed', error);
-    },
-  });
+  readonly #updateBudgetLineMutation = (fail: FailSink) =>
+    cachedMutation<BudgetLineUpdate, { data: BudgetLine }, RewindPoint | null>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (data) => this.#budgetApi.updateBudgetLine$(data.id, data),
+      onMutate: (data) => {
+        const previous = this.budgetDetails();
+        this.#updateDetails((details) => ({
+          ...details,
+          budgetLines: details.budgetLines.map((line) =>
+            line.id === data.id
+              ? { ...line, ...data, updatedAt: new Date().toISOString() }
+              : line,
+          ),
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (error, _args, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#localizeError(error, 'budget.forecastUpdateError'));
+        this.#logger.error('Budget line update failed', error);
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async updateBudgetLine(data: BudgetLineUpdate): Promise<string | null> {
-    this.#lastMutationError = null;
-    await this.#updateBudgetLineMutation.mutate(data);
-    return this.#lastMutationError;
+    const { error } = await this.#runMutation(
+      this.#updateBudgetLineMutation,
+      data,
+    );
+    return error;
   }
 
-  readonly #updateTransactionMutation = cachedMutation<
-    { id: string; data: TransactionUpdate },
-    { data: Transaction },
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: ({ id, data }) => this.#budgetApi.updateTransaction$(id, data),
-    onMutate: ({ id, data }) => {
-      const previous = this.budgetDetails();
-      this.#updateDetails((details) => ({
-        ...details,
-        transactions: details.transactions.map((tx) =>
-          tx.id === id
-            ? { ...tx, ...data, updatedAt: new Date().toISOString() }
-            : tx,
-        ),
-      }));
-      return previous;
-    },
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (_err, _args, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#failMutation(
-        this.#transloco.translate('budget.transactionUpdateError'),
-      );
-    },
-  });
+  readonly #updateTransactionMutation = (fail: FailSink) =>
+    cachedMutation<
+      { id: string; data: TransactionUpdate },
+      { data: Transaction },
+      RewindPoint | null
+    >({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: ({ id, data }) =>
+        this.#budgetApi.updateTransaction$(id, data),
+      onMutate: ({ id, data }) => {
+        const previous = this.budgetDetails();
+        this.#updateDetails((details) => ({
+          ...details,
+          transactions: details.transactions.map((tx) =>
+            tx.id === id
+              ? { ...tx, ...data, updatedAt: new Date().toISOString() }
+              : tx,
+          ),
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (_err, _args, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#transloco.translate('budget.transactionUpdateError'));
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async updateTransaction(
     id: string,
     data: TransactionUpdate,
   ): Promise<string | null> {
-    this.#lastMutationError = null;
-    await this.#updateTransactionMutation.mutate({ id, data });
-    return this.#lastMutationError;
+    const { error } = await this.#runMutation(this.#updateTransactionMutation, {
+      id,
+      data,
+    });
+    return error;
   }
 
-  readonly #deleteBudgetLineMutation = cachedMutation<
-    string,
-    void,
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (id) =>
-      this.#budgetApi.deleteBudgetLine$(id).pipe(map(() => void 0 as void)),
-    onMutate: (id) => {
-      const previous = this.budgetDetails();
-      this.#updateDetails((details) => ({
-        ...details,
-        budgetLines: details.budgetLines.filter((line) => line.id !== id),
-        transactions: details.transactions.map((tx) =>
-          tx.budgetLineId === id ? { ...tx, budgetLineId: null } : tx,
-        ),
-      }));
-      return previous;
-    },
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (_err, _args, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#failMutation(
-        this.#transloco.translate('budget.forecastDeleteError'),
-      );
-    },
-  });
+  readonly #deleteBudgetLineMutation = (fail: FailSink) =>
+    cachedMutation<string, void, RewindPoint | null>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (id) =>
+        this.#budgetApi.deleteBudgetLine$(id).pipe(map(() => void 0 as void)),
+      onMutate: (id) => {
+        const previous = this.budgetDetails();
+        this.#updateDetails((details) => ({
+          ...details,
+          budgetLines: details.budgetLines.filter((line) => line.id !== id),
+          transactions: details.transactions.map((tx) =>
+            tx.budgetLineId === id ? { ...tx, budgetLineId: null } : tx,
+          ),
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (_err, _args, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#transloco.translate('budget.forecastDeleteError'));
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async deleteBudgetLine(id: string): Promise<string | null> {
-    this.#lastMutationError = null;
-    await this.#deleteBudgetLineMutation.mutate(id);
-    return this.#lastMutationError;
+    const { error } = await this.#runMutation(
+      this.#deleteBudgetLineMutation,
+      id,
+    );
+    return error;
   }
 
-  readonly #deleteTransactionMutation = cachedMutation<
-    string,
-    void,
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (id) =>
-      this.#budgetApi.deleteTransaction$(id).pipe(map(() => void 0 as void)),
-    onMutate: (id) => {
-      const previous = this.budgetDetails();
-      this.#updateDetails((details) => ({
-        ...details,
-        transactions: details.transactions.filter((tx) => tx.id !== id),
-      }));
-      return previous;
-    },
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (_err, _args, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#failMutation(
-        this.#transloco.translate('budget.transactionDeleteError'),
-      );
-    },
-  });
+  readonly #deleteTransactionMutation = (fail: FailSink) =>
+    cachedMutation<string, void, RewindPoint | null>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (id) =>
+        this.#budgetApi.deleteTransaction$(id).pipe(map(() => void 0 as void)),
+      onMutate: (id) => {
+        const previous = this.budgetDetails();
+        this.#updateDetails((details) => ({
+          ...details,
+          transactions: details.transactions.filter((tx) => tx.id !== id),
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (_err, _args, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#transloco.translate('budget.transactionDeleteError'));
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async deleteTransaction(id: string): Promise<string | null> {
-    this.#lastMutationError = null;
-    await this.#deleteTransactionMutation.mutate(id);
-    return this.#lastMutationError;
+    const { error } = await this.#runMutation(
+      this.#deleteTransactionMutation,
+      id,
+    );
+    return error;
   }
 
-  readonly #createAllocatedTransactionMutation = cachedMutation<
-    TransactionCreate & { id: string },
-    { data: Transaction },
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (data) => this.#budgetApi.createTransaction$(data),
-    onMutate: (data) => {
-      const previous = this.budgetDetails();
-      const optimisticTransaction: Transaction = {
-        ...data,
-        budgetLineId: data.budgetLineId ?? null,
-        transactionDate: data.transactionDate ?? formatLocalDate(new Date()),
-        tagIds: data.tagIds,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        checkedAt: data.checkedAt ?? null,
-      };
-      this.#updateDetails((details) => ({
-        ...details,
-        transactions: [...details.transactions, optimisticTransaction],
-      }));
-      return previous;
-    },
-    onSuccess: (response, data) => {
-      this.#updateDetails((details) => ({
-        ...details,
-        transactions: details.transactions.map((tx) =>
-          tx.id === data.id
-            ? {
-                ...response.data,
-                checkedAt: tx.checkedAt ?? response.data.checkedAt,
-              }
-            : tx,
-        ),
-      }));
-      this.#onFinancialMutationSuccess();
-    },
-    onError: (_err, _args, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#failMutation(
-        this.#transloco.translate('budget.transactionCreateError'),
-      );
-    },
-  });
+  readonly #createAllocatedTransactionMutation = (fail: FailSink) =>
+    cachedMutation<
+      TransactionCreate & { id: string },
+      { data: Transaction },
+      RewindPoint | null
+    >({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (data) => this.#budgetApi.createTransaction$(data),
+      onMutate: (data) => {
+        const previous = this.budgetDetails();
+        const optimisticTransaction: Transaction = {
+          ...data,
+          budgetLineId: data.budgetLineId ?? null,
+          transactionDate: data.transactionDate ?? formatLocalDate(new Date()),
+          tagIds: data.tagIds,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          checkedAt: data.checkedAt ?? null,
+        };
+        this.#updateDetails((details) => ({
+          ...details,
+          transactions: [...details.transactions, optimisticTransaction],
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: (response, data) => {
+        this.#updateDetails((details) => ({
+          ...details,
+          transactions: details.transactions.map((tx) =>
+            tx.id === data.id
+              ? {
+                  ...response.data,
+                  checkedAt: tx.checkedAt ?? response.data.checkedAt,
+                }
+              : tx,
+          ),
+        }));
+        this.#onFinancialMutationSuccess();
+      },
+      onError: (_err, _args, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#transloco.translate('budget.transactionCreateError'));
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async createAllocatedTransaction(
     transactionData: TransactionCreate,
   ): Promise<string | null> {
     const id = transactionData.id ?? uuidv4();
-    this.#lastMutationError = null;
-    await this.#createAllocatedTransactionMutation.mutate({
-      ...transactionData,
-      id,
-    });
-    return this.#lastMutationError;
+    const { error } = await this.#runMutation(
+      this.#createAllocatedTransactionMutation,
+      { ...transactionData, id },
+    );
+    return error;
   }
 
-  readonly #resetBudgetLineMutation = cachedMutation<
-    string,
-    { data: BudgetLine },
-    void
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (id) => this.#budgetApi.resetBudgetLineFromTemplate$(id),
-    onSuccess: (response, id) => {
-      this.#updateDetails((details) => ({
-        ...details,
-        budgetLines: details.budgetLines.map((line) =>
-          line.id === id ? response.data : line,
-        ),
-      }));
-      this.#onFinancialMutationSuccess();
-    },
-    onError: (error) => {
-      this.#failMutation(
-        this.#localizeError(error, 'budget.forecastResetError'),
-      );
-      this.#logger.error('Error resetting budget line from template', error);
-    },
-  });
+  readonly #resetBudgetLineMutation = (fail: FailSink) =>
+    cachedMutation<string, { data: BudgetLine }, void>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (id) => this.#budgetApi.resetBudgetLineFromTemplate$(id),
+      onSuccess: (response, id) => {
+        this.#updateDetails((details) => ({
+          ...details,
+          budgetLines: details.budgetLines.map((line) =>
+            line.id === id ? response.data : line,
+          ),
+        }));
+        this.#onFinancialMutationSuccess();
+      },
+      onError: (error) => {
+        fail(this.#localizeError(error, 'budget.forecastResetError'));
+        this.#logger.error('Error resetting budget line from template', error);
+      },
+    });
 
   /**
    * Returns the localized error message on failure, or `null` on success.
@@ -1011,129 +1073,114 @@ export class BudgetDetailsStore {
   async resetBudgetLineFromTemplate(id: string): Promise<string | null> {
     if (this.#mutatingIds.has(id)) return null;
     this.#mutatingIds.add(id);
-    this.#lastMutationError = null;
     try {
-      await this.#resetBudgetLineMutation.mutate(id);
-      return this.#lastMutationError;
+      return (await this.#runMutation(this.#resetBudgetLineMutation, id)).error;
     } finally {
       this.#mutatingIds.delete(id);
     }
   }
 
-  readonly #postponeBudgetLineMutation = cachedMutation<
-    string,
-    BudgetLinePostponeResponse,
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (id) => this.#budgetApi.postponeBudgetLine$(id),
-    // Optimistically remove the line — it moved to next month's budget.
-    onMutate: (id) => {
-      const previous = this.budgetDetails();
-      this.#updateDetails((details) => ({
-        ...details,
-        budgetLines: details.budgetLines.filter((line) => line.id !== id),
-      }));
-      return previous;
-    },
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (error, _id, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#handlePostponeError(error);
-    },
-  });
+  readonly #postponeBudgetLineMutation = (fail: FailSink) =>
+    cachedMutation<string, BudgetLinePostponeResponse, RewindPoint | null>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (id) => this.#budgetApi.postponeBudgetLine$(id),
+      // Optimistically remove the line — it moved to next month's budget.
+      onMutate: (id) => {
+        const previous = this.budgetDetails();
+        this.#updateDetails((details) => ({
+          ...details,
+          budgetLines: details.budgetLines.filter((line) => line.id !== id),
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (error, _id, rewind) => {
+        this.#rollback(rewind);
+        this.#handlePostponeError(fail, error);
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async postponeBudgetLine(id: string): Promise<string | null> {
     if (this.#mutatingIds.has(id)) return null;
     this.#mutatingIds.add(id);
-    this.#lastMutationError = null;
     try {
-      await this.#postponeBudgetLineMutation.mutate(id);
-      return this.#lastMutationError;
+      return (await this.#runMutation(this.#postponeBudgetLineMutation, id))
+        .error;
     } finally {
       this.#mutatingIds.delete(id);
     }
   }
 
-  readonly #postponeTransactionMutation = cachedMutation<
-    string,
-    TransactionPostponeResponse,
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (id) => this.#budgetApi.postponeTransaction$(id),
-    // Optimistically remove the transaction — it moved to next month's budget.
-    onMutate: (id) => {
-      const previous = this.budgetDetails();
-      this.#updateDetails((details) => ({
-        ...details,
-        transactions: details.transactions.filter((tx) => tx.id !== id),
-      }));
-      return previous;
-    },
-    onSuccess: () => this.#onFinancialMutationSuccess(),
-    onError: (error, _id, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#handlePostponeError(error);
-    },
-  });
+  readonly #postponeTransactionMutation = (fail: FailSink) =>
+    cachedMutation<string, TransactionPostponeResponse, RewindPoint | null>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (id) => this.#budgetApi.postponeTransaction$(id),
+      // Optimistically remove the transaction — it moved to next month's budget.
+      onMutate: (id) => {
+        const previous = this.budgetDetails();
+        this.#updateDetails((details) => ({
+          ...details,
+          transactions: details.transactions.filter((tx) => tx.id !== id),
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: () => this.#onFinancialMutationSuccess(),
+      onError: (error, _id, rewind) => {
+        this.#rollback(rewind);
+        this.#handlePostponeError(fail, error);
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async postponeTransaction(id: string): Promise<string | null> {
     if (this.#mutatingIds.has(id)) return null;
     this.#mutatingIds.add(id);
-    this.#lastMutationError = null;
     try {
-      await this.#postponeTransactionMutation.mutate(id);
-      return this.#lastMutationError;
+      return (await this.#runMutation(this.#postponeTransactionMutation, id))
+        .error;
     } finally {
       this.#mutatingIds.delete(id);
     }
   }
 
-  readonly #toggleCheckMutation = cachedMutation<
-    string,
-    { data: BudgetLine },
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (id) => this.#budgetApi.toggleBudgetLineCheck$(id),
-    onMutate: (id) => {
-      const details = this.budgetDetails();
-      if (!details) return null;
-      const result = calculateBudgetLineToggle(id, {
-        budgetLines: details.budgetLines,
-        transactions: details.transactions,
-      });
-      if (!result) return null;
-      const previous = details;
-      this.#updateDetails((d) => ({
-        ...d,
-        budgetLines: result.updatedBudgetLines,
-        transactions: result.updatedTransactions,
-      }));
-      return previous;
-    },
-    onSuccess: (response, id) => {
-      this.#updateDetails((d) => ({
-        ...d,
-        budgetLines: d.budgetLines.map((line) =>
-          line.id === id ? response.data : line,
-        ),
-      }));
-      this.#onFinancialMutationSuccess();
-    },
-    onError: (_err, _id, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#failMutation(
-        this.#transloco.translate('budget.forecastToggleError'),
-      );
-    },
-  });
+  readonly #toggleCheckMutation = (fail: FailSink) =>
+    cachedMutation<string, { data: BudgetLine }, RewindPoint | null>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (id) => this.#budgetApi.toggleBudgetLineCheck$(id),
+      onMutate: (id) => {
+        const details = this.budgetDetails();
+        if (!details) return null;
+        const result = calculateBudgetLineToggle(id, {
+          budgetLines: details.budgetLines,
+          transactions: details.transactions,
+        });
+        if (!result) return null;
+        const previous = details;
+        this.#updateDetails((d) => ({
+          ...d,
+          budgetLines: result.updatedBudgetLines,
+          transactions: result.updatedTransactions,
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: (response, id) => {
+        this.#updateDetails((d) => ({
+          ...d,
+          budgetLines: d.budgetLines.map((line) =>
+            line.id === id ? response.data : line,
+          ),
+        }));
+        this.#onFinancialMutationSuccess();
+      },
+      onError: (_err, _id, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#transloco.translate('budget.forecastToggleError'));
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async toggleCheck(id: string): Promise<string | null> {
@@ -1146,119 +1193,108 @@ export class BudgetDetailsStore {
     if (!lineExists) return null;
 
     this.#mutatingIds.add(id);
-    this.#lastMutationError = null;
     try {
-      await this.#toggleCheckMutation.mutate(id);
-      return this.#lastMutationError;
+      return (await this.#runMutation(this.#toggleCheckMutation, id)).error;
     } finally {
       this.#mutatingIds.delete(id);
     }
   }
 
-  readonly #toggleTransactionCheckMutation = cachedMutation<
-    string,
-    { data: Transaction },
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (id) => this.#budgetApi.toggleTransactionCheck$(id),
-    onMutate: (id) => {
-      const details = this.budgetDetails();
-      if (!details) return null;
-      const result = calculateTransactionToggle(id, {
-        budgetLines: details.budgetLines,
-        transactions: details.transactions,
-      });
-      if (!result) return null;
-      const previous = details;
-      this.#updateDetails((d) => ({
-        ...d,
-        transactions: result.updatedTransactions,
-      }));
-      return previous;
-    },
-    onSuccess: (response, id) => {
-      this.#updateDetails((d) => ({
-        ...d,
-        transactions: d.transactions.map((tx) =>
-          tx.id === id ? response.data : tx,
-        ),
-      }));
-      this.#onFinancialMutationSuccess();
-    },
-    onError: (_err, _id, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#failMutation(
-        this.#transloco.translate('budget.transactionToggleError'),
-      );
-    },
-  });
+  readonly #toggleTransactionCheckMutation = (fail: FailSink) =>
+    cachedMutation<string, { data: Transaction }, RewindPoint | null>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (id) => this.#budgetApi.toggleTransactionCheck$(id),
+      onMutate: (id) => {
+        const details = this.budgetDetails();
+        if (!details) return null;
+        const result = calculateTransactionToggle(id, {
+          budgetLines: details.budgetLines,
+          transactions: details.transactions,
+        });
+        if (!result) return null;
+        const previous = details;
+        this.#updateDetails((d) => ({
+          ...d,
+          transactions: result.updatedTransactions,
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: (response, id) => {
+        this.#updateDetails((d) => ({
+          ...d,
+          transactions: d.transactions.map((tx) =>
+            tx.id === id ? response.data : tx,
+          ),
+        }));
+        this.#onFinancialMutationSuccess();
+      },
+      onError: (_err, _id, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#transloco.translate('budget.transactionToggleError'));
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async toggleTransactionCheck(id: string): Promise<string | null> {
     if (this.#mutatingIds.has(id)) return null;
     this.#mutatingIds.add(id);
-    this.#lastMutationError = null;
     try {
-      await this.#toggleTransactionCheckMutation.mutate(id);
-      return this.#lastMutationError;
+      return (await this.#runMutation(this.#toggleTransactionCheckMutation, id))
+        .error;
     } finally {
       this.#mutatingIds.delete(id);
     }
   }
 
-  readonly #checkAllAllocatedMutation = cachedMutation<
-    string,
-    TransactionListResponse,
-    BudgetDetailsViewModel | null
-  >({
-    cache: this.#budgetApi.cache,
-    invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
-    mutationFn: (budgetLineId) =>
-      this.#budgetApi.checkBudgetLineTransactions$(budgetLineId),
-    onMutate: (budgetLineId) => {
-      const details = this.budgetDetails();
-      if (!details) return null;
-      const previous = details;
-      const now = new Date().toISOString();
-      const uncheckedIds = new Set(
-        details.transactions
-          .filter(
-            (tx) => tx.budgetLineId === budgetLineId && tx.checkedAt === null,
-          )
-          .map((tx) => tx.id),
-      );
-      if (uncheckedIds.size === 0) return null;
-      this.#updateDetails((d) => ({
-        ...d,
-        budgetLines: d.budgetLines.map((line) =>
-          line.id === budgetLineId
-            ? { ...line, checkedAt: line.checkedAt ?? now, updatedAt: now }
-            : line,
-        ),
-        transactions: d.transactions.map((tx) =>
-          uncheckedIds.has(tx.id) ? { ...tx, checkedAt: now } : tx,
-        ),
-      }));
-      return previous;
-    },
-    onSuccess: (response) => {
-      const responseMap = new Map(response.data.map((tx) => [tx.id, tx]));
-      this.#updateDetails((d) => ({
-        ...d,
-        transactions: d.transactions.map((tx) => {
-          const serverTx = responseMap.get(tx.id);
-          return serverTx ? { ...tx, checkedAt: serverTx.checkedAt } : tx;
-        }),
-      }));
-      this.#onFinancialMutationSuccess();
-    },
-    onError: (_err, _id, previous) => {
-      if (previous) this.#budgetDetailsResource.set(previous);
-      this.#failMutation(this.#transloco.translate('budget.checkAllError'));
-    },
-  });
+  readonly #checkAllAllocatedMutation = (fail: FailSink) =>
+    cachedMutation<string, TransactionListResponse, RewindPoint | null>({
+      cache: this.#budgetApi.cache,
+      invalidateKeys: () => BUDGET_DETAIL_INVALIDATION_KEYS,
+      mutationFn: (budgetLineId) =>
+        this.#budgetApi.checkBudgetLineTransactions$(budgetLineId),
+      onMutate: (budgetLineId) => {
+        const details = this.budgetDetails();
+        if (!details) return null;
+        const previous = details;
+        const now = new Date().toISOString();
+        const uncheckedIds = new Set(
+          details.transactions
+            .filter(
+              (tx) => tx.budgetLineId === budgetLineId && tx.checkedAt === null,
+            )
+            .map((tx) => tx.id),
+        );
+        if (uncheckedIds.size === 0) return null;
+        this.#updateDetails((d) => ({
+          ...d,
+          budgetLines: d.budgetLines.map((line) =>
+            line.id === budgetLineId
+              ? { ...line, checkedAt: line.checkedAt ?? now, updatedAt: now }
+              : line,
+          ),
+          transactions: d.transactions.map((tx) =>
+            uncheckedIds.has(tx.id) ? { ...tx, checkedAt: now } : tx,
+          ),
+        }));
+        return this.#rewindPoint(previous);
+      },
+      onSuccess: (response) => {
+        const responseMap = new Map(response.data.map((tx) => [tx.id, tx]));
+        this.#updateDetails((d) => ({
+          ...d,
+          transactions: d.transactions.map((tx) => {
+            const serverTx = responseMap.get(tx.id);
+            return serverTx ? { ...tx, checkedAt: serverTx.checkedAt } : tx;
+          }),
+        }));
+        this.#onFinancialMutationSuccess();
+      },
+      onError: (_err, _id, rewind) => {
+        this.#rollback(rewind);
+        fail(this.#transloco.translate('budget.checkAllError'));
+      },
+    });
 
   /** Returns the localized error message on failure, or `null` on success. */
   async checkAllAllocatedTransactions(
@@ -1272,10 +1308,10 @@ export class BudgetDetailsStore {
     );
     if (!hasUnchecked) return null;
     this.#mutatingIds.add(budgetLineId);
-    this.#lastMutationError = null;
     try {
-      await this.#checkAllAllocatedMutation.mutate(budgetLineId);
-      return this.#lastMutationError;
+      return (
+        await this.#runMutation(this.#checkAllAllocatedMutation, budgetLineId)
+      ).error;
     } finally {
       this.#mutatingIds.delete(budgetLineId);
     }
@@ -1287,6 +1323,49 @@ export class BudgetDetailsStore {
 
   // ── 6. Private utility methods ──
 
+  /**
+   * Runs ONE call of `factory` and hands back both halves of its outcome: the
+   * response it resolved and the localized reason it refused. The sink lives
+   * here, in the call frame, which is what keeps a call's outcome off `this` —
+   * overlapping calls each read their own cell. Public methods project this into
+   * whichever shape they promise: `.error` alone, or the pair.
+   */
+  async #runMutation<TArgs, TResponse>(
+    factory: MutationFactory<TArgs, TResponse>,
+    args: TArgs,
+  ): Promise<{ data: TResponse | undefined; error: string | null }> {
+    let error: string | null = null;
+    const mutation = factory((message) => {
+      error = message;
+    });
+    const data = await mutation.mutate(args);
+    return { data, error };
+  }
+
+  /** The pair `#rollback` needs, or `null` when there is nothing to undo. */
+  #rewindPoint(previous: BudgetDetailsViewModel | null): RewindPoint | null {
+    const optimistic = this.budgetDetails();
+    return previous && optimistic ? { previous, optimistic } : null;
+  }
+
+  #rollback(rewind: RewindPoint | null | undefined): void {
+    if (!rewind) return;
+    const { previous, optimistic } = rewind;
+    this.#updateDetails((current) => ({
+      ...current,
+      budgetLines: rewindRows(
+        current.budgetLines,
+        previous.budgetLines,
+        optimistic.budgetLines,
+      ),
+      transactions: rewindRows(
+        current.transactions,
+        previous.transactions,
+        optimistic.transactions,
+      ),
+    }));
+  }
+
   #updateDetails(
     fn: (details: BudgetDetailsViewModel) => BudgetDetailsViewModel,
   ): void {
@@ -1297,16 +1376,12 @@ export class BudgetDetailsStore {
     });
   }
 
-  #failMutation(message: string): void {
-    this.#lastMutationError = message;
-  }
-
   // Shared failure path for the 2 postpone mutations (mirrors #handleSpreadError):
   // localize via the common helper, then log only UNEXPECTED (non-API) errors —
   // expected business errors (already-checked, concurrent-mod) are surfaced to
   // the user, not logged as noise.
-  #handlePostponeError(error: unknown): void {
-    this.#failMutation(this.#localizeError(error, 'budget.postponeError'));
+  #handlePostponeError(fail: FailSink, error: unknown): void {
+    fail(this.#localizeError(error, 'budget.postponeError'));
     if (!isApiError(error)) {
       this.#logger.error('Error postponing item to next month', error);
     }
@@ -1321,17 +1396,15 @@ export class BudgetDetailsStore {
   }
 
   // Shared failure path for the 3 spread mutations (identical key + log).
-  #handleSpreadError(error: unknown): void {
-    this.#failMutation(this.#localizeError(error, 'budgetLine.spread.error'));
+  #handleSpreadError(fail: FailSink, error: unknown): void {
+    fail(this.#localizeError(error, 'budgetLine.spread.error'));
     this.#logger.error('Spread mutation failed', error);
   }
 
   // Shared failure path for the 2 savings-withdrawal mutations (PUL-292):
   // localize a typed ApiError via its code, else fall back to the generic key.
-  #handleSavingsWithdrawalError(error: unknown): void {
-    this.#failMutation(
-      this.#localizeError(error, 'budget.savingsWithdrawal.error'),
-    );
+  #handleSavingsWithdrawalError(fail: FailSink, error: unknown): void {
+    fail(this.#localizeError(error, 'budget.savingsWithdrawal.error'));
     this.#logger.error('Savings withdrawal mutation failed', error);
   }
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/store/budget-details-store.ts
@@ -240,24 +240,27 @@ export class BudgetDetailsStore {
       const id = this.#state.budgetId();
       return id ? { budgetId: id } : undefined;
     },
-    loader: async ({ params }) => {
-      const response = await firstValueFrom(
-        this.#budgetApi.getBudgetWithDetails$(params.budgetId),
-      );
+    // The Observable is handed straight to the loader rather than awaited: only
+    // that form lets the resource unsubscribe on `abortSignal`, so switching
+    // budgets cancels the request for the one being left instead of letting it
+    // run to completion.
+    loader: ({ params }) =>
+      this.#budgetApi.getBudgetWithDetails$(params.budgetId).pipe(
+        map((response) => {
+          if (!response.success || !response.data) {
+            this.#logger.error('Failed to fetch budget details', {
+              budgetId: params.budgetId,
+            });
+            throw new Error('Failed to fetch budget details');
+          }
 
-      if (!response.success || !response.data) {
-        this.#logger.error('Failed to fetch budget details', {
-          budgetId: params.budgetId,
-        });
-        throw new Error('Failed to fetch budget details');
-      }
-
-      return {
-        ...response.data.budget,
-        budgetLines: response.data.budgetLines,
-        transactions: response.data.transactions,
-      };
-    },
+          return {
+            ...response.data.budget,
+            budgetLines: response.data.budgetLines,
+            transactions: response.data.transactions,
+          };
+        }),
+      ),
   });
 
   readonly #allBudgetsResource = cachedResource({

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.spec.ts
@@ -259,9 +259,7 @@ describe('submitSpreadWithRetry', () => {
       .mockReturnValue({ onAction: () => new Subject<void>() });
     const snackBar = { open } as unknown as MatSnackBar;
     const create = vi.fn().mockResolvedValue({
-      lines: [{}],
-      createdBudgets: [],
-      skippedMonths: [],
+      data: { lines: [{}], createdBudgets: [], skippedMonths: [] },
     });
 
     await submitSpreadWithRetry(spreadValue, create, snackBar, transloco);
@@ -276,7 +274,7 @@ describe('submitSpreadWithRetry', () => {
     const action$ = new Subject<void>();
     const open = vi.fn().mockReturnValue({ onAction: () => action$ });
     const snackBar = { open } as unknown as MatSnackBar;
-    const create = vi.fn().mockResolvedValue(undefined);
+    const create = vi.fn().mockResolvedValue({});
 
     await submitSpreadWithRetry(spreadValue, create, snackBar, transloco);
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.spec.ts
@@ -274,7 +274,7 @@ describe('submitSpreadWithRetry', () => {
     const action$ = new Subject<void>();
     const open = vi.fn().mockReturnValue({ onAction: () => action$ });
     const snackBar = { open } as unknown as MatSnackBar;
-    const create = vi.fn().mockResolvedValue({});
+    const create = vi.fn().mockResolvedValue({ retryable: true });
 
     await submitSpreadWithRetry(spreadValue, create, snackBar, transloco);
 
@@ -293,23 +293,28 @@ describe('submitSpreadWithRetry', () => {
     expect(create).toHaveBeenNthCalledWith(2, spreadValue);
   });
 
-  it('carries the server motive instead of the generic spread key', async () => {
+  // A horizon refusal is a verdict on this exact body: replaying it earns the
+  // same 422, so the action must not invite the user into that loop.
+  it('carries the server motive and closes instead of retrying a refusal', async () => {
     const transloco = createMockTransloco();
-    const open = vi
-      .fn()
-      .mockReturnValue({ onAction: () => new Subject<void>() });
+    const action$ = new Subject<void>();
+    const open = vi.fn().mockReturnValue({ onAction: () => action$ });
     const snackBar = { open } as unknown as MatSnackBar;
     const create = vi.fn().mockResolvedValue({
       error: "Cette épargne dépasse l'horizon de ton objectif",
+      retryable: false,
     });
 
     await submitSpreadWithRetry(spreadValue, create, snackBar, transloco);
 
     expect(open).toHaveBeenLastCalledWith(
       "Cette épargne dépasse l'horizon de ton objectif",
-      'common.retry',
+      'common.close',
       expect.objectContaining({ duration: 8000 }),
     );
+
+    action$.next();
+    expect(create).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.spec.ts
@@ -292,6 +292,25 @@ describe('submitSpreadWithRetry', () => {
     expect(create).toHaveBeenCalledTimes(2);
     expect(create).toHaveBeenNthCalledWith(2, spreadValue);
   });
+
+  it('carries the server motive instead of the generic spread key', async () => {
+    const transloco = createMockTransloco();
+    const open = vi
+      .fn()
+      .mockReturnValue({ onAction: () => new Subject<void>() });
+    const snackBar = { open } as unknown as MatSnackBar;
+    const create = vi.fn().mockResolvedValue({
+      error: "Cette épargne dépasse l'horizon de ton objectif",
+    });
+
+    await submitSpreadWithRetry(spreadValue, create, snackBar, transloco);
+
+    expect(open).toHaveBeenLastCalledWith(
+      "Cette épargne dépasse l'horizon de ton objectif",
+      'common.retry',
+      expect.objectContaining({ duration: 8000 }),
+    );
+  });
 });
 
 describe('computeTransactionSnackbarMessage', () => {

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.ts
@@ -11,6 +11,7 @@ import type {
 } from 'pulpe-shared';
 
 import { AppCurrencyPipe } from '@core/currency';
+import type { MutationOutcome } from '../store/budget-details-store';
 
 const currencyPipe = new AppCurrencyPipe();
 
@@ -76,14 +77,14 @@ export async function submitSpreadWithRetry(
   value: BudgetLineSpreadCreate,
   create: (
     value: BudgetLineSpreadCreate,
-  ) => Promise<BudgetLineSpreadResponse['data'] | undefined>,
+  ) => Promise<MutationOutcome<BudgetLineSpreadResponse['data']>>,
   snackBar: MatSnackBar,
   transloco: TranslocoService,
 ): Promise<void> {
   const outcome = await create(value);
-  if (outcome) {
+  if (outcome.data) {
     snackBar.open(
-      computeSpreadSnackbarMessage(outcome, transloco),
+      computeSpreadSnackbarMessage(outcome.data, transloco),
       transloco.translate('common.close'),
       { duration: 5000 },
     );
@@ -130,12 +131,12 @@ export async function submitSavingsWithdrawalWithRetry(
   value: BudgetLineSavingsWithdrawalCreate,
   create: (
     value: BudgetLineSavingsWithdrawalCreate,
-  ) => Promise<BudgetLineSavingsWithdrawalResponse['data'] | undefined>,
+  ) => Promise<MutationOutcome<BudgetLineSavingsWithdrawalResponse['data']>>,
   snackBar: MatSnackBar,
   transloco: TranslocoService,
 ): Promise<void> {
   const outcome = await create(value);
-  if (outcome) {
+  if (outcome.data) {
     snackBar.open(
       transloco.translate('budget.savingsWithdrawal.success'),
       transloco.translate('common.close'),

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.ts
@@ -204,3 +204,18 @@ export function computeTransactionSnackbarMessage(
     ),
   });
 }
+
+/**
+ * A refused mutation surfaces here, never on the page-level error signal: the
+ * budget stays on screen and the server's own reason is what the user reads.
+ */
+export function openMutationErrorSnackbar(
+  message: string,
+  snackBar: MatSnackBar,
+  transloco: TranslocoService,
+): void {
+  snackBar.open(message, transloco.translate('common.close'), {
+    duration: 5000,
+    panelClass: ['bg-error-container', 'text-on-error-container'],
+  });
+}

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.ts
@@ -92,7 +92,7 @@ export async function submitSpreadWithRetry(
   }
 
   const ref = snackBar.open(
-    transloco.translate('budgetLine.spread.error'),
+    outcome.error ?? transloco.translate('budgetLine.spread.error'),
     transloco.translate('common.retry'),
     { duration: 8000 },
   );
@@ -146,7 +146,7 @@ export async function submitSavingsWithdrawalWithRetry(
   }
 
   const ref = snackBar.open(
-    transloco.translate('budget.savingsWithdrawal.error'),
+    outcome.error ?? transloco.translate('budget.savingsWithdrawal.error'),
     transloco.translate('common.retry'),
     { duration: 8000 },
   );

--- a/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.ts
+++ b/frontend/projects/webapp/src/app/feature/budget/budget-details/utils/budget-details-snackbar.utils.ts
@@ -64,11 +64,15 @@ export function computeSpreadSnackbarMessage(
 /**
  * PUL-17 — submit a smoothed expense (additive create) and surface the outcome.
  *
- * On success: the occurrences toast. On failure: a "Réessayer" toast whose action
- * re-submits the SAME DTO — crucially the SAME `spreadGroupId`. That is what makes
- * the idempotency key actually do its job: the retry replays the original group
- * server-side (or heals a balance left stale by a post-commit failure) instead of
- * creating a duplicate. Recurses so each failed retry can be retried again.
+ * On success: the occurrences toast. On a failure that could land differently, a
+ * "Réessayer" toast whose action re-submits the SAME DTO — crucially the SAME
+ * `spreadGroupId`. That is what makes the idempotency key actually do its job:
+ * the retry replays the original group server-side (or heals a balance left
+ * stale by a post-commit failure) instead of creating a duplicate. Recurses so
+ * each failed retry can be retried again.
+ *
+ * A refusal the server already decided on gets "Fermer" instead: replaying the
+ * same body earns the same verdict, and the message already says what to change.
  *
  * The mutation is injected as `create` so this stays decoupled from the store; the
  * caller passes `(v) => store.createBudgetLineSpread(v)`.
@@ -93,9 +97,10 @@ export async function submitSpreadWithRetry(
 
   const ref = snackBar.open(
     outcome.error ?? transloco.translate('budgetLine.spread.error'),
-    transloco.translate('common.retry'),
+    transloco.translate(outcome.retryable ? 'common.retry' : 'common.close'),
     { duration: 8000 },
   );
+  if (!outcome.retryable) return;
   ref.onAction().subscribe(() => {
     void submitSpreadWithRetry(value, create, snackBar, transloco);
   });
@@ -121,11 +126,12 @@ export function spreadCreateEcho(value: BudgetLineSpreadCreate): {
 
 /**
  * PUL-292 — submit a savings withdrawal (create the linked couple) and surface
- * the outcome. On success: a confirmation toast. On failure: a "Réessayer" toast
- * that re-submits the SAME DTO — the SAME `groupId` — so the retry replays the
- * original couple server-side (or heals a balance left stale by a post-commit
- * failure) instead of creating a duplicate. Recurses so each failed retry can be
- * retried again. Mirrors `submitSpreadWithRetry`.
+ * the outcome. On success: a confirmation toast. On a failure that could land
+ * differently, a "Réessayer" toast that re-submits the SAME DTO — the SAME
+ * `groupId` — so the retry replays the original couple server-side (or heals a
+ * balance left stale by a post-commit failure) instead of creating a duplicate.
+ * Recurses so each failed retry can be retried again. A refusal the server
+ * already decided on gets "Fermer". Mirrors `submitSpreadWithRetry`.
  */
 export async function submitSavingsWithdrawalWithRetry(
   value: BudgetLineSavingsWithdrawalCreate,
@@ -147,9 +153,10 @@ export async function submitSavingsWithdrawalWithRetry(
 
   const ref = snackBar.open(
     outcome.error ?? transloco.translate('budget.savingsWithdrawal.error'),
-    transloco.translate('common.retry'),
+    transloco.translate(outcome.retryable ? 'common.retry' : 'common.close'),
     { duration: 8000 },
   );
+  if (!outcome.retryable) return;
   ref.onAction().subscribe(() => {
     void submitSavingsWithdrawalWithRetry(value, create, snackBar, transloco);
   });

--- a/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.spec.ts
+++ b/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.spec.ts
@@ -1,6 +1,7 @@
 import { provideZonelessChangeDetection, signal } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { TestBed, type ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { MatSelect, type MatSelectChange } from '@angular/material/select';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -29,6 +30,17 @@ const goalWithDeadline = (targetDate: string | null): SavingsGoal =>
   ({ ...goal, targetDate }) as SavingsGoal;
 
 const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+/** Drives the very output the template listens to, so the pick counts as the user's. */
+const pickInSelect = (
+  fixture: ComponentFixture<SavingsGoalPickerField>,
+  goalId: string | null,
+): void =>
+  fixture.debugElement
+    .query(By.directive(MatSelect))
+    .componentInstance.selectionChange.emit({
+      value: goalId,
+    } as MatSelectChange);
 
 describe('SavingsGoalPickerField', () => {
   const getAll$ = vi.fn();
@@ -211,6 +223,61 @@ describe('SavingsGoalPickerField', () => {
       );
 
       expect(option.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    // Disabling the option only guards a goal picked AFTER the period is known.
+    // A spread range widened later moves the period past an already-linked goal.
+    it('clears a goal picked here once the period widens past its deadline', async () => {
+      getAll$.mockReturnValue(
+        of({ data: [goalWithDeadline('2026-06-15')], success: true }),
+      );
+      const fixture = TestBed.createComponent(SavingsGoalPickerField);
+      setTestInput(fixture.componentInstance.budgetPeriod, {
+        month: 6,
+        year: 2026,
+      });
+      const emitted = vi.spyOn(fixture.componentInstance.valueChanged, 'emit');
+
+      fixture.detectChanges();
+      await settle();
+      fixture.detectChanges();
+
+      pickInSelect(fixture, goal.id);
+      setTestInput(fixture.componentInstance.value, goal.id);
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      expect(emitted).toHaveBeenCalledExactlyOnceWith(goal.id);
+
+      setTestInput(fixture.componentInstance.budgetPeriod, {
+        month: 11,
+        year: 2026,
+      });
+      fixture.detectChanges();
+      TestBed.flushEffects();
+
+      expect(emitted).toHaveBeenLastCalledWith(null);
+    });
+
+    // An edit surface opens carrying a link saved while it was still valid.
+    // Withdrawing it on open would edit the user's data without them asking.
+    it('keeps a link it was opened with even when out of horizon', async () => {
+      getAll$.mockReturnValue(
+        of({ data: [goalWithDeadline('2026-06-15')], success: true }),
+      );
+      const fixture = TestBed.createComponent(SavingsGoalPickerField);
+      setTestInput(fixture.componentInstance.value, goal.id);
+      setTestInput(fixture.componentInstance.budgetPeriod, {
+        month: 11,
+        year: 2026,
+      });
+      const emitted = vi.spyOn(fixture.componentInstance.valueChanged, 'emit');
+
+      fixture.detectChanges();
+      await settle();
+      fixture.detectChanges();
+      TestBed.flushEffects();
+
+      expect(emitted).not.toHaveBeenCalled();
     });
 
     it('keeps that same deadline in horizon once the pay day moves it forward', async () => {

--- a/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.spec.ts
+++ b/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.spec.ts
@@ -1,11 +1,12 @@
-import { provideZonelessChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SavingsGoal } from 'pulpe-shared';
+import type { BudgetPeriod, SavingsGoal } from 'pulpe-shared';
 import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
+import { UserSettingsStore } from '@core/user-settings';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
 import { setTestInput } from '@app/testing/signal-test-utils';
 import { SavingsGoalPickerField } from './savings-goal-picker-field';
@@ -24,13 +25,18 @@ const goal = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 } as SavingsGoal;
 
+const goalWithDeadline = (targetDate: string | null): SavingsGoal =>
+  ({ ...goal, targetDate }) as SavingsGoal;
+
 const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
 
 describe('SavingsGoalPickerField', () => {
   const getAll$ = vi.fn();
+  const payDayOfMonth = signal<number | null>(1);
 
   beforeEach(async () => {
     getAll$.mockReset();
+    payDayOfMonth.set(1);
     mockCache.get.mockReturnValue(null);
     mockCache.set.mockClear();
     mockCache.invalidate.mockClear();
@@ -50,6 +56,10 @@ describe('SavingsGoalPickerField', () => {
             cache: mockCache,
             getAll$,
           },
+        },
+        {
+          provide: UserSettingsStore,
+          useValue: { currency: signal('CHF'), payDayOfMonth },
         },
       ],
     }).compileComponents();
@@ -116,5 +126,102 @@ describe('SavingsGoalPickerField', () => {
     expect(getAll$).toHaveBeenCalledTimes(2);
     expect(emitted).toHaveBeenCalledOnce();
     expect(emitted).toHaveBeenCalledWith(null);
+  });
+
+  // PUL-313 — the picker must not offer a link the enforce_savings_goal_line_link
+  // trigger would reject with a 422.
+  describe('goal horizon', () => {
+    // Returns the rendered goal option (the "Aucun objectif" entry comes first).
+    const openAndReadGoalOption = async (
+      goals: SavingsGoal[],
+      budgetPeriod: BudgetPeriod | null,
+    ): Promise<HTMLElement> => {
+      getAll$.mockReturnValue(of({ data: goals, success: true }));
+      const fixture = TestBed.createComponent(SavingsGoalPickerField);
+      setTestInput(fixture.componentInstance.budgetPeriod, budgetPeriod);
+
+      fixture.detectChanges();
+      await settle();
+      fixture.detectChanges();
+
+      const trigger = fixture.nativeElement.querySelector(
+        '.mat-mdc-select-trigger',
+      ) as HTMLElement;
+      trigger.click();
+      fixture.detectChanges();
+      await settle();
+
+      const option = document.querySelector(
+        `.cdk-overlay-container [data-testid="savings-goal-picker-option-${goals[0].id}"]`,
+      );
+      return option as HTMLElement;
+    };
+
+    it('lists a goal whose deadline precedes the budget period, but disables it with the deadline as reason', async () => {
+      const option = await openAndReadGoalOption(
+        [goalWithDeadline('2027-08-01')],
+        {
+          month: 9,
+          year: 2027,
+        },
+      );
+
+      expect(option.textContent).toContain('Vacances');
+      expect(option.getAttribute('aria-disabled')).toBe('true');
+      expect(option.textContent).toContain('août 2027');
+    });
+
+    it('keeps a goal selectable when its deadline is at or after the budget period', async () => {
+      const option = await openAndReadGoalOption(
+        [goalWithDeadline('2027-08-01')],
+        {
+          month: 8,
+          year: 2027,
+        },
+      );
+
+      expect(option.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('keeps an undated goal selectable — it has no horizon to fall outside of', async () => {
+      const option = await openAndReadGoalOption([goalWithDeadline(null)], {
+        month: 12,
+        year: 2030,
+      });
+
+      expect(option.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('disables nothing when no budget period is supplied (template lines)', async () => {
+      const option = await openAndReadGoalOption(
+        [goalWithDeadline('2027-08-01')],
+        null,
+      );
+
+      expect(option.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    // 28 August straddles the pay cycle: on payDay 1 it belongs to the August
+    // period, on payDay 27 it opens the September one (règle quinzaine). The
+    // same goal must therefore flip state on a September budget.
+    it('puts a deadline late in the month out of horizon on a calendar pay day', async () => {
+      const option = await openAndReadGoalOption(
+        [goalWithDeadline('2027-08-28')],
+        { month: 9, year: 2027 },
+      );
+
+      expect(option.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('keeps that same deadline in horizon once the pay day moves it forward', async () => {
+      payDayOfMonth.set(27);
+
+      const option = await openAndReadGoalOption(
+        [goalWithDeadline('2027-08-28')],
+        { month: 9, year: 2027 },
+      );
+
+      expect(option.getAttribute('aria-disabled')).toBe('false');
+    });
   });
 });

--- a/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.ts
+++ b/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.ts
@@ -14,8 +14,17 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { combineLatest, map } from 'rxjs';
 import { cachedResource } from 'ngx-ziflux';
+import { formatDate } from 'date-fns';
+import {
+  getBudgetPeriodForDate,
+  parseIsoDateLocal,
+  periodIndex,
+  type BudgetPeriod,
+} from 'pulpe-shared';
 
 import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
+import { UserSettingsStore } from '@core/user-settings';
+import { dateFnsLocaleFor } from '@core/locale';
 
 /**
  * Reusable "Objectif" picker for the 3 CA26 saving-line surfaces.
@@ -23,6 +32,12 @@ import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
  * Value-based (not a Signal-Forms field): the caller passes the current
  * `savingsGoalId` via `[value]` and reacts to `(valueChanged)`. A first
  * option maps to `null` ("Aucun objectif").
+ *
+ * PUL-313 — when the caller supplies the budget's period, goals whose deadline
+ * falls before it are listed but disabled: the `enforce_savings_goal_line_link`
+ * trigger would reject the link. Listed, not hidden — a goal that silently
+ * disappears is unexplainable. Template lines carry no period and stay
+ * unfiltered; the trigger only bounds `budget_line`.
  */
 @Component({
   selector: 'pulpe-savings-goal-picker-field',
@@ -76,8 +91,22 @@ import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
           <mat-option [value]="null">{{
             'savingsGoals.pickerNone' | transloco
           }}</mat-option>
-          @for (g of goals(); track g.id) {
-            <mat-option [value]="g.id">{{ g.name }}</mat-option>
+          @for (option of goalOptions(); track option.id) {
+            <mat-option
+              [value]="option.id"
+              [disabled]="option.deadlineLabel !== null"
+              [attr.data-testid]="'savings-goal-picker-option-' + option.id"
+            >
+              {{ option.name }}
+              @if (option.deadlineLabel; as deadline) {
+                <span class="block text-body-small text-on-surface-variant">
+                  {{
+                    'savingsGoals.pickerOutsideHorizon'
+                      | transloco: { month: deadline }
+                  }}
+                </span>
+              }
+            </mat-option>
           }
         </mat-select>
       </mat-form-field>
@@ -94,9 +123,12 @@ import { SavingsGoalApi } from '@core/savings-goal/savings-goal-api';
 })
 export class SavingsGoalPickerField {
   readonly value = input<string | null>(null);
+  /** Budget period the line will live in. Omitted on template lines. */
+  readonly budgetPeriod = input<BudgetPeriod | null>(null);
   readonly valueChanged = output<string | null>();
 
   readonly #api = inject(SavingsGoalApi);
+  readonly #settings = inject(UserSettingsStore);
 
   // Shares the SavingsGoalApi DataCache (key ['savings-goals','list']) with
   // SavingsGoalStore: dedups the fetch across pickers/list and picks up store
@@ -110,6 +142,40 @@ export class SavingsGoalPickerField {
   protected readonly goals = computed(() => this.#goalsResource.value() ?? []);
   protected readonly isLoading = this.#goalsResource.isInitialLoading;
   protected readonly error = this.#goalsResource.error;
+
+  /**
+   * `deadlineLabel` is non-null exactly when the goal is out of horizon: it
+   * both disables the option and names the month that puts it out of reach.
+   * Mirrors the trigger's own arithmetic via the shared period calculator —
+   * an undated goal has no horizon, so it is never out of it.
+   */
+  protected readonly goalOptions = computed(() => {
+    const period = this.budgetPeriod();
+    const payDay = this.#settings.payDayOfMonth();
+    const locale = dateFnsLocaleFor(this.#settings.currency());
+
+    return this.goals().map((goal) => {
+      if (!period || !goal.targetDate) {
+        return { id: goal.id, name: goal.name, deadlineLabel: null };
+      }
+      const deadline = getBudgetPeriodForDate(
+        parseIsoDateLocal(goal.targetDate),
+        payDay,
+      );
+      const isOutsideHorizon = periodIndex(period) > periodIndex(deadline);
+      return {
+        id: goal.id,
+        name: goal.name,
+        deadlineLabel: isOutsideHorizon
+          ? formatDate(
+              new Date(deadline.year, deadline.month - 1, 1),
+              'MMMM yyyy',
+              { locale },
+            )
+          : null,
+      };
+    });
+  });
 
   constructor() {
     combineLatest([

--- a/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.ts
+++ b/frontend/projects/webapp/src/app/pattern/savings-goal-picker/savings-goal-picker-field.ts
@@ -5,6 +5,7 @@ import {
   inject,
   input,
   output,
+  signal,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -12,7 +13,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslocoPipe } from '@jsverse/transloco';
-import { combineLatest, map } from 'rxjs';
+import { filter, map } from 'rxjs';
 import { cachedResource } from 'ngx-ziflux';
 import { formatDate } from 'date-fns';
 import {
@@ -85,7 +86,7 @@ import { dateFnsLocaleFor } from '@core/locale';
         <mat-label>{{ 'savingsGoals.pickerLabel' | transloco }}</mat-label>
         <mat-select
           [value]="value()"
-          (selectionChange)="valueChanged.emit($event.value)"
+          (selectionChange)="onSelectionChange($event.value)"
           data-testid="savings-goal-picker-select"
         >
           <mat-option [value]="null">{{
@@ -177,22 +178,52 @@ export class SavingsGoalPickerField {
     });
   });
 
+  /**
+   * Set once the user picks in THIS picker, as opposed to the link the caller
+   * handed us. The distinction decides who may be auto-unlinked below.
+   */
+  readonly #pickedHere = signal(false);
+
+  protected onSelectionChange(goalId: string | null): void {
+    this.#pickedHere.set(true);
+    this.valueChanged.emit(goalId);
+  }
+
+  /**
+   * True when the selection must be withdrawn. Disabling the option is not
+   * enough on its own: the caller can widen the period AFTER a goal was picked
+   * (a spread range extended past the deadline), leaving a stale id that would
+   * still submit. Reuses `goalOptions` — the very list the template disables
+   * from — so nothing shown as unselectable can survive as a selection.
+   *
+   * The two reasons are NOT symmetric. A goal that vanished can never be saved
+   * again, so it goes whoever chose it. A goal that is merely out of horizon
+   * was legitimately linkable when the line was saved, and an edit surface
+   * opens carrying it — dropping that on open would edit the user's data for
+   * them, so only a pick made here is taken back.
+   *
+   * The raw resource value gates the whole thing: the option list collapses to
+   * `[]` while loading or errored, and clearing on that would wipe a valid pick.
+   */
+  readonly #hasStaleSelection = computed(() => {
+    if (
+      this.#goalsResource.error() ||
+      this.#goalsResource.value() === undefined
+    )
+      return false;
+    const selectedId = this.value();
+    if (selectedId === null) return false;
+    const selected = this.goalOptions().find(
+      (option) => option.id === selectedId,
+    );
+    if (!selected) return true;
+    return selected.deadlineLabel !== null && this.#pickedHere();
+  });
+
   constructor() {
-    combineLatest([
-      toObservable(this.#goalsResource.value),
-      toObservable(this.#goalsResource.error),
-      toObservable(this.value),
-    ])
-      .pipe(takeUntilDestroyed())
-      .subscribe(([goals, error, selectedId]) => {
-        if (error || goals === undefined) return;
-        if (
-          selectedId !== null &&
-          !goals.some((goal) => goal.id === selectedId)
-        ) {
-          this.valueChanged.emit(null);
-        }
-      });
+    toObservable(this.#hasStaleSelection)
+      .pipe(filter(Boolean), takeUntilDestroyed())
+      .subscribe(() => this.valueChanged.emit(null));
   }
 
   protected reloadGoals(): void {

--- a/ios/Pulpe/Core/Network/APIError.swift
+++ b/ios/Pulpe/Core/Network/APIError.swift
@@ -123,8 +123,8 @@ enum APIError: LocalizedError {
         case .savingsGoalNotFound:
             return "Cet objectif n'existe plus"
         case .savingsGoalLineOutsideHorizon:
-            return "Certaines périodes dépassent l'échéance de cet objectif — "
-                + "raccourcis le lissage ou choisis un autre objectif"
+            return "Cette épargne tombe après l'échéance de ton objectif — "
+                + "repousse l'échéance ou choisis un autre objectif"
         case .savingsGoalDeletionImpactChanged:
             return "Les éléments rattachés ont changé entre-temps — "
                 + "vérifie le nouvel impact avant de confirmer"

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -128,7 +128,10 @@ struct AddBudgetLineSheet: View {
             descriptionField
 
             if Self.showsSavingsGoalPicker(kind: kind) {
-                SavingsGoalPickerField(selection: $savingsGoalId)
+                SavingsGoalPickerField(
+                    selection: $savingsGoalId,
+                    budgetPeriod: BudgetPeriod(month: anchorMonth, year: anchorYear)
+                )
             }
 
             if isSpreadMode {

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/AddBudgetLineSheet.swift
@@ -65,6 +65,22 @@ struct AddBudgetLineSheet: View {
 
     static func showsSavingsGoalPicker(kind: TransactionKind) -> Bool { kind == .saving }
 
+    /// The period the goal link has to survive. A spread submits one line per selected
+    /// month and `enforce_savings_goal_line_link` rejects the WHOLE fan-out as soon as
+    /// a single one lands past the goal's deadline — so the LAST month binds, not the
+    /// anchor the sheet was opened on. `selectedMonths` is ascending, hence `.last`.
+    /// Pass an empty array outside spread mode: only the anchor is written then.
+    static func savingsGoalPeriod(
+        spreadMonths: [SpreadMonth],
+        anchorMonth: Int,
+        anchorYear: Int
+    ) -> BudgetPeriod {
+        guard let last = spreadMonths.last else {
+            return BudgetPeriod(month: anchorMonth, year: anchorYear)
+        }
+        return BudgetPeriod(month: last.month, year: last.year)
+    }
+
     var isSavingsWithdrawalMode: Bool { kind == .income && remitNextMonth }
 
     private var amountFieldHint: String? {
@@ -130,7 +146,11 @@ struct AddBudgetLineSheet: View {
             if Self.showsSavingsGoalPicker(kind: kind) {
                 SavingsGoalPickerField(
                     selection: $savingsGoalId,
-                    budgetPeriod: BudgetPeriod(month: anchorMonth, year: anchorYear)
+                    budgetPeriod: Self.savingsGoalPeriod(
+                        spreadMonths: isSpreadMode ? spreadCalculator.selectedMonths : [],
+                        anchorMonth: anchorMonth,
+                        anchorYear: anchorYear
+                    )
                 )
             }
 

--- a/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Routing.swift
+++ b/ios/Pulpe/Features/Budgets/BudgetDetails/BudgetDetailsView+Routing.swift
@@ -44,15 +44,28 @@ extension BudgetDetailsView {
         )
     }
 
+    /// The OPENED budget's period bounds which savings goals the line may be
+    /// tagged to (PUL-313) — a goal whose deadline precedes it is refused
+    /// server-side, so the picker disables it instead of offering the 422.
+    @ViewBuilder
+    private func editBudgetLineSheet(for line: BudgetLine) -> some View {
+        let openBudget = coordinator.dataStore.budget
+        EditBudgetLineSheet(
+            budgetLine: line,
+            userCurrency: userSettingsStore.currency,
+            budgetPeriod: openBudget.map { BudgetPeriod(month: $0.month, year: $0.year) }
+        ) { updatedLine in
+            Task { await coordinator.dispatch(.updateBudgetLine(updatedLine)) }
+        }
+    }
+
     @ViewBuilder
     func sheetContent(for destination: BudgetDetailDestination) -> some View {
         switch destination {
         case .addBudgetLine:
             addBudgetLineSheet
         case .editBudgetLine(let line):
-            EditBudgetLineSheet(budgetLine: line, userCurrency: userSettingsStore.currency) { updatedLine in
-                Task { await coordinator.dispatch(.updateBudgetLine(updatedLine)) }
-            }
+            editBudgetLineSheet(for: line)
         case .previousBudget(let item):
             PreviousBudgetSheet(budgetId: item.id)
         case .realizedBalance:

--- a/ios/Pulpe/Shared/Components/EditBudgetLineSheet.swift
+++ b/ios/Pulpe/Shared/Components/EditBudgetLineSheet.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Sheet for editing an existing budget line (prévision) — hero amount layout
 struct EditBudgetLineSheet: View {
     let budgetLine: BudgetLine
+    /// Period of the budget holding the line — bounds its savings-goal links.
+    let budgetPeriod: BudgetPeriod?
     let onUpdate: (BudgetLine) -> Void
 
     @Environment(\.dismiss) private var dismiss
@@ -28,10 +30,12 @@ struct EditBudgetLineSheet: View {
     init(
         budgetLine: BudgetLine,
         userCurrency: SupportedCurrency,
+        budgetPeriod: BudgetPeriod? = nil,
         dependencies: EditBudgetLineDependencies = .live,
         onUpdate: @escaping (BudgetLine) -> Void
     ) {
         self.budgetLine = budgetLine
+        self.budgetPeriod = budgetPeriod
         self.dependencies = dependencies
         self.onUpdate = onUpdate
         _name = State(initialValue: budgetLine.name)
@@ -86,7 +90,7 @@ struct EditBudgetLineSheet: View {
             )
             descriptionField
             if kind == .saving {
-                SavingsGoalPickerField(selection: $savingsGoalId)
+                SavingsGoalPickerField(selection: $savingsGoalId, budgetPeriod: budgetPeriod)
             }
             TagPickerField(selection: $selectedTagIds)
 

--- a/ios/Pulpe/Shared/Components/SavingsGoalPickerField.swift
+++ b/ios/Pulpe/Shared/Components/SavingsGoalPickerField.swift
@@ -6,6 +6,12 @@ import SwiftUI
 /// budget-line Add/Edit sheets. Callers show it only for `kind == .saving`;
 /// `selection` is the goal id (`nil` = "Aucun objectif"). Reads goals from the
 /// app-level `SavingsGoalStore` and refreshes them when it appears.
+///
+/// PUL-313 — when the caller passes `budgetPeriod`, goals whose deadline falls
+/// before it are listed but disabled: `enforce_savings_goal_line_link` would
+/// reject the link with a 422. Listed, not hidden — a goal that silently
+/// disappears is unexplainable. Template lines pass no period and stay
+/// unfiltered; the trigger's horizon branch only bounds `budget_line`.
 struct SavingsGoalPickerField: View {
     struct SelectionState: Equatable {
         let hasLoadedOnce: Bool
@@ -22,8 +28,32 @@ struct SavingsGoalPickerField: View {
     }
 
     @Binding var selection: String?
+    var budgetPeriod: BudgetPeriod?
 
     @Environment(SavingsGoalStore.self) private var store
+    @Environment(UserSettingsStore.self) private var userSettingsStore
+
+    /// The deadline period a goal puts a saving out of reach past, or `nil` when
+    /// the link is allowed. Mirrors the trigger's own arithmetic through the
+    /// shared period port — an undated goal has no horizon to fall outside of,
+    /// and neither does a template line, which carries no period at all.
+    static func exceededDeadline(
+        for goal: SavingsGoal,
+        budgetPeriod: BudgetPeriod?,
+        payDayOfMonth: Int?
+    ) -> BudgetPeriod? {
+        guard let budgetPeriod, let targetDate = goal.targetDateValue else { return nil }
+        let deadline = BudgetPeriodCalculator.periodForDate(targetDate, payDayOfMonth: payDayOfMonth)
+        return BudgetPeriodCalculator.comparePeriods(budgetPeriod, deadline) > 0 ? deadline : nil
+    }
+
+    private func exceededDeadline(for goal: SavingsGoal) -> BudgetPeriod? {
+        Self.exceededDeadline(
+            for: goal,
+            budgetPeriod: budgetPeriod,
+            payDayOfMonth: userSettingsStore.payDayOfMonth
+        )
+    }
 
     private var selectedGoal: SavingsGoal? {
         guard let selection else { return nil }
@@ -108,8 +138,17 @@ struct SavingsGoalPickerField: View {
             }
             Divider()
             ForEach(store.goals) { goal in
-                pickerButton(title: goal.name, isSelected: goal.id == selection) {
-                    selection = goal.id
+                if let deadline = exceededDeadline(for: goal) {
+                    pickerButton(
+                        title: goal.name,
+                        subtitle: "Échéance dépassée · \(Formatters.monthName(for: deadline.month)) \(deadline.year)",
+                        isSelected: goal.id == selection
+                    ) {}
+                    .disabled(true)
+                } else {
+                    pickerButton(title: goal.name, isSelected: goal.id == selection) {
+                        selection = goal.id
+                    }
                 }
             }
         } label: {
@@ -140,13 +179,23 @@ struct SavingsGoalPickerField: View {
         )
     }
 
+    /// `subtitle` rides in the same button so the reason travels with the goal
+    /// it disables — a menu entry cannot carry a separate explanatory row.
     @ViewBuilder
-    private func pickerButton(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+    private func pickerButton(
+        title: String,
+        subtitle: String? = nil,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             if isSelected {
                 Label(title, systemImage: "checkmark")
             } else {
                 Text(title)
+            }
+            if let subtitle {
+                Text(subtitle)
             }
         }
     }

--- a/ios/Pulpe/Shared/Components/SavingsGoalPickerField.swift
+++ b/ios/Pulpe/Shared/Components/SavingsGoalPickerField.swift
@@ -12,23 +12,40 @@ import SwiftUI
 /// reject the link with a 422. Listed, not hidden — a goal that silently
 /// disappears is unexplainable. Template lines pass no period and stay
 /// unfiltered; the trigger's horizon branch only bounds `budget_line`.
+/// `budgetPeriod` can move under a live selection (a spread window extended past
+/// a goal's deadline), so the selection is reconciled against it, not just the
+/// goal list.
 struct SavingsGoalPickerField: View {
     struct SelectionState: Equatable {
         let hasLoadedOnce: Bool
         let isLoading: Bool
         let hasError: Bool
-        let goalIDs: Set<String>
+        let knownGoalIDs: Set<String>
+        /// Goals the caller's period can still link to — NOT every known goal. The
+        /// period moves under a live selection when a spread window is extended.
+        let linkableGoalIDs: Set<String>
+        /// Whether the live selection was made in this picker rather than handed in.
+        let pickedHere: Bool
 
+        /// The two reasons a selection can go stale are NOT symmetric. A goal that
+        /// vanished can never be saved again, so it drops whoever chose it. A goal
+        /// that is merely out of horizon was legitimately linkable when the line was
+        /// saved, and an edit sheet opens carrying it — withdrawing that on open
+        /// would edit the user's data for them, so only a pick made here is taken back.
         func reconciled(_ selection: String?) -> String? {
             guard hasLoadedOnce, !isLoading, !hasError, let selection else {
                 return selection
             }
-            return goalIDs.contains(selection) ? selection : nil
+            guard knownGoalIDs.contains(selection) else { return nil }
+            if linkableGoalIDs.contains(selection) { return selection }
+            return pickedHere ? nil : selection
         }
     }
 
     @Binding var selection: String?
     var budgetPeriod: BudgetPeriod?
+
+    @State private var pickedHere = false
 
     @Environment(SavingsGoalStore.self) private var store
     @Environment(UserSettingsStore.self) private var userSettingsStore
@@ -65,7 +82,9 @@ struct SavingsGoalPickerField: View {
             hasLoadedOnce: store.hasLoadedOnce,
             isLoading: store.isLoading,
             hasError: store.error != nil,
-            goalIDs: Set(store.goals.map(\.id))
+            knownGoalIDs: Set(store.goals.map(\.id)),
+            linkableGoalIDs: Set(store.goals.filter { exceededDeadline(for: $0) == nil }.map(\.id)),
+            pickedHere: pickedHere
         )
     }
 
@@ -134,6 +153,7 @@ struct SavingsGoalPickerField: View {
     private var menuContent: some View {
         Menu {
             pickerButton(title: "Aucun objectif", isSelected: selection == nil) {
+                pickedHere = true
                 selection = nil
             }
             Divider()
@@ -147,6 +167,7 @@ struct SavingsGoalPickerField: View {
                     .disabled(true)
                 } else {
                     pickerButton(title: goal.name, isSelected: goal.id == selection) {
+                        pickedHere = true
                         selection = goal.id
                     }
                 }

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/AddBudgetLineSheetTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/AddBudgetLineSheetTests.swift
@@ -15,4 +15,28 @@ struct AddBudgetLineSheetTests {
         #expect(!AddBudgetLineSheet.showsSavingsGoalPicker(kind: .expense))
         #expect(!AddBudgetLineSheet.showsSavingsGoalPicker(kind: .income))
     }
+
+    // PUL-313 — a spread writes every selected month, so a goal whose deadline
+    // covers the anchor but precedes a later month must still be refused: the
+    // server rejects the whole fan-out, not just the offending tranche.
+    @Test("The savings-goal horizon binds on the last spread month, not the anchor")
+    func savingsGoalPeriodFollowsLastSpreadMonth() {
+        let withoutSpread = AddBudgetLineSheet.savingsGoalPeriod(
+            spreadMonths: [],
+            anchorMonth: 6,
+            anchorYear: 2026
+        )
+        let acrossYearEnd = AddBudgetLineSheet.savingsGoalPeriod(
+            spreadMonths: [
+                SpreadMonth(year: 2026, month: 11),
+                SpreadMonth(year: 2026, month: 12),
+                SpreadMonth(year: 2027, month: 1),
+            ],
+            anchorMonth: 11,
+            anchorYear: 2026
+        )
+
+        #expect(withoutSpread == BudgetPeriod(month: 6, year: 2026))
+        #expect(acrossYearEnd == BudgetPeriod(month: 1, year: 2027))
+    }
 }

--- a/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/AddBudgetLineSpreadSavingsGoalTests.swift
+++ b/ios/PulpeTests/Features/Budgets/BudgetDetails/Spread/AddBudgetLineSpreadSavingsGoalTests.swift
@@ -40,10 +40,12 @@ struct AddBudgetLineSpreadSavingsGoalTests {
             message: nil
         )
 
+        // The same code now reaches a single line as well as a spread, so the
+        // copy must read correctly for both — no "raccourcis le lissage".
         #expect(
             error.errorDescription ==
-                "Certaines périodes dépassent l'échéance de cet objectif — "
-                + "raccourcis le lissage ou choisis un autre objectif"
+                "Cette épargne tombe après l'échéance de ton objectif — "
+                + "repousse l'échéance ou choisis un autre objectif"
         )
     }
 

--- a/ios/PulpeTests/Shared/Components/SavingsGoalPickerFieldTests.swift
+++ b/ios/PulpeTests/Shared/Components/SavingsGoalPickerFieldTests.swift
@@ -15,21 +15,29 @@ private func goal(targetDate: String?) -> SavingsGoal {
     )
 }
 
+private func selectionState(
+    hasLoadedOnce: Bool = true,
+    isLoading: Bool = false,
+    hasError: Bool = false,
+    knownGoalIDs: Set<String> = [],
+    linkableGoalIDs: Set<String> = [],
+    pickedHere: Bool = false
+) -> SavingsGoalPickerField.SelectionState {
+    SavingsGoalPickerField.SelectionState(
+        hasLoadedOnce: hasLoadedOnce,
+        isLoading: isLoading,
+        hasError: hasError,
+        knownGoalIDs: knownGoalIDs,
+        linkableGoalIDs: linkableGoalIDs,
+        pickedHere: pickedHere
+    )
+}
+
 struct SavingsGoalPickerFieldTests {
     @Test("a missing selection is preserved while goals are loading or failed")
     func missingSelection_preservedUntilSuccessfulLoad() {
-        let loading = SavingsGoalPickerField.SelectionState(
-            hasLoadedOnce: false,
-            isLoading: true,
-            hasError: false,
-            goalIDs: []
-        )
-        let failed = SavingsGoalPickerField.SelectionState(
-            hasLoadedOnce: false,
-            isLoading: false,
-            hasError: true,
-            goalIDs: []
-        )
+        let loading = selectionState(hasLoadedOnce: false, isLoading: true)
+        let failed = selectionState(hasLoadedOnce: false, hasError: true)
 
         #expect(loading.reconciled("missing") == "missing")
         #expect(failed.reconciled("missing") == "missing")
@@ -37,16 +45,33 @@ struct SavingsGoalPickerFieldTests {
 
     @Test("a successful load clears only selections absent from the response")
     func successfulLoad_reconcilesSelection() {
-        let loaded = SavingsGoalPickerField.SelectionState(
-            hasLoadedOnce: true,
-            isLoading: false,
-            hasError: false,
-            goalIDs: ["available"]
+        let loaded = selectionState(
+            knownGoalIDs: ["available"],
+            linkableGoalIDs: ["available"]
         )
 
         #expect(loaded.reconciled("missing") == nil)
         #expect(loaded.reconciled("available") == "available")
         #expect(loaded.reconciled(nil) == nil)
+    }
+
+    // The two staleness reasons are not symmetric: a vanished goal can never be
+    // saved again, but a goal merely out of horizon was legitimately linkable
+    // when the line was saved — an edit sheet opens carrying it.
+    @Test("an out-of-horizon goal is withdrawn only when it was picked here")
+    func outOfHorizonGoal_withdrawnOnlyWhenPickedHere() {
+        let pickedHere = selectionState(
+            knownGoalIDs: ["expired"],
+            linkableGoalIDs: [],
+            pickedHere: true
+        )
+        let openedWith = selectionState(
+            knownGoalIDs: ["expired"],
+            linkableGoalIDs: []
+        )
+
+        #expect(pickedHere.reconciled("expired") == nil)
+        #expect(openedWith.reconciled("expired") == "expired")
     }
 
     // PUL-313 — the picker must not offer a link `enforce_savings_goal_line_link`

--- a/ios/PulpeTests/Shared/Components/SavingsGoalPickerFieldTests.swift
+++ b/ios/PulpeTests/Shared/Components/SavingsGoalPickerFieldTests.swift
@@ -1,5 +1,19 @@
+import Foundation
 @testable import Pulpe
 import Testing
+
+private func goal(targetDate: String?) -> SavingsGoal {
+    SavingsGoal(
+        id: "goal-1",
+        userId: "user-1",
+        name: "Vacances",
+        targetAmount: 3_000,
+        targetDate: targetDate,
+        status: .active,
+        createdAt: Date(),
+        updatedAt: Date()
+    )
+}
 
 struct SavingsGoalPickerFieldTests {
     @Test("a missing selection is preserved while goals are loading or failed")
@@ -33,5 +47,79 @@ struct SavingsGoalPickerFieldTests {
         #expect(loaded.reconciled("missing") == nil)
         #expect(loaded.reconciled("available") == "available")
         #expect(loaded.reconciled(nil) == nil)
+    }
+
+    // PUL-313 — the picker must not offer a link `enforce_savings_goal_line_link`
+    // would reject with a 422.
+    @Test("a deadline before the budget period puts the goal out of horizon")
+    func deadlineBeforeBudgetPeriod_isOutsideHorizon() {
+        let deadline = SavingsGoalPickerField.exceededDeadline(
+            for: goal(targetDate: "2027-08-01"),
+            budgetPeriod: BudgetPeriod(month: 9, year: 2027),
+            payDayOfMonth: 1
+        )
+
+        #expect(deadline == BudgetPeriod(month: 8, year: 2027))
+    }
+
+    @Test("a deadline at or after the budget period keeps the goal reachable")
+    func deadlineAtOrAfterBudgetPeriod_staysInHorizon() {
+        let sameMonth = SavingsGoalPickerField.exceededDeadline(
+            for: goal(targetDate: "2027-08-01"),
+            budgetPeriod: BudgetPeriod(month: 8, year: 2027),
+            payDayOfMonth: 1
+        )
+        let laterDeadline = SavingsGoalPickerField.exceededDeadline(
+            for: goal(targetDate: "2027-08-01"),
+            budgetPeriod: BudgetPeriod(month: 3, year: 2027),
+            payDayOfMonth: 1
+        )
+
+        #expect(sameMonth == nil)
+        #expect(laterDeadline == nil)
+    }
+
+    @Test("an undated goal has no horizon to fall outside of")
+    func undatedGoal_neverOutsideHorizon() {
+        let deadline = SavingsGoalPickerField.exceededDeadline(
+            for: goal(targetDate: nil),
+            budgetPeriod: BudgetPeriod(month: 12, year: 2030),
+            payDayOfMonth: 1
+        )
+
+        #expect(deadline == nil)
+    }
+
+    @Test("no budget period means no bound — the template-line case")
+    func withoutBudgetPeriod_neverOutsideHorizon() {
+        let deadline = SavingsGoalPickerField.exceededDeadline(
+            for: goal(targetDate: "2027-08-01"),
+            budgetPeriod: nil,
+            payDayOfMonth: 1
+        )
+
+        #expect(deadline == nil)
+    }
+
+    // 28 August straddles the pay cycle: on payDay 1 it belongs to the August
+    // period, on payDay 27 it opens the September one (règle quinzaine). The
+    // same goal must therefore flip verdict on a September budget.
+    @Test("the verdict follows the pay day")
+    func verdictFollowsPayDay() {
+        let september = BudgetPeriod(month: 9, year: 2027)
+
+        let onCalendarPayDay = SavingsGoalPickerField.exceededDeadline(
+            for: goal(targetDate: "2027-08-28"),
+            budgetPeriod: september,
+            payDayOfMonth: 1
+        )
+        let onLatePayDay = SavingsGoalPickerField.exceededDeadline(
+            for: goal(targetDate: "2027-08-28"),
+            budgetPeriod: september,
+            payDayOfMonth: 27
+        )
+
+        #expect(onCalendarPayDay == BudgetPeriod(month: 8, year: 2027))
+        #expect(onLatePayDay == nil)
     }
 }


### PR DESCRIPTION
Ajouter une épargne à un objectif **après la date de fin de cet objectif** renvoyait un `500` et remplaçait toute la page budget par « Impossible de charger ton budget ». Trois défauts empilés, corrigés ici de la couche la plus profonde à la plus haute.

Closes PUL-330.

## 1. Le serveur disait 500 pour un refus métier

Le trigger `enforce_savings_goal_line_link` lève `P0001 'Savings goal line outside target horizon'` quand la période du budget dépasse l'échéance de l'objectif (pay-day inclus). Seul `createSpread` reconnaissait ce code : l'insert, l'update et l'update par RPC taggé retombaient sur `*_FAILED`, donc un refus légitime arrivait au client en `500` sans code exploitable. **C'est le chemin RPC taggé que prend la boîte de dialogue d'édition du webapp.** Les trois chemins mappent désormais vers `422 SAVINGS_GOAL_LINE_OUTSIDE_HORIZON`, et le client en tire une phrase.

## 2. La page se vidait à chaque mutation refusée

`BudgetDetailsStore.error` agrégeait l'erreur de la ressource **et** un message de mutation. La page rend ce signal comme une carte qui **remplace tout le budget** — donc n'importe quelle suppression, réinitialisation, pointage, report ou lissage refusé vidait l'écran, tout en jetant le message précis que le store venait de calculer (la carte n'affiche qu'une clé figée, `budget.loadError`).

`error` ne remonte plus que l'erreur de chargement. Les **17 mutations** rendent leur motif à l'appelant : `Promise<string | null>` pour les 13 sans charge utile, `MutationOutcome<T>` pour les 4 qui en portent une. Le succès, c'est un motif nul — jamais `response !== undefined` : deux suppressions sont typées `void`, donc `undefined` est aussi leur valeur de succès.

## 3. Sept gestes confirmaient un succès qui n'avait pas eu lieu

Édition, suppression et pointage d'un réel, ajout d'un réel lié, réinitialisation depuis le mois type, pointage en cascade, suppression depuis la table : tous ouvraient leur toast de confirmation sans regarder l'issue. Un utilisateur voyait donc **la page vide ET « Modification enregistrée »**. Chacun lit maintenant le motif ; un refus ouvre le toast d'erreur partagé et s'arrête là, un succès garde exactement la formulation qu'il avait. Les deux toasts « Réessayer » (lissage, pioche) portent la phrase du serveur quand il en donne une, et le lissage d'un élément existant, muet jusqu'ici en cas d'échec, annonce son refus.

## 4. Prévenir plutôt que guérir (web + iOS)

Le sélecteur d'objectif d'épargne grise les objectifs dont l'échéance est déjà passée pour la période du budget, avec la raison affichée. Le refus serveur reste le filet de sécurité, il n'est plus le premier contact.

## Ce qui empêche la rechute

La règle `angular-store-pattern.md` **enseignait le défaut** : son store canonique montrait le signal d'erreur agrégé, son exemple de mutation y écrivait depuis un `catch`, et elle désignait `BudgetDetailsStore` comme implémentation de référence. Recopiée telle quelle, elle recréait la page blanche dans le prochain store. Elle est corrigée, avec deux lignes d'anti-patterns nommant les deux pièges (le signal agrégé, et le succès lu sur `response !== undefined`).

Côté tests : une spec paramétrée provoque un échec serveur sur **chacune des 17 mutations** et vérifie que le motif revient par l'appel pendant que `error()` reste nul. Un dernier test compare les méthodes async du store à la liste couverte — une 18ᵉ mutation ajoutée plus tard fait échouer la suite au lieu de passer inaperçue. Avant ce PR, 5 mutations sur 17 n'avaient aucun test d'échec.

## Vérification

- `pnpm quality` vert sur chacun des 7 commits (hook pre-commit : turbo quality sur 4 packages + tests sécurité + public-surface)
- 457 tests dans `budget-details` (contre 423), suite frontend complète verte
- iOS : tests `SavingsGoalPickerFieldTests` ajoutés

**Note** : `typecheck:spec` était **déjà rouge sur cette branche** avant ce travail — `budget-line/edit/dialog.spec.ts` n'avait jamais reçu le `budgetPeriod` rendu obligatoire par un commit antérieur. Vitest ne type-checke pas, d'où le silence. Corrigé en une ligne dans le premier commit.
