### PR TITLE
fix(analytics): harden replay privacy and screen tracking

### DIFF
--- a/frontend/projects/webapp/src/app/core/analytics/posthog-sanitizer.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/posthog-sanitizer.spec.ts
@@ -263,6 +263,34 @@ describe('posthog-sanitizer', () => {
       );
     });
 
+    it('masks dynamic resource IDs in the $pathname system property', () => {
+      const event = {
+        event: '$pageview',
+        properties: {
+          $pathname: '/budgets/example-budget-id',
+        },
+      } as unknown as CaptureResult;
+
+      const sanitized = sanitizeEventPayload(event);
+
+      expect(sanitized?.properties?.['$pathname']).toBe('/budget/[id]');
+    });
+
+    it('preserves business properties that merely contain pathname in their key', () => {
+      const event = {
+        event: 'navigation_diagnostic',
+        properties: {
+          pathname_strategy: 'history based',
+        },
+      } as unknown as CaptureResult;
+
+      const sanitized = sanitizeEventPayload(event);
+
+      expect(sanitized?.properties?.['pathname_strategy']).toBe(
+        'history based',
+      );
+    });
+
     it('handles null or missing properties gracefully', () => {
       const event = {
         event: 'test_event',

--- a/frontend/projects/webapp/src/app/core/analytics/posthog-sanitizer.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/posthog-sanitizer.ts
@@ -173,7 +173,8 @@ const isSensitiveProperty = (normalizedKey: string): boolean => {
 const isUrlKey = (normalizedKey: string): boolean =>
   normalizedKey.includes('url') ||
   normalizedKey.includes('href') ||
-  normalizedKey.includes('link');
+  normalizedKey.includes('link') ||
+  normalizedKey === '$pathname';
 
 const applyDynamicSegmentMasks = (pathname: string): string =>
   DYNAMIC_SEGMENT_MASKS.reduce(

--- a/frontend/projects/webapp/src/app/core/analytics/posthog.spec.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/posthog.spec.ts
@@ -145,6 +145,87 @@ describe('PostHogService', () => {
     );
   });
 
+  it('applies the configured session replay sample rate', async () => {
+    postHogSignal.set({
+      ...defaultConfig,
+      sessionRecording: {
+        ...defaultConfig.sessionRecording,
+        sampleRate: 0.1,
+      },
+    });
+
+    await service.initialize();
+
+    expect(initializationOptions).toEqual(
+      expect.objectContaining({
+        session_recording: expect.objectContaining({
+          sampleRate: 0.1,
+        }),
+      }),
+    );
+  });
+
+  it('defaults session replay sampling to ten percent when omitted', async () => {
+    const configWithoutSampleRate = {
+      ...defaultConfig,
+      sessionRecording: {
+        enabled: true,
+        maskInputs: true,
+      },
+    } as typeof defaultConfig;
+    postHogSignal.set(configWithoutSampleRate);
+
+    await service.initialize();
+
+    expect(initializationOptions).toEqual(
+      expect.objectContaining({
+        session_recording: expect.objectContaining({
+          sampleRate: 0.1,
+        }),
+      }),
+    );
+  });
+
+  it('keeps session replay request bodies and headers disabled', async () => {
+    await service.initialize();
+
+    expect(initializationOptions).toEqual(
+      expect.objectContaining({
+        session_recording: expect.objectContaining({
+          recordBody: false,
+          recordHeaders: false,
+        }),
+      }),
+    );
+  });
+
+  it('sanitizes replay URLs and drops payload fields defensively', async () => {
+    await service.initialize();
+
+    const sessionRecording = initializationOptions?.[
+      'session_recording'
+    ] as Record<string, unknown>;
+    const sanitizeCapturedUrl = sessionRecording[
+      'maskCapturedNetworkRequestFn'
+    ] as (request: Record<string, unknown>) => Record<string, unknown>;
+
+    const sanitized = sanitizeCapturedUrl({
+      name: 'https://app.local/budgets/123?token=private&safe=1#access_token=private',
+      requestHeaders: { authorization: 'private' },
+      responseHeaders: { 'set-cookie': 'private' },
+      requestBody: 'private request',
+      responseBody: 'private response',
+      status: 200,
+    });
+
+    expect(sanitized['name']).toBe('https://app.local/budget/[id]?safe=1');
+    expect(sanitized['status']).toBe(200);
+    expect(sanitized).not.toHaveProperty('requestHeaders');
+    expect(sanitized).not.toHaveProperty('responseHeaders');
+    expect(sanitized).not.toHaveProperty('requestBody');
+    expect(sanitized).not.toHaveProperty('responseBody');
+  });
+
   it('isolates app persistence and removes the legacy shared identity before init', async () => {
     document.cookie =
       'ph_test-api-key_posthog=legacy-identity; Path=/; SameSite=Lax';

--- a/frontend/projects/webapp/src/app/core/analytics/posthog.ts
+++ b/frontend/projects/webapp/src/app/core/analytics/posthog.ts
@@ -7,7 +7,7 @@ import { Logger } from '../logging/logger';
 import { StorageService } from '../storage/storage.service';
 import { STORAGE_KEYS } from '../storage/storage-keys';
 import { buildInfo } from '@env/build-info';
-import { sanitizeEventPayload } from './posthog-sanitizer';
+import { sanitizeEventPayload, sanitizeUrl } from './posthog-sanitizer';
 
 const POSTHOG_PERSISTENCE_NAME = 'pulpe_app';
 
@@ -109,6 +109,24 @@ export class PostHogService {
         session_recording: {
           maskAllInputs: true,
           recordCrossOriginIframes: false,
+          recordBody: false,
+          recordHeaders: false,
+          // posthog-js hashes the session ID, so the sampling decision remains
+          // stable across page reloads for the whole session.
+          sampleRate: config.sessionRecording?.sampleRate ?? 0.1,
+          // PostHog also applies this callback to the page URL stored in replay
+          // snapshots, not only to captured network requests.
+          maskCapturedNetworkRequestFn: (request) => {
+            const sanitizedRequest = { ...request };
+            delete sanitizedRequest.requestHeaders;
+            delete sanitizedRequest.responseHeaders;
+            delete sanitizedRequest.requestBody;
+            delete sanitizedRequest.responseBody;
+            if (sanitizedRequest.name) {
+              sanitizedRequest.name = sanitizeUrl(sanitizedRequest.name);
+            }
+            return sanitizedRequest;
+          },
         },
         disable_session_recording: !this.#sessionReplayEnabled,
 

--- a/ios/Pulpe/Core/Analytics/AnalyticsService.swift
+++ b/ios/Pulpe/Core/Analytics/AnalyticsService.swift
@@ -15,6 +15,43 @@ struct AuthSessionDiagnosticSnapshot: Sendable {
     let isExpectedUserAction: Bool?
 }
 
+struct ScreenViewDeduplicator {
+    private static let targetScreenName = "SavingsGoalsList"
+    private let minimumInterval: TimeInterval
+    private var lastScreenName: String?
+    private var lastCapturedAt: TimeInterval?
+
+    init(minimumInterval: TimeInterval = 1) {
+        self.minimumInterval = minimumInterval
+    }
+
+    mutating func shouldCapture(
+        _ name: String,
+        hasProperties: Bool,
+        at timestamp: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> Bool {
+        guard name == Self.targetScreenName, !hasProperties else {
+            reset()
+            return true
+        }
+
+        if lastScreenName == name,
+           let lastCapturedAt,
+           timestamp - lastCapturedAt < minimumInterval {
+            return false
+        }
+
+        lastScreenName = name
+        lastCapturedAt = timestamp
+        return true
+    }
+
+    mutating func reset() {
+        lastScreenName = nil
+        lastCapturedAt = nil
+    }
+}
+
 /// Central analytics service wrapping PostHog iOS SDK.
 /// All callers are @MainActor (SwiftUI views, stores), so MainActor isolation
 /// ensures thread-safe access to `isInitialized` without requiring actor hops.
@@ -50,6 +87,7 @@ final class AnalyticsService {
     private let isConfiguredEnabled: Bool
     private var cachedIdentity: (userId: String, properties: [String: Any])?
     private(set) var currentPersonProperties: [String: Any] = [:]
+    private var screenViewDeduplicator = ScreenViewDeduplicator()
 
     init(isConfiguredEnabled: Bool = AppConfiguration.isPostHogEnabled) {
         self.isConfiguredEnabled = isConfiguredEnabled
@@ -202,14 +240,6 @@ final class AnalyticsService {
         )
     }
 
-    // MARK: - Screen Tracking
-
-    func screen(_ name: String, properties: [String: Any] = [:]) {
-        guard isEventCapturingEnabled else { return }
-        let sanitized = Self.sanitizeProperties(properties)
-        PostHogSDK.shared.screen(name, properties: sanitized)
-    }
-
     // MARK: - User Identity
 
     func identify(userId: String, properties: [String: Any] = [:]) {
@@ -256,6 +286,7 @@ final class AnalyticsService {
         cachedIdentity = nil
         currentPersonProperties = [:]
         isIdentified = false
+        screenViewDeduplicator.reset()
     }
 
     func setDiagnosticSharingEnabled(_ enabled: Bool) {
@@ -279,6 +310,7 @@ final class AnalyticsService {
             isDiagnosticSharingEnabled = false
             isEventCapturingEnabled = false
             isIdentified = false
+            screenViewDeduplicator.reset()
         }
     }
 
@@ -383,5 +415,18 @@ final class AnalyticsService {
             }
         }
         return sanitized
+    }
+}
+
+extension AnalyticsService {
+    func screen(_ name: String, properties: [String: Any] = [:]) {
+        guard isEventCapturingEnabled,
+              screenViewDeduplicator.shouldCapture(
+                  name,
+                  hasProperties: !properties.isEmpty
+              )
+        else { return }
+        let sanitized = Self.sanitizeProperties(properties)
+        PostHogSDK.shared.screen(name, properties: sanitized)
     }
 }

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -299,3 +299,74 @@ struct AnalyticsServiceTests {
         #expect(sut.isEventCapturingEnabled == false)
     }
 }
+
+@Suite
+struct ScreenViewDeduplicatorTests {
+    @Test func suppressesOnlySavingsGoalsBursts() {
+        let start: TimeInterval = 1_000
+        var deduplicator = ScreenViewDeduplicator(minimumInterval: 1)
+
+        #expect(deduplicator.shouldCapture(
+            "SavingsGoalsList",
+            hasProperties: false,
+            at: start
+        ))
+        #expect(!deduplicator.shouldCapture(
+            "SavingsGoalsList",
+            hasProperties: false,
+            at: start + 0.05
+        ))
+        #expect(deduplicator.shouldCapture(
+            "BudgetDetails",
+            hasProperties: false,
+            at: start + 0.06
+        ))
+        #expect(deduplicator.shouldCapture(
+            "SavingsGoalsList",
+            hasProperties: false,
+            at: start + 0.07
+        ))
+    }
+
+    @Test func rejectionsDoNotExtendTheWindow() {
+        let start: TimeInterval = 1_000
+        var deduplicator = ScreenViewDeduplicator(minimumInterval: 1)
+
+        #expect(deduplicator.shouldCapture(
+            "SavingsGoalsList",
+            hasProperties: false,
+            at: start
+        ))
+        #expect(!deduplicator.shouldCapture(
+            "SavingsGoalsList",
+            hasProperties: false,
+            at: start + 0.9
+        ))
+        #expect(deduplicator.shouldCapture(
+            "SavingsGoalsList",
+            hasProperties: false,
+            at: start + 1.01
+        ))
+    }
+
+    @Test func preservesNonTargetAndEnrichedViews() {
+        let start: TimeInterval = 1_000
+        var deduplicator = ScreenViewDeduplicator(minimumInterval: 1)
+
+        #expect(deduplicator.shouldCapture(
+            "BudgetDetails",
+            hasProperties: false,
+            at: start
+        ))
+        #expect(deduplicator.shouldCapture(
+            "BudgetDetails",
+            hasProperties: false,
+            at: start + 0.01
+        ))
+        #expect(deduplicator.shouldCapture(
+            "SavingsGoalsList",
+            hasProperties: true,
+            at: start + 0.02
+        ))
+    }
+}

