### PR TITLE
Standardize analytics event taxonomy across web and iOS onboarding

### DIFF
--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -11,33 +11,37 @@ paths: "**/analytics/**"
 
 ```typescript
 // Good
-captureEvent('signup_started');
-captureEvent('budget_created');
-captureEvent('tutorial_completed');
+captureEvent("signup_started");
+captureEvent("budget_created");
+captureEvent("transaction_created");
 
 // Bad
-captureEvent('SignupStarted');      // PascalCase
-captureEvent('user-signed-up');     // kebab-case
-captureEvent('click');              // Too vague
+captureEvent("SignupStarted"); // PascalCase
+captureEvent("user-signed-up"); // kebab-case
+captureEvent("click"); // Too vague
 ```
 
 ## Conversion Funnel
 
 **Web:**
+
 ```
-$pageview (landing) → cta_clicked → welcome_page_viewed → signup_started
-→ signup_completed → vault_code_setup_completed → onboarding_started
-→ profile_step1_completed → profile_step2_completed → first_budget_created
+$pageview (landing) → cta_clicked → welcome_viewed → signup_started
+→ signup_completed → pin_setup_completed → onboarding_started
+→ onboarding_step_completed (profile) → onboarding_step_completed (charges)
+→ first_budget_created
 ```
 
 **Web (with demo):**
+
 ```
-welcome_page_viewed → demo_started → signup_started → signup_completed → ...
+welcome_viewed → demo_started → signup_started → signup_completed → ...
 ```
 
 **iOS:**
