### PR TITLE
fix(ci): allow first internal build number

### DIFF
--- a/.github/workflows/ios-distribute.yml
+++ b/.github/workflows/ios-distribute.yml
@@ -133,8 +133,8 @@ jobs:
             echo "::error::Release build $BUILD_NUMBER is not recorded in project.yml (found $project_build)"
             exit 1
           fi
-          if [ "$CHANNEL" = "internal" ] && [ "$BUILD_NUMBER" -le "$project_build" ]; then
-            echo "::error::Internal build $BUILD_NUMBER must be higher than project.yml build $project_build"
+          if [ "$CHANNEL" = "internal" ] && [ "$BUILD_NUMBER" -lt "$project_build" ]; then
+            echo "::error::Internal build $BUILD_NUMBER must be at least project.yml build $project_build"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Allow an internal TestFlight build number to equal `CURRENT_PROJECT_VERSION`.

The workflow previously required it to be strictly higher, which rejected the valid first build of a newly bumped marketing version (`1.3.2 (1)`). Lower build numbers remain blocked; release builds still require exact equality.

## Validation

- actionlint + ShellCheck
- Prettier
- `git diff --check`

No App Review, external distribution, tag, GitHub Release, or public publication.