--- a/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
+++ b/ios/PulpeTests/Core/Analytics/AnalyticsServiceTests.swift
@@ -306,67 +306,80 @@ struct ScreenViewDeduplicatorTests {
         let start: TimeInterval = 1_000
         var deduplicator = ScreenViewDeduplicator(minimumInterval: 1)
 
-        #expect(deduplicator.shouldCapture(
+        let initialCapture = deduplicator.shouldCapture(
             "SavingsGoalsList",
             hasProperties: false,
             at: start
-        ))
-        #expect(!deduplicator.shouldCapture(
+        )
+        let duplicateCapture = deduplicator.shouldCapture(
             "SavingsGoalsList",
             hasProperties: false,
             at: start + 0.05
-        ))
-        #expect(deduplicator.shouldCapture(
+        )
+        let otherScreenCapture = deduplicator.shouldCapture(
             "BudgetDetails",
             hasProperties: false,
             at: start + 0.06
-        ))
-        #expect(deduplicator.shouldCapture(
+        )
+        let rearmedCapture = deduplicator.shouldCapture(
             "SavingsGoalsList",
             hasProperties: false,
             at: start + 0.07
-        ))
+        )
+
+        #expect(initialCapture)
+        #expect(!duplicateCapture)
+        #expect(otherScreenCapture)
+        #expect(rearmedCapture)
     }
 
     @Test func rejectionsDoNotExtendTheWindow() {
         let start: TimeInterval = 1_000
         var deduplicator = ScreenViewDeduplicator(minimumInterval: 1)
 
-        #expect(deduplicator.shouldCapture(
+        let initialCapture = deduplicator.shouldCapture(
             "SavingsGoalsList",
             hasProperties: false,
             at: start
-        ))
-        #expect(!deduplicator.shouldCapture(
+        )
+        let duplicateCapture = deduplicator.shouldCapture(
             "SavingsGoalsList",
             hasProperties: false,
             at: start + 0.9
-        ))
-        #expect(deduplicator.shouldCapture(
+        )
+        let captureAfterWindow = deduplicator.shouldCapture(
             "SavingsGoalsList",
             hasProperties: false,
             at: start + 1.01
-        ))
+        )
+
+        #expect(initialCapture)
+        #expect(!duplicateCapture)
+        #expect(captureAfterWindow)
     }
 
     @Test func preservesNonTargetAndEnrichedViews() {
         let start: TimeInterval = 1_000
         var deduplicator = ScreenViewDeduplicator(minimumInterval: 1)
 
-        #expect(deduplicator.shouldCapture(
+        let firstNonTargetCapture = deduplicator.shouldCapture(
             "BudgetDetails",
             hasProperties: false,
             at: start
-        ))
-        #expect(deduplicator.shouldCapture(
+        )
+        let repeatedNonTargetCapture = deduplicator.shouldCapture(
             "BudgetDetails",
             hasProperties: false,
             at: start + 0.01
-        ))
-        #expect(deduplicator.shouldCapture(
+        )
+        let enrichedTargetCapture = deduplicator.shouldCapture(
             "SavingsGoalsList",
             hasProperties: true,
             at: start + 0.02
-        ))
+        )
+
+        #expect(firstNonTargetCapture)
+        #expect(repeatedNonTargetCapture)
+        #expect(enrichedTargetCapture)
     }
 }


### PR DESCRIPTION
## Résumé

- masque les identifiants de ressources dans `$pathname`, en plus de `$current_url`
- applique un échantillonnage Session Replay stable à 10 % par session
- neutralise corps et en-têtes réseau et nettoie les URLs page/réseau avant capture
- déduplique uniquement les rafales `SavingsGoalsList` iOS sans supprimer les vues enrichies ni prolonger la fenêtre sur rejet

## Validation

- [x] tests analytics web ciblés : 58/58
- [x] suite frontend complète : 2 859/2 859
- [x] type-checks, lint et format frontend
- [x] build Angular + contrôle CSP
- [x] qualité monorepo : 12/12 tâches Turbo
- [x] tests de sécurité CI existants
- [ ] tests iOS `PulpeTests` via le pipeline requis `✅ CI Success` sur runner macOS

## Notes

- La déduplication iOS est limitée à une seconde et au seul écran dont la boucle a été reproduite : 3 323/3 404 vues (97,6 %) étaient espacées de moins de 100 ms dans l’agrégat outlier observé.
- Aucun replay historique n’est supprimé et aucune session ni aucun jeton n’est révoqué dans cette PR.
- Aucun changement Railway n’est inclus dans la PR ; le watchdog local reste strictement en lecture seule.