+
 ```
-app_opened → welcome_screen_viewed → onboarding_started
+app_opened → welcome_viewed → onboarding_started
 → onboarding_step_completed (first_name) → signup_started → signup_completed
 → onboarding_step_completed (income, charges, savings, budget_preview)
 → pin_setup_completed → first_budget_created
@@ -46,6 +50,7 @@ app_opened → welcome_screen_viewed → onboarding_started
 `onboarding_started` fires once per session on first transition out of welcome (email tap) or on fresh social OAuth entry into flow. `signup_started` fires when user reach registration form (post reorder — step 3, not step 1).
 
 **Tracking approach:**
+
 - Pre-auth events (`signup_started`) captured as anonymous (`person_profiles: 'identified_only'`)
 - Full auto-capture (pageviews, autocapture) enabled after auth
 - Google OAuth use `PostHogService.setPendingSignupMethod()` to store method via `StorageService`, then `capturePendingSignupCompleted()` fire `signup_completed` after redirect
@@ -58,80 +63,96 @@ app_opened → welcome_screen_viewed → onboarding_started
 
 ### Landing Page Events
 
-| Event | When | Properties |
-|-------|------|------------|
-| `$pageview` | Auto-captured on page load | `$current_url` |
-| `cta_clicked` | User click CTA button | `cta_name`, `cta_location`, `destination` |
+| Event         | When                       | Properties                                |
+| ------------- | -------------------------- | ----------------------------------------- |
+| `$pageview`   | Auto-captured on page load | `$current_url`                            |
+| `cta_clicked` | User click CTA button      | `cta_name`, `cta_location`, `destination` |
 
 ### Welcome & Auth Flow Events
 
-| Event | When | Properties |
-|-------|------|------------|
-| `welcome_page_viewed` | User land on /welcome | `$referrer`, `$utm_source` (auto) |
-| `signup_started` | User click signup button | `method` (`email` \| `google`) |
-| `signup_completed` | Signup succeed (email direct, Google via pending method) | `method` (`email` \| `google`) |
-| `vault_code_setup_completed` | New user create vault code | — |
-| `vault_code_entered` | Returning user enter vault code | — |
-| `demo_started` | Demo session created | — |
+| Event                 | When                                                     | Properties                     |
+| --------------------- | -------------------------------------------------------- | ------------------------------ |
+| `welcome_viewed`      | User lands on /welcome                                   | —                              |
+| `signup_started`      | User click signup button                                 | `method` (`email` \| `google`) |
+| `signup_completed`    | Signup succeed (email direct, Google via pending method) | `method` (`email` \| `google`) |
+| `pin_setup_completed` | New user creates a PIN                                   | —                              |
+| `pin_entered`         | Returning user enters their PIN                          | —                              |
+| `demo_started`        | Demo session created                                     | —                              |
 
 ### Onboarding Events
 
-| Event | When | Properties |
-|-------|------|------------|
-| `onboarding_started` | User land on complete-profile | — |
-| `profile_step1_completed` | First profile step done | — |
-| `profile_step2_completed` | Second profile step done | — |
-| `profile_step2_skipped` | Second profile step skipped | — |
-| `first_budget_created` | User create initial budget | `signup_method`, `has_pay_day`, `charges_count`, `custom_transactions_count` |
-| `onboarding_suggestion_toggled` | User tap suggestion chip (charges or savings step) | `step` (`charges` \| `savings` \| `income`), `suggestion_name`, `selected` (bool) |
-| `custom_transaction_added` | User add custom row via dialog or suggestion chip | `step`, `kind` (`expense` \| `saving` \| `income`), `source` (`manual` \| `suggestion`) |
-| `custom_transaction_removed` | User remove custom row | `step`, `kind`, `source` |
-
-### Tutorial Events
-
-| Event | When | Properties |
-|-------|------|------------|
-| `tutorial_started` | Tutorial begin | — |
-| `tutorial_completed` | Tutorial finish | — |
-| `tutorial_cancelled` | User skip tutorial | — |
+| Event                           | When                                               | Properties                                                                              |
+| ------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `onboarding_started`            | User land on complete-profile                      | —                                                                                       |
+| `onboarding_step_completed`     | User completes profile or charges step             | `step` (`profile` \| `charges`), `skipped` (charges only)                               |
+| `first_budget_created`          | User create initial budget                         | `signup_method`, `has_pay_day`, `charges_count`, `custom_transactions_count`            |
+| `onboarding_suggestion_toggled` | User tap suggestion chip (charges or savings step) | `step` (`charges` \| `savings` \| `income`), `suggestion_name`, `selected` (bool)       |
+| `custom_transaction_added`      | User add custom row via dialog or suggestion chip  | `step`, `kind` (`expense` \| `saving` \| `income`), `source` (`manual` \| `suggestion`) |
+| `custom_transaction_removed`    | User remove custom row                             | `step`, `kind`, `source`                                                                |
 
 ### Settings / Account Events
 
-| Event | When | Properties | Web | iOS |
-|-------|------|------------|-----|-----|
-| `currency_changed` | User select different currency in settings + save (web) or pick (iOS) succeeds | `from` (`CHF` \| `EUR`), `to` (`CHF` \| `EUR`) | ✅ | ✅ |
-| `currency_selector_toggled` | User toggle "Saisir dans une autre devise" + save succeeds | `enabled` (bool) | ✅ | ✅ |
+| Event                       | When                                                                           | Properties                                     | Web | iOS |
+| --------------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------- | --- | --- |
+| `currency_changed`          | User select different currency in settings + save (web) or pick (iOS) succeeds | `from` (`CHF` \| `EUR`), `to` (`CHF` \| `EUR`) | ✅  | ✅  |
+| `currency_selector_toggled` | User toggle "Saisir dans une autre devise" + save succeeds                     | `enabled` (bool)                               | ✅  | ✅  |
+| `currency_persist_failed`   | iOS exhausts onboarding currency persistence retries                           | `currency`, `attempts`                         | —   | ✅  |
 
-Both events are available to every authenticated user. The selector itself follows the `showCurrencySelector` user preference; neither event is feature-gated. Event names + property keys are sourced from `pulpe-shared` (`ANALYTICS_EVENTS`) — never hardcode.
+The settings events are available to every authenticated user. The selector itself follows the `showCurrencySelector` user preference; none is feature-gated. Event names + property keys are sourced from `pulpe-shared` (`ANALYTICS_EVENTS`) — never hardcode.
 
 ### iOS App Events
 
-| Event | When | Properties |
-|-------|------|------------|
-| `app_opened` | App enter foreground | — |
-| `welcome_screen_viewed` | Welcome screen appear (new user), idempotent per view instance | — |
-| `onboarding_started` | First exit from welcome (email tap) or fresh social OAuth entry | `method` (`email` \| `apple` \| `google`) |
-| `onboarding_step_completed` | User complete onboarding step | `step` (`first_name` \| `registration` \| `income` \| `charges` \| `savings` \| `budget_preview`), `step_index`, `step_total`, `auth_method` (`email` \| `apple` \| `google`) |
-| `onboarding_abandoned` | User exit onboarding before complete | `last_step`, `exit_method` (`background` \| `quit_button` \| `restart_button`), `was_authenticated`, `auth_method` |
-| `onboarding_resumed` | Email user cold-start in-progress signup | `method` (`email`), `source` (`pending_user` \| `session_fallback`), `resumed_at_step` |
-| `signup_started` | User reach registration form (step 3) | `method` (`email` \| `apple` \| `google`) |
-| `signup_completed` | Signup succeed | `method` (`email` \| `apple` \| `google`) |
-| `login_completed` | Login succeed | `method` (`email` \| `biometric` \| `google` \| `apple`) |
-| `login_failed` | Login fail (any method) | `method`, `error_kind`, `error_message` |
-| `signup_failed` | Signup fail | `method`, `error_kind`, `error_message` |
-| `session_restore_failed` | Session restore at startup fail | `method`, `error_kind`, `error_message` |
-| `auth_session_observed` | Supabase session lifecycle or storage signal | `source`, `outcome`, optional `status`, `request_id`, `endpoint`, `is_retry`, `storage_state`, `access_token_expires_in_seconds`, `is_expected_user_action` |
-| `pin_setup_completed` | PIN created | — |
-| `pin_entered` | PIN entered on return visit | — |
-| `first_budget_created` | Initial budget created at end of onboarding | `signup_method` (`email` \| `apple` \| `google`), `has_pay_day`, `charges_count`, `custom_transactions_count` |
-| `onboarding_suggestion_toggled` | User tap suggestion chip (charges or savings step) | `step` (`charges` \| `savings` \| `income`), `suggestion_name`, `selected` (bool) |
-| `custom_transaction_added` | User add custom row via "+ Ajouter" sheet or suggestion chip | `step`, `kind` (`expense` \| `saving` \| `income`), `source` (`manual` \| `suggestion`) |
-| `custom_transaction_removed` | User remove custom row via swipe, trash, or toggling suggestion off | `step`, `kind`, `source` |
-| `budget_created` | Budget created outside onboarding flow | — |
-| `transaction_created` | Transaction added | `type` (`expense` \| `income` \| `saving`) |
-| `tab_switched` | User switch tab | `tab` (`currentMonth` \| `budgets` \| `templates`) |
-| `logout_completed` | User log out | `source` (`user_initiated` \| `system`) |
-| `ios_whats_new_shown` | Dialog shown after app update with new release notes | `version` |
+| Event                             | When                                                                | Properties                                                                                                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app_opened`                      | App enter foreground                                                | —                                                                                                                                                                             |
+| `welcome_viewed`                  | Welcome screen appears for a new user, once per session             | —                                                                                                                                                                             |
+| `onboarding_started`              | First exit from welcome (email tap) or fresh social OAuth entry     | `method` (`email` \| `apple` \| `google`)                                                                                                                                     |
+| `onboarding_step_completed`       | User complete onboarding step                                       | `step` (`first_name` \| `registration` \| `income` \| `charges` \| `savings` \| `budget_preview`), `step_index`, `step_total`, `auth_method` (`email` \| `apple` \| `google`) |
+| `onboarding_abandoned`            | User exit onboarding before complete                                | `last_step`, `exit_method` (`background` \| `quit_button` \| `restart_button`), `was_authenticated`, `auth_method`                                                            |
+| `onboarding_resumed`              | Email user cold-start in-progress signup                            | `method` (`email`), `source` (`pending_user` \| `session_fallback`), `resumed_at_step`                                                                                        |
+| `signup_started`                  | User reach registration form (step 3)                               | `method` (`email` \| `apple` \| `google`)                                                                                                                                     |
+| `signup_completed`                | Signup succeed                                                      | `method` (`email` \| `apple` \| `google`)                                                                                                                                     |
+| `login_completed`                 | Login succeed                                                       | `method` (`email` \| `biometric` \| `google` \| `apple`)                                                                                                                      |
+| `login_failed`                    | Login fail (any method)                                             | `method`, `error_kind`, `error_message`                                                                                                                                       |
+| `signup_failed`                   | Signup fail                                                         | `method`, `error_kind`, `error_message`                                                                                                                                       |
+| `session_restore_failed`          | Session restore at startup fail                                     | `method`, `error_kind`, `error_message`                                                                                                                                       |
+| `auth_session_observed`           | Supabase session lifecycle or storage signal                        | `source`, `outcome`, optional `status`, `request_id`, `endpoint`, `is_retry`, `storage_state`, `access_token_expires_in_seconds`, `is_expected_user_action`                   |
+| `pin_setup_completed`             | PIN created                                                         | —                                                                                                                                                                             |
+| `pin_entered`                     | PIN entered on return visit                                         | —                                                                                                                                                                             |
+| `pin_changed`                     | Existing PIN changed                                                | —                                                                                                                                                                             |
+| `first_budget_created`            | Initial budget created at end of onboarding                         | `signup_method` (`email` \| `apple` \| `google`), `has_pay_day`, `charges_count`, `custom_transactions_count`                                                                 |
+| `onboarding_suggestion_toggled`   | User tap suggestion chip (charges or savings step)                  | `step` (`charges` \| `savings` \| `income`), `suggestion_name`, `selected` (bool)                                                                                             |
+| `custom_transaction_added`        | User add custom row via "+ Ajouter" sheet or suggestion chip        | `step`, `kind` (`expense` \| `saving` \| `income`), `source` (`manual` \| `suggestion`)                                                                                       |
+| `custom_transaction_removed`      | User remove custom row via swipe, trash, or toggling suggestion off | `step`, `kind`, `source`                                                                                                                                                      |
+| `budget_created`                  | Budget created outside onboarding flow                              | —                                                                                                                                                                             |
+| `transaction_created`             | Transaction added                                                   | `type` (`expense` \| `income` \| `saving`)                                                                                                                                    |
+| `tab_switched`                    | User switch tab                                                     | `tab` (`currentMonth` \| `budgets` \| `templates`)                                                                                                                            |
+| `logout_completed`                | User log out                                                        | `source` (`user_initiated` \| `system`)                                                                                                                                       |
+| `notification_prime_shown`        | Notification pre-permission sheet shown                             | —                                                                                                                                                                             |
+| `notification_permission_granted` | Notification permission granted                                     | —                                                                                                                                                                             |
+| `notification_permission_denied`  | Notification permission denied                                      | —                                                                                                                                                                             |
+| `reminder_toggled`                | Reminder preference changed                                         | `enabled` (bool)                                                                                                                                                              |
+| `ios_whats_new_shown`             | Dialog shown after app update with new release notes                | `version`                                                                                                                                                                     |
+| `currency_changed`                | Display currency changed                                            | `from`, `to`                                                                                                                                                                  |
+| `currency_selector_toggled`       | Per-amount currency selector preference changed                     | `enabled` (bool)                                                                                                                                                              |
+| `currency_persist_failed`         | Onboarding currency persistence retries exhausted                   | `currency`, `attempts`                                                                                                                                                        |
+| `savings_goals_intro_viewed`      | Savings-goals intro opened                                          | —                                                                                                                                                                             |
+| `savings_goals_intro_completed`   | First savings goal created from the intro                           | —                                                                                                                                                                             |
+| `savings_goals_intro_skipped`     | Savings-goals intro skipped                                         | —                                                                                                                                                                             |
+
+### Legacy event names
+
+These definitions remain queryable for historical data but must not be emitted.
+
+| Legacy event                 | Canonical replacement                                              |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `welcome_page_viewed`        | `welcome_viewed`                                                   |
+| `welcome_screen_viewed`      | `welcome_viewed`                                                   |
+| `vault_code_entered`         | `pin_entered`                                                      |
+| `vault_code_setup_completed` | `pin_setup_completed`                                              |
+| `profile_step1_completed`    | `onboarding_step_completed` with `step: profile`                   |
+| `profile_step2_completed`    | `onboarding_step_completed` with `step: charges`, `skipped: false` |
+| `profile_step2_skipped`      | `onboarding_step_completed` with `step: charges`, `skipped: true`  |
 
 `auth_session_observed` value spaces:
 
