### PR TITLE
fix(auth): clear stale demo state for real sessions

### DIFF
--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -27,6 +27,7 @@ import { type E2EWindow } from './e2e-window';
 import { AuthCleanupService } from './auth-cleanup.service';
 import { PostHogService } from '../analytics/posthog';
 import { ROUTES } from '@core/routing/routes-constants';
+import { DemoModeService } from '../demo/demo-mode.service';
 import {
   createMockSupabaseClient,
   type MockSupabaseClient,
@@ -69,6 +70,11 @@ describe('AuthSessionService', () => {
   let mockSupabaseClient: MockSupabaseClient;
   let mockCleanup: { performCleanup: Mock };
   let mockPostHog: { captureEvent: Mock };
+  let mockDemoMode: {
+    isDemoMode: Mock;
+    demoUserEmail: Mock;
+    deactivateDemoMode: Mock;
+  };
   let mockRouter: { navigate: Mock };
   let mockUserSignal: ReturnType<typeof signal<User | null>>;
 
@@ -127,6 +133,11 @@ describe('AuthSessionService', () => {
 
     mockCleanup = { performCleanup: vi.fn() };
     mockPostHog = { captureEvent: vi.fn() };
+    mockDemoMode = {
+      isDemoMode: vi.fn().mockReturnValue(false),
+      demoUserEmail: vi.fn().mockReturnValue(null),
+      deactivateDemoMode: vi.fn(),
+    };
     mockRouter = { navigate: vi.fn() };
     mockSupabaseClient = createMockSupabaseClient();
     createClientMock.mockReturnValue(mockSupabaseClient);
@@ -142,6 +153,7 @@ describe('AuthSessionService', () => {
         { provide: AuthErrorLocalizer, useValue: mockErrorLocalizer },
         { provide: AuthCleanupService, useValue: mockCleanup },
         { provide: PostHogService, useValue: mockPostHog },
+        { provide: DemoModeService, useValue: mockDemoMode },
         { provide: Router, useValue: mockRouter },
       ],
     });
@@ -193,6 +205,38 @@ describe('AuthSessionService', () => {
       session: mockSession,
     });
     expect(mockSupabaseClient.auth.onAuthStateChange).toHaveBeenCalled();
+  });
+
+  it('should clear stale demo mode when restoring a real session', async () => {
+    mockDemoMode.isDemoMode.mockReturnValue(true);
+    mockDemoMode.demoUserEmail.mockReturnValue('demo@pulpe.app');
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+    mockSupabaseClient.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+
+    await service.initializeAuthState();
+
+    expect(mockDemoMode.deactivateDemoMode).toHaveBeenCalledOnce();
+  });
+
+  it('should keep demo mode when restoring its matching session', async () => {
+    mockDemoMode.isDemoMode.mockReturnValue(true);
+    mockDemoMode.demoUserEmail.mockReturnValue(mockSession.user.email);
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+    mockSupabaseClient.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+
+    await service.initializeAuthState();
+
+    expect(mockDemoMode.deactivateDemoMode).not.toHaveBeenCalled();
   });
 
   it('should not reinitialize if already initialized', async () => {

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.spec.ts
@@ -239,6 +239,25 @@ describe('AuthSessionService', () => {
     expect(mockDemoMode.deactivateDemoMode).not.toHaveBeenCalled();
   });
 
+  it('should clear demo mode when no session is restored', async () => {
+    mockDemoMode.isDemoMode.mockReturnValue(true);
+    mockDemoMode.demoUserEmail.mockReturnValue('demo@pulpe.app');
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseClient.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+
+    await service.initializeAuthState();
+
+    expect(mockDemoMode.deactivateDemoMode).toHaveBeenCalledOnce();
+    expect(mockAuthStore.set).toHaveBeenCalledWith({
+      phase: 'unauthenticated',
+    });
+  });
+
   it('should not reinitialize if already initialized', async () => {
     mockSupabaseClient.auth.getSession.mockResolvedValue({
       data: { session: mockSession },

--- a/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
+++ b/frontend/projects/webapp/src/app/core/auth/auth-session.service.ts
@@ -16,6 +16,7 @@ import { AuthCleanupService } from './auth-cleanup.service';
 import { isE2EMode, type E2EWindow } from './e2e-window';
 import { ROUTES } from '@core/routing/routes-constants';
 import { PostHogService } from '../analytics/posthog';
+import { DemoModeService } from '../demo/demo-mode.service';
 
 export type SignOutSource =
   | 'user_initiated'
@@ -40,6 +41,7 @@ export class AuthSessionService {
   readonly #logger = inject(Logger);
   readonly #cleanup = inject(AuthCleanupService);
   readonly #postHog = inject(PostHogService);
+  readonly #demoMode = inject(DemoModeService);
   readonly #transloco = inject(TranslocoService);
   readonly #destroyRef = inject(DestroyRef);
 
@@ -394,6 +396,13 @@ export class AuthSessionService {
   }
 
   #updateAuthStateFromSession(session: Session | null): void {
+    if (
+      this.#demoMode.isDemoMode() &&
+      session?.user.email !== this.#demoMode.demoUserEmail()
+    ) {
+      this.#demoMode.deactivateDemoMode();
+    }
+
     this.#authStore.set(
       session
         ? { phase: 'authenticated', session }


### PR DESCRIPTION
## Résumé

- réconcilie le marqueur local du mode démo avec la session Supabase active ;
- désactive un état démo périmé lorsqu’une vraie session est restaurée ;
- préserve une session démo valide lorsque les emails correspondent.

## Cause racine

Le marqueur `pulpe-demo-mode` et la session Supabase étaient restaurés indépendamment. Une valeur locale périmée pouvait donc afficher le bandeau et l’identité démo alors que les données étaient chargées avec la vraie session utilisateur.

Le correctif est placé dans `AuthSessionService.#updateAuthStateFromSession`, le point central emprunté par la restauration initiale et les changements de session.

## Validation

- test de régression rouge avant correctif : `3424eab5b` ;
- tests ciblés : 36/36, dont l’absence de session restaurée ;
- suite frontend complète : 206 fichiers, 2 631 tests ;
- `pnpm quality` ;
- build Angular ;
- contrôle CSP des scripts inline.

## Linear

Fixes PUL-333

https://linear.app/pulpe/issue/PUL-333/empecher-une-session-reelle-de-conserver-letat-du-mode-demo