### PR TITLE
feat(landing): add user help center

### DIFF
--- a/landing/app/accessibility.test.tsx
+++ b/landing/app/accessibility.test.tsx
@@ -1282,6 +1282,13 @@ describe("landing accessibility contracts", () => {
     assert.doesNotMatch(componentSources.supportGuide, /<Image|next\/image/);
   });
 
+  it("owns the guide social metadata instead of inheriting the homepage", () => {
+    assert.match(componentSources.supportGuide, /const GUIDE_PATH/);
+    assert.match(componentSources.supportGuide, /openGraph:\s*\{/);
+    assert.match(componentSources.supportGuide, /url: GUIDE_PATH/);
+    assert.match(componentSources.supportGuide, /twitter:\s*\{/);
+  });
+
   it("links the first help journey from support and navigation", () => {
     assert.match(componentSources.support, /Guides pour utiliser Pulpe/);
     assert.match(componentSources.support, /\/support\/modeles-et-budgets/);

--- a/landing/app/accessibility.test.tsx
+++ b/landing/app/accessibility.test.tsx
@@ -29,6 +29,10 @@ const componentSources = {
   ),
   page: readFileSync(new URL("./page.tsx", import.meta.url), "utf8"),
   support: readFileSync(new URL("./support/page.tsx", import.meta.url), "utf8"),
+  supportGuide: readFileSync(
+    new URL("./support/modeles-et-budgets/page.tsx", import.meta.url),
+    "utf8",
+  ),
   painPoints: readFileSync(
     new URL("../components/sections/PainPoints.tsx", import.meta.url),
     "utf8",
@@ -1268,8 +1272,29 @@ describe("landing accessibility contracts", () => {
     assert.doesNotMatch(componentSources.support, /<details|<summary/);
   });
 
+  it("explains when to edit a model versus a monthly budget", () => {
+    assert.match(componentSources.supportGuide, /base de départ/);
+    assert.match(componentSources.supportGuide, /mois précis/);
+    assert.match(componentSources.supportGuide, /Appliquer/);
+    assert.match(componentSources.supportGuide, /modifiée manuellement/);
+    assert.match(componentSources.supportGuide, /Changer uniquement ce mois/);
+    assert.doesNotMatch(componentSources.supportGuide, /catégor/i);
+    assert.doesNotMatch(componentSources.supportGuide, /<Image|next\/image/);
+  });
+
+  it("links the first help journey from support and navigation", () => {
+    assert.match(componentSources.support, /Guides pour utiliser Pulpe/);
+    assert.match(componentSources.support, /\/support\/modeles-et-budgets/);
+    assert.match(componentSources.header, /href: "\/support", label: "Aide"/);
+    assert.match(componentSources.footer, /label: "Aide", href: "\/support"/);
+  });
+
   it("keeps skip links keyboard-only and moves focus to main content", () => {
-    for (const source of [componentSources.page, componentSources.support]) {
+    for (const source of [
+      componentSources.page,
+      componentSources.support,
+      componentSources.supportGuide,
+    ]) {
       const skipLinkClass = source.match(
         /href="#main-content"\s+className="([^"]+)"/,
       )?.[1];

--- a/landing/app/support/modeles-et-budgets/page.tsx
+++ b/landing/app/support/modeles-et-budgets/page.tsx
@@ -5,12 +5,52 @@ import { Container, Section } from "@/components/ui";
 import { Footer, Header } from "@/components/sections";
 import { CONTACT_EMAIL } from "@/lib/config";
 
+const GUIDE_PATH = "/support/modeles-et-budgets";
+const GUIDE_TITLE = "Modèle ou budget : que faut-il modifier ?";
+const GUIDE_DESCRIPTION =
+  "Comprendre la différence entre un modèle et un budget mensuel dans Pulpe, puis savoir lequel modifier sur iPhone.";
+const SOCIAL_TITLE = `${GUIDE_TITLE} | Pulpe`;
+const SOCIAL_PREVIEW_IMAGE = "/pulpe-social-preview.png?v=2";
+const SOCIAL_PREVIEW_ALT =
+  "Pulpe projette ton budget sur l’année et montre combien il te restera";
+
 export const metadata: Metadata = {
-  title: "Modèle ou budget : que faut-il modifier ?",
-  description:
-    "Comprendre la différence entre un modèle et un budget mensuel dans Pulpe, puis savoir lequel modifier sur iPhone.",
+  title: GUIDE_TITLE,
+  description: GUIDE_DESCRIPTION,
   alternates: {
-    canonical: "/support/modeles-et-budgets",
+    canonical: GUIDE_PATH,
+  },
+  openGraph: {
+    title: SOCIAL_TITLE,
+    description: GUIDE_DESCRIPTION,
+    siteName: "Pulpe",
+    type: "article",
+    url: GUIDE_PATH,
+    locale: "fr_CH",
+    alternateLocale: ["fr_FR"],
+    images: [
+      {
+        url: SOCIAL_PREVIEW_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: SOCIAL_PREVIEW_ALT,
+        type: "image/png",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SOCIAL_TITLE,
+    description: GUIDE_DESCRIPTION,
+    images: [
+      {
+        url: SOCIAL_PREVIEW_IMAGE,
+        alt: SOCIAL_PREVIEW_ALT,
+        type: "image/png",
+        width: 1200,
+        height: 630,
+      },
+    ],
   },
 };
 

--- a/landing/app/support/modeles-et-budgets/page.tsx
+++ b/landing/app/support/modeles-et-budgets/page.tsx
@@ -1,0 +1,254 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { Container, Section } from "@/components/ui";
+import { Footer, Header } from "@/components/sections";
+import { CONTACT_EMAIL } from "@/lib/config";
+
+export const metadata: Metadata = {
+  title: "Modèle ou budget : que faut-il modifier ?",
+  description:
+    "Comprendre la différence entre un modèle et un budget mensuel dans Pulpe, puis savoir lequel modifier sur iPhone.",
+  alternates: {
+    canonical: "/support/modeles-et-budgets",
+  },
+};
+
+const choices = [
+  {
+    intent: "Changer uniquement ce mois-ci",
+    destination: "Le budget du mois",
+  },
+  {
+    intent: "Changer mes mois habituels",
+    destination: "Le modèle",
+  },
+  {
+    intent: "Créer le prochain mois",
+    destination: "Un nouveau budget",
+  },
+  {
+    intent: "Créer une autre base réutilisable",
+    destination: "Un nouveau modèle",
+  },
+] as const;
+
+const budgetSteps = [
+  "Ouvre l’onglet « Budgets ».",
+  "Touche + pour créer le budget du prochain mois, ou ouvre un mois existant.",
+  "Dans le budget, touche + pour ajouter une prévision.",
+  "Touche une prévision existante pour la modifier ou la supprimer.",
+] as const;
+
+const modelSteps = [
+  "Ouvre l’onglet « Modèles ».",
+  "Touche + pour créer une nouvelle base, ou ouvre un modèle existant.",
+  "Touche une prévision existante pour la modifier.",
+  "Choisis « Appliquer » pour reporter la modification sur les budgets en cours et futurs.",
+] as const;
+
+function Steps({ items }: { items: readonly string[] }) {
+  return (
+    <ol className="mt-7 space-y-5">
+      {items.map((item, index) => (
+        <li key={item} className="flex gap-4">
+          <span
+            aria-hidden="true"
+            className="grid size-8 shrink-0 place-items-center rounded-full bg-primary/10 text-sm font-semibold text-primary"
+          >
+            {index + 1}
+          </span>
+          <p className="pt-0.5 leading-relaxed text-text-secondary">{item}</p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export default function ModelsAndBudgetsGuidePage() {
+  return (
+    <>
+      <a
+        href="#main-content"
+        className="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:left-4 focus-visible:top-4 focus-visible:z-[60] focus-visible:rounded-lg focus-visible:bg-primary focus-visible:px-4 focus-visible:py-2 focus-visible:text-white"
+      >
+        Aller au contenu
+      </a>
+
+      <Header />
+
+      <main id="main-content" tabIndex={-1}>
+        <section className="hero-mesh relative overflow-hidden pb-10 pt-[calc(8.5rem+env(safe-area-inset-top))] md:pb-16 md:pt-[calc(10rem+env(safe-area-inset-top))]">
+          <Container>
+            <div className="mx-auto max-w-4xl">
+              <Link
+                href="/support"
+                className="inline-flex min-h-11 items-center gap-2 rounded-md text-sm font-semibold text-primary transition-colors hover:text-primary-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
+                <ArrowLeft aria-hidden="true" size={17} />
+                Aide
+              </Link>
+              <p className="mt-8 text-sm font-semibold uppercase tracking-[0.16em] text-primary">
+                Modèles et budgets
+              </p>
+              <h1 className="balance mt-4 max-w-4xl text-4xl font-bold leading-[1.05] tracking-[-0.035em] text-text sm:text-5xl lg:text-6xl">
+                Modèle ou budget&nbsp;: que faut-il modifier&nbsp;?
+              </h1>
+              <p className="pretty mt-6 max-w-3xl text-lg leading-relaxed text-text-secondary sm:text-xl">
+                Le modèle prépare tes mois habituels. Un budget représente un
+                mois précis.
+              </p>
+            </div>
+          </Container>
+        </section>
+
+        <Section aria-labelledby="difference-heading">
+          <div className="mx-auto max-w-4xl">
+            <h2
+              id="difference-heading"
+              className="max-w-3xl text-3xl font-bold leading-tight tracking-[-0.03em] text-text sm:text-4xl"
+            >
+              La différence en une phrase.
+            </h2>
+
+            <div className="mt-10 grid overflow-hidden rounded-[var(--radius-large)] border border-text/10 bg-surface md:grid-cols-2">
+              <article className="p-6 sm:p-8 md:border-r md:border-text/10">
+                <p className="text-sm font-semibold uppercase tracking-[0.14em] text-primary">
+                  Le modèle
+                </p>
+                <h3 className="mt-3 text-2xl font-semibold tracking-[-0.025em] text-text">
+                  Ta base de départ
+                </h3>
+                <p className="mt-4 leading-relaxed text-text-secondary">
+                  Il contient tes revenus, dépenses et épargnes habituels. Il
+                  sert à préparer tes budgets mensuels sans tout ressaisir.
+                </p>
+              </article>
+
+              <article className="border-t border-text/10 p-6 sm:p-8 md:border-t-0">
+                <p className="text-sm font-semibold uppercase tracking-[0.14em] text-accent">
+                  Le budget
+                </p>
+                <h3 className="mt-3 text-2xl font-semibold tracking-[-0.025em] text-text">
+                  Un mois précis
+                </h3>
+                <p className="mt-4 leading-relaxed text-text-secondary">
+                  Il correspond par exemple à août 2026. Tu peux l’ajuster pour
+                  ce mois sans changer ta base habituelle.
+                </p>
+              </article>
+            </div>
+          </div>
+        </Section>
+
+        <Section aria-labelledby="choice-heading">
+          <div className="mx-auto max-w-4xl">
+            <h2
+              id="choice-heading"
+              className="max-w-3xl text-3xl font-bold leading-tight tracking-[-0.03em] text-text sm:text-4xl"
+            >
+              Choisis selon ce que tu veux changer.
+            </h2>
+
+            <dl className="mt-10 divide-y divide-text/10 border-y border-text/10">
+              {choices.map((choice) => (
+                <div
+                  key={choice.intent}
+                  className="grid gap-2 py-5 sm:grid-cols-[1fr_auto_1fr] sm:items-center sm:gap-6"
+                >
+                  <dt className="font-medium text-text">{choice.intent}</dt>
+                  <ArrowRight
+                    aria-hidden="true"
+                    className="hidden text-primary sm:block"
+                    size={18}
+                  />
+                  <dd className="font-semibold text-primary sm:text-right">
+                    {choice.destination}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </Section>
+
+        <Section aria-labelledby="iphone-heading">
+          <div className="mx-auto max-w-4xl">
+            <header className="max-w-3xl">
+              <p className="text-sm font-semibold uppercase tracking-[0.16em] text-primary">
+                Sur iPhone
+              </p>
+              <h2
+                id="iphone-heading"
+                className="mt-3 text-3xl font-bold leading-tight tracking-[-0.03em] text-text sm:text-4xl"
+              >
+                Les deux parcours, étape par étape.
+              </h2>
+            </header>
+
+            <div className="mt-12 grid gap-12 lg:grid-cols-2 lg:gap-16">
+              <article>
+                <p className="text-sm font-semibold text-accent">
+                  Un seul mois
+                </p>
+                <h3 className="mt-2 text-2xl font-semibold tracking-[-0.025em] text-text">
+                  Modifier un budget mensuel
+                </h3>
+                <Steps items={budgetSteps} />
+              </article>
+
+              <article className="border-t border-text/10 pt-10 lg:border-l lg:border-t-0 lg:pl-16 lg:pt-0">
+                <p className="text-sm font-semibold text-primary">
+                  Tes mois habituels
+                </p>
+                <h3 className="mt-2 text-2xl font-semibold tracking-[-0.025em] text-text">
+                  Modifier le modèle
+                </h3>
+                <Steps items={modelSteps} />
+              </article>
+            </div>
+
+            <aside className="mt-12 rounded-[var(--radius-large)] border border-primary/15 bg-primary/6 p-6 sm:p-8">
+              <h3 className="text-lg font-semibold text-text">
+                Tes ajustements restent protégés
+              </h3>
+              <p className="mt-3 leading-relaxed text-text-secondary">
+                Quand tu choisis « Appliquer », Pulpe met à jour les budgets en
+                cours et futurs. Une prévision déjà modifiée manuellement dans
+                un budget n’est pas remplacée.
+              </p>
+              <p className="mt-4 leading-relaxed text-text-secondary">
+                Sur iPhone, tu peux créer un modèle et modifier ses prévisions.
+                Pour ajouter ou supprimer une prévision dans un modèle déjà
+                créé, utilise actuellement la version web.
+              </p>
+            </aside>
+          </div>
+        </Section>
+
+        <Section aria-labelledby="contact-heading">
+          <div className="mx-auto max-w-4xl border-t border-text/10 pt-10">
+            <h2
+              id="contact-heading"
+              className="text-3xl font-bold leading-tight tracking-[-0.025em] text-text"
+            >
+              Toujours bloqué&nbsp;?
+            </h2>
+            <p className="mt-4 max-w-2xl leading-relaxed text-text-secondary">
+              Écris-moi en précisant l’écran où tu te trouves. Je te répondrai
+              directement.
+            </p>
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className="mt-5 inline-flex min-h-11 items-center gap-2 rounded-md font-semibold text-primary transition-colors hover:text-primary-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              {CONTACT_EMAIL}
+              <ArrowRight aria-hidden="true" size={17} />
+            </a>
+          </div>
+        </Section>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/landing/app/support/page.tsx
+++ b/landing/app/support/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import type { ReactNode } from "react";
+import { ArrowRight } from "lucide-react";
 import { AccordionItem, Container, Section } from "@/components/ui";
 import { FinalCTA, Footer, Header } from "@/components/sections";
 import { angularUrl, CONTACT_EMAIL, GITHUB_URL } from "@/lib/config";
@@ -7,7 +9,7 @@ import { angularUrl, CONTACT_EMAIL, GITHUB_URL } from "@/lib/config";
 export const metadata: Metadata = {
   title: "Aide et questions fréquentes",
   description:
-    "Questions fréquentes sur Pulpe : saisie manuelle, protection des montants, gratuité, mode démo et disponibilité en Suisse et en France.",
+    "Guides et réponses pour utiliser Pulpe : comprendre les modèles et budgets, protéger ses montants et gérer son compte.",
   alternates: {
     canonical: "/support",
   },
@@ -167,15 +169,51 @@ export default function SupportPage() {
           <Container>
             <div className="mx-auto max-w-3xl">
               <h1 className="text-4xl font-bold leading-[1.05] tracking-[-0.035em] text-text sm:text-5xl lg:text-6xl">
-                Tout ce que tu veux savoir sur Pulpe.
+                Comment puis-je t&apos;aider&nbsp;?
               </h1>
               <p className="pretty mt-6 max-w-2xl text-lg leading-relaxed text-text-secondary sm:text-xl">
-                Les réponses aux questions qu&apos;on me pose avant de
-                commencer. Si la tienne manque, écris-moi.
+                Des guides courts pour utiliser Pulpe, puis les réponses aux
+                questions fréquentes. Si la tienne manque, écris-moi.
               </p>
             </div>
           </Container>
         </section>
+
+        <Section aria-labelledby="guides-heading">
+          <div className="mx-auto max-w-3xl">
+            <h2
+              id="guides-heading"
+              className="max-w-2xl text-4xl font-bold leading-[1.05] tracking-[-0.035em] text-text sm:text-5xl"
+            >
+              Guides pour utiliser Pulpe.
+            </h2>
+
+            <Link
+              href="/support/modeles-et-budgets"
+              className="group mt-10 block rounded-[var(--radius-large)] border border-text/10 bg-surface p-6 transition-[border-color,transform] hover:-translate-y-0.5 hover:border-primary/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary motion-reduce:transform-none motion-reduce:transition-none sm:p-8"
+            >
+              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-primary">
+                Bien démarrer
+              </p>
+              <div className="mt-4 flex items-start justify-between gap-6">
+                <div>
+                  <h3 className="text-2xl font-semibold leading-tight tracking-[-0.025em] text-text">
+                    Modèle ou budget&nbsp;: que faut-il modifier&nbsp;?
+                  </h3>
+                  <p className="mt-3 max-w-2xl leading-relaxed text-text-secondary">
+                    Choisis le bon endroit selon que ton changement concerne un
+                    seul mois ou tes mois habituels.
+                  </p>
+                </div>
+                <ArrowRight
+                  aria-hidden="true"
+                  className="mt-1 shrink-0 text-primary transition-transform group-hover:translate-x-1 motion-reduce:transform-none motion-reduce:transition-none"
+                  size={24}
+                />
+              </div>
+            </Link>
+          </div>
+        </Section>
 
         <Section aria-labelledby="faq-heading">
           <div className="mx-auto max-w-3xl">

--- a/landing/components/sections/Footer.tsx
+++ b/landing/components/sections/Footer.tsx
@@ -11,7 +11,7 @@ const FOOTER_LINKS = [
     href: `${ANGULAR_APP_URL}/legal/confidentialite`,
   },
   { label: "Nouveautés", href: "/changelog", internal: true },
-  { label: "Support", href: "/support", internal: true },
+  { label: "Aide", href: "/support", internal: true },
   { label: "Contact", href: `mailto:${CONTACT_EMAIL}` },
 ] as const;
 

--- a/landing/components/sections/Header.tsx
+++ b/landing/components/sections/Header.tsx
@@ -13,6 +13,7 @@ const navLinks = [
   { href: "/#pain-points", label: "Pourquoi Pulpe" },
   { href: "/#how-it-works", label: "Comment ça marche" },
   { href: "/#platforms", label: "Applications" },
+  { href: "/support", label: "Aide" },
   { href: "/#why-free", label: "Pourquoi c’est gratuit" },
 ];
 

--- a/landing/components/sections/Header.tsx
+++ b/landing/components/sections/Header.tsx
@@ -58,13 +58,13 @@ export function Header() {
 
           <div className="relative z-10 hidden items-center gap-1 lg:flex">
             {navLinks.map((link) => (
-              <a
+              <Link
                 key={link.href}
                 href={link.href}
                 className="inline-flex min-h-11 items-center rounded-full px-4 py-2 text-sm font-medium text-text transition-[color,background-color,scale] duration-200 hover:bg-primary/8 hover:text-primary active:scale-[0.96] active:bg-primary/12 motion-reduce:transition-none motion-reduce:scale-100"
               >
                 {link.label}
-              </a>
+              </Link>
             ))}
           </div>
 
@@ -130,14 +130,14 @@ export function Header() {
               écran opaque avec ~300px de vide au-dessus et ~200px en dessous. */}
           <div className="flex h-full w-full flex-col gap-2">
             {navLinks.map((link) => (
-              <a
+              <Link
                 key={link.href}
                 href={link.href}
                 tabIndex={-1}
                 className="flex min-h-14 items-center justify-center rounded-lg px-4 py-3 text-center text-lg font-semibold text-text transition-[background-color,scale] duration-200 hover:bg-primary/8 active:scale-[0.96] active:bg-primary/12 motion-reduce:transition-none motion-reduce:scale-100"
               >
                 {link.label}
-              </a>
+              </Link>
             ))}
             <Button
               href={angularUrl("/signup", "mobile_menu_commencer")}

--- a/landing/public/sitemap.xml
+++ b/landing/public/sitemap.xml
@@ -16,12 +16,12 @@
     <loc>https://pulpe.app/support</loc>
     <lastmod>2026-08-09</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://pulpe.app/support/modeles-et-budgets</loc>
     <lastmod>2026-08-09</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/landing/public/sitemap.xml
+++ b/landing/public/sitemap.xml
@@ -14,8 +14,14 @@
   </url>
   <url>
     <loc>https://pulpe.app/support</loc>
-    <lastmod>2026-02-15</lastmod>
+    <lastmod>2026-08-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://pulpe.app/support/modeles-et-budgets</loc>
+    <lastmod>2026-08-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Résumé

- transforme `/support` en point d’entrée du centre d’aide
- ajoute le premier guide textuel « Modèle ou budget : que faut-il modifier ? »
- ajoute le lien Aide dans la navigation et le footer
- documente les parcours iPhone sans captures à maintenir
- met à jour les métadonnées, le sitemap et les contrats d’accessibilité

## Vérifications

- `pnpm --filter pulpe-landing test` — 75 tests OK
- `pnpm --filter pulpe-landing type-check` — OK
- `pnpm --filter pulpe-landing lint` — OK
- `pnpm --filter pulpe-landing build` — OK
- rendu vérifié en desktop et mobile 390 px

## Note environnement

Le hook global du dépôt bloque sur `bunx` absent du VPS lors du lint backend. Aucun fichier backend n’est modifié et tous les contrôles de la landing passent.