### PR TITLE
chore(deps): remonter js-yaml hors des versions vulnérables

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5925,20 +5925,16 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -9223,7 +9219,7 @@ snapshots:
   '@changesets/parse@0.4.1':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -9614,7 +9610,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -12535,7 +12531,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -12544,7 +12540,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -13255,7 +13251,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.5
+      minimatch: 3.1.2
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -14369,7 +14365,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -14378,11 +14374,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -15705,7 +15697,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
Le job Dependabot security update sur `js-yaml` échoue en `security_update_not_possible` : la dépendance n'est directe dans aucun `package.json`, donc le job n'a aucun manifeste à éditer.

Aucun override n'est nécessaire — quatre des cinq parents déclarent déjà un range qui couvre la version corrigée. Un simple rafraîchissement du lockfile suffit :

| parent | range | avant | après |
|---|---|---|---|
| `@changesets/parse` | `^3.13.1` | 3.14.2 | 3.15.1 |
| `read-yaml-file` | `^3.6.1` | 3.14.2 | 3.15.1 |
| `@eslint/eslintrc` | `^4.3.0` | 4.3.0 | 4.3.1 |
| `cosmiconfig` | `^4.1.0` | 4.1.1 | 4.3.1 |
| `@nestjs/swagger@11.2.0` | `4.1.0` (pin exact) | 4.1.0 | inchangé |

`@nestjs/swagger` épingle `js-yaml` à `4.1.0` exactement. Les trois advisories de la ligne 4.x (GHSA-5p4m-2wfm-xmqj, GHSA-52cp-r559-cp3m, GHSA-h67p-54hq-rp68) décrivent toutes une consommation CPU quadratique au **parsing** — résolution `!!omap`, chaînes de merge-keys, alias répétés. Or l'unique appel js-yaml du paquet est une sérialisation :

```
node_modules/@nestjs/swagger/dist/swagger-module.js:147
    const yamlDocument = jsyaml.dump(documentToSerialize, {
```

Forcer `4.3.1` via un override contre un pin exact ferait courir un risque de compatibilité pour du code hors chemin d'exécution. Les alertes correspondantes sont écartées en `not_used`.

## Vérification

- `bun run quality` (backend) : 0 erreur, depcruise et prettier verts — couvre le chargement de config par `@eslint/eslintrc` et `cosmiconfig`
- `changeset status` : nominal — couvre `@changesets/parse`
- Diff limité à `pnpm-lock.yaml`, aucun `package.json` touché