### PR TITLE
fix(analytics): preserve iOS when filtering bots

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -26,6 +26,19 @@
 Ce document décrit le comportement technique; il ne constitue pas une validation
 juridique du fondement choisi.
 
+### Filtrage bots multi-plateforme
+
+Le SDK iOS ne fournit pas de user-agent. PostHog classe donc actuellement ses
+événements natifs comme `Automation`, avec `$virt_is_bot = true`. Un insight
+cross-platform doit exclure les bots avec la règle
+`$lib = posthog-ios OR $virt_is_bot = false`. Pour un insight web-only,
+`$virt_is_bot = false` suffit.
+
+Ne pas ajouter de faux `$user_agent` au payload iOS et ne pas filtrer ces événements
+à l'ingestion : les propriétés virtuelles permettent un filtrage rétroactif et
+réversible dans les insights. Conserver `filterTestAccounts` et l'exclusion TestFlight
+comme filtres séparés.
+
 ## 🚀 TLDR - Monitoring Opérationnel
 
 ### ⚡ Status Check Rapide


### PR DESCRIPTION
# Preserve iOS events when filtering bots in PostHog

## ✅ Type of PR

- [x] Bug Fix
- [ ] Documentation Update

## 🗒️ Description

Corrige le filtrage des bots afin que les événements iOS natifs restent inclus. Documente la règle PostHog cross-platform appliquée aux insights `5336000`, `5133271` et `5138078`.

## 🚶‍➡️ Behavior

- Conserve iOS avec `$lib = posthog-ios`.
- Exclut les bots web et landing avec `$virt_is_bot = false`.
- Ne modifie ni le payload ni l’ingestion iOS.

## 🧪 Steps to test

- [x] Vérifier les trois requêtes PostHog persistées.
- [x] Confirmer que le funnel iOS reste identique.
- [x] Confirmer que les deux insights iOS-only restent intacts.
- [x] Exécuter `pnpm quality`.