### PR TITLE
Track web logout sources and scope sign-outs locally

### DIFF
--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -81,15 +81,17 @@ app_opened → welcome_viewed → signup_started → signup_completed
 
 ### Welcome & Auth Flow Events
 
-| Event                 | When                                  | Properties                                                                                                                                                               |
-| --------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `welcome_viewed`      | User lands on /welcome                | —                                                                                                                                                                        |
-| `signup_started`      | User click signup button              | `method` (`email` \| `google`)                                                                                                                                           |
-| `signup_completed`    | Signup succeed                        | `method` (`email` \| `google`)                                                                                                                                           |
-| `pin_setup_completed` | New user creates a PIN                | —                                                                                                                                                                        |
-| `pin_entered`         | Returning user enters their PIN       | —                                                                                                                                                                        |
-| `demo_started`        | Demo session created                  | —                                                                                                                                                                        |
-| `logout_completed`    | Web session ends after local sign-out | `source` (`user_initiated` \| `vault_code` \| `demo_exit` \| `scheduled_deletion` \| `account_blocked` \| `session_expired` \| `refresh_failed`)                       |
+| Event                 | When                                                     | Properties                                                                                                                                       |
+| --------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `welcome_viewed`      | User lands on /welcome                                   | —                                                                                                                                                |
+| `signup_started`      | User click signup button                                 | `method` (`email` \| `google`)                                                                                                                   |
+| `signup_completed`    | Signup succeed (email direct, Google via pending method) | `method` (`email` \| `google`)                                                                                                                   |
+| `pin_setup_completed` | New user creates a PIN                                   | —                                                                                                                                                |
+| `pin_entered`         | Returning user enters their PIN                          | —                                                                                                                                                |
+| `demo_started`        | Demo session created                                     | —                                                                                                                                                |
+| `logout_completed`    | Web session ends after local sign-out                    | `source` (`user_initiated` \| `vault_code` \| `demo_exit` \| `scheduled_deletion` \| `account_blocked` \| `session_expired` \| `refresh_failed`) |
+
+`logout_completed.source` is platform-specific: use the web values above or the iOS values below, and segment analyses by platform before grouping by `source`.
 
 ### Onboarding Events
 

--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -81,15 +81,15 @@ app_opened → welcome_viewed → signup_started → signup_completed
 
 ### Welcome & Auth Flow Events
 
-| Event                 | When                                     | Properties                                                                                                                        |
-| --------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `welcome_viewed`      | User lands on /welcome                   | —                                                                                                                                 |
-| `signup_started`      | User click signup button                 | `method` (`email` \| `google`)                                                                                                    |
-| `signup_completed`    | Signup succeed                           | `method` (`email` \| `google`)                                                                                                    |
-| `pin_setup_completed` | New user creates a PIN                   | —                                                                                                                                 |
-| `pin_entered`         | Returning user enters their PIN          | —                                                                                                                                 |
-| `demo_started`        | Demo session created                     | —                                                                                                                                 |
-| `logout_completed`    | Web session ends after local sign-out    | `source` (`user_initiated` \| `vault_code` \| `demo_exit` \| `scheduled_deletion` \| `account_blocked`)                          |
+| Event                 | When                                  | Properties                                                                                                                                                               |
+| --------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `welcome_viewed`      | User lands on /welcome                | —                                                                                                                                                                        |
+| `signup_started`      | User click signup button              | `method` (`email` \| `google`)                                                                                                                                           |
+| `signup_completed`    | Signup succeed                        | `method` (`email` \| `google`)                                                                                                                                           |
+| `pin_setup_completed` | New user creates a PIN                | —                                                                                                                                                                        |
+| `pin_entered`         | Returning user enters their PIN       | —                                                                                                                                                                        |
+| `demo_started`        | Demo session created                  | —                                                                                                                                                                        |
+| `logout_completed`    | Web session ends after local sign-out | `source` (`user_initiated` \| `vault_code` \| `demo_exit` \| `scheduled_deletion` \| `account_blocked` \| `session_expired` \| `refresh_failed`)                       |
 
 ### Onboarding Events
 

