### PR TITLE
fix: harden preview release readiness

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -399,10 +399,11 @@ Execute ONLY after user confirms.
 Run the checked-in What's New contracts from the repository root for every release:
 
 ```bash
+pnpm build:shared
 (cd backend-nest && bun test src/modules/whats-new/domain/releases-data.parity.spec.ts)
 (cd frontend && pnpm test \
-  projects/webapp/src/app/layout/whats-new/whats-new-releases.spec.ts \
-  projects/webapp/src/app/layout/whats-new/whats-new-toast.spec.ts)
+  --include 'projects/webapp/src/app/layout/whats-new/whats-new-releases.spec.ts' \
+  --include 'projects/webapp/src/app/layout/whats-new/whats-new-toast.spec.ts')
 ```
 
 Stop on any contract failure. These targeted tests are the local fail-fast gate; the complete CI after the `preview` and `main` pushes remains the second barrier.
@@ -473,7 +474,7 @@ Only after "oui":
 
 Treat every shell block below as an independent session. Step 9.2 is the only writer of `pulpe-release-sha`, stored under the path returned by `git rev-parse --git-path` so linked worktrees cannot share or overwrite release identity. Every later block must read that frozen SHA, resolve it as the same full commit, and require the current `HEAD` to remain equal to it. Never replace the frozen identity with a later `HEAD`.
 
-1. Confirm that the available Railway and Vercel capabilities can inspect production deployments and their Git commit metadata. Also confirm that the Railway integration can apply the pending web gate after deployment. If any required capability is missing, stop before committing; never skip a proof or invent a command.
+1. Confirm that the available Railway capabilities can inspect preview and production deployments, their Git commit metadata, and the preview public domain. Confirm that the available Vercel capabilities can inspect production deployments and their Git commit metadata. Also confirm that the Railway integration can apply the pending web gate after deployment. If any required capability is missing, stop before committing; never skip a proof or invent a command.
 2. Create the release commit without a tag and freeze its identity:
 
    ```bash
@@ -537,7 +538,15 @@ Treat every shell block below as an independent session. Step 9.2 is the only wr
 
    Missing, cancelled, or failed CI means stop. Fix the release on `preview`; do not promote it.
 
-5. After green CI, refetch and reject any drift or loss of ancestry:
+5. After green preview CI, independently inspect the Railway `pulpe-backend` deployment in the `preview` environment, `backend` service:
+   - before each inspection, independently read `pulpe-release-sha` through `git rev-parse --git-path`, validate it as the same full commit, and require `HEAD` to equal it;
+   - poll the deployment created from that frozen SHA for up to 5 minutes; do not accept an older active deployment as evidence;
+   - require the deployment to reach `SUCCESS`, become active, and report that exact frozen SHA;
+   - resolve the preview service's public domain and require its `/health` endpoint to respond successfully.
+
+   A missing deployment, timeout, different SHA, `SKIPPED`, any other terminal state, or failed health check stops the release before even a dry-run toward `main`.
+
+6. After the Railway preview proof, refetch and reject any drift or loss of ancestry:
 
    ```bash
    set -euo pipefail
@@ -556,7 +565,7 @@ Treat every shell block below as an independent session. Step 9.2 is the only wr
 
    The dry-run checks fast-forward feasibility, not ruleset authorization. The Step 0 bypass check remains mandatory.
 
-6. Promote the same immutable object, never the mutable `origin/preview` ref:
+7. Promote the same immutable object, never the mutable `origin/preview` ref:
 
    ```bash
    set -euo pipefail
@@ -576,7 +585,7 @@ Treat every shell block below as an independent session. Step 9.2 is the only wr
    test "$(git rev-parse origin/main)" = "${SHA}"
    ```
 
-7. Poll for up to 5 minutes for the `ci.yml` run whose `headSha` is the release SHA, `headBranch` is `main`, and event is `push`. Do not filter cancelled runs. Resolve and consume the run id in the same session:
+8. Poll for up to 5 minutes for the `ci.yml` run whose `headSha` is the release SHA, `headBranch` is `main`, and event is `push`. Do not filter cancelled runs. Resolve and consume the run id in the same session:
 
    ```bash
    set -euo pipefail
@@ -606,7 +615,7 @@ Treat every shell block below as an independent session. Step 9.2 is the only wr
    ```
 
    This includes the main-only `migrate`, `posthog-annotate`, and `verify-prod-csp` jobs after `ci-success`. Missing, cancelled, or failed CI stops publication.
-8. Independently inspect the production deployments:
+9. Independently inspect the production deployments:
    - before each provider inspection, independently read `pulpe-release-sha` through `git rev-parse --git-path`, validate it as the same full commit, and require `HEAD` to equal it;
    - both Vercel production projects are ready and report that frozen SHA;
    - the Railway production deployment is successful and reports that frozen SHA;
@@ -614,7 +623,7 @@ Treat every shell block below as an independent session. Step 9.2 is the only wr
 
    Vercel and Railway react to GitHub pushes; do not assume GitHub `ci-success` delayed those webhooks. If a status, SHA, or health check differs, stop without a tag, GitHub Release, or client gate. Correct through `preview` while keeping the same product version.
 
-9. Only after every production proof passes, refetch `main` and tags, require `origin/main` to equal the release SHA, and recheck that the local tag, remote tag, and GitHub Release are still absent. Then create and push the one immutable tag:
+10. Only after every production proof passes, refetch `main` and tags, require `origin/main` to equal the release SHA, and recheck that the local tag, remote tag, and GitHub Release are still absent. Then create and push the one immutable tag:
 
    ```bash
    set -euo pipefail
@@ -634,7 +643,7 @@ Treat every shell block below as an independent session. Step 9.2 is the only wr
    git push origin "refs/tags/${TAG}"
    ```
 
-10. Create the GitHub Release using the **GitHub Release template** from Step 5:
+11. Create the GitHub Release using the **GitHub Release template** from Step 5:
 
 ```bash
 set -euo pipefail
@@ -667,8 +676,8 @@ EOF
 )"
 ```
 
-11. Apply the pending `LATEST_WEB_VERSION` update from [references/jsts-release.md](references/jsts-release.md) in `preview` and `production`, then verify `GET /api/v1/app/version`.
-12. Never schedule a Railway `LATEST_IOS_VERSION` operation: the backend reads the published iOS version from the App Store itself (see [references/ios-release.md](references/ios-release.md)). No post-App-Store follow-up is owed for this gate, so do not report one.
+12. Apply the pending `LATEST_WEB_VERSION` update from [references/jsts-release.md](references/jsts-release.md) in `preview` and `production`, then verify `GET /api/v1/app/version`.
+13. Never schedule a Railway `LATEST_IOS_VERSION` operation: the backend reads the published iOS version from the App Store itself (see [references/ios-release.md](references/ios-release.md)). No post-App-Store follow-up is owed for this gate, so do not report one.
 
 Release rules:
 