@@ -160,16 +181,18 @@ compatibility sentinel; no known production path should emit it. Supabase termin
 present when the SDK exposes a matching response and are never inferred from an API 401.
 
 **iOS funnel idempotency guarantees:**
+
 - `onboarding_started` fire once per `OnboardingFlow` instance (@State guard). Reset on view re-instantiation via `.id(appState.onboardingSessionID)` after abandon.
 - `onboarding_abandoned` fire at most once per `OnboardingState` (state.hasAbandoned flag).
 - `onboarding_resumed` fire once per instance, mutually exclusive with `onboarding_started` for same session.
-- `welcome_screen_viewed` fire once per **session** via `state.hasEmittedWelcomeViewed` on `OnboardingState`. Critical: guard live on state (not on `WelcomeStep` view) because `OnboardingFlow` tear down and re-create step views on every step change via `.id(state.currentStep)` — local `@State` guard would double-fire on back-nav.
-- `signup_started` fire once per **session** via `state.hasEmittedSignupStarted` on `OnboardingState`. Same re-instantiation trap as `welcome_screen_viewed`.
+- `welcome_viewed` fire once per **session** via `state.hasEmittedWelcomeViewed` on `OnboardingState`. Critical: guard live on state (not on `WelcomeStep` view) because `OnboardingFlow` tear down and re-create step views on every step change via `.id(state.currentStep)` — local `@State` guard would double-fire on back-nav.
+- `signup_started` fire once per **session** via `state.hasEmittedSignupStarted` on `OnboardingState`. Same re-instantiation trap as `welcome_viewed`.
 - `onboarding_step_completed` for `budget_preview` fire once per session via `state.hasEmittedBudgetPreviewCompleted`. Prevent rapid-double-tap and retry-after-error from double-firing funnel event; CTA also disable once `state.readyToComplete` or `state.isSubmitting` true.
 
 ## Properties
 
 **Global properties** (sent with every iOS event):
+
 ```
 environment: 'local' | 'preview' | 'production'
 app_version: string
@@ -179,17 +202,17 @@ platform: 'ios'
 
 ```typescript
 // Use snake_case, be specific