--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -81,14 +81,15 @@ app_opened → welcome_viewed → signup_started → signup_completed
 
 ### Welcome & Auth Flow Events
 
-| Event                 | When                                                     | Properties                     |
-| --------------------- | -------------------------------------------------------- | ------------------------------ |
-| `welcome_viewed`      | User lands on /welcome                                   | —                              |
-| `signup_started`      | User click signup button                                 | `method` (`email` \| `google`) |
-| `signup_completed`    | Signup succeed (email direct, Google via pending method) | `method` (`email` \| `google`) |
-| `pin_setup_completed` | New user creates a PIN                                   | —                              |
-| `pin_entered`         | Returning user enters their PIN                          | —                              |
-| `demo_started`        | Demo session created                                     | —                              |
+| Event                 | When                                     | Properties                                                                                                                        |
+| --------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `welcome_viewed`      | User lands on /welcome                   | —                                                                                                                                 |
+| `signup_started`      | User click signup button                 | `method` (`email` \| `google`)                                                                                                    |
+| `signup_completed`    | Signup succeed                           | `method` (`email` \| `google`)                                                                                                    |
+| `pin_setup_completed` | New user creates a PIN                   | —                                                                                                                                 |
+| `pin_entered`         | Returning user enters their PIN          | —                                                                                                                                 |
+| `demo_started`        | Demo session created                     | —                                                                                                                                 |
+| `logout_completed`    | Web session ends after local sign-out    | `source` (`user_initiated` \| `vault_code` \| `demo_exit` \| `scheduled_deletion` \| `account_blocked`)                          |
 
 ### Onboarding Events
 

--- a/frontend/projects/webapp/src/app/core/auth/auth-credentials.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-credentials.service.ts
@@ -74,7 +74,7 @@ export class AuthCredentialsService {
           userId: data.session?.user.id,
         });
         try {
-          await this.#session.signOut();
+          await this.#session.signOut('scheduled_deletion');
         } catch (signOutError) {
           this.#logger.error(
             'signOut failed during scheduled-deletion handling',

--- a/frontend/projects/webapp/src/app/core/auth/auth-interceptor.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-interceptor.spec.ts
@@ -227,9 +227,31 @@ describe('authInterceptor', () => {
 
       const result = await promise1;
 
-      expect(mockAuthSession.signOut).toHaveBeenCalled();
+      expect(mockAuthSession.signOut).toHaveBeenCalledTimes(1);
+      expect(mockAuthSession.signOut).toHaveBeenCalledWith('session_expired');
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/', 'login']);
       expect(result).toBeInstanceOf(Error);
+    });
+
+    it('should use refresh_failed when refresh rejects', async () => {
+      mockAuthSession.refreshSession.mockRejectedValue(
+        new Error('Refresh failed'),
+      );
+      const result = firstValueFrom(http.get(`${BACKEND_URL}/endpoint1`)).catch(
+        (err) => err,
+      );
+
+      await flushMicrotasks();
+
+      httpTesting
+        .expectOne(`${BACKEND_URL}/endpoint1`)
+        .flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+
+      const error = await result;
+
+      expect(mockAuthSession.signOut).toHaveBeenCalledTimes(1);
+      expect(mockAuthSession.signOut).toHaveBeenCalledWith('refresh_failed');
+      expect(error).toBeInstanceOf(Error);
     });
   });
 
@@ -320,7 +342,7 @@ describe('authInterceptor', () => {
 
       const error = await result;
 
-      expect(mockAuthSession.signOut).toHaveBeenCalled();
+      expect(mockAuthSession.signOut).toHaveBeenCalledWith('account_blocked');
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/', 'login']);
       expect(error).toBeInstanceOf(Error);
     });
@@ -341,7 +363,7 @@ describe('authInterceptor', () => {
 
       const error = await result;
 
-      expect(mockAuthSession.signOut).toHaveBeenCalled();
+      expect(mockAuthSession.signOut).toHaveBeenCalledWith('account_blocked');
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/', 'login']);
       expect(error).toBeInstanceOf(Error);
     });