--- a/.github/scripts/ci-security.test.mjs
+++ b/.github/scripts/ci-security.test.mjs
@@ -8,6 +8,7 @@ const read = (path) =>
 const action = read(".github/actions/setup-supabase-cli/action.yml");
 const workflow = read(".github/workflows/ci.yml");
 const dockerfile = read("backend-nest/Dockerfile");
+const rootPackage = JSON.parse(read("package.json"));
 const backendPackage = JSON.parse(read("backend-nest/package.json"));
 const ciGuide = read("docs/CI.md");
 
@@ -66,4 +67,12 @@ test("pull requests cannot execute production migration credentials", () => {
 
 test("the backend image does not install Bun", () => {
   assert.doesNotMatch(dockerfile, /bun\.sh\/install|\/root\/\.bun/);
+});
+
+test("critical production dependency audit stays in CI", () => {
+  assert.equal(
+    rootPackage.scripts["audit:prod:critical"],
+    "pnpm audit --prod --audit-level critical",
+  );
+  assert.match(workflow, /check:\s*\[[^\]]*"audit:prod:critical"[^\]]*\]/);
 });

--- a/.github/scripts/ci-security.test.mjs
+++ b/.github/scripts/ci-security.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import test from "node:test";
+
+const require = createRequire(import.meta.url);
 
 const read = (path) =>
   readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
@@ -11,6 +14,7 @@ const dockerfile = read("backend-nest/Dockerfile");
 const rootPackage = JSON.parse(read("package.json"));
 const backendPackage = JSON.parse(read("backend-nest/package.json"));
 const ciGuide = read("docs/CI.md");