-captureEvent('budget_created', {
+captureEvent("budget_created", {
   has_pay_day: true,
   charges_count: 5,
-  signup_method: 'google'
+  signup_method: "google",
 });
 ```
 
 ## Rules
 
 1. Always `snake_case`
-2. Format: `object_action` in past tense (`signup_completed`, `budget_created`, `welcome_screen_viewed`). Follow [Segment Tracking Plan spec](https://segment.com/docs/connections/spec/semantic/) used by Mixpanel, Amplitude, and PostHog's own SDK examples (`user_signed_up`). Events represent things that *already happened*, so past tense read naturally. PostHog's best-practices page contradict itself on tense — ignore it, trust examples.
+2. Format: `object_action` in past tense (`signup_completed`, `budget_created`, `welcome_viewed`). Follow [Segment Tracking Plan spec](https://segment.com/docs/connections/spec/semantic/) used by Mixpanel, Amplitude, and PostHog's own SDK examples (`user_signed_up`). Events represent things that _already happened_, so past tense read naturally. PostHog's best-practices page contradict itself on tense — ignore it, trust examples.
 3. Be specific: `budget_created` not `created`
 4. Flow markers: `_started`, `_completed`, `_cancelled`, `_abandoned`, `_resumed`, `_failed`
 5. Event names static strings — never interpolated (`page_viewed_${name}` forbidden; use fixed name + property)

--- a/.claude/rules/05-workflows-and-processes/posthog-events.md
+++ b/.claude/rules/05-workflows-and-processes/posthog-events.md
@@ -38,16 +38,27 @@ $pageview (landing) → cta_clicked → welcome_viewed → signup_started
 welcome_viewed → demo_started → signup_started → signup_completed → ...
 ```
 
-**iOS:**
+**iOS (email):**
 
 ```
 app_opened → welcome_viewed → onboarding_started
 → onboarding_step_completed (first_name) → signup_started → signup_completed
-→ onboarding_step_completed (income, charges, savings, budget_preview)
-→ pin_setup_completed → first_budget_created
+→ onboarding_step_completed (registration → income → charges → savings)
+→ pin_setup_completed → onboarding_step_completed (budget_preview)
+→ first_budget_created
 ```
 
-`onboarding_started` fires once per session on first transition out of welcome (email tap) or on fresh social OAuth entry into flow. `signup_started` fires when user reach registration form (post reorder — step 3, not step 1).
+**iOS (social):**
+
+```
+app_opened → welcome_viewed → signup_started → signup_completed
+→ onboarding_started → onboarding_step_completed (first_name, if missing)
+→ onboarding_step_completed (income → charges → savings)
+→ pin_setup_completed → onboarding_step_completed (budget_preview)
+→ first_budget_created
+```
+
+`onboarding_started` fires once per session on first transition out of welcome (email tap) or on fresh social OAuth entry into flow. `signup_started` fires on email registration form entry or on a social provider signup attempt from welcome.
 
 **Tracking approach:**
 
@@ -186,7 +197,7 @@ present when the SDK exposes a matching response and are never inferred from an 
 - `onboarding_abandoned` fire at most once per `OnboardingState` (state.hasAbandoned flag).
 - `onboarding_resumed` fire once per instance, mutually exclusive with `onboarding_started` for same session.
 - `welcome_viewed` fire once per **session** via `state.hasEmittedWelcomeViewed` on `OnboardingState`. Critical: guard live on state (not on `WelcomeStep` view) because `OnboardingFlow` tear down and re-create step views on every step change via `.id(state.currentStep)` — local `@State` guard would double-fire on back-nav.
-- `signup_started` fire once per **session** via `state.hasEmittedSignupStarted` on `OnboardingState`. Same re-instantiation trap as `welcome_viewed`.
+- Email `signup_started` fire once per **session** via `state.hasEmittedSignupStarted` on `OnboardingState`. Social `signup_started` fire on each provider signup attempt from `SocialLoginSection`.
 - `onboarding_step_completed` for `budget_preview` fire once per session via `state.hasEmittedBudgetPreviewCompleted`. Prevent rapid-double-tap and retry-after-error from double-firing funnel event; CTA also disable once `state.readyToComplete` or `state.isSubmitting` true.
 
 ## Properties

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, signal } from '@angular/core';
 import type { WritableSignal } from '@angular/core';
-import type { UserSettings } from 'pulpe-shared';
+import { ANALYTICS_EVENTS, type UserSettings } from 'pulpe-shared';
 import { AnalyticsService } from './analytics';
 import { PostHogService } from './posthog';
 import { AuthStore } from '../auth/auth-store';
@@ -608,10 +608,13 @@ describe('captureEvent', () => {
   it('delegates captures to PostHogService', () => {
     const properties = { feature: 'onboarding', step: 'welcome' };
 
-    analyticsService.captureEvent('user_action', properties);
+    analyticsService.captureEvent(
+      ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED,
+      properties,
+    );
 
     expect(mockPostHogService.captureEvent).toHaveBeenCalledWith(
-      'user_action',
+      ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED,
       properties,
     );
   });
@@ -622,7 +625,9 @@ describe('captureEvent', () => {
       throw error;
     });
 
-    expect(() => analyticsService.captureEvent('failing_event')).toThrow(error);
+    expect(() =>
+      analyticsService.captureEvent(ANALYTICS_EVENTS.SIGNUP_FAILED),
+    ).toThrow(error);
   });
 
   it('delegates setPersonProperties to PostHogService once identified', () => {

--- a/frontend/projects/webapp/src/app/core/analytics/analytics.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/analytics.ts
@@ -7,7 +7,7 @@ import {
   type EffectRef,
   type OnDestroy,
 } from '@angular/core';
-import { ANALYTICS_PROPERTIES } from 'pulpe-shared';
+import { ANALYTICS_PROPERTIES, type AnalyticsEventName } from 'pulpe-shared';
 import { AuthStore } from '../auth/auth-store';
 import { PostHogService } from './posthog';
 import { Logger } from '../logging/logger';
@@ -152,7 +152,7 @@ export class AnalyticsService implements OnDestroy {
   /**
    * Capture event - PostHog handles data sanitization automatically
    */
-  captureEvent(event: string, properties?: Properties): void {
+  captureEvent(event: AnalyticsEventName, properties?: Properties): void {
     this.#postHogService.captureEvent(event, properties);
   }
 

--- a/frontend/projects/webapp/src/app/core/analytics/posthog.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/posthog.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core';
 import { PLATFORM_ID } from '@angular/core';
 import type { CaptureResult } from 'posthog-js';
+import { ANALYTICS_EVENTS } from 'pulpe-shared';
 import { PostHogService } from './posthog';
 import { ApplicationConfiguration } from '../config/application-configuration';
 import { Logger } from '../logging/logger';
@@ -227,7 +228,7 @@ describe('PostHogService', () => {
     const posthogModule = await import('posthog-js');
     const posthog = posthogModule.default;
 
-    service.captureEvent('pre_init_event');
+    service.captureEvent(ANALYTICS_EVENTS.APP_OPENED);
 
     expect(posthog.capture).not.toHaveBeenCalled();
   });
@@ -237,11 +238,16 @@ describe('PostHogService', () => {
     const posthog = posthogModule.default;
 
     await service.initialize();
-    service.captureEvent('user_action', { feature: 'budget' });
-
-    expect(posthog.capture).toHaveBeenCalledWith('user_action', {
+    service.captureEvent(ANALYTICS_EVENTS.BUDGET_CREATED, {
       feature: 'budget',
     });
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.BUDGET_CREATED,
+      {
+        feature: 'budget',
+      },
+    );
   });
 
   it('opts out immediately, clears identity, and preserves the local choice', async () => {
@@ -250,13 +256,15 @@ describe('PostHogService', () => {
     await service.initialize();
 
     service.setDiagnosticSharingEnabled(false);
-    service.captureEvent('blocked_event');
+    service.captureEvent(ANALYTICS_EVENTS.TAB_SWITCHED);
 
     expect(posthog.stopSessionRecording).toHaveBeenCalledTimes(1);
     expect(posthog.reset).toHaveBeenCalledWith(true);
     expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1);
     expect(service.diagnosticSharingEnabled()).toBe(false);
-    expect(posthog.capture).not.toHaveBeenCalledWith('blocked_event');
+    expect(posthog.capture).not.toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.TAB_SWITCHED,
+    );
   });
 
   it('opts back in without emitting a consent event', async () => {

--- a/frontend/projects/webapp/src/app/core/analytics/posthog.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/posthog.ts
@@ -1,6 +1,7 @@
 import { Service, PLATFORM_ID, inject, signal, computed } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import type { PostHog, Properties, CaptureResult } from 'posthog-js';
+import { ANALYTICS_EVENTS, type AnalyticsEventName } from 'pulpe-shared';
 import { ApplicationConfiguration } from '../config/application-configuration';
 import { Logger } from '../logging/logger';
 import { StorageService } from '../storage/storage.service';
@@ -246,7 +247,7 @@ export class PostHogService {
   /**
    * Capture event - PostHog handles data sanitization automatically
    */
-  captureEvent(event: string, properties?: Properties): void {
+  captureEvent(event: AnalyticsEventName, properties?: Properties): void {
     if (!this.#canCapture()) return;
 
     try {
@@ -340,7 +341,7 @@ export class PostHogService {
     if (!method) return;
 
     this.clearPendingSignupMethod();
-    this.captureEvent('signup_completed', { method });
+    this.captureEvent(ANALYTICS_EVENTS.SIGNUP_COMPLETED, { method });
     this.#logger.debug('Pending signup_completed captured', { method });
   }
 

--- a/frontend/projects/webapp/src/app/feature/auth/enter-vault-code/enter-vault-code.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/enter-vault-code/enter-vault-code.spec.ts
@@ -5,7 +5,7 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import { provideRouter, Router } from '@angular/router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of, throwError } from 'rxjs';
-import { API_ERROR_CODES } from 'pulpe-shared';
+import { ANALYTICS_EVENTS, API_ERROR_CODES } from 'pulpe-shared';
 
 import { ClientKeyService, EncryptionApi } from '@core/encryption';
 import * as cryptoUtils from '@core/encryption/crypto.utils';
@@ -246,11 +246,11 @@ describe('EnterVaultCode', () => {
       );
     });
 
-    it('should call captureEvent with vault_code_entered on successful submission', async () => {
+    it('should capture pin_entered on successful submission', async () => {
       await triggerAutoSubmit();
       await vi.waitFor(() =>
         expect(mockPostHogService.captureEvent).toHaveBeenCalledWith(
-          'vault_code_entered',
+          ANALYTICS_EVENTS.PIN_ENTERED,
         ),
       );
     });

--- a/frontend/projects/webapp/src/app/feature/auth/enter-vault-code/enter-vault-code.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/enter-vault-code/enter-vault-code.ts
@@ -17,7 +17,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { SpinnerComponent } from 'ngx-unicode-spinners';
 import { filter, firstValueFrom } from 'rxjs';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
-import { API_ERROR_CODES } from 'pulpe-shared';
+import { ANALYTICS_EVENTS, API_ERROR_CODES } from 'pulpe-shared';
 
 import {
   ClientKeyService,
@@ -248,7 +248,7 @@ export default class EnterVaultCode {
       const rememberDevice = this.form.getRawValue().rememberDevice;
       this.#clientKeyService.setDirectKey(clientKeyHex, rememberDevice);
 
-      this.#postHogService.captureEvent('vault_code_entered');
+      this.#postHogService.captureEvent(ANALYTICS_EVENTS.PIN_ENTERED);
       await this.#router.navigate(['/', ROUTES.DASHBOARD]);
     } catch (error) {
       this.#logger.error('Enter vault code failed:', error);

--- a/frontend/projects/webapp/src/app/feature/auth/setup-vault-code/setup-vault-code.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/setup-vault-code/setup-vault-code.spec.ts
@@ -13,7 +13,7 @@ import { ClientKeyService, EncryptionApi } from '@core/encryption';
 import * as cryptoUtils from '@core/encryption/crypto.utils';
 import { Logger } from '@core/logging/logger';
 import { provideTranslocoForTest } from '@app/testing/transloco-testing';
-import { API_ERROR_CODES } from 'pulpe-shared';
+import { ANALYTICS_EVENTS, API_ERROR_CODES } from 'pulpe-shared';
 
 import SetupVaultCode from './setup-vault-code';
 
@@ -285,10 +285,10 @@ describe('SetupVaultCode', () => {
       );
     });
 
-    it('should call captureEvent with vault_code_setup_completed on success', async () => {
+    it('should capture pin_setup_completed on success', async () => {
       await component['onSubmit']();
       expect(mockPostHogService.captureEvent).toHaveBeenCalledWith(
-        'vault_code_setup_completed',
+        ANALYTICS_EVENTS.PIN_SETUP_COMPLETED,
       );
     });
   });

--- a/frontend/projects/webapp/src/app/feature/auth/setup-vault-code/setup-vault-code.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/setup-vault-code/setup-vault-code.ts
@@ -40,7 +40,7 @@ import { LogoutDialog } from '@ui/dialogs/logout-dialog';
 import { PostHogService } from '@core/analytics';
 import { setupVaultCodeFormSchema } from './setup-vault-code-form.schema';
 import { isApiError } from '@core/api/api-error';
-import { API_ERROR_CODES } from 'pulpe-shared';
+import { ANALYTICS_EVENTS, API_ERROR_CODES } from 'pulpe-shared';
 
 @Component({
   selector: 'pulpe-setup-vault-code',
@@ -302,7 +302,7 @@ export default class SetupVaultCode {
         .auth.updateUser({ data: { vaultCodeConfigured: true } });
       if (error) throw error;
 
-      this.#postHogService.captureEvent('vault_code_setup_completed');
+      this.#postHogService.captureEvent(ANALYTICS_EVENTS.PIN_SETUP_COMPLETED);
 
       // 5. Redirect to dashboard
       this.#router.navigate(['/', ROUTES.DASHBOARD]);

--- a/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
+++ b/frontend/projects/webapp/src/app/feature/auth/signup/signup.ts
@@ -23,6 +23,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { Router, RouterLink } from '@angular/router';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { ANALYTICS_EVENTS } from 'pulpe-shared';
 
 import {
   AuthCredentialsService,
@@ -362,7 +363,9 @@ export default class Signup {
     this.isOAuthLoading.set(isLoading);
     if (isLoading) {
       this.#postHogService.setPendingSignupMethod(method);
-      this.#postHogService.captureEvent('signup_started', { method });
+      this.#postHogService.captureEvent(ANALYTICS_EVENTS.SIGNUP_STARTED, {
+        method,
+      });
     }
     // Pas de clear sur `false` : le succès OAuth émet loadingChange(false)
     // avant que le redirect n'emporte la page — effacer ici tue le
@@ -415,7 +418,7 @@ export default class Signup {
       if (result.success) {
         this.#postHogService.clearPendingSignupMethod();
         this.#postHogService.enableTracking();
-        this.#postHogService.captureEvent('signup_completed', {
+        this.#postHogService.captureEvent(ANALYTICS_EVENTS.SIGNUP_COMPLETED, {
           method: 'email',
         });
         // Guard redirects to setup-vault-code where recovery key is set up

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.spec.ts
@@ -16,7 +16,7 @@ import { PostHogService } from '@core/analytics/posthog';
 import { UserSettingsStore } from '@core/user-settings';
 import { provideTranslocoForTest } from '../../testing/transloco-testing';
 
-describe('CompleteProfilePage — health-insurance currency gating', () => {
+describe('CompleteProfilePage', () => {
   let updateHealthInsurance: ReturnType<typeof vi.fn>;
   let captureEvent: ReturnType<typeof vi.fn>;
 

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { type SupportedCurrency } from 'pulpe-shared';
+import { ANALYTICS_EVENTS, type SupportedCurrency } from 'pulpe-shared';
 import CompleteProfilePage from './complete-profile-page';
 import { CompleteProfileStore } from './complete-profile-store';
 import { PostHogService } from '@core/analytics/posthog';
@@ -18,12 +18,24 @@ import { provideTranslocoForTest } from '../../testing/transloco-testing';
 
 describe('CompleteProfilePage — health-insurance currency gating', () => {
   let updateHealthInsurance: ReturnType<typeof vi.fn>;
+  let captureEvent: ReturnType<typeof vi.fn>;
 
-  function createPage(initialCurrency: SupportedCurrency): CompleteProfilePage {
+  function createPage(
+    initialCurrency: SupportedCurrency,
+    hasAnyCharge = false,
+  ): CompleteProfilePage {
     updateHealthInsurance = vi.fn();
+    captureEvent = vi.fn();
     const mockStore = {
+      housingCosts: signal<number | null>(hasAnyCharge ? 100 : null),
       healthInsurance: signal<number | null>(null),
+      phonePlan: signal<number | null>(null),
+      internetPlan: signal<number | null>(null),
+      transportCosts: signal<number | null>(null),
+      leasingCredit: signal<number | null>(null),
       updateHealthInsurance,
+      isStep1Valid: vi.fn().mockReturnValue(true),
+      submitProfile: vi.fn().mockResolvedValue(false),
       // Awaited by the constructor's #initPage — resolve so it never rejects.
       checkExistingBudgets: vi.fn().mockResolvedValue(false),
       prefillFromOAuthMetadata: vi.fn(),
@@ -36,7 +48,7 @@ describe('CompleteProfilePage — health-insurance currency gating', () => {
         { provide: CompleteProfileStore, useValue: mockStore },
         { provide: Router, useValue: {} },
         { provide: MatDialog, useValue: {} },
-        { provide: PostHogService, useValue: { captureEvent: vi.fn() } },
+        { provide: PostHogService, useValue: { captureEvent } },
         {
           provide: UserSettingsStore,
           useValue: {
@@ -91,4 +103,46 @@ describe('CompleteProfilePage — health-insurance currency gating', () => {
 
     expect(updateHealthInsurance).not.toHaveBeenCalled();
   });
+
+  it('maps the profile step to onboarding_step_completed', async () => {
+    const page = createPage('CHF') as unknown as { nextStep: () => void };
+    await vi.waitFor(() =>
+      expect(captureEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.ONBOARDING_STARTED,
+      ),
+    );
+    captureEvent.mockClear();
+
+    page.nextStep();
+
+    expect(captureEvent).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED,
+      { step: 'profile' },
+    );
+  });
+
+  it.each([
+    [true, false],
+    [false, true],
+  ])(
+    'maps charges presence %s to skipped %s',
+    async (hasAnyCharge, skipped) => {
+      const page = createPage('CHF', hasAnyCharge) as unknown as {
+        onSubmit: () => Promise<void>;
+      };
+      await vi.waitFor(() =>
+        expect(captureEvent).toHaveBeenCalledWith(
+          ANALYTICS_EVENTS.ONBOARDING_STARTED,
+        ),
+      );
+      captureEvent.mockClear();
+
+      await page.onSubmit();
+
+      expect(captureEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED,
+        { step: 'charges', skipped },
+      );
+    },
+  );
 });

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-page.ts
@@ -33,6 +33,7 @@ import {
 } from './complete-profile-store';
 import { OnboardingLivePreview } from './components/onboarding-live-preview';
 import {
+  ANALYTICS_EVENTS,
   CURRENCY_METADATA,
   PAY_DAY_MAX,
   SUPPORTED_CURRENCIES,
@@ -961,7 +962,7 @@ export default class CompleteProfilePage {
     // Previously this ran in the constructor, which mutated a now-orphan store
     // for users redirected away by `hasExisting`.
     this.store.prefillFromOAuthMetadata();
-    this.#postHogService.captureEvent('onboarding_started');
+    this.#postHogService.captureEvent(ANALYTICS_EVENTS.ONBOARDING_STARTED);
   }
 
   protected onCurrencyChange(value: SupportedCurrency): void {
@@ -975,7 +976,10 @@ export default class CompleteProfilePage {
 
   protected nextStep(): void {
     if (this.store.isStep1Valid()) {
-      this.#postHogService.captureEvent('profile_step1_completed');
+      this.#postHogService.captureEvent(
+        ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED,
+        { step: 'profile' },
+      );
       this.currentStep.set(2);
     }
   }
@@ -1045,9 +1049,9 @@ export default class CompleteProfilePage {
       this.store.transportCosts() !== null ||
       this.store.leasingCredit() !== null;
 
-    const event = hasAnyCharge
-      ? 'profile_step2_completed'
-      : 'profile_step2_skipped';
-    this.#postHogService.captureEvent(event);
+    this.#postHogService.captureEvent(
+      ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED,
+      { step: 'charges', skipped: !hasAnyCharge },
+    );
   }
 }

--- a/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.ts
+++ b/frontend/projects/webapp/src/app/feature/complete-profile/complete-profile-store.ts
@@ -11,7 +11,7 @@ import { UserSettingsStore } from '@core/user-settings';
 import { AuthOAuthService } from '@core/auth/auth-oauth.service';
 import { firstValueFrom } from 'rxjs';
 import { TranslocoService } from '@jsverse/transloco';
-import { type SupportedCurrency } from 'pulpe-shared';
+import { ANALYTICS_EVENTS, type SupportedCurrency } from 'pulpe-shared';
 
 /**
  * An onboarding suggestion chip. Carries a stable `id` independent of the
@@ -265,7 +265,11 @@ export class CompleteProfileStore {
     this.#patchState({
       customTransactions: [...this.#state().customTransactions, { ...tx }],
     });
-    this.#trackCustomTransactionEvent('custom_transaction_added', tx, 'manual');
+    this.#trackCustomTransactionEvent(
+      ANALYTICS_EVENTS.CUSTOM_TRANSACTION_ADDED,
+      tx,
+      'manual',
+    );
   }
 
   removeCustomTransaction(index: number): void {
@@ -276,7 +280,7 @@ export class CompleteProfileStore {
       customTransactions: current.filter((_, i) => i !== index),
     });
     this.#trackCustomTransactionEvent(
-      'custom_transaction_removed',
+      ANALYTICS_EVENTS.CUSTOM_TRANSACTION_REMOVED,
       removed,
       removed.__suggestionId ? 'suggestion' : 'manual',
     );
@@ -324,15 +328,20 @@ export class CompleteProfileStore {
     suggestion: OnboardingTransaction,
     selected: boolean,
   ): void {
-    this.#postHogService.captureEvent('onboarding_suggestion_toggled', {
-      step: this.#analyticsStepFor(suggestion.type),
-      suggestion_name: suggestion.name,
-      selected,
-    });
+    this.#postHogService.captureEvent(
+      ANALYTICS_EVENTS.ONBOARDING_SUGGESTION_TOGGLED,
+      {
+        step: this.#analyticsStepFor(suggestion.type),
+        suggestion_name: suggestion.name,
+        selected,
+      },
+    );
   }
 
   #trackCustomTransactionEvent(
-    event: 'custom_transaction_added' | 'custom_transaction_removed',
+    event:
+      | typeof ANALYTICS_EVENTS.CUSTOM_TRANSACTION_ADDED
+      | typeof ANALYTICS_EVENTS.CUSTOM_TRANSACTION_REMOVED,
     tx: OnboardingTransaction,
     source: 'manual' | 'suggestion',
   ): void {
@@ -456,7 +465,7 @@ export class CompleteProfileStore {
         }
       }
 
-      this.#postHogService.captureEvent('first_budget_created', {
+      this.#postHogService.captureEvent(ANALYTICS_EVENTS.FIRST_BUDGET_CREATED, {
         signup_method: this.#determineSignupMethod(),
         has_pay_day: state.payDayOfMonth !== null,
         charges_count: this.#countOptionalCharges(state),

--- a/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
+++ b/frontend/projects/webapp/src/app/feature/current-month/services/dashboard-store.ts
@@ -16,6 +16,7 @@ import { cachedMutation, cachedResource } from 'ngx-ziflux';
 import { firstValueFrom } from 'rxjs';
 import { UserSettingsStore } from '@core/user-settings';
 import {
+  ANALYTICS_EVENTS,
   type BudgetLine,
   type Transaction,
   type TransactionCreate,
@@ -311,9 +312,12 @@ export class DashboardStore {
           ...current,
           transactions: [...current.transactions, response.data],
         }));
-        this.#postHogService.captureEvent('transaction_created', {
-          type: response.data.kind,
-        });
+        this.#postHogService.captureEvent(
+          ANALYTICS_EVENTS.TRANSACTION_CREATED,
+          {
+            type: response.data.kind,
+          },
+        );
       },
       onError: (error) => {
         fail(

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.spec.ts
@@ -9,6 +9,7 @@ import { DemoInitializerService } from '@core/demo/demo-initializer.service';
 import { Logger } from '@core/logging/logger';
 import { TurnstileService } from '@core/turnstile';
 import { PostHogService } from '@core/analytics/posthog';
+import { ANALYTICS_EVENTS } from 'pulpe-shared';
 
 describe('WelcomePage', () => {
   let fixture: ComponentFixture<WelcomePage>;
@@ -233,7 +234,7 @@ describe('WelcomePage', () => {
       component['onOAuthLoadingChange']('google', true);
 
       expect(mockPostHogService.captureEvent).toHaveBeenCalledWith(
-        'signup_started',
+        ANALYTICS_EVENTS.SIGNUP_STARTED,
         { method: 'google' },
       );
     });
@@ -247,9 +248,9 @@ describe('WelcomePage', () => {
       );
     });
 
-    it('should track welcome_page_viewed on render', () => {
+    it('should track welcome_viewed on render', () => {
       expect(mockPostHogService.captureEvent).toHaveBeenCalledWith(
-        'welcome_page_viewed',
+        ANALYTICS_EVENTS.WELCOME_VIEWED,
       );
     });
 

--- a/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
+++ b/frontend/projects/webapp/src/app/feature/welcome/welcome-page.ts
@@ -21,6 +21,7 @@ import { TurnstileService } from '@core/turnstile';
 import { ErrorAlert } from '@ui/error-alert';
 import { LoadingButton } from '@ui/loading-button';
 import { NgxTurnstileModule, type NgxTurnstileComponent } from 'ngx-turnstile';
+import { ANALYTICS_EVENTS } from 'pulpe-shared';
 
 @Component({
   selector: 'pulpe-welcome-page',
@@ -221,7 +222,7 @@ export default class WelcomePage {
 
   constructor() {
     afterNextRender(() => {
-      this.#postHogService.captureEvent('welcome_page_viewed');
+      this.#postHogService.captureEvent(ANALYTICS_EVENTS.WELCOME_VIEWED);
     });
   }
 
@@ -245,7 +246,9 @@ export default class WelcomePage {
     this.isOAuthLoading.set(isLoading);
     if (isLoading) {
       this.#postHogService.setPendingSignupMethod(method);
-      this.#postHogService.captureEvent('signup_started', { method });
+      this.#postHogService.captureEvent(ANALYTICS_EVENTS.SIGNUP_STARTED, {
+        method,
+      });
     }
     // Pas de clear sur `false` : le succès OAuth émet loadingChange(false)
     // avant que le redirect n'emporte la page — effacer ici tue le
@@ -259,7 +262,9 @@ export default class WelcomePage {
   }
 
   onEmailSignupClick(): void {
-    this.#postHogService.captureEvent('signup_started', { method: 'email' });
+    this.#postHogService.captureEvent(ANALYTICS_EVENTS.SIGNUP_STARTED, {
+      method: 'email',
+    });
   }
 
   startDemoMode(): void {
@@ -275,7 +280,7 @@ export default class WelcomePage {
   async #startDemoWithToken(token: string): Promise<void> {
     try {
       await this.#demoInitializer.startDemoSession(token);
-      this.#postHogService.captureEvent('demo_started');
+      this.#postHogService.captureEvent(ANALYTICS_EVENTS.DEMO_STARTED);
     } catch (error) {
       this.#logger.error('Failed to start demo mode', { error });
       this.errorMessage.set(

--- a/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsEvent.swift
@@ -6,7 +6,7 @@ enum AnalyticsEvent: String, CaseIterable {
     case appOpened = "app_opened"
 
     // MARK: - Onboarding Funnel
-    case welcomeScreenViewed = "welcome_screen_viewed"
+    case welcomeViewed = "welcome_viewed"
     /// Fires once per session when the user enters the multi-step onboarding
     /// flow — either by tapping "S'inscrire avec email" on welcome, or via a
     /// fresh social OAuth that routes them straight into the questionnaire.

--- a/ios/Pulpe/Features/Onboarding/Steps/WelcomeStep.swift
+++ b/ios/Pulpe/Features/Onboarding/Steps/WelcomeStep.swift
@@ -134,7 +134,7 @@ struct WelcomeStep: View {
             // reset between firstName → Retour → Welcome and re-fire the funnel event.
             guard !state.hasEmittedWelcomeViewed else { return }
             state.hasEmittedWelcomeViewed = true
-            AnalyticsService.shared.capture(.welcomeScreenViewed)
+            AnalyticsService.shared.capture(.welcomeViewed)
         }
         .sheet(isPresented: $showLogin) {
             LoginView(isPresented: $showLogin)

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -21,18 +21,45 @@ struct AnalyticsServiceTests {
     }
 
     @Test func eventRawValues_matchWebConvention() {
-        #expect(AnalyticsEvent.appOpened.rawValue == "app_opened")
-        #expect(AnalyticsEvent.welcomeScreenViewed.rawValue == "welcome_screen_viewed")
-        #expect(AnalyticsEvent.signupStarted.rawValue == "signup_started")
-        #expect(AnalyticsEvent.signupCompleted.rawValue == "signup_completed")
-        #expect(AnalyticsEvent.onboardingStepCompleted.rawValue == "onboarding_step_completed")
-        #expect(AnalyticsEvent.loginCompleted.rawValue == "login_completed")
-        #expect(AnalyticsEvent.authSessionObserved.rawValue == "auth_session_observed")
-        #expect(AnalyticsEvent.pinSetupCompleted.rawValue == "pin_setup_completed")
-        #expect(AnalyticsEvent.budgetCreated.rawValue == "budget_created")
-        #expect(AnalyticsEvent.transactionCreated.rawValue == "transaction_created")
-        #expect(AnalyticsEvent.tabSwitched.rawValue == "tab_switched")
-        #expect(AnalyticsEvent.currencyPersistFailed.rawValue == "currency_persist_failed")
+        let expected: Set<String> = [
+            "app_opened",
+            "welcome_viewed",
+            "onboarding_started",
+            "signup_started",
+            "signup_completed",
+            "onboarding_step_completed",
+            "onboarding_abandoned",
+            "onboarding_resumed",
+            "onboarding_suggestion_toggled",
+            "custom_transaction_added",
+            "custom_transaction_removed",
+            "login_completed",
+            "login_failed",
+            "signup_failed",
+            "session_restore_failed",
+            "auth_session_observed",
+            "logout_completed",
+            "pin_setup_completed",
+            "pin_entered",
+            "pin_changed",
+            "budget_created",
+            "first_budget_created",
+            "transaction_created",
+            "tab_switched",
+            "notification_prime_shown",
+            "notification_permission_granted",
+            "notification_permission_denied",
+            "reminder_toggled",
+            "ios_whats_new_shown",
+            "currency_changed",
+            "currency_selector_toggled",
+            "currency_persist_failed",
+            "savings_goals_intro_viewed",
+            "savings_goals_intro_completed",
+            "savings_goals_intro_skipped"
+        ]
+
+        #expect(Set(AnalyticsEvent.allCases.map(\.rawValue)) == expected)
     }
 
     @Test func authSessionSnapshot_identityChangesBeforeCapture_keepsSignalValues() {

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -254,9 +254,11 @@ Frontend (Angular) + iOS (SwiftUI) share PostHog project (EU region).
 
 **Onboarding funnel (iOS)**:
 ```
-app_opened → welcome_viewed → signup_started
-→ onboarding_step_completed (×3) → signup_completed
-→ pin_setup_completed → budget_created → transaction_created
+app_opened → welcome_viewed
+├─ email: onboarding_started → onboarding_step_completed (first_name) → signup_started → signup_completed → onboarding_step_completed (registration)
+└─ social: signup_started → signup_completed → onboarding_started → onboarding_step_completed (first_name, if missing)
+→ onboarding_step_completed (income → charges → savings) → pin_setup_completed
+→ onboarding_step_completed (budget_preview) → first_budget_created → transaction_created
 ```
 
 **Financial data sanitization**: properties split by `_`, each component checked vs word set (`amount`, `balance`, `income`, `savings`, `total`, `projection`, `rollover`, `expenses`, `available`). Catches compound keys like `total_amount`, `current_balance`.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -254,7 +254,7 @@ Frontend (Angular) + iOS (SwiftUI) share PostHog project (EU region).
 
 **Onboarding funnel (iOS)**:
 ```
-app_opened → welcome_screen_viewed → signup_started
+app_opened → welcome_viewed → signup_started
 → onboarding_step_completed (×3) → signup_completed
 → pin_setup_completed → budget_created → transaction_created
 ```

--- a/shared/src/feature-flags.ts
+++ b/shared/src/feature-flags.ts
@@ -32,10 +32,78 @@ export const ANALYTICS_PROPERTIES = {
  * on iOS — keep `AnalyticsEvent.swift` in sync.
  */
 export const ANALYTICS_EVENTS = {
+  /** Fires when the iOS app enters the foreground. Properties: none. */
+  APP_OPENED: 'app_opened',
+  /** Fires when the welcome screen is rendered. Properties: none. */
+  WELCOME_VIEWED: 'welcome_viewed',
+  /** Fires after the web demo session starts. Properties: none. */
+  DEMO_STARTED: 'demo_started',
+  /** Fires when the multi-step onboarding begins. Properties: `method` on iOS. */
+  ONBOARDING_STARTED: 'onboarding_started',
+  /** Fires when registration begins. Properties: `method`. */
+  SIGNUP_STARTED: 'signup_started',
+  /** Fires after registration succeeds. Properties: `method`. */
+  SIGNUP_COMPLETED: 'signup_completed',
+  /** Fires after registration fails. Properties: `method`, `error_kind`, `error_message`. */
+  SIGNUP_FAILED: 'signup_failed',
+  /** Fires after an onboarding step. Properties: `step`, optional `skipped`, `step_index`, `step_total`, `auth_method`. */
+  ONBOARDING_STEP_COMPLETED: 'onboarding_step_completed',
+  /** Fires when onboarding is exited early. Properties: `last_step`, `exit_method`, `was_authenticated`, `auth_method`. */
+  ONBOARDING_ABANDONED: 'onboarding_abandoned',
+  /** Fires when an incomplete signup resumes. Properties: `method`, `source`, `resumed_at_step`. */
+  ONBOARDING_RESUMED: 'onboarding_resumed',
+  /** Fires when an onboarding suggestion changes. Properties: `step`, `suggestion_name`, `selected`. */
+  ONBOARDING_SUGGESTION_TOGGLED: 'onboarding_suggestion_toggled',
+  /** Fires when a custom onboarding row is added. Properties: `step`, `kind`, `source`. */
+  CUSTOM_TRANSACTION_ADDED: 'custom_transaction_added',
+  /** Fires when a custom onboarding row is removed. Properties: `step`, `kind`, `source`. */
+  CUSTOM_TRANSACTION_REMOVED: 'custom_transaction_removed',
+  /** Fires after the initial budget is created. Properties: `signup_method`, `has_pay_day`, `charges_count`, `custom_transactions_count`. */
+  FIRST_BUDGET_CREATED: 'first_budget_created',
+  /** Fires after login succeeds. Properties: `method`. */
+  LOGIN_COMPLETED: 'login_completed',
+  /** Fires after login fails. Properties: `method`, `error_kind`, `error_message`. */
+  LOGIN_FAILED: 'login_failed',
+  /** Fires when startup session restoration fails. Properties: `method`, `error_kind`, `error_message`. */
+  SESSION_RESTORE_FAILED: 'session_restore_failed',
+  /** Fires for iOS auth lifecycle diagnostics. Properties: `source`, `outcome`, optional diagnostic context. */
+  AUTH_SESSION_OBSERVED: 'auth_session_observed',
+  /** Fires after logout completes. Properties: `source`. */
+  LOGOUT_COMPLETED: 'logout_completed',
+  /** Fires after PIN creation succeeds. Properties: none. */
+  PIN_SETUP_COMPLETED: 'pin_setup_completed',
+  /** Fires after an existing PIN is accepted. Properties: none. */
+  PIN_ENTERED: 'pin_entered',
+  /** Fires after an existing PIN is changed. Properties: none. */
+  PIN_CHANGED: 'pin_changed',
+  /** Fires when a budget is created outside onboarding. Properties: none. */
+  BUDGET_CREATED: 'budget_created',
+  /** Fires after a transaction is created. Properties: `type`. */
+  TRANSACTION_CREATED: 'transaction_created',
+  /** Fires when the active tab changes. Properties: `tab`. */
+  TAB_SWITCHED: 'tab_switched',
+  /** Fires when the notification pre-permission prompt appears. Properties: none. */
+  NOTIFICATION_PRIME_SHOWN: 'notification_prime_shown',
+  /** Fires when notification permission is granted. Properties: none. */
+  NOTIFICATION_PERMISSION_GRANTED: 'notification_permission_granted',
+  /** Fires when notification permission is denied. Properties: none. */
+  NOTIFICATION_PERMISSION_DENIED: 'notification_permission_denied',
+  /** Fires when the reminders preference changes. Properties: `enabled`. */
+  REMINDER_TOGGLED: 'reminder_toggled',
+  /** Fires when iOS release notes are shown after an update. Properties: `version`. */
+  IOS_WHATS_NEW_SHOWN: 'ios_whats_new_shown',
   /** Fires after a successful currency change in settings. Properties: `from`, `to`. */
   CURRENCY_CHANGED: 'currency_changed',
   /** Fires after a successful "Saisir dans une autre devise" toggle in settings. Properties: `enabled`. */
   CURRENCY_SELECTOR_TOGGLED: 'currency_selector_toggled',
+  /** Fires after all onboarding currency persistence retries fail. Properties: `currency`, `attempts`. */
+  CURRENCY_PERSIST_FAILED: 'currency_persist_failed',
+  /** Fires when the savings-goals first-run intro opens. Properties: none. */
+  SAVINGS_GOALS_INTRO_VIEWED: 'savings_goals_intro_viewed',
+  /** Fires when the savings-goals intro creates its first goal. Properties: none. */
+  SAVINGS_GOALS_INTRO_COMPLETED: 'savings_goals_intro_completed',
+  /** Fires when the savings-goals intro is skipped. Properties: none. */
+  SAVINGS_GOALS_INTRO_SKIPPED: 'savings_goals_intro_skipped',
 } as const;
 
 export type AnalyticsEventName =


### PR DESCRIPTION
## Summary

- Define and document a shared PostHog analytics event taxonomy.
- Align web and iOS onboarding events with the standardized naming and properties.
- Update analytics services, feature flows, shared flags, and related tests.

## Testing

- Updated unit tests for analytics services and affected onboarding flows.
- Not run (not requested).

## Linear

- [PUL-332 — Unifier la taxonomie analytics entre le Web et iOS](https://linear.app/pulpe/issue/PUL-332/unifier-la-taxonomie-analytics-entre-le-web-et-ios)