--- a/frontend/projects/webapp/src/app/core/auth/auth-interceptor.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-interceptor.ts
@@ -113,7 +113,7 @@ function signOutAndRedirect(
   ctx: InterceptorContext,
   errorKey: string,
 ): Observable<never> {
-  return from(ctx.session.signOut()).pipe(
+  return from(ctx.session.signOut('account_blocked')).pipe(
     switchMap(() => from(ctx.router.navigate(['/', ROUTES.LOGIN]))),
     switchMap(() =>
       throwError(() => new Error(ctx.transloco.translate(errorKey))),

--- a/frontend/projects/webapp/src/app/core/auth/auth-interceptor.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-interceptor.ts
@@ -9,7 +9,7 @@ import {
 import { Router } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
 import { type Observable, throwError, from, switchMap, catchError } from 'rxjs';
-import { AuthSessionService } from './auth-session.service';
+import { AuthSessionService, type SignOutSource } from './auth-session.service';
 import { AuthStore } from './auth-store';
 import { ApplicationConfiguration } from '../config/application-configuration';
 import { ROUTES } from '../routing/routes-constants';
@@ -72,12 +72,22 @@ function handleAuthError(
 ): Observable<HttpEvent<unknown>> {
   if (error.status === 401 && ctx.authStore.isAuthenticated()) {
     return from(ctx.session.refreshSession()).pipe(
+      catchError(() =>
+        signOutAndRedirect(
+          ctx,
+          AUTH_ERROR_KEYS.REFRESH_FAILED,
+          'refresh_failed',
+        ),
+      ),
       switchMap((refreshed) =>
         refreshed
           ? ctx.next(addAuthToken(ctx.req, ctx.authStore))
-          : signOutAndRedirect(ctx, AUTH_ERROR_KEYS.SESSION_EXPIRED),
+          : signOutAndRedirect(
+              ctx,
+              AUTH_ERROR_KEYS.SESSION_EXPIRED,
+              'session_expired',
+            ),
       ),
-      catchError(() => signOutAndRedirect(ctx, AUTH_ERROR_KEYS.REFRESH_FAILED)),
     );
   }
 
@@ -103,7 +113,11 @@ function handleAuthError(
     (error.error?.code === 'ERR_USER_ACCOUNT_BLOCKED' ||
       error.error?.error === 'ERR_USER_ACCOUNT_BLOCKED')
   ) {
-    return signOutAndRedirect(ctx, AUTH_ERROR_KEYS.ACCOUNT_BLOCKED);
+    return signOutAndRedirect(
+      ctx,
+      AUTH_ERROR_KEYS.ACCOUNT_BLOCKED,
+      'account_blocked',
+    );
   }
 
   return throwError(() => error);
@@ -112,8 +126,9 @@ function handleAuthError(
 function signOutAndRedirect(
   ctx: InterceptorContext,
   errorKey: string,
+  source: SignOutSource,
 ): Observable<never> {
-  return from(ctx.session.signOut('account_blocked')).pipe(
+  return from(ctx.session.signOut(source)).pipe(
     switchMap(() => from(ctx.router.navigate(['/', ROUTES.LOGIN]))),
     switchMap(() =>
       throwError(() => new Error(ctx.transloco.translate(errorKey))),

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -681,7 +681,7 @@ describe('AuthSessionService', () => {
     await service.signOut('user_initiated');
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      'Erreur inattendue lors de la déconnexion:',
+      'Erreur inattendue lors du tracking de déconnexion:',
       error,
     );
     expect(mockSupabaseClient.auth.signOut).toHaveBeenCalledWith({
@@ -690,6 +690,13 @@ describe('AuthSessionService', () => {
     expect(mockAuthStore.set).toHaveBeenCalledWith({
       phase: 'unauthenticated',
     });
+    expect(mockCleanup.performCleanup).toHaveBeenCalled();
+  });
+
+  it('should not track logout without an initialized Supabase client', async () => {
+    await service.signOut('user_initiated');
+
+    expect(mockPostHog.captureEvent).not.toHaveBeenCalled();
     expect(mockCleanup.performCleanup).toHaveBeenCalled();
   });
 
@@ -724,6 +731,7 @@ describe('AuthSessionService', () => {
       phase: 'unauthenticated',
     });
     expect(mockSupabaseClient.auth.signOut).not.toHaveBeenCalled();
+    expect(mockPostHog.captureEvent).not.toHaveBeenCalled();
     expect(mockCleanup.performCleanup).toHaveBeenCalled();
   });
 

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -9,7 +9,13 @@ import {
 } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, signal } from '@angular/core';
-import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js';
+import {
+  AuthRetryableFetchError,
+  type AuthChangeEvent,
+  type Session,
+  type User,
+} from '@supabase/supabase-js';
+import type * as SupabaseJsModule from '@supabase/supabase-js';
 import { Router } from '@angular/router';
 import { AuthSessionService } from './auth-session.service';
 import { AuthStore } from './auth-store';
@@ -31,7 +37,8 @@ const { createClientMock } = vi.hoisted(() => ({
   createClientMock: vi.fn(),
 }));
 
-vi.mock('@supabase/supabase-js', () => ({
+vi.mock('@supabase/supabase-js', async (importOriginal) => ({
+  ...(await importOriginal<typeof SupabaseJsModule>()),
   createClient: createClientMock,
 }));
 
@@ -467,6 +474,25 @@ describe('AuthSessionService', () => {
 
     expect(result).toBe(false);
     expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('should reject when refreshSession fails transiently', async () => {
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+    mockSupabaseClient.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+    await service.initializeAuthState();
+
+    const error = new AuthRetryableFetchError('Network unavailable', 0);
+    mockSupabaseClient.auth.refreshSession.mockResolvedValue({
+      data: { session: null, user: null },
+      error,
+    });
+
+    await expect(service.refreshSession()).rejects.toBe(error);
   });
 
   describe('setSession', () => {

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -661,6 +661,24 @@ describe('AuthSessionService', () => {
     expect(mockCleanup.performCleanup).toHaveBeenCalled();
   });
 
+  it('should clear local auth state when logout tracking throws', async () => {
+    const error = new Error('PostHog unavailable');
+    mockPostHog.captureEvent.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await service.signOut('user_initiated');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Erreur inattendue lors de la déconnexion:',
+      error,
+    );
+    expect(mockAuthStore.set).toHaveBeenCalledWith({
+      phase: 'unauthenticated',
+    });
+    expect(mockCleanup.performCleanup).toHaveBeenCalled();
+  });
+
   it('should sign out in E2E mode and apply unauthenticated state', async () => {
     const mockE2EState = {
       user: mockSession.user,

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -19,6 +19,7 @@ import { AuthErrorLocalizer } from './auth-error-localizer';
 import { SCHEDULED_DELETION_PARAMS } from './auth-constants';
 import { type E2EWindow } from './e2e-window';
 import { AuthCleanupService } from './auth-cleanup.service';
+import { PostHogService } from '../analytics/posthog';
 import { ROUTES } from '@core/routing/routes-constants';
 import {
   createMockSupabaseClient,
@@ -60,6 +61,7 @@ describe('AuthSessionService', () => {
   };
   let mockSupabaseClient: MockSupabaseClient;
   let mockCleanup: { performCleanup: Mock };
+  let mockPostHog: { captureEvent: Mock };
   let mockRouter: { navigate: Mock };
   let mockUserSignal: ReturnType<typeof signal<User | null>>;
 
@@ -117,6 +119,7 @@ describe('AuthSessionService', () => {
     };
 
     mockCleanup = { performCleanup: vi.fn() };
+    mockPostHog = { captureEvent: vi.fn() };
     mockRouter = { navigate: vi.fn() };
     mockSupabaseClient = createMockSupabaseClient();
     createClientMock.mockReturnValue(mockSupabaseClient);
@@ -131,6 +134,7 @@ describe('AuthSessionService', () => {
         { provide: Logger, useValue: mockLogger },
         { provide: AuthErrorLocalizer, useValue: mockErrorLocalizer },
         { provide: AuthCleanupService, useValue: mockCleanup },
+        { provide: PostHogService, useValue: mockPostHog },
         { provide: Router, useValue: mockRouter },
       ],
     });
@@ -611,11 +615,20 @@ describe('AuthSessionService', () => {
     mockAuthStore.set.mockClear();
     mockCleanup.performCleanup.mockClear();
 
-    await service.signOut();
+    await service.signOut('user_initiated');
 
     expect(mockSupabaseClient.auth.signOut).toHaveBeenCalledWith({
       scope: 'local',
     });
+    expect(mockPostHog.captureEvent).toHaveBeenCalledWith('logout_completed', {
+      source: 'user_initiated',
+    });
+    expect(mockPostHog.captureEvent.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSupabaseClient.auth.signOut.mock.invocationCallOrder[0],
+    );
+    expect(mockPostHog.captureEvent.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCleanup.performCleanup.mock.invocationCallOrder[0],
+    );
     expect(mockAuthStore.set).toHaveBeenCalledWith({
       phase: 'unauthenticated',
     });
@@ -644,7 +657,7 @@ describe('AuthSessionService', () => {
     mockCleanup.performCleanup.mockClear();
     mockLogger.info.mockClear();
 
-    await service.signOut();
+    await service.signOut('user_initiated');
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
       '🎭 Mode test E2E: Simulation du logout',
@@ -736,9 +749,9 @@ describe('AuthSessionService', () => {
       );
 
       const pendingSignOuts = Promise.all([
-        service.signOut(),
-        service.signOut(),
-        service.signOut(),
+        service.signOut('user_initiated'),
+        service.signOut('user_initiated'),
+        service.signOut('user_initiated'),
       ]);
       resolveSignOut({ error: null });
       await pendingSignOuts;
@@ -750,8 +763,8 @@ describe('AuthSessionService', () => {
     it('should allow a new signOut after the previous one completed', async () => {
       mockSupabaseClient.auth.signOut.mockResolvedValue({ error: null });
 
-      await service.signOut();
-      await service.signOut();
+      await service.signOut('user_initiated');
+      await service.signOut('user_initiated');
 
       expect(mockSupabaseClient.auth.signOut).toHaveBeenCalledTimes(2);
     });

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -613,7 +613,9 @@ describe('AuthSessionService', () => {
 
     await service.signOut();
 
-    expect(mockSupabaseClient.auth.signOut).toHaveBeenCalled();
+    expect(mockSupabaseClient.auth.signOut).toHaveBeenCalledWith({
+      scope: 'local',
+    });
     expect(mockAuthStore.set).toHaveBeenCalledWith({
       phase: 'unauthenticated',
     });

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -493,6 +493,7 @@ describe('AuthSessionService', () => {
     });
 
     await expect(service.refreshSession()).rejects.toBe(error);
+    expect(mockLogger.error).not.toHaveBeenCalled();
   });
 
   describe('setSession', () => {
@@ -661,7 +662,17 @@ describe('AuthSessionService', () => {
     expect(mockCleanup.performCleanup).toHaveBeenCalled();
   });
 
-  it('should clear local auth state when logout tracking throws', async () => {
+  it('should sign out and clear local auth state when logout tracking throws', async () => {
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+    mockSupabaseClient.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+    mockSupabaseClient.auth.signOut.mockResolvedValue({ error: null });
+    await service.initializeAuthState();
+
     const error = new Error('PostHog unavailable');
     mockPostHog.captureEvent.mockImplementationOnce(() => {
       throw error;
@@ -673,6 +684,9 @@ describe('AuthSessionService', () => {
       'Erreur inattendue lors de la déconnexion:',
       error,
     );
+    expect(mockSupabaseClient.auth.signOut).toHaveBeenCalledWith({
+      scope: 'local',
+    });
     expect(mockAuthStore.set).toHaveBeenCalledWith({
       phase: 'unauthenticated',
     });

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -1,7 +1,11 @@
 import { Service, inject, DestroyRef } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
-import type { Session, SupabaseClient } from '@supabase/supabase-js';
+import {
+  isAuthRetryableFetchError,
+  type Session,
+  type SupabaseClient,
+} from '@supabase/supabase-js';
 import { ANALYTICS_EVENTS } from 'pulpe-shared';
 import { ApplicationConfiguration } from '../config/application-configuration';
 import { Logger } from '../logging/logger';
@@ -322,6 +326,9 @@ export class AuthSessionService {
       const { data, error } = await this.getClient().auth.refreshSession();
 
       if (error) {
+        if (isAuthRetryableFetchError(error)) {
+          throw error;
+        }
         this.#logger.error(
           'Erreur lors du rafraîchissement de la session:',
           error,
@@ -332,11 +339,8 @@ export class AuthSessionService {
       this.#updateAuthStateFromSession(data.session ?? null);
       return !!data.session;
     } catch (error) {
-      this.#logger.error(
-        'Erreur inattendue lors du rafraîchissement de la session:',
-        error,
-      );
-      return false;
+      this.#logger.error('Échec du rafraîchissement de la session:', error);
+      throw error;
     }
   }
 

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -224,7 +224,8 @@ export class AuthSessionService {
         );
       }
 
-      // Global scope revokes iOS sessions; device-wide revocation is handled server-side by signOutGlobally.
+      // Local scope preserves other devices, including iOS. Global revocation
+      // is reserved for server-side account deletion.
       const { error } = await this.#supabaseClient.auth.signOut({
         scope: 'local',
       });

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -10,6 +10,14 @@ import { AUTH_ERROR_KEYS, SCHEDULED_DELETION_PARAMS } from './auth-constants';
 import { AuthCleanupService } from './auth-cleanup.service';
 import { isE2EMode, type E2EWindow } from './e2e-window';
 import { ROUTES } from '@core/routing/routes-constants';
+import { PostHogService } from '../analytics/posthog';
+
+export type SignOutSource =
+  | 'user_initiated'
+  | 'vault_code'
+  | 'demo_exit'
+  | 'scheduled_deletion'
+  | 'account_blocked';
 
 interface DecodedJwt {
   readonly sub: string;
@@ -24,6 +32,7 @@ export class AuthSessionService {
   readonly #errorLocalizer = inject(AuthErrorLocalizer);
   readonly #logger = inject(Logger);
   readonly #cleanup = inject(AuthCleanupService);
+  readonly #postHog = inject(PostHogService);
   readonly #transloco = inject(TranslocoService);
   readonly #destroyRef = inject(DestroyRef);
 
@@ -178,13 +187,17 @@ export class AuthSessionService {
     }
   }
 
-  signOut(): Promise<void> {
-    return (this.#signOutPromise ??= this.#performSignOut().finally(() => {
-      this.#signOutPromise = null;
-    }));
+  signOut(source: SignOutSource): Promise<void> {
+    return (this.#signOutPromise ??= this.#performSignOut(source).finally(
+      () => {
+        this.#signOutPromise = null;
+      },
+    ));
   }
 
-  async #performSignOut(): Promise<void> {
+  async #performSignOut(source: SignOutSource): Promise<void> {
+    this.#postHog.captureEvent('logout_completed', { source });
+
     try {
       if (isE2EMode()) {
         this.#logger.debug('🎭 Mode test E2E: Simulation du logout');
@@ -338,7 +351,7 @@ export class AuthSessionService {
         'User account scheduled for deletion detected, signing out',
         { userId: session.user.id },
       );
-      this.signOut().finally(() => {
+      this.signOut('scheduled_deletion').finally(() => {
         this.#router.navigate(['/', ROUTES.LOGIN], {
           queryParams: {
             [SCHEDULED_DELETION_PARAMS.REASON]:

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -2,6 +2,7 @@ import { Service, inject, DestroyRef } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
 import type { Session, SupabaseClient } from '@supabase/supabase-js';
+import { ANALYTICS_EVENTS } from 'pulpe-shared';
 import { ApplicationConfiguration } from '../config/application-configuration';
 import { Logger } from '../logging/logger';
 import { AuthStore, type AuthSessionState } from './auth-store';
@@ -17,7 +18,9 @@ export type SignOutSource =
   | 'vault_code'
   | 'demo_exit'
   | 'scheduled_deletion'
-  | 'account_blocked';
+  | 'account_blocked'
+  | 'session_expired'
+  | 'refresh_failed';
 
 interface DecodedJwt {
   readonly sub: string;
@@ -196,7 +199,7 @@ export class AuthSessionService {
   }
 
   async #performSignOut(source: SignOutSource): Promise<void> {
-    this.#postHog.captureEvent('logout_completed', { source });
+    this.#postHog.captureEvent(ANALYTICS_EVENTS.LOGOUT_COMPLETED, { source });
 
     try {
       if (isE2EMode()) {

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -204,7 +204,16 @@ export class AuthSessionService {
 
   async #performSignOut(source: SignOutSource): Promise<void> {
     try {
-      this.#postHog.captureEvent(ANALYTICS_EVENTS.LOGOUT_COMPLETED, { source });
+      try {
+        this.#postHog.captureEvent(ANALYTICS_EVENTS.LOGOUT_COMPLETED, {
+          source,
+        });
+      } catch (trackingError) {
+        this.#logger.error(
+          'Erreur inattendue lors de la déconnexion:',
+          trackingError,
+        );
+      }
 
       if (isE2EMode()) {
         this.#logger.debug('🎭 Mode test E2E: Simulation du logout');
@@ -322,26 +331,21 @@ export class AuthSessionService {
   }
 
   async #refreshSessionAndUpdateState(): Promise<boolean> {
-    try {
-      const { data, error } = await this.getClient().auth.refreshSession();
+    const { data, error } = await this.getClient().auth.refreshSession();
 
-      if (error) {
-        if (isAuthRetryableFetchError(error)) {
-          throw error;
-        }
-        this.#logger.error(
-          'Erreur lors du rafraîchissement de la session:',
-          error,
-        );
-        return false;
+    if (error) {
+      if (isAuthRetryableFetchError(error)) {
+        throw error;
       }
-
-      this.#updateAuthStateFromSession(data.session ?? null);
-      return !!data.session;
-    } catch (error) {
-      this.#logger.error('Échec du rafraîchissement de la session:', error);
-      throw error;
+      this.#logger.error(
+        'Erreur lors du rafraîchissement de la session:',
+        error,
+      );
+      return false;
     }
+
+    this.#updateAuthStateFromSession(data.session ?? null);
+    return !!data.session;
   }
 
   #handleAuthEvent(event: string, session: Session | null): void {

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -203,9 +203,9 @@ export class AuthSessionService {
   }
 
   async #performSignOut(source: SignOutSource): Promise<void> {
-    this.#postHog.captureEvent(ANALYTICS_EVENTS.LOGOUT_COMPLETED, { source });
-
     try {
+      this.#postHog.captureEvent(ANALYTICS_EVENTS.LOGOUT_COMPLETED, { source });
+
       if (isE2EMode()) {
         this.#logger.debug('🎭 Mode test E2E: Simulation du logout');
         return;

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -204,17 +204,6 @@ export class AuthSessionService {
 
   async #performSignOut(source: SignOutSource): Promise<void> {
     try {
-      try {
-        this.#postHog.captureEvent(ANALYTICS_EVENTS.LOGOUT_COMPLETED, {
-          source,
-        });
-      } catch (trackingError) {
-        this.#logger.error(
-          'Erreur inattendue lors de la déconnexion:',
-          trackingError,
-        );
-      }
-
       if (isE2EMode()) {
         this.#logger.debug('🎭 Mode test E2E: Simulation du logout');
         return;
@@ -222,6 +211,17 @@ export class AuthSessionService {
 
       if (!this.#supabaseClient) {
         return;
+      }
+
+      try {
+        this.#postHog.captureEvent(ANALYTICS_EVENTS.LOGOUT_COMPLETED, {
+          source,
+        });
+      } catch (trackingError) {
+        this.#logger.error(
+          'Erreur inattendue lors du tracking de déconnexion:',
+          trackingError,
+        );
       }
 
       // Global scope revokes iOS sessions; device-wide revocation is handled server-side by signOutGlobally.

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -195,9 +195,12 @@ export class AuthSessionService {
         return;
       }
 
-      const { error } = await this.#supabaseClient.auth.signOut();
+      // Global scope revokes iOS sessions; device-wide revocation is handled server-side by signOutGlobally.
+      const { error } = await this.#supabaseClient.auth.signOut({
+        scope: 'local',
+      });
       if (error) {
-        this.#logger.error('Erreur lors de la déconnexion globale:', error);
+        this.#logger.error('Erreur lors de la déconnexion locale:', error);
       }
     } catch (error) {
       this.#logger.error('Erreur inattendue lors de la déconnexion:', error);

--- a/frontend/projects/webapp/src/app/core/demo/demo-initializer.service.ts
+++ b/frontend/projects/webapp/src/app/core/demo/demo-initializer.service.ts
@@ -133,7 +133,7 @@ export class DemoInitializerService {
    */
   async exitDemoMode(): Promise<void> {
     this.#demoModeService.deactivateDemoMode();
-    await this.#authSession.signOut();
+    await this.#authSession.signOut('demo_exit');
     this.#logger.info('Demo mode exited and user signed out');
   }
 

--- a/frontend/projects/webapp/src/app/feature/auth/enter-vault-code/enter-vault-code.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/enter-vault-code/enter-vault-code.ts
@@ -293,7 +293,7 @@ export default class EnterVaultCode {
     this.#dialog.open(LogoutDialog, { disableClose: true });
 
     try {
-      await this.#authSession.signOut();
+      await this.#authSession.signOut('vault_code');
     } catch (error) {
       this.#logger.error('Erreur lors de la déconnexion:', error);
     } finally {

--- a/frontend/projects/webapp/src/app/feature/auth/setup-vault-code/setup-vault-code.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/setup-vault-code/setup-vault-code.ts
@@ -361,7 +361,7 @@ export default class SetupVaultCode {
     this.#dialog.open(LogoutDialog, { disableClose: true });
 
     try {
-      await this.#authSession.signOut();
+      await this.#authSession.signOut('vault_code');
     } catch (error) {
       this.#logger.error('Erreur lors de la déconnexion:', error);
     } finally {

--- a/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
+++ b/frontend/projects/webapp/src/app/feature/settings/settings-page.ts
@@ -714,7 +714,7 @@ export default class SettingsPage {
     this.#clientKeyService.clear();
 
     try {
-      await this.#authSession.signOut();
+      await this.#authSession.signOut('scheduled_deletion');
     } catch (error) {
       this.#logger.warn(
         'Sign out failed after account deletion scheduling',

--- a/frontend/projects/webapp/src/app/layout/main-layout.ts
+++ b/frontend/projects/webapp/src/app/layout/main-layout.ts
@@ -974,7 +974,7 @@ export default class MainLayout {
     this.#dialog.open(LogoutDialog, { disableClose: true });
 
     try {
-      await this.#authSession.signOut();
+      await this.#authSession.signOut('user_initiated');
     } catch (error) {
       if (!this.#applicationConfig.isProduction()) {
         this.#logger.error('Erreur lors de la déconnexion:', error);


### PR DESCRIPTION
## Summary

- Add `logout_completed` analytics with the sign-out source.
- Attribute all web logout flows, including expiry, refresh failures, blocked accounts, demo exit, and scheduled deletion.
- Restrict Supabase web sign-outs to the local session.
- Update authentication tests for source attribution and event ordering.

## Testing

- Not run (not requested)