+const frontendEslintConfig = require("../../frontend/eslint.config.js");
 
 test("Supabase archives are pinned and verified before extraction", () => {
   assert.match(
@@ -69,10 +73,45 @@ test("the backend image does not install Bun", () => {
   assert.doesNotMatch(dockerfile, /bun\.sh\/install|\/root\/\.bun/);
 });
 
-test("critical production dependency audit stays in CI", () => {
+test("critical dependency audit stays in CI", () => {
   assert.equal(
-    rootPackage.scripts["audit:prod:critical"],
-    "pnpm audit --prod --audit-level critical",
+    rootPackage.scripts["audit:critical"],
+    "pnpm audit --audit-level critical",
   );
-  assert.match(workflow, /check:\s*\[[^\]]*"audit:prod:critical"[^\]]*\]/);
+  assert.match(workflow, /check:\s*\[[^\]]*"audit:critical"[^\]]*\]/);
+});
+
+test("the boundaries upgrade keeps a modern explicit policy", () => {
+  const settings = frontendEslintConfig.find(
+    (config) => config.settings?.["boundaries/dependency-nodes"],
+  )?.settings;
+  const rules = frontendEslintConfig.find(
+    (config) => config.rules?.["boundaries/dependencies"]?.[1]?.rules,
+  )?.rules;
+
+  assert.deepEqual(settings?.["boundaries/dependency-nodes"], [
+    "import",
+    "dynamic-import",
+  ]);
+  assert.equal(settings?.["boundaries/legacy-templates"], false);
+  assert.ok(rules, "the boundaries dependency policy must be configured");
+  for (const deprecatedRule of [
+    "boundaries/element-types",
+    "boundaries/entry-point",
+    "boundaries/external",
+    "boundaries/no-private",
+  ]) {
+    assert.equal(rules[deprecatedRule], "off");
+  }
+  assert.doesNotMatch(JSON.stringify(rules), /\$\{/);
+
+  const privacyRule = rules["boundaries/dependencies"][1].rules.at(-1);
+  assert.deepEqual(privacyRule, {
+    disallow: {
+      to: { parent: { type: "*" } },
+      dependency: {
+        relationship: { to: [null, "!(child|sibling|uncle)"] },
+      },
+    },
+  });
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,7 +475,7 @@ jobs:
     needs: [install, build]
     strategy:
       matrix:
-        check: [lint, format:check, quality, deps:check]
+        check: [lint, format:check, quality, deps:check, "audit:prod:critical"]
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,7 +475,7 @@ jobs:
     needs: [install, build]
     strategy:
       matrix:
-        check: [lint, format:check, quality, deps:check, "audit:prod:critical"]
+        check: [lint, format:check, quality, deps:check, "audit:critical"]
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/backend-nest/src/modules/savings-goal/application/get-savings-goal-withdrawals.use-case.spec.ts
+++ b/backend-nest/src/modules/savings-goal/application/get-savings-goal-withdrawals.use-case.spec.ts
@@ -207,6 +207,42 @@ describe('GetSavingsGoalWithdrawalsUseCase', () => {
     expect(result.withdrawals).toHaveLength(3);
   });
 
+  it('normalizes floating-point residue as fully realized', async () => {
+    mockRepo.findPlannedWithdrawalRecords.mockResolvedValueOnce([
+      {
+        budgetLineId: '223e4567-e89b-12d3-a456-426614174010',
+        budgetId: '123e4567-e89b-12d3-a456-426614174001',
+        name: 'Total décimal',
+        month: 9,
+        year: 2026,
+        amount: 10.05,
+      },
+    ]);
+    mockRepo.findWithdrawals.mockResolvedValueOnce([
+      {
+        ...withdrawal,
+        budgetLineId: '223e4567-e89b-12d3-a456-426614174010',
+        amount: 0.01,
+      },
+      {
+        ...withdrawal,
+        transactionId: '123e4567-e89b-12d3-a456-426614174020',
+        budgetLineId: '223e4567-e89b-12d3-a456-426614174010',
+        amount: 10.04,
+      },
+    ]);
+
+    const result = await useCase.execute('goal-1');
+
+    expect(result.planned[0]).toEqual(
+      expect.objectContaining({
+        realizedAmount: 10.049999999999999,
+        remainingAmount: 0,
+        status: 'realized',
+      }),
+    );
+  });
+
   it('recomputes after an edit or deletion and ignores pointing state', async () => {
     mockRepo.findWithdrawals.mockResolvedValueOnce([
       {

--- a/backend-nest/src/modules/savings-goal/application/get-savings-goal-withdrawals.use-case.spec.ts
+++ b/backend-nest/src/modules/savings-goal/application/get-savings-goal-withdrawals.use-case.spec.ts
@@ -236,11 +236,11 @@ describe('GetSavingsGoalWithdrawalsUseCase', () => {
 
     expect(result.planned[0]).toEqual(
       expect.objectContaining({
-        realizedAmount: 10.049999999999999,
         remainingAmount: 0,
         status: 'realized',
       }),
     );
+    expect(result.planned[0]?.realizedAmount).toBeCloseTo(10.05);
   });
 
   it('recomputes after an edit or deletion and ignores pointing state', async () => {

--- a/backend-nest/src/modules/savings-goal/application/get-savings-goal-withdrawals.use-case.ts
+++ b/backend-nest/src/modules/savings-goal/application/get-savings-goal-withdrawals.use-case.ts
@@ -3,10 +3,11 @@ import {
   SAVINGS_GOAL_REPOSITORY,
   type SavingsGoalRepositoryPort,
 } from '../domain/ports/savings-goal-repository.port';
-import type {
-  SavingsGoalPlannedWithdrawal,
-  SavingsGoalPlanOnlyWithdrawal,
-  SavingsGoalWithdrawal,
+import {
+  WITHDRAWAL_BALANCE_TOLERANCE,
+  type SavingsGoalPlannedWithdrawal,
+  type SavingsGoalPlanOnlyWithdrawal,
+  type SavingsGoalWithdrawal,
 } from 'pulpe-shared';
 
 export interface SavingsGoalWithdrawalsReadModel {
@@ -73,7 +74,9 @@ export class GetSavingsGoalWithdrawalsUseCase {
     realizedByLine: ReadonlyMap<string, number>,
   ): SavingsGoalPlannedWithdrawal {
     const realizedAmount = realizedByLine.get(record.budgetLineId) ?? 0;
-    const remainingAmount = Math.max(0, record.amount - realizedAmount);
+    const remaining = record.amount - realizedAmount;
+    const remainingAmount =
+      remaining > WITHDRAWAL_BALANCE_TOLERANCE ? remaining : 0;
     return {
       budgetLineId: record.budgetLineId,
       budgetId: record.budgetId,

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -41,6 +41,7 @@ module.exports = tseslint.config(
         },
       },
       "boundaries/dependency-nodes": ["import", "dynamic-import"],
+      "boundaries/legacy-templates": false,
       "boundaries/root-path": path.resolve(__dirname, ".."),
       "boundaries/elements": [
         {
@@ -172,145 +173,219 @@ module.exports = tseslint.config(
   {
     files: ["**/*.ts"],
     rules: {
-      "boundaries/element-types": [
+      "boundaries/element-types": "off",
+      "boundaries/entry-point": "off",
+      "boundaries/external": "off",
+      "boundaries/no-private": "off",
+      "boundaries/dependencies": [
         "error",
         {
           default: "disallow",
           rules: [
             {
-              from: "main",
+              from: { type: "main" },
               allow: [
-                ["app", { app: "${from.app}" }],
-                ["env", { app: "${from.app}" }],
+                {
+                  to: {
+                    type: "app",
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
+                {
+                  to: {
+                    type: "env",
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
               ],
             },
             {
-              from: "core",
+              from: { type: "core" },
               allow: [
-                ["shared"],
-                ["lib-api"],
-                ["core", { app: "${from.app}" }],
-                ["env", { app: "${from.app}" }],
+                { to: { type: ["shared", "lib-api"] } },
+                {
+                  to: {
+                    type: ["core", "env"],
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
               ],
             },
             {
-              from: "ui",
+              from: { type: "ui" },
               allow: [
-                ["shared"],
-                ["lib-api"],
-                ["ui", { app: "${from.app}" }],
-                ["env", { app: "${from.app}" }],
+                { to: { type: ["shared", "lib-api"] } },
+                {
+                  to: {
+                    type: ["ui", "env"],
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
               ],
             },
             {
-              from: "layout",
+              from: { type: "layout" },
               allow: [
-                ["shared"],
-                ["lib-api"],
-                ["core", { app: "${from.app}" }],
-                ["ui", { app: "${from.app}" }],
-                ["layout", { app: "${from.app}" }],
-                ["pattern", { app: "${from.app}" }],
-                ["env", { app: "${from.app}" }],
+                { to: { type: ["shared", "lib-api"] } },
+                {
+                  to: {
+                    type: ["core", "ui", "layout", "pattern", "env"],
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
               ],
             },
             {
-              from: "app",
+              from: { type: "app" },
               allow: [
-                ["shared"],
-                ["lib-api"],
-                ["app", { app: "${from.app}" }],
-                ["core", { app: "${from.app}" }],
-                ["ui", { app: "${from.app}" }],
-                ["layout", { app: "${from.app}" }],
-                ["pattern", { app: "${from.app}" }],
-                ["feature-routes", { app: "${from.app}" }],
-                ["feature", { app: "${from.app}" }],
-                ["env", { app: "${from.app}" }],
+                { to: { type: ["shared", "lib-api"] } },
+                {
+                  to: {
+                    type: [
+                      "app",
+                      "core",
+                      "ui",
+                      "layout",
+                      "pattern",
+                      "feature-routes",
+                      "feature",
+                      "env",
+                    ],
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
               ],
             },
             {
-              from: ["pattern"],
+              from: { type: "pattern" },
               allow: [
-                ["shared"],
-                ["lib-api"],
-                ["core", { app: "${from.app}" }],
-                ["ui", { app: "${from.app}" }],
-                ["env", { app: "${from.app}" }],
+                { to: { type: ["shared", "lib-api"] } },
+                {
+                  to: {
+                    type: ["core", "ui", "env"],
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
               ],
             },
             {
-              from: ["feature"],
+              from: { type: "feature" },
               allow: [
-                ["shared"],
-                ["lib-api"],
-                ["core", { app: "${from.app}" }],
-                ["ui", { app: "${from.app}" }],
-                ["pattern", { app: "${from.app}" }],
-                ["feature", { app: "${from.app}", feature: "${from.feature}" }],
-                ["env", { app: "${from.app}" }],
+                { to: { type: ["shared", "lib-api"] } },
+                {
+                  to: {
+                    type: ["core", "ui", "pattern", "env"],
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
+                {
+                  to: {
+                    type: "feature",
+                    captured: {
+                      app: "{{ from.captured.app }}",
+                      feature: "{{ from.captured.feature }}",
+                    },
+                  },
+                },
               ],
             },
             {
-              from: ["feature-routes"],
+              from: { type: "feature-routes" },
               allow: [
-                ["shared"],
-                ["lib-api"],
-                ["core", { app: "${from.app}" }],
-                ["pattern", { app: "${from.app}", feature: "${from.feature}" }],
-                ["feature", { app: "${from.app}", feature: "${from.feature}" }],
-                [
-                  "feature-routes",
-                  { app: "${from.app}", feature: "!${from.feature}" },
-                ],
-                ["env", { app: "${from.app}" }],
+                { to: { type: ["shared", "lib-api"] } },
+                {
+                  to: {
+                    type: ["core", "env"],
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
+                {
+                  to: {
+                    type: ["pattern", "feature"],
+                    captured: {
+                      app: "{{ from.captured.app }}",
+                      feature: "{{ from.captured.feature }}",
+                    },
+                  },
+                },
+                {
+                  to: {
+                    type: "feature-routes",
+                    captured: {
+                      app: "{{ from.captured.app }}",
+                      feature: "!{{ from.captured.feature }}",
+                    },
+                  },
+                },
               ],
             },
             {
-              from: ["lib-api"],
-              allow: [["lib", { lib: "${from.lib}" }]],
-            },
-            {
-              from: ["lib"],
-              allow: [["lib", { lib: "${from.lib}" }]],
-            },
-            {
-              from: ["test-config"],
-              allow: [["lib-api"]],
-            },
-            {
-              from: ["e2e-config"],
-              allow: [["lib-api"]],
-            },
-            {
-              from: ["e2e"],
-              allow: [["e2e"], ["lib-api"], ["shared"]],
-            },
-            {
-              from: ["testing"],
-              allow: ["shared"],
-            },
-            {
-              from: ["script"],
-              allow: [["shared"], ["core"], ["lib-api"]],
-            },
-            {
-              from: ["test-spec"],
+              from: { type: "lib-api" },
               allow: [
-                ["shared"],
-                ["lib-api"],
-                ["testing"],
+                {
+                  to: {
+                    type: "lib",
+                    captured: { lib: "{{ from.captured.lib }}" },
+                  },
+                },
+              ],
+            },
+            {
+              from: { type: "lib" },
+              allow: [
+                {
+                  to: {
+                    type: "lib",
+                    captured: { lib: "{{ from.captured.lib }}" },
+                  },
+                },
+              ],
+            },
+            {
+              from: { type: "test-config" },
+              allow: [{ to: { type: "lib-api" } }],
+            },
+            {
+              from: { type: "e2e-config" },
+              allow: [{ to: { type: "lib-api" } }],
+            },
+            {
+              from: { type: "e2e" },
+              allow: [{ to: { type: ["e2e", "lib-api", "shared"] } }],
+            },
+            {
+              from: { type: "testing" },
+              allow: [{ to: { type: "shared" } }],
+            },
+            {
+              from: { type: "script" },
+              allow: [{ to: { type: ["shared", "core", "lib-api"] } }],
+            },
+            {
+              from: { type: "test-spec" },
+              allow: [
+                { to: { type: ["shared", "lib-api", "testing"] } },
                 // e2e *.spec.ts files also classify as `test-spec`; they import
                 // their fixtures/helpers (type `e2e`). Permit it here rather than
                 // re-typing e2e specs (which destabilises unit-spec matching).
-                ["e2e"],
-                ["core", { app: "${from.app}" }],
-                ["ui", { app: "${from.app}" }],
-                ["layout", { app: "${from.app}" }],
-                ["pattern", { app: "${from.app}" }],
-                ["feature", { app: "${from.app}" }],
-                ["env", { app: "${from.app}" }],
+                { to: { type: "e2e" } },
+                {
+                  to: {
+                    type: ["core", "ui", "layout", "pattern", "feature", "env"],
+                    captured: { app: "{{ from.captured.app }}" },
+                  },
+                },
               ],
+            },
+            {
+              disallow: {
+                to: { parent: { type: "*" } },
+                dependency: {
+                  relationship: {
+                    to: [null, "!(child|sibling|uncle)"],
+                  },
+                },
+              },
             },
           ],
         },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,7 +92,7 @@
     "esbuild-visualizer": "^0.7.0",
     "eslint": "^9.28.0",
     "eslint-import-resolver-typescript": "^4.4.3",
-    "eslint-plugin-boundaries": "^5.0.1",
+    "eslint-plugin-boundaries": "^6.0.2",
     "http-server": "^14.1.1",
     "jsdom": "^26.1.0",
     "madge": "^8.0.0",

--- a/frontend/projects/webapp/eslint.config.js
+++ b/frontend/projects/webapp/eslint.config.js
@@ -36,7 +36,7 @@ module.exports = tseslint.config(
   {
     files: ["**/feature/design-system/design-system-page.ts"],
     rules: {
-      "boundaries/element-types": "off",
+      "boundaries/dependencies": "off",
     },
   },
 );

--- a/frontend/projects/webapp/src/app/core/config/config.schema.spec.ts
+++ b/frontend/projects/webapp/src/app/core/config/config.schema.spec.ts
@@ -1,0 +1,82 @@
+import { ConfigSchema, EnvSchema, envToConfig } from './config.schema';
+
+const validEnv = {
+  PUBLIC_ENVIRONMENT: 'local',
+  PUBLIC_SUPABASE_URL: 'http://localhost:54321',
+  PUBLIC_SUPABASE_ANON_KEY: 'sb_publishable_test',
+  PUBLIC_BACKEND_API_URL: 'http://localhost:3000/api/v1',
+  PUBLIC_POSTHOG_API_KEY: `phc_${'x'.repeat(36)}`,
+  PUBLIC_POSTHOG_HOST: 'https://eu.i.posthog.com',
+  PUBLIC_POSTHOG_ENABLED: 'false',
+  PUBLIC_POSTHOG_CAPTURE_PAGEVIEWS: 'true',
+  PUBLIC_POSTHOG_CAPTURE_PAGELEAVES: 'true',
+  PUBLIC_POSTHOG_SESSION_RECORDING_ENABLED: 'false',
+  PUBLIC_POSTHOG_MASK_INPUTS: 'true',
+  PUBLIC_POSTHOG_SAMPLE_RATE: '0.1',
+  PUBLIC_POSTHOG_DEBUG: 'false',
+  PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAB46FJOy2Xtrp9V6',
+} as const;
+
+function expectRejectedByBoth(
+  envPatch: Partial<Record<keyof typeof validEnv, string>>,
+  configPatch: Record<string, unknown>,
+): void {
+  expect(EnvSchema.safeParse({ ...validEnv, ...envPatch }).success).toBe(false);
+
+  const config = envToConfig(EnvSchema.parse(validEnv));
+  expect(ConfigSchema.safeParse({ ...config, ...configPatch }).success).toBe(
+    false,
+  );
+}
+
+describe('configuration URL validation', () => {
+  it('accepts the documented local and production formats', () => {
+    const localEnv = EnvSchema.parse(validEnv);
+    expect(ConfigSchema.safeParse(envToConfig(localEnv)).success).toBe(true);
+
+    const productionEnv = EnvSchema.parse({
+      ...validEnv,
+      PUBLIC_ENVIRONMENT: 'production',
+      PUBLIC_SUPABASE_URL: 'https://project.supabase.co',
+      PUBLIC_BACKEND_API_URL: 'https://api.pulpe.app/api/v1',
+      PUBLIC_POSTHOG_HOST: '/ph',
+      PUBLIC_POSTHOG_ENABLED: 'true',
+    });
+    expect(ConfigSchema.safeParse(envToConfig(productionEnv)).success).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    'https://project.supabase.co.attacker.example',
+    'https://attacker.example/?next=supabase.co',
+  ])('rejects deceptive Supabase URL %s', (url) => {
+    expectRejectedByBoth(
+      { PUBLIC_SUPABASE_URL: url },
+      { supabase: { ...envToConfig(EnvSchema.parse(validEnv)).supabase, url } },
+    );
+  });
+
+  it('rejects a backend URL whose API path only appears in the query', () => {
+    const apiUrl = 'https://attacker.example/?next=/api/v1';
+    expectRejectedByBoth(
+      { PUBLIC_BACKEND_API_URL: apiUrl },
+      { backend: { apiUrl } },
+    );
+  });
+
+  it.each(['https://posthog.com.attacker.example', '//attacker.example/ph'])(
+    'rejects deceptive PostHog host %s',
+    (host) => {
+      expectRejectedByBoth(
+        { PUBLIC_POSTHOG_HOST: host },
+        {
+          postHog: {
+            ...envToConfig(EnvSchema.parse(validEnv)).postHog,
+            host,
+          },
+        },
+      );
+    },
+  );
+});

--- a/frontend/projects/webapp/src/app/core/config/config.schema.spec.ts
+++ b/frontend/projects/webapp/src/app/core/config/config.schema.spec.ts
@@ -65,18 +65,20 @@ describe('configuration URL validation', () => {
     );
   });
 
-  it.each(['https://posthog.com.attacker.example', '//attacker.example/ph'])(
-    'rejects deceptive PostHog host %s',
-    (host) => {
-      expectRejectedByBoth(
-        { PUBLIC_POSTHOG_HOST: host },
-        {
-          postHog: {
-            ...envToConfig(EnvSchema.parse(validEnv)).postHog,
-            host,
-          },
+  it.each([
+    'https://posthog.com.attacker.example',
+    '//attacker.example/ph',
+    '/\t/attacker.example/ph',
+    '/\n/attacker.example/ph',
+  ])('rejects deceptive PostHog host %s', (host) => {
+    expectRejectedByBoth(
+      { PUBLIC_POSTHOG_HOST: host },
+      {
+        postHog: {
+          ...envToConfig(EnvSchema.parse(validEnv)).postHog,
+          host,
         },
-      );
-    },
-  );
+      },
+    );
+  });
 });

--- a/frontend/projects/webapp/src/app/core/config/config.schema.ts
+++ b/frontend/projects/webapp/src/app/core/config/config.schema.ts
@@ -41,8 +41,13 @@ function isAllowedBackendUrl(value: string): boolean {
 }
 
 function isAllowedPostHogHost(value: string): boolean {
-  if (value.startsWith('/') && value[1] !== '/' && value[1] !== '\\') {
-    return true;
+  if (value.startsWith('/')) {
+    try {
+      const proxyUrl = new URL(value, 'https://relative.invalid');
+      return proxyUrl.origin === 'https://relative.invalid';
+    } catch {
+      return false;
+    }
   }
 
   const url = parseHttpUrl(value);

--- a/frontend/projects/webapp/src/app/core/config/config.schema.ts
+++ b/frontend/projects/webapp/src/app/core/config/config.schema.ts
@@ -6,6 +6,54 @@ import { z } from 'zod';
  */
 const POSTHOG_KEY_PATTERN = /^phc_[A-Za-z0-9_-]+$/;
 
+function parseHttpUrl(value: string): URL | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function isDomainOrSubdomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+function isAllowedSupabaseUrl(value: string): boolean {
+  const url = parseHttpUrl(value);
+  if (!url) return false;
+
+  return (
+    url.hostname === 'localhost' ||
+    url.hostname === '127.0.0.1' ||
+    /^192\.168\.\d{1,3}\.\d{1,3}$/.test(url.hostname) ||
+    isDomainOrSubdomain(url.hostname, 'supabase.co') ||
+    isDomainOrSubdomain(url.hostname, 'supabase.in')
+  );
+}
+
+function isAllowedBackendUrl(value: string): boolean {
+  const url = parseHttpUrl(value);
+  return (
+    url !== null &&
+    (url.pathname === '/api' || url.pathname.startsWith('/api/'))
+  );
+}
+
+function isAllowedPostHogHost(value: string): boolean {
+  if (value.startsWith('/') && value[1] !== '/' && value[1] !== '\\') {
+    return true;
+  }
+
+  const url = parseHttpUrl(value);
+  return (
+    url !== null &&
+    (url.hostname === 'localhost' ||
+      isDomainOrSubdomain(url.hostname, 'posthog.com') ||
+      isDomainOrSubdomain(url.hostname, 'posthog.dev'))
+  );
+}
+
 /**
  * Configuration Schema for Pulpe Application
  * ==========================================
@@ -56,24 +104,10 @@ export const EnvSchema = z.object({
   ),
   PUBLIC_SUPABASE_URL: z
     .url({ error: 'Supabase URL must be a valid URL' })
-    .refine(
-      (url) => {
-        // Allow localhost and LAN IPs for development
-        if (
-          url.includes('localhost') ||
-          url.includes('127.0.0.1') ||
-          /^https?:\/\/192\.168\.\d+\.\d+/.test(url)
-        ) {
-          return true;
-        }
-        // For production, ensure it's a Supabase URL
-        return url.includes('supabase.co') || url.includes('supabase.in');
-      },
-      {
-        error:
-          'URL must be a valid Supabase URL or localhost/LAN IP for development',
-      },
-    ),
+    .refine(isAllowedSupabaseUrl, {
+      error:
+        'URL must be a valid Supabase URL or localhost/LAN IP for development',
+    }),
   PUBLIC_SUPABASE_ANON_KEY: z
     .string()
     .min(1, { error: 'Supabase anon key is required' })
@@ -91,34 +125,16 @@ export const EnvSchema = z.object({
     ),
   PUBLIC_BACKEND_API_URL: z
     .url({ error: 'Backend API URL must be a valid URL' })
-    .refine(
-      (url) => {
-        // Ensure it ends with /api/v1 or similar API path
-        return url.includes('/api/') || url.includes('localhost');
-      },
-      {
-        error: 'Backend API URL should contain an API path',
-      },
-    ),
+    .refine(isAllowedBackendUrl, {
+      error: 'Backend API URL should contain an API path',
+    }),
   PUBLIC_POSTHOG_API_KEY: z.string().regex(POSTHOG_KEY_PATTERN, {
     error: 'PostHog API key must match format phc_[A-Za-z0-9_-]+',
   }),
-  PUBLIC_POSTHOG_HOST: z.string().refine(
-    (val) => {
-      // Allow relative proxy path (e.g., /ph via Vercel reverse proxy)
-      if (val.startsWith('/')) return true;
-      // Allow common PostHog hosts
-      return (
-        val.includes('posthog.com') ||
-        val.includes('posthog.dev') ||
-        val.includes('localhost')
-      );
-    },
-    {
-      error:
-        'PostHog host must be a PostHog URL or a relative proxy path (e.g., /ph)',
-    },
-  ),
+  PUBLIC_POSTHOG_HOST: z.string().refine(isAllowedPostHogHost, {
+    error:
+      'PostHog host must be a PostHog URL or a relative proxy path (e.g., /ph)',
+  }),
   PUBLIC_POSTHOG_ENABLED: z
     .string()
     .refine((val) => val === 'true' || val === 'false', {
@@ -250,24 +266,12 @@ export function envToConfig(env: EnvironmentVariables): ApplicationConfig {
  */
 export const ConfigSchema = z.object({
   supabase: z.object({
-    url: z.url({ error: 'Supabase URL must be a valid URL' }).refine(
-      (url) => {
-        // Allow localhost and LAN IPs for development
-        if (
-          url.includes('localhost') ||
-          url.includes('127.0.0.1') ||
-          /^https?:\/\/192\.168\.\d+\.\d+/.test(url)
-        ) {
-          return true;
-        }
-        // For production, ensure it's a Supabase URL
-        return url.includes('supabase.co') || url.includes('supabase.in');
-      },
-      {
+    url: z
+      .url({ error: 'Supabase URL must be a valid URL' })
+      .refine(isAllowedSupabaseUrl, {
         error:
           'URL must be a valid Supabase URL or localhost/LAN IP for development',
-      },
-    ),
+      }),
     anonKey: z
       .string()
       .min(1, { error: 'Supabase anon key is required' })
@@ -285,15 +289,11 @@ export const ConfigSchema = z.object({
       ),
   }),
   backend: z.object({
-    apiUrl: z.url({ error: 'Backend API URL must be a valid URL' }).refine(
-      (url) => {
-        // Ensure it ends with /api/v1 or similar API path
-        return url.includes('/api/') || url.includes('localhost');
-      },
-      {
+    apiUrl: z
+      .url({ error: 'Backend API URL must be a valid URL' })
+      .refine(isAllowedBackendUrl, {
         error: 'Backend API URL should contain an API path',
-      },
-    ),
+      }),
   }),
   postHog: z
     .object({
@@ -315,22 +315,10 @@ export const ConfigSchema = z.object({
         ),
       host: z
         .string()
-        .refine(
-          (val) => {
-            // Allow relative proxy path (e.g., /ph via Vercel reverse proxy)
-            if (val.startsWith('/')) return true;
-            // Allow common PostHog hosts
-            return (
-              val.includes('posthog.com') ||
-              val.includes('posthog.dev') ||
-              val.includes('localhost')
-            );
-          },
-          {
-            error:
-              'PostHog host must be a PostHog URL or a relative proxy path (e.g., /ph)',
-          },
-        )
+        .refine(isAllowedPostHogHost, {
+          error:
+            'PostHog host must be a PostHog URL or a relative proxy path (e.g., /ph)',
+        })
         .default('https://eu.i.posthog.com'),
       enabled: z.boolean().default(true),
       capturePageviews: z.boolean().default(true),

--- a/ios/Pulpe/Domain/Formulas/SavingsPlanCalculator.swift
+++ b/ios/Pulpe/Domain/Formulas/SavingsPlanCalculator.swift
@@ -129,8 +129,7 @@ enum SavingsPlanCalculator {
             // A retrait ANNONCÉ weighs only for the part not yet taken, which the
             // server already deducted per month: adding the full announced amount
             // would count the realized part twice.
-            let budgetPlannedWithdrawal = max(
-                0,
+            let budgetPlannedWithdrawal = normalizedWithdrawalRemainder(
                 month.remainingPlannedWithdrawalAmount - (
                     movement.replacesExistingPlanWithdrawal
                         ? month.planOnlyWithdrawalAmount + month.planLinkedWithdrawalAmount
@@ -302,8 +301,12 @@ extension SavingsPlanCalculator {
                     ? month.planOnlyWithdrawalAmount + month.planLinkedWithdrawalAmount
                     : 0
             )
-            return partial + month.withdrawnAmount + max(0, remaining)
+            return partial + month.withdrawnAmount + normalizedWithdrawalRemainder(remaining)
         }
+    }
+
+    private static func normalizedWithdrawalRemainder(_ amount: Decimal) -> Decimal {
+        amount > SavingsGoalProgress.withdrawalBalanceTolerance ? amount : 0
     }
 
     private static func signedPinnedEffect(

--- a/ios/PulpeTests/Domain/Formulas/SavingsPlanRealizationLockTests.swift
+++ b/ios/PulpeTests/Domain/Formulas/SavingsPlanRealizationLockTests.swift
@@ -90,8 +90,17 @@ struct SavingsPlanRealizationLockTests {
             timeline: exactTimeline,
             targetAmount: 3000
         )
+        let simulation = try SavingsPlanCalculator.simulate(
+            timeline: timeline,
+            targetAmount: 3000
+        )
+        let exactSimulation = try SavingsPlanCalculator.simulate(
+            timeline: exactTimeline,
+            targetAmount: 3000
+        )
 
         #expect(result.remainingEffort == exactResult.remainingEffort)
+        #expect(simulation.simulatedFinal == exactSimulation.simulatedFinal)
     }
 
     /// A realization started on ONE month freezes that month, not the whole plan:

--- a/ios/PulpeTests/Domain/Formulas/SavingsPlanRealizationLockTests.swift
+++ b/ios/PulpeTests/Domain/Formulas/SavingsPlanRealizationLockTests.swift
@@ -62,6 +62,38 @@ private let realizingMay = planMonth(
 
 @Suite("SavingsPlanCalculator.realization lock")
 struct SavingsPlanRealizationLockTests {
+    @Test("normalizes the same 10.05 = 0.01 + 10.04 residue as TypeScript")
+    func floatingResidue_weighsNothing() throws {
+        let residue = try #require(Decimal(string: "0.0000000000000017763568394002505"))
+        let timeline = [
+            planMonth(
+                month: 5,
+                year: 2026,
+                withdrawnAmount: 10.05,
+                plannedWithdrawalAmount: 10.05,
+                remainingPlannedWithdrawalAmount: residue
+            ),
+        ]
+        let exactTimeline = [
+            planMonth(
+                month: 5,
+                year: 2026,
+                withdrawnAmount: 10.05,
+                plannedWithdrawalAmount: 10.05
+            ),
+        ]
+        let result = SavingsPlanCalculator.redistributeRemainingEffort(
+            timeline: timeline,
+            targetAmount: 3000
+        )
+        let exactResult = SavingsPlanCalculator.redistributeRemainingEffort(
+            timeline: exactTimeline,
+            targetAmount: 3000
+        )
+
+        #expect(result.remainingEffort == exactResult.remainingEffort)
+    }
+
     /// A realization started on ONE month freezes that month, not the whole plan:
     /// mars, avril and juin stay valid redistribution targets.
     @Test("keeps redistributing the other months when one starts realizing")

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "type-check": "turbo type-check",
     "quality": "turbo quality && pnpm format:check:automation && pnpm test:ci-security && pnpm test:public-surface",
     "quality:fix": "turbo quality:fix && pnpm format:automation",
-    "audit:prod:critical": "pnpm audit --prod --audit-level critical",
+    "audit:critical": "pnpm audit --audit-level critical",
     "test:ci-security": "node --test .github/scripts/ci-security.test.mjs",
     "test:public-surface": "node --test .github/scripts/public-surface.test.mjs",
     "checks": "turbo checks",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "type-check": "turbo type-check",
     "quality": "turbo quality && pnpm format:check:automation && pnpm test:ci-security && pnpm test:public-surface",
     "quality:fix": "turbo quality:fix && pnpm format:automation",
+    "audit:prod:critical": "pnpm audit --prod --audit-level critical",
     "test:ci-security": "node --test .github/scripts/ci-security.test.mjs",
     "test:public-surface": "node --test .github/scripts/public-surface.test.mjs",
     "checks": "turbo checks",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid@<3.3.17: 3.3.17
+  hono@<4.12.34: 4.12.34
+  dompurify@<=3.4.12: 3.4.13
+  protobufjs@<7.5.5: 7.5.5
+
 importers:
 
   .:
@@ -1560,7 +1566,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4708,8 +4714,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -5535,8 +5541,8 @@ packages:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hookified@1.15.1:
@@ -6527,11 +6533,6 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.17:
     resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -7123,8 +7124,8 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -9639,9 +9640,9 @@ snapshots:
   '@harperfast/extended-iterable@1.0.3':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.34)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.34
 
   '@humanfs/core@0.19.1': {}
 
@@ -10142,7 +10143,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.2)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10152,7 +10153,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.6.0(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10552,7 +10553,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -12794,7 +12795,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -13979,7 +13980,7 @@ snapshots:
 
   hex-rgb@4.3.0: {}
 
-  hono@4.12.18: {}
+  hono@4.12.34: {}
 
   hookified@1.15.1: {}
 
@@ -14945,8 +14946,6 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.15: {}
-
   nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
@@ -15517,13 +15516,13 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -15543,7 +15542,7 @@ snapshots:
       '@posthog/core': 1.24.4
       '@posthog/types': 1.364.4
       core-js: 3.48.0
-      dompurify: 3.3.3
+      dompurify: 3.4.13
       fflate: 0.4.8
       preact: 10.28.4
       query-selector-shadow-dom: 1.0.1
@@ -15555,7 +15554,7 @@ snapshots:
       '@posthog/core': 1.45.0
       '@posthog/types': 1.398.0
       core-js: 3.49.0
-      dompurify: 3.3.3
+      dompurify: 3.4.13
       fflate: 0.4.8
       preact: 10.29.7
       query-selector-shadow-dom: 1.0.1
@@ -15621,7 +15620,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,8 +324,8 @@ importers:
         specifier: ^4.4.3
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-boundaries:
-        specifier: ^5.0.1
-        version: 5.3.1(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
+        specifier: ^6.0.2
+        version: 6.0.2(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -895,8 +895,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@boundaries/elements@1.1.2':
-    resolution: {integrity: sha512-DnGHL+v36YVMoWhWZqyJYVZ9dapNm7h4N3/P0lDPirJj0CHVPkjChMCCotj74cg6LW7iPJZFGrdEfh0X0g2bmQ==}
+  '@boundaries/elements@2.0.1':
+    resolution: {integrity: sha512-sAWO3D8PFP6pBXdxxW93SQi/KQqqhE2AAHo3AgWfdtJXwO6bfK6/wUN81XnOZk0qRC6vHzUEKhjwVD9dtDWvxg==}
     engines: {node: '>=18.18'}
 
   '@cacheable/utils@2.3.4':
@@ -5001,8 +5001,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-plugin-boundaries@5.3.1:
-    resolution: {integrity: sha512-91StsOYtDyrna1fyRJ+1Ps5CnrfyFLbdCouPZ3E/o2cllLxJke3OoScdqjpBSl7pNEYbojhpNlurQAr30sf9Bg==}
+  eslint-plugin-boundaries@6.0.2:
+    resolution: {integrity: sha512-wSHgiYeMEbziP91lH0UQ9oslgF2djG1x+LV9z/qO19ggMKZaCB8pKIGePHAY91eLF4EAgpsxQk8MRSFGRPfPzw==}
     engines: {node: '>=18.18'}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -5470,8 +5470,8 @@ packages:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -7460,8 +7460,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -7771,10 +7771,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
@@ -9089,11 +9088,11 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.10':
     optional: true
 
-  '@boundaries/elements@1.1.2(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))':
+  '@boundaries/elements@2.0.1(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))':
     dependencies:
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       is-core-module: 2.16.1
       micromatch: 4.0.8
     transitivePeerDependencies:
@@ -13220,13 +13219,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-boundaries@5.3.1(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-boundaries@6.0.2(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
-      '@boundaries/elements': 1.1.2(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
+      '@boundaries/elements': 2.0.1(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
       chalk: 4.1.2
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
+      handlebars: 4.7.9
       micromatch: 4.0.8
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -13921,7 +13921,7 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -15064,7 +15064,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.8.5
-      tar: 7.5.7
+      tar: 7.5.22
       tinyglobby: 0.2.17
       which: 6.0.0
     transitivePeerDependencies:
@@ -15138,7 +15138,7 @@ snapshots:
       minimatch: 3.1.2
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.8.3
+      shell-quote: 1.10.0
       string.prototype.padend: 3.1.6
 
   nth-check@2.1.1:
@@ -15317,7 +15317,7 @@ snapshots:
       proc-log: 6.1.0
       sigstore: 4.1.0
       ssri: 13.0.0
-      tar: 7.5.7
+      tar: 7.5.22
     transitivePeerDependencies:
       - supports-color
 
@@ -16073,7 +16073,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -16433,7 +16433,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.7:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  nanoid@<3.3.17: 3.3.17
-  hono@<4.12.34: 4.12.34
-  dompurify@<=3.4.12: 3.4.13
-  protobufjs@<7.5.5: 7.5.5
-
 importers:
 
   .:
@@ -1566,7 +1560,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.34
+      hono: ^4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,12 @@ packages:
   - backend-nest
   - landing
 
+overrides:
+  "nanoid@<3.3.17": 3.3.17
+  "hono@<4.12.34": 4.12.34
+  "dompurify@<=3.4.12": 3.4.13
+  "protobufjs@<7.5.5": 7.5.5
+
 onlyBuiltDependencies:
   - '@nestjs/core'
   - '@parcel/watcher'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,12 +4,6 @@ packages:
   - backend-nest
   - landing
 
-overrides:
-  "nanoid@<3.3.17": 3.3.17
-  "hono@<4.12.34": 4.12.34
-  "dompurify@<=3.4.12": 3.4.13
-  "protobufjs@<7.5.5": 7.5.5
-
 onlyBuiltDependencies:
   - '@nestjs/core'
   - '@parcel/watcher'

--- a/shared/src/calculators/savings-goal-plan.spec.ts
+++ b/shared/src/calculators/savings-goal-plan.spec.ts
@@ -684,6 +684,47 @@ describe('redistributeRemainingEffort', () => {
     planMonth({ month: 4, year: 2026, state: 'future' }),
   ];
 
+  it('normalizes the 10.05 = 0.01 + 10.04 residue in both plan paths', () => {
+    const residue = 10.05 - (0.01 + 10.04);
+    const residueTimeline = [
+      planMonth({
+        month: 5,
+        year: 2026,
+        plannedAmount: 0,
+        plannedWithdrawalAmount: 10.05,
+        remainingPlannedWithdrawalAmount: residue,
+      }),
+    ];
+    const exactTimeline = [
+      planMonth({
+        month: 5,
+        year: 2026,
+        plannedAmount: 0,
+        plannedWithdrawalAmount: 10.05,
+      }),
+    ];
+
+    expect(residue).toBeGreaterThan(0);
+    expect(
+      redistributeRemainingEffort({
+        timeline: residueTimeline,
+        targetAmount: 0,
+      }).remainingEffort,
+    ).toBe(
+      redistributeRemainingEffort({
+        timeline: exactTimeline,
+        targetAmount: 0,
+      }).remainingEffort,
+    );
+    expect(
+      simulateSavingsPlan({ timeline: residueTimeline, targetAmount: 0 })
+        .simulatedFinal,
+    ).toBe(
+      simulateSavingsPlan({ timeline: exactTimeline, targetAmount: 0 })
+        .simulatedFinal,
+    );
+  });
+
   it('should split the remaining effort over open months cents-exact', () => {
     const result = redistributeRemainingEffort({
       timeline,

--- a/shared/src/calculators/savings-goal-plan.spec.ts
+++ b/shared/src/calculators/savings-goal-plan.spec.ts
@@ -691,6 +691,7 @@ describe('redistributeRemainingEffort', () => {
         month: 5,
         year: 2026,
         plannedAmount: 0,
+        withdrawnAmount: 10.05,
         plannedWithdrawalAmount: 10.05,
         remainingPlannedWithdrawalAmount: residue,
       }),
@@ -700,6 +701,7 @@ describe('redistributeRemainingEffort', () => {
         month: 5,
         year: 2026,
         plannedAmount: 0,
+        withdrawnAmount: 10.05,
         plannedWithdrawalAmount: 10.05,
       }),
     ];
@@ -708,19 +710,19 @@ describe('redistributeRemainingEffort', () => {
     expect(
       redistributeRemainingEffort({
         timeline: residueTimeline,
-        targetAmount: 0,
+        targetAmount: 3000,
       }).remainingEffort,
     ).toBe(
       redistributeRemainingEffort({
         timeline: exactTimeline,
-        targetAmount: 0,
+        targetAmount: 3000,
       }).remainingEffort,
     );
     expect(
-      simulateSavingsPlan({ timeline: residueTimeline, targetAmount: 0 })
+      simulateSavingsPlan({ timeline: residueTimeline, targetAmount: 3000 })
         .simulatedFinal,
     ).toBe(
-      simulateSavingsPlan({ timeline: exactTimeline, targetAmount: 0 })
+      simulateSavingsPlan({ timeline: exactTimeline, targetAmount: 3000 })
         .simulatedFinal,
     );
   });

--- a/shared/src/calculators/savings-goal-plan.ts
+++ b/shared/src/calculators/savings-goal-plan.ts
@@ -449,6 +449,10 @@ function managedPlanWithdrawalAmount(month: SavingsPlanTimelineMonth): number {
   );
 }
 
+function normalizedWithdrawalRemainder(amount: number): number {
+  return amount > WITHDRAWAL_BALANCE_TOLERANCE ? amount : 0;
+}
+
 /** Mouvement réellement affiché avant édition : retrait géré, sinon contribution. */
 export function currentPlanMovement(month: SavingsPlanTimelineMonth): number {
   const withdrawal = managedPlanWithdrawalAmount(month);
@@ -540,8 +544,7 @@ export function simulateSavingsPlan(input: {
     // annoncé le suit : il porte déjà sa propre fenêtre, posée à la construction.
     simulatedCumulative -=
       (month.withdrawnAmount ?? 0) +
-      Math.max(
-        0,
+      normalizedWithdrawalRemainder(
         (month.remainingPlannedWithdrawalAmount ?? 0) -
           (replacesExistingPlanWithdrawal
             ? (month.planOnlyWithdrawalAmount ?? 0) +
@@ -657,8 +660,7 @@ export function redistributeRemainingEffort(input: {
     return (
       sum +
       (month.withdrawnAmount ?? 0) +
-      Math.max(
-        0,
+      normalizedWithdrawalRemainder(
         (month.remainingPlannedWithdrawalAmount ?? 0) -
           (replacesExistingPlanWithdrawal
             ? (month.planOnlyWithdrawalAmount ?? 0) +

--- a/shared/src/calculators/savings-goal-progress.spec.ts
+++ b/shared/src/calculators/savings-goal-progress.spec.ts
@@ -12,6 +12,7 @@ import {
   PACE_TOLERANCE_PERCENT,
   calculatePaceStatus,
   computeSavingsGoalProgress,
+  remainingPlannedWithdrawal,
   suggestedMonthlyContribution,
   type LinkedSavingLine,
   type LinkedSavingTransaction,
@@ -138,6 +139,20 @@ describe('calculatePaceStatus', () => {
 
   it('la tolérance par défaut est 5 %', () => {
     expect(PACE_TOLERANCE_PERCENT).toBe(5);
+  });
+});
+
+describe('remainingPlannedWithdrawal', () => {
+  it('normalizes floating-point residue after full realization', () => {
+    expect(
+      remainingPlannedWithdrawal(
+        { id: 'planned', amount: 10.05, month: 6, year: 2026 },
+        [
+          { budgetLineId: 'planned', amount: 0.01, month: 6, year: 2026 },
+          { budgetLineId: 'planned', amount: 10.04, month: 6, year: 2026 },
+        ],
+      ),
+    ).toBe(0);
   });
 });
 

--- a/shared/src/calculators/savings-goal-progress.ts
+++ b/shared/src/calculators/savings-goal-progress.ts
@@ -121,7 +121,8 @@ export function remainingPlannedWithdrawal(
   const realized = withdrawals
     .filter((withdrawal) => withdrawal.budgetLineId === planned.id)
     .reduce((sum, withdrawal) => sum + withdrawal.amount, 0);
-  return Math.max(0, planned.amount - realized);
+  const remaining = planned.amount - realized;
+  return remaining > WITHDRAWAL_BALANCE_TOLERANCE ? remaining : 0;
 }
 
 export interface SavingsGoalProgressInput {


### PR DESCRIPTION
# Harden preview release readiness

## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Corrige les défauts de readiness confirmés sur `preview`, indépendamment de la branche feature/UI : reliquats monétaires, validation des URL, dépendances critiques et contrôles de release.

## 🚶‍➡️ Behavior

- Les retraits entièrement réalisés ne restent plus « partiellement réalisés » à cause d’un résidu flottant, avec parité des formules TypeScript et Swift.
- Les URL trompeuses sont rejetées aux barrières de configuration.
- Les sept résolutions critiques confirmées sont corrigées sans override : mise à jour naturelle des parents lorsque nécessaire, dont `eslint-plugin-boundaries` et sa migration de configuration v6.
- L’audit critique complet — dépendances de production et de développement — bloque désormais la CI.
- La release exige un déploiement Railway preview sain sur le SHA exact avant toute promotion vers `main`.
- Les contrôles What's New ciblés utilisent les commandes valides.

## 🧪 Steps to test

- [x] Exécuter `pnpm quality`.
- [x] Exécuter `pnpm test`.
- [x] Exécuter le build Angular.
- [x] Exécuter `pnpm audit:critical`.
- [x] Vérifier les specs backend, shared, frontend et iOS ciblées.
- [x] Vérifier les contrats What's New backend et frontend